### PR TITLE
#28036: Augment allocator to support multiple overlapped allocators

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
     PRIVATE
         allocator/test_free_list_opt_allocator.cpp
         allocator/test_l1_banking_allocator.cpp
+        allocator/test_overlapped_bank_manager.cpp
         circular_buffer/test_CircularBuffer_allocation.cpp
         circular_buffer/test_CircularBuffer_creation.cpp
         circular_buffer/test_CircularBuffer_non_blocking.cpp

--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -371,3 +371,61 @@ TEST(FreeListOptTest, ReallocateAtSameAddressWithAllocateAtAddress) {
     auto a_realloc = allocator.allocate_at_address(alloc_address, 1_KiB);
     ASSERT_THAT(a_realloc, ::testing::Optional(alloc_address));
 }
+
+TEST(FreeListOptTest, AllocatedAddresses) {
+    auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
+
+    // Check that allocated addresses is empty
+    auto empty_allocated_addresses = allocator.allocated_addresses();
+    ASSERT_TRUE(empty_allocated_addresses.empty());
+
+    // Allocate some blocks and validate allocated addresses
+    auto a = allocator.allocate(512_KiB, /*bottom_up=*/false);
+    ASSERT_THAT(a, ::testing::Optional(1_GiB - 512_KiB));
+
+    auto b = allocator.allocate(2_KiB);
+    ASSERT_THAT(b, ::testing::Optional(0));
+
+    // Unaligned size should be aligned to the next multiple of 1_KiB
+    auto c = allocator.allocate(500);
+    ASSERT_THAT(c, ::testing::Optional(2_KiB));
+
+    auto allocated_addresses = allocator.allocated_addresses();
+    ASSERT_EQ(allocated_addresses.size(), 3);
+
+    // Allocated addresses are not sorted by start address; in this case, it should be in order of: a, b, c
+    ASSERT_EQ(allocated_addresses[0], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{1_GiB - 512_KiB, 1_GiB}));
+    ASSERT_EQ(allocated_addresses[1], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{0, 2_KiB}));
+    ASSERT_EQ(allocated_addresses[2], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{2_KiB, 3_KiB}));
+
+    /*********************************************************
+     * Check allocated_addresses is correct after other APIs *
+     *********************************************************/
+    // Deallocate first block
+    allocator.deallocate(a.value());
+    auto after_free = allocator.allocated_addresses();
+    ASSERT_EQ(after_free.size(), 2);
+    ASSERT_EQ(after_free[0], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{0_KiB, 2_KiB}));
+    ASSERT_EQ(after_free[1], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{2_KiB, 3_KiB}));
+
+    // Clear -> empty again
+    allocator.clear();
+    auto after_clear = allocator.allocated_addresses();
+    ASSERT_TRUE(after_clear.empty());
+
+    // Allocate from top to leave space at bottom, then shrink and reset
+    allocator.allocate(1_KiB, /*bottom_up=*/false);
+    auto after_top = allocator.allocated_addresses();
+    ASSERT_EQ(after_top.size(), 1);
+    ASSERT_EQ(after_top[0], (std::pair<tt::tt_metal::DeviceAddr, tt::tt_metal::DeviceAddr>{1_GiB - 1_KiB, 1_GiB}));
+
+    // Shrink from bottom (should not affect allocated block near top)
+    allocator.shrink_size(1_KiB);
+    auto after_shrink = allocator.allocated_addresses();
+    ASSERT_EQ(after_shrink, after_top);
+
+    // Reset size back
+    allocator.reset_size();
+    auto after_reset = allocator.allocated_addresses();
+    ASSERT_EQ(after_reset, after_top);
+}

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -1,0 +1,1098 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "gmock/gmock.h"
+#include <cstdint>
+#include <tt-metalium/allocator.hpp>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/device.hpp>
+#include "device_fixture.hpp"
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/metal_soc_descriptor.h>
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/impl/allocator/bank_manager.hpp"
+
+namespace overlapped_bank_manager_tests {
+struct AllocatorDependenciesParam {
+    std::unordered_map<
+        tt::tt_metal::BankManager::AllocatorDependencies::AllocatorID,
+        ttsl::SmallVector<tt::tt_metal::BankManager::AllocatorDependencies::AllocatorID>>
+        input;
+    // Expected dependencies per allocator (missing keys imply empty list)
+    tt::tt_metal::BankManager::AllocatorDependencies::AdjacencyList expected_dependencies;
+};
+
+tt::tt_metal::BankManager get_bank_manager_with_allocator_dependencies(
+    const uint64_t size,
+    const uint32_t alignment,
+    const tt::tt_metal::BankManager::AllocatorDependencies& allocator_dependencies) {
+    std::vector<int64_t> bank_desc = {0};
+    const uint64_t unreserved_base = 0;
+    return tt::tt_metal::BankManager(
+        tt::tt_metal::BufferType::DRAM, bank_desc, size, alignment, unreserved_base, false, allocator_dependencies);
+}
+
+}  // namespace overlapped_bank_manager_tests
+
+using namespace overlapped_bank_manager_tests;
+using namespace tt::tt_metal;
+using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+
+/*******************************
+ * AllocatorDependencies Tests *
+ *******************************/
+TEST(AllocatorDependencies, DefaultAllocatorDependencies) {
+    BankManager::AllocatorDependencies allocator_dependencies;
+    EXPECT_EQ(allocator_dependencies.dependencies, BankManager::AllocatorDependencies::AdjacencyList{{}});
+}
+
+TEST(AllocatorDependencies, DuplicateDependencies) {
+    const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map = {
+        {AllocatorID{0}, ttsl::SmallVector<AllocatorID>{AllocatorID{1}, AllocatorID{1}}}};
+
+    EXPECT_THAT(
+        [&]() { BankManager::AllocatorDependencies allocator_dependencies{dependencies_map}; },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Duplicate dependency for allocator 0: 1 appears more than once!")));
+}
+
+TEST(AllocatorDependencies, EquivalentDependenciesMaps) {
+    const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map1 = {
+        {AllocatorID{0}, ttsl::SmallVector<AllocatorID>{AllocatorID{1}}},
+        {AllocatorID{1}, ttsl::SmallVector<AllocatorID>{AllocatorID{0}}}};
+    const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map2 = {
+        {AllocatorID{0}, ttsl::SmallVector<AllocatorID>{AllocatorID{1}}}};
+    const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map3 = {
+        {AllocatorID{1}, ttsl::SmallVector<AllocatorID>{AllocatorID{0}}}};
+
+    EXPECT_EQ(
+        BankManager::AllocatorDependencies(dependencies_map1), BankManager::AllocatorDependencies(dependencies_map2));
+    EXPECT_EQ(
+        BankManager::AllocatorDependencies(dependencies_map1), BankManager::AllocatorDependencies(dependencies_map3));
+}
+
+class AllocatorDependenciesParamTest : public ::testing::TestWithParam<AllocatorDependenciesParam> {};
+
+TEST_P(AllocatorDependenciesParamTest, ValidateDependencies) {
+    const auto& params = GetParam();
+
+    BankManager::AllocatorDependencies allocator_dependencies{params.input};
+
+    // Validate dependencies
+    EXPECT_EQ(allocator_dependencies.dependencies, params.expected_dependencies);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllocatorDependencies,
+    AllocatorDependenciesParamTest,
+    ::testing::Values(
+        // Empty input
+        AllocatorDependenciesParam{
+            /*input=*/{},
+            /*expected_dependencies=*/{{}}},
+        // Single allocator default behavior (explicit input)
+        AllocatorDependenciesParam{
+            /*input=*/{{AllocatorID{0}, {}}},
+            /*expected_dependencies=*/{{}}},
+        // Two-way dependency
+        AllocatorDependenciesParam{
+            /*input=*/{{AllocatorID{0}, {AllocatorID{1}}}, {AllocatorID{1}, {AllocatorID{0}}}},
+            /*expected_dependencies=*/{{AllocatorID{1}}, {AllocatorID{0}}}},
+        // Sparse keys with one dependency specified
+        AllocatorDependenciesParam{
+            /*input=*/{{AllocatorID{3}, {AllocatorID{0}, AllocatorID{1}}}},
+            /*expected_dependencies=*/{{AllocatorID{3}}, {AllocatorID{3}}, {}, {AllocatorID{0}, AllocatorID{1}}}},
+        // Sparse keys with one dependency specified (value of dependents imply more allocators)
+        AllocatorDependenciesParam{
+            /*input=*/{{AllocatorID{1}, {AllocatorID{3}}}},
+            /*expected_dependencies=*/{{}, {AllocatorID{3}}, {}, {AllocatorID{1}}}},
+        // Fan-in: 1,2,3 depend on 0
+        AllocatorDependenciesParam{
+            /*input=*/{
+                {AllocatorID{1}, {AllocatorID{0}}},
+                {AllocatorID{2}, {AllocatorID{0}}},
+                {AllocatorID{3}, {AllocatorID{0}}}},
+            /*expected_dependencies=*/
+            {{AllocatorID{1}, AllocatorID{2}, AllocatorID{3}}, {AllocatorID{0}}, {AllocatorID{0}}, {AllocatorID{0}}}},
+        // Fan-out: 0 depends on 1,2,3
+        AllocatorDependenciesParam{
+            /*input=*/{{AllocatorID{0}, {AllocatorID{1}, AllocatorID{2}, AllocatorID{3}}}},
+            /*expected_dependencies=*/
+            {{AllocatorID{1}, AllocatorID{2}, AllocatorID{3}}, {AllocatorID{0}}, {AllocatorID{0}}, {AllocatorID{0}}}},
+        // Chain: 0->1->2->3
+        AllocatorDependenciesParam{
+            /*input=*/{
+                {AllocatorID{0}, {AllocatorID{1}}},
+                {AllocatorID{1}, {AllocatorID{2}}},
+                {AllocatorID{2}, {AllocatorID{3}}}},
+            /*expected_dependencies=*/
+            {{AllocatorID{1}}, {AllocatorID{0}, AllocatorID{2}}, {AllocatorID{1}, AllocatorID{3}}, {AllocatorID{2}}}},
+        // Cycle: 0->1->2->0
+        AllocatorDependenciesParam{
+            /*input=*/{
+                {AllocatorID{0}, {AllocatorID{1}}},
+                {AllocatorID{1}, {AllocatorID{2}}},
+                {AllocatorID{2}, {AllocatorID{0}}}},
+            /*expected_dependencies=*/{
+                {AllocatorID{1}, AllocatorID{2}},
+                {AllocatorID{0}, AllocatorID{2}},
+                {AllocatorID{0}, AllocatorID{1}}}}));
+
+/********************************
+ * Overlapped BankManager Tests *
+ ********************************/
+TEST(OverlappedAllocators, InvalidAllocator) {
+    // Create bank manager with 2 allocators (0 and 1)
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+
+    // Test accessing invalid allocator that's greater than num_allocators
+    AllocatorID invalid_allocator{2};  // Should fail since we only have allocators 0 and 1
+
+    // Test non-const overload of get_allocator_from_id
+    EXPECT_THAT(
+        [&]() {
+            bank_manager.allocate_buffer(
+                1024, 1024, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, invalid_allocator);
+        },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Invalid allocator ID 2 (num_allocators=2)")));
+
+    // Test const overload of get_allocator_from_id
+    EXPECT_THAT(
+        [&]() { bank_manager.lowest_occupied_address(0, invalid_allocator); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Invalid allocator ID 2 (num_allocators=2)")));
+}
+
+TEST(OverlappedAllocators, InvalidAPIsForOverlappedAllocators) {
+    // Create bank manager with 2 allocators (0 and 1)
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+
+    // Test accessing an API that only works for single allocator
+    EXPECT_THAT(
+        [&]() { bank_manager.reset_size(AllocatorID{0}); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+    EXPECT_THAT(
+        [&]() { bank_manager.reset_size(AllocatorID{1}); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+    EXPECT_THAT(
+        [&]() { bank_manager.shrink_size(1024, true, AllocatorID{0}); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+    EXPECT_THAT(
+        [&]() { bank_manager.shrink_size(1024, true, AllocatorID{1}); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+}
+
+TEST(OverlappedAllocators, DeallocateAllAndClear) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+    const uint32_t bank_id = 0;
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_1K = 1024;
+    const uint32_t alloc_size_2K = 2048;
+
+    // Verify no allocations exist initially
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), std::nullopt);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{1}), std::nullopt);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{2}), std::nullopt);
+
+    // Allocate in each allocator
+    bank_manager.allocate_buffer(
+        alloc_size_1K, alloc_size_1K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{0});
+    auto addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K, alloc_size_2K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{1});
+    bank_manager.allocate_buffer(
+        alloc_size_1K, alloc_size_1K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{2});
+
+    // Verify allocations exist in all allocators
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), 0);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{1}), 0);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{2}), addr1 + alloc_size_2K);
+
+    // Clear all allocations
+    bank_manager.deallocate_all();
+    bank_manager.clear();
+
+    // Verify all allocations are cleared in all allocators
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), std::nullopt);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{1}), std::nullopt);
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{2}), std::nullopt);
+
+    // Verify we can allocate from the beginning again in all allocators
+    auto new_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K, alloc_size_1K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{0});
+    auto new_addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K, alloc_size_2K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{1});
+    auto new_addr2 = bank_manager.allocate_buffer(
+        alloc_size_1K, alloc_size_1K, true, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, AllocatorID{2});
+
+    EXPECT_EQ(new_addr0, 0);
+    EXPECT_EQ(new_addr1, 0);
+    EXPECT_EQ(new_addr2, new_addr1 + alloc_size_2K);
+}
+
+TEST(OverlappedAllocators, IndependentAllocAndDeallocBottomUp) {
+    // 2 independent allocators, no overlaps
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+    const uint32_t bank_id = 0;
+
+    // Hard-coded allocation sizes
+    uint32_t alloc_size_1K = 1024;
+    uint32_t alloc_size_2K = 2048;
+
+    // Allocate 1K in allocator 0
+    // - Alloc0: | 1K | free |
+    // - Alloc1: |   free    |
+    auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, 0);
+
+    // Allocate 2K in allocator 1
+    // - Alloc0: | 1K |   free   |
+    // - Alloc1: |   2K   | free |
+    auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, 0);
+
+    // Allocate another 1K in allocator 0
+    // - Alloc0: | 1K | 1K | free |
+    // - Alloc1: |   2K    | free |
+    auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc0_addr0 + alloc_size_1K);
+
+    // Allocate another 2K in allocator 1
+    // - Alloc0: | 1K | 1K |     free      |
+    // - Alloc1: |   2K    |   2K   | free |
+    auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc1_addr0 + alloc_size_2K);
+
+    // Deallocate first 2K in allocator 1
+    // - Alloc0: | 1K | 1K |     free      |
+    // - Alloc1: | 2K free |   2K   | free |
+    bank_manager.deallocate_buffer(alloc1_addr0, AllocatorID{1});
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{1}), alloc1_addr1);
+
+    // Allocate 1K in allocator 1
+    // - Alloc0: |   1K    |   1K    |       free        |
+    // - Alloc1: |   1K    | 1K free |     2K     | free |
+    auto alloc1_addr3 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr3, 0);
+
+    // Deallocate first 1K in allocator 0
+    // - Alloc0: | 1K free |   1K    |       free        |
+    // - Alloc1: |   1K    | 1K free |     2K     | free |
+    bank_manager.deallocate_buffer(alloc0_addr0, AllocatorID{0});
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), alloc0_addr1);
+}
+
+TEST(OverlappedAllocators, IndependentAllocAndDeallocTopDown) {
+    // 2 independent allocators, no overlaps
+    const uint64_t total_size = 1024 * 1024;
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(total_size, 1024, deps);
+    const uint32_t bank_id = 0;
+
+    // Hard-coded allocation sizes
+    uint32_t alloc_size_1K = 1024;
+    uint32_t alloc_size_2K = 2048;
+
+    // Allocate 1K in allocator 0
+    // - Alloc0: | free | 1K |
+    // - Alloc1: |   free    |
+    auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, total_size - alloc_size_1K);
+
+    // Allocate 2K in allocator 1
+    // - Alloc0: |   free   | 1K |
+    // - Alloc1: | free |   2K   |
+    auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, total_size - alloc_size_2K);
+
+    // Allocate another 1K in allocator 0
+    // - Alloc0: | free | 1K | 1K |
+    // - Alloc1: | free |   2K    |
+    auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc0_addr0 - alloc_size_1K);
+
+    // Allocate another 2K in allocator 1
+    // - Alloc0: |     free      | 1K | 1K |
+    // - Alloc1: | free |   2K   |   2K    |
+    auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc1_addr0 - alloc_size_2K);
+
+    // Deallocate first 2K in allocator 1
+    // - Alloc0: |      free      | 1K | 1K |
+    // - Alloc1: | free |   2K    | 2K free |
+    bank_manager.deallocate_buffer(alloc1_addr0, AllocatorID{1});
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{1}), alloc1_addr1);
+
+    // Allocate 1K in allocator 1
+    // - Alloc0: |       free        |   1K    |   1K    |
+    // - Alloc1: | free |     2K     | 1K free |   1K    |
+    auto alloc1_addr3 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr3, total_size - alloc_size_1K);
+
+    // Deallocate first 1K in allocator 0
+    // - Alloc0: |       free        |   1K    | 1K free |
+    // - Alloc1: | free |     2K     | 1K free |   1K    |
+    bank_manager.deallocate_buffer(alloc0_addr0, AllocatorID{0});
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), alloc0_addr1);
+}
+
+TEST(OverlappedAllocators, OverlappedAllocAndDeallocBottomUp) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+    const uint32_t bank_id = 0;
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_1K = 1024;
+    const uint32_t alloc_size_2K = 2048;
+
+    // Allocate 1K in allocator 0
+    // - Alloc0: | 1K | free |
+    // - Alloc1: |   free    |
+    // - Alloc2: |   free    |
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, 0);
+
+    // Allocate 2K in allocator 1
+    // - Alloc0: | 1K |   free   |
+    // - Alloc1: |   2K   | free |
+    // - Alloc2: |     free      |
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, 0);
+
+    // Allocate 1K in allocator 1
+    // - Alloc0: | 1K |     free      |
+    // - Alloc1: |   2K   | 1K | free |
+    // - Alloc2: |        free        |
+    const auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc1_addr0 + alloc_size_2K);
+
+    // Allocate 1K in overlapped allocator 2 (should be placed after allocator 1's 1K)
+    // - Alloc0: | 1K |        free        |
+    // - Alloc1: |   2K   | 1K |   free    |
+    // - Alloc2: |    free     | 1K | free |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, alloc1_addr1 + alloc_size_1K);
+
+    // Allocate 1K in allocator 0 (should be placed after allocator 0's 1K and before allocator 2's 1K)
+    // - Alloc0: | 1K | 1K |      free      |
+    // - Alloc1: |   2K    | 1K |   free    |
+    // - Alloc2: |     free     | 1K | free |
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc0_addr0 + alloc_size_1K);
+
+    // Allocate 1K in allocator 1 (should be placed after allocator 2's 1K)
+    // - Alloc0: | 1K | 1K |         free          |
+    // - Alloc1: |   2K    | 1K | free | 1K | free |
+    // - Alloc2: |     free     |  1K  |   free    |
+    const auto alloc1_addr2 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr2, alloc2_addr0 + alloc_size_1K);
+
+    /****************************************************************************
+     * Deallocate from allocator 2 and allocate in 0 and 1, reusing freed space *
+     ****************************************************************************/
+    // Deallocate 1K from allocator 2
+    // - Alloc0: | 1K | 1K |           free           |
+    // - Alloc1: |   2K    | 1K |  free   | 1K | free |
+    // - Alloc2: |     free     | 1K free |   free    |
+    bank_manager.deallocate_buffer(alloc2_addr0, AllocatorID{2});
+    // Lowest occupied address does not account for allocations in other allocators
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{2}), std::nullopt);
+    // Allocate 2K in allocator 0 (reusing freed space from allocator 2)
+    // - Alloc0: | 1K | 1K |      2K      |   free    |
+    // - Alloc1: |   2K    | 1K |  free   | 1K | free |
+    // - Alloc2: |     free     | 1K free |   free    |
+    const auto alloc0_addr2 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr2, alloc0_addr1 + alloc_size_1K);
+    // Allocate 1K in allocator 1 (reusing freed space from allocator 2)
+    // - Alloc0: | 1K | 1K |      2K      |   free    |
+    // - Alloc1: |   2K    | 1K |   1K    | 1K | free |
+    // - Alloc2: |     free     | 1K free |   free    |
+    const auto alloc1_addr3 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr3, alloc2_addr0);
+
+    /****************************************************************************
+     * Deallocate from allocator 0 and 1 and allocate in 2, reusing freed space *
+     ****************************************************************************/
+    // Deallocate 1K from allocator 0 and 2K from allocator 1
+    // - Alloc0: | 1K | 1K free |      2K      |   free    |
+    // - Alloc1: |   2K free    | 1K |   1K    | 1K | free |
+    // - Alloc2: |       free        | 1K free |   free    |
+    bank_manager.deallocate_buffer(alloc0_addr1, AllocatorID{0});
+    bank_manager.deallocate_buffer(alloc1_addr0, AllocatorID{1});
+    // Allocate 1K in allocator 2 (reusing freed space)
+    // - Alloc0: |  1K  | 1K free |       2K       |   free    |
+    // - Alloc1: |    2K free     |  1K  |   1K    | 1K | free |
+    // - Alloc2: | free |   1K    | free | 1K free |   free    |
+    const auto alloc2_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr1, alloc0_addr1);
+}
+
+TEST(OverlappedAllocators, OverlappedAllocAndDeallocTopDown) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    const uint64_t total_size = 1024 * 1024;
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(total_size, 1024, deps);
+    const uint32_t bank_id = 0;
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_1K = 1024;
+    const uint32_t alloc_size_2K = 2048;
+
+    // Allocate 1K in allocator 0
+    // - Alloc0: | free | 1K |
+    // - Alloc1: |   free    |
+    // - Alloc2: |   free    |
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, total_size - alloc_size_1K);
+
+    // Allocate 2K in allocator 1
+    // - Alloc0: |   free   | 1K |
+    // - Alloc1: | free |   2K   |
+    // - Alloc2: |     free      |
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, total_size - alloc_size_2K);
+
+    // Allocate 1K in allocator 1
+    // - Alloc0: |     free      | 1K |
+    // - Alloc1: | free | 1K |   2K   |
+    // - Alloc2: |        free        |
+    const auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc1_addr0 - alloc_size_1K);
+
+    // Allocate 1K in overlapped allocator 2 (should be placed before allocator 1's 1K)
+    // - Alloc0: |        free        | 1K |
+    // - Alloc1: |   free    | 1K |   2K   |
+    // - Alloc2: | free | 1K |    free     |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, alloc1_addr1 - alloc_size_1K);
+
+    // Allocate 1K in allocator 0 (should be placed before allocator 0's 1K and after allocator 2's 1K)
+    // - Alloc0: |      free      | 1K | 1K |
+    // - Alloc1: |   free    | 1K |   2K    |
+    // - Alloc2: | free | 1K |     free     |
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc0_addr0 - alloc_size_1K);
+
+    // Allocate 1K in allocator 1 (should be placed before allocator 2's 1K)
+    // - Alloc0: |         free          | 1K | 1K |
+    // - Alloc1: | free | 1K | free | 1K |   2K    |
+    // - Alloc2: |   free    |  1K  |     free     |
+    const auto alloc1_addr2 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr2, alloc2_addr0 - alloc_size_1K);
+
+    /****************************************************************************
+     * Deallocate from allocator 2 and allocate in 0 and 1, reusing freed space *
+     ****************************************************************************/
+    // Deallocate 1K from allocator 2
+    // - Alloc0: |           free           | 1K | 1K |
+    // - Alloc1: | free | 1K |  free   | 1K |   2K    |
+    // - Alloc2: |   free    | 1K free |     free     |
+    bank_manager.deallocate_buffer(alloc2_addr0, AllocatorID{2});
+    // Lowest occupied address does not account for allocations in other allocators
+    EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{2}), std::nullopt);
+    // Allocate 2K in allocator 0 (reusing freed space from allocator 2)
+    // - Alloc0: |   free    |      2K      | 1K | 1K |
+    // - Alloc1: | free | 1K |  free   | 1K |   2K    |
+    // - Alloc2: |   free    | 1K free |     free     |
+    const auto alloc0_addr2 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr2, alloc0_addr1 - alloc_size_2K);
+    // Allocate 1K in allocator 1 (reusing freed space from allocator 2)
+    // - Alloc0: |   free    |      2K      | 1K | 1K |
+    // - Alloc1: | free | 1K |   1K    | 1K |   2K    |
+    // - Alloc2: |   free    | 1K free |     free     |
+    const auto alloc1_addr3 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr3, alloc2_addr0);
+
+    /****************************************************************************
+     * Deallocate from allocator 0 and 1 and allocate in 2, reusing freed space *
+     ****************************************************************************/
+    // Deallocate 1K from allocator 0 and 2K from allocator 1
+    // - Alloc0: |   free    |      2K      | 1K free | 1K |
+    // - Alloc1: | free | 1K |   1K    | 1K |   2K free    |
+    // - Alloc2: |   free    | 1K free |       free        |
+    bank_manager.deallocate_buffer(alloc0_addr1, AllocatorID{0});
+    bank_manager.deallocate_buffer(alloc1_addr0, AllocatorID{1});
+    // Allocate 1K in allocator 2 (reusing freed space)
+    // - Alloc0: |   free    |       2K       | 1K free |  1K  |
+    // - Alloc1: | free | 1K |   1K    |  1K  |    2K free     |
+    // - Alloc2: |   free    | 1K free | free |   1K    | free |
+    const auto alloc2_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr1, alloc0_addr1);
+}
+
+TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesBottomUp) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    const uint32_t alignment = 1024;
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, alignment, deps);
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_unaligned = 512;
+    const uint32_t alloc_size_aligned = (alloc_size_unaligned + alignment - 1) / alignment * alignment;
+    ASSERT_EQ(alloc_size_aligned, 1024);
+    const uint32_t alloc_size_2K = 2048;
+
+    // Allocate unaligned size in allocator 0
+    // - Alloc0: | 1K | free |
+    // - Alloc1: |   free    |
+    // - Alloc2: |   free    |
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, 0);
+
+    // Allocate unaligned size in allocator 2
+    // - Alloc0: |  1K  |   free    |
+    // - Alloc1: |       free       |
+    // - Alloc2: | free | 1K | free |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, alloc0_addr0 + alloc_size_aligned);
+
+    // Allocate unaligned size in allocator 1
+    // - Alloc0: |  1K  |   free    |
+    // - Alloc1: |  1K  |   free    |
+    // - Alloc2: | free | 1K | free |
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, 0);
+
+    // Allocate another unaligned size in allocator 1 (should be placed after allocator 2's 1K)
+    // - Alloc0: |  1K  |       free       |
+    // - Alloc1: |  1K  | free | 1K | free |
+    // - Alloc2: | free |  1K  |   free    |
+    const auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc2_addr0 + alloc_size_aligned);
+
+    // Allocate 2K in allocator 0 (should be placed after allocator 2's 1K)
+    // - Alloc0: |  1K  | free |   2K   | free |
+    // - Alloc1: |  1K  | free | 1K |   free   |
+    // - Alloc2: | free |  1K  |     free      |
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc2_addr0 + alloc_size_aligned);
+}
+
+TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesTopDown) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    const uint64_t total_size = 1024 * 1024;
+    const uint32_t alignment = 1024;
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(total_size, alignment, deps);
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_unaligned = 512;
+    const uint32_t alloc_size_aligned = (alloc_size_unaligned + alignment - 1) / alignment * alignment;
+    ASSERT_EQ(alloc_size_aligned, 1024);
+    const uint32_t alloc_size_2K = 2048;
+
+    // Allocate unaligned size in allocator 0
+    // - Alloc0: | free | 1K |
+    // - Alloc1: |   free    |
+    // - Alloc2: |   free    |
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, total_size - alloc_size_aligned);
+
+    // Allocate unaligned size in allocator 2
+    // - Alloc0: |   free    |  1K  |
+    // - Alloc1: |       free       |
+    // - Alloc2: | free | 1K | free |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, alloc0_addr0 - alloc_size_aligned);
+
+    // Allocate unaligned size in allocator 1
+    // - Alloc0: |   free    |  1K  |
+    // - Alloc1: |   free    |  1K  |
+    // - Alloc2: | free | 1K | free |
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, total_size - alloc_size_aligned);
+
+    // Allocate another unaligned size in allocator 1 (should be placed before allocator 2's 1K)
+    // - Alloc0: |       free       |  1K  |
+    // - Alloc1: | free | 1K | free |  1K  |
+    // - Alloc2: |   free    |  1K  | free |
+    const auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_unaligned,
+        alloc_size_unaligned,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr1, alloc2_addr0 - alloc_size_aligned);
+
+    // Allocate 2K in allocator 0 (should be placed before allocator 2's 1K)
+    // - Alloc0: | free |   2K   | free |  1K  |
+    // - Alloc1: |   free   | 1K | free |  1K  |
+    // - Alloc2: |     free      |  1K  | free |
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc2_addr0 - alloc_size_2K);
+}
+
+TEST(OverlappedAllocators, OverlappedAllocationsFromBothSides) {
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    const uint64_t total_size = 1024 * 1024;
+    const uint32_t alignment = 1024;
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(total_size, alignment, deps);
+
+    // Hard-coded allocation sizes
+    const uint32_t alloc_size_1K = 1024;
+    const uint32_t alloc_size_2K = 2048;
+    const uint32_t alloc_size_half_of_total_size = total_size / 2;
+    const uint32_t alloc_size_quarter_of_total_size = total_size / 4;
+
+    // Set up initial allocations
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_half_of_total_size,
+        alloc_size_half_of_total_size,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_2K,
+        alloc_size_2K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    const auto alloc1_addr1 = bank_manager.allocate_buffer(
+        alloc_size_half_of_total_size,
+        alloc_size_half_of_total_size,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+
+    // Initial allocator states after all allocations
+    // Deallocate 512K from allocator 1
+    // - Alloc0: |                     512k                      |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                     512k                      |   2K   |
+    // - Alloc2: |                                             free                                              |
+
+    // Try to allocate in allocator 2 (overlapped) which should fail due to no available space
+    EXPECT_THAT(
+        [&]() {
+            bank_manager.allocate_buffer(
+                alloc_size_1K,
+                alloc_size_1K,
+                /*bottom_up=*/true,
+                CoreRangeSet(std::vector<CoreRange>{}),
+                std::nullopt,
+                AllocatorID{2});
+        },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Out of Memory: Not enough space after considering dependencies to allocate 1024 B "
+                                 "DRAM across 1 banks (1024 B per bank)")));
+
+    // Deallocate 512K from allocator 1
+    // - Alloc0: |                     512k                      |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                                             free                                              |
+    bank_manager.deallocate_buffer(alloc1_addr1, AllocatorID{1});
+
+    // Allocate 1K in allocator 2 bottom-up (should be placed after allocator 0's 1K)
+    // - Alloc0: |                     512k                      |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                         free                         | 1K |               free                |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, alloc0_addr1 + alloc_size_1K);
+
+    // Allocate another 1K in allocator 2 top-down (should be placed before allocator 1's 2K)
+    // - Alloc0: |                     512k                      |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                     free                      | free | 1K |        free         | 1K |  free  |
+    const auto alloc2_addr1 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr1, alloc1_addr0 - alloc_size_1K);
+
+    // Deallocate 512K from allocator 0
+    // - Alloc0: |                   512k free                   |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                     free                      | free | 1K |        free         | 1K |  free  |
+    bank_manager.deallocate_buffer(alloc0_addr0, AllocatorID{0});
+
+    // Allocate 512K in allocator 2 top-down:
+    // - Alloc0: |                   512k free                   |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                     512K                      | free | 1K |        free         | 1K |  free  |
+    const auto alloc2_addr2 = bank_manager.allocate_buffer(
+        alloc_size_half_of_total_size,
+        alloc_size_half_of_total_size,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr2, alloc0_addr1 - alloc_size_half_of_total_size);
+    EXPECT_EQ(alloc2_addr2, 0);  // Should be placed at the start of the bank
+
+    // Allocate 256K in allocator 2 bottom-up
+    // - Alloc0: |                   512k free                   |  1K  |                  free                  |
+    // - Alloc1: |                 free                 |                   512k free                   |   2K   |
+    // - Alloc2: |                     512K                      | free | 1K |   256K   |   free   | 1K |  free  |
+    const auto alloc2_addr3 = bank_manager.allocate_buffer(
+        alloc_size_quarter_of_total_size,
+        alloc_size_quarter_of_total_size,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr3, alloc2_addr0 + alloc_size_1K);
+}
+
+TEST(OverlappedAllocators, NonzeroAddressLimit) {
+    // This test tests the clamping logic in BankManager::allocate_buffer when address_limit is not 0
+
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    const uint64_t total_size = 1024 * 1024;
+    const uint32_t alignment = 1024;
+    const DeviceAddr address_limit = 256 * 1024;  // 256KB - allocations must start from this address or later
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+
+    // Use the constructor that takes interleaved_address_limit for L1 buffer type
+    std::unordered_map<uint32_t, int64_t> bank_id_to_offset = {{0, 0}};
+    BankManager bank_manager(
+        BufferType::L1,
+        bank_id_to_offset,
+        total_size,
+        address_limit,  // interleaved_address_limit
+        alignment,
+        0,      // alloc_offset
+        false,  // disable_interleaved
+        deps);
+
+    const uint32_t alloc_size_1K = 1024;
+    const uint32_t alloc_size_a_bit_more_than_half_of_total_size = total_size / 2 + alloc_size_1K;
+    const uint32_t alloc_size_same_as_address_limit = address_limit;
+
+    // Allocate 1K in allocator 0 - should be placed at address_limit (256KB)
+    // - Alloc0: |    256K addr_limit    | 1K |                               free                               |
+    // - Alloc1: |    256K addr_limit    |                                 free                                  |
+    // - Alloc2: |    256K addr_limit    |                                 free                                  |
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, address_limit);  // Should start at 256KB, not 0
+
+    // Allocate 2K in allocator 1 - should also start at address_limit since it's independent
+    // - Alloc0: |    256K addr_limit    | 1K |                               free                               |
+    // - Alloc1: |    256K addr_limit    |                      512K + 1K                       |      free      |
+    // - Alloc2: |    256K addr_limit    |                                 free                                  |
+    const auto alloc1_addr0 = bank_manager.allocate_buffer(
+        alloc_size_a_bit_more_than_half_of_total_size,
+        alloc_size_a_bit_more_than_half_of_total_size,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{1});
+    EXPECT_EQ(alloc1_addr0, address_limit);  // Should start at 256KB, not 0
+
+    EXPECT_THAT(
+        [&]() {
+            // address_limit is 256KB, which is a quarter of total size
+            // In allocator 1, we allocated a bit over half of total size, so the only valid allocation of 256KB is
+            // within the address_limit
+            // - Alloc0: |    256K addr_limit    | 1K |                               free |
+            // - Alloc1: |    256K addr_limit    |                      512K + 1K                       |      free |
+            // - Alloc2: |    256K addr_limit    |                                 free |
+            bank_manager.allocate_buffer(
+                alloc_size_same_as_address_limit,
+                alloc_size_same_as_address_limit,
+                /*bottom_up=*/false,
+                CoreRangeSet(std::vector<CoreRange>{}),
+                std::nullopt,
+                AllocatorID{2});
+        },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Out of Memory: Not enough space after considering dependencies to allocate 262144 B "
+                                 "L1 across 1 banks (262144 B per bank)")));
+
+    // Allocate 1K in overlapped allocator 2 (should be placed after allocator 1's allocation)
+    // - Alloc0: |    256K addr_limit    | 1K |                               free                               |
+    // - Alloc1: |    256K addr_limit    |                      512K + 1K                       |      free      |
+    // - Alloc2: |    256K addr_limit    |                      512K + 1K                       | 1K |   free    |
+    const auto alloc2_addr0 = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{2});
+    EXPECT_EQ(alloc2_addr0, address_limit + alloc_size_a_bit_more_than_half_of_total_size);
+
+    // Deallocate all allocations and reallocate
+    // This tests BankManager's destructor when:
+    // - There are dependencies between allocators
+    // - Address limit is not 0
+    // - Reallocating after BankManager::deallocate_buffer() or BankManager::deallocate_all()
+    // (@TT-BrianLiu) In the above scenario, I saw some error with memory freeing when using a custom destructor.
+    // The custom destructor calls BankManager::deallocate_all(). There are two ways to fix this situation:
+    //   1. Use default destructor
+    //   2. Call bank_manager.clear() after deallocate_all()
+    // I am switching back to default destructor because it doesn't look like there's a need for the custom destructor
+    bank_manager.deallocate_all();
+
+    // Reallocate 1K in allocator 0
+    // - Alloc0: |    256K addr_limit    | 1K |                               free                               |
+    // - Alloc1: |    256K addr_limit    |                                 free                                  |
+    // - Alloc2: |    256K addr_limit    |                                 free                                  |
+    const auto alloc0_addr0_realloc = bank_manager.allocate_buffer(
+        alloc_size_1K,
+        alloc_size_1K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0_realloc, address_limit);  // Should still start at 256KB
+}

--- a/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
+++ b/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 #include <optional>
 #include <vector>
-#include "hostdevcommon/common_values.hpp"
 
 #include <assert.hpp>
 #include <hal_types.hpp>
@@ -52,7 +51,12 @@ public:
 
     virtual std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const = 0;
 
+    // Returns all allocated address ranges as (start_address, end_address) pairs; start address is not sorted
+    virtual std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses() const = 0;
+
     // bottom_up=true indicates that allocation grows from address 0
+    // Address limit is only used as a final check to see if selected address is > address limit
+    // - Effectively, this means that address limit should only be used with top-down allocation
     virtual std::optional<DeviceAddr> allocate(
         DeviceAddr size_bytes, bool bottom_up = true, DeviceAddr address_limit = 0) = 0;
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -207,6 +207,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     segregated_list.erase(it);
 
     size_t offset = start_address - block_address_[target_block_index];
+    // Allocated addresses cache is invalidated by allocate_in_block
     allocate_in_block(target_block_index, alloc_size, offset);
     update_lowest_occupied_address(start_address);
     return absolute_start_address;
@@ -346,6 +347,19 @@ std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::available_addresses(
         }
     }
     return addresses;
+}
+
+std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::allocated_addresses() const {
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses;
+    allocated_addresses.reserve(block_address_.size());
+
+    for (size_t i = 0; i < block_address_.size(); i++) {
+        if (meta_block_is_allocated_[i] && block_is_allocated_[i]) {
+            allocated_addresses.emplace_back(block_address_[i], block_address_[i] + block_size_[i]);
+        }
+    }
+
+    return allocated_addresses;
 }
 
 size_t FreeListOpt::alloc_meta_block(

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -42,6 +42,8 @@ public:
 
     std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const override;
 
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses() const override;
+
     std::optional<DeviceAddr> allocate(
         DeviceAddr size_bytes, bool bottom_up = true, DeviceAddr address_limit = 0) override;
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <string_view>
 #include <utility>
+#include <algorithm>
 
 #include "allocator/algorithms/allocator_algorithm.hpp"
 #include "allocator_types.hpp"
@@ -22,9 +23,97 @@ namespace tt {
 
 namespace tt_metal {
 
-void BankManager::init_allocator(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset) {
-    allocator_ = std::make_unique<allocator::FreeListOpt>(
-        size_bytes, offset, alignment_bytes, alignment_bytes, allocator::FreeListOpt::SearchPolicy::FIRST);
+BankManager::AllocatorDependencies::AllocatorDependencies() = default;
+
+BankManager::AllocatorDependencies::AllocatorDependencies(
+    const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>>& dependencies_map) {
+    // Determine total number of allocators as max allocator id seen anywhere (keys or values)
+    if (dependencies_map.empty()) {
+        dependencies = AdjacencyList{{}};
+        return;
+    }
+
+    uint32_t max_id = 0;
+    for (const auto& [allocator_id, dependencies] : dependencies_map) {
+        max_id = std::max(max_id, allocator_id.get());
+        for (const auto dep_allocator_id : dependencies) {
+            max_id = std::max(max_id, dep_allocator_id.get());
+        }
+    }
+    const uint32_t num_allocators = static_cast<uint32_t>(max_id) + 1;  // +1 because allocator ids are zero-indexed
+
+    // Use set form to ensure uniqueness while building undirected adjacency list
+    ttsl::SmallVector<std::unordered_set<uint32_t>> undirected_sets(num_allocators);
+
+    // Build undirected adjacency: for each edge (u -> v), add v to u and u to v
+    for (const auto& [allocator_id, dependencies] : dependencies_map) {
+        // Ensure uniqueness of dependency values per allocator (catch duplicates in provided list)
+        std::unordered_set<uint32_t> seen_values;
+        for (const auto dep_allocator_id : dependencies) {
+            const bool inserted = seen_values.insert(dep_allocator_id.get()).second;
+            TT_FATAL(
+                inserted,
+                "Duplicate dependency for allocator {}: {} appears more than once!",
+                allocator_id.get(),
+                dep_allocator_id.get());
+        }
+
+        for (const auto dep_allocator_id : dependencies) {
+            const uint32_t u = allocator_id.get();
+            const uint32_t v = dep_allocator_id.get();
+            undirected_sets[u].insert(v);
+            undirected_sets[v].insert(u);
+        }
+    }
+
+    // Build dependencies list: for each allocator s, which allocators s depends on / depends on s
+    // Note: Need to sort dependencies because dependencies_map is unordered
+    dependencies.clear();
+    dependencies.resize(num_allocators);
+    for (uint32_t i = 0; i < num_allocators; ++i) {
+        auto& dst = dependencies[i];
+        dst.assign(undirected_sets[i].begin(), undirected_sets[i].end());
+        std::sort(dst.begin(), dst.end());
+    }
+}
+
+uint32_t BankManager::AllocatorDependencies::num_allocators() const {
+    return static_cast<uint32_t>(dependencies.size());
+}
+
+ttsl::SmallVector<BankManager::AllocatorDependencies::AllocatorID> BankManager::AllocatorDependencies::allocator_ids()
+    const {
+    ttsl::SmallVector<AllocatorID> allocators;
+    allocators.reserve(num_allocators());
+    for (size_t i = 0; i < num_allocators(); i++) {
+        allocators.push_back(AllocatorID{static_cast<uint32_t>(i)});
+    }
+    return allocators;
+}
+
+bool BankManager::AllocatorDependencies::operator==(const BankManager::AllocatorDependencies& other) const noexcept {
+    if (dependencies.size() != other.dependencies.size()) {
+        return false;
+    }
+    // Direct comparison assuming dependencies are already sorted
+    for (size_t i = 0; i < dependencies.size(); ++i) {
+        if (dependencies[i] != other.dependencies[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void BankManager::init_allocators(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset) {
+    const uint32_t n = allocator_dependencies_.num_allocators();
+    allocators_.resize(n);
+    allocated_buffers_.resize(n);
+    allocated_ranges_cache_.resize(n);
+
+    for (uint32_t allocator_id = 0; allocator_id < n; ++allocator_id) {
+        allocators_[allocator_id] = std::make_unique<allocator::FreeListOpt>(
+            size_bytes, offset, alignment_bytes, alignment_bytes, allocator::FreeListOpt::SearchPolicy::FIRST);
+    }
 }
 
 void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool disable_interleaved) {
@@ -52,8 +141,12 @@ BankManager::BankManager(
     DeviceAddr size_bytes,
     uint32_t alignment_bytes,
     DeviceAddr alloc_offset,
-    bool disable_interleaved) :
-    buffer_type_(buffer_type), interleaved_address_limit_(0), alignment_bytes_(alignment_bytes) {
+    bool disable_interleaved,
+    const AllocatorDependencies& dependencies) :
+    buffer_type_(buffer_type),
+    interleaved_address_limit_(0),
+    alignment_bytes_(alignment_bytes),
+    allocator_dependencies_(dependencies) {
     unsigned int bank_id = 0;
     for (const auto bank_offset : bank_offsets) {
         bank_id_to_bank_offset_.insert({bank_id, bank_offset});
@@ -61,7 +154,9 @@ BankManager::BankManager(
     }
 
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
-    this->init_allocator(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
+
+    // Initialize all allocators; sets up allocator-dependent members
+    this->init_allocators(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
 }
 
 BankManager::BankManager(
@@ -71,20 +166,25 @@ BankManager::BankManager(
     DeviceAddr interleaved_address_limit,
     uint32_t alignment_bytes,
     DeviceAddr alloc_offset,
-    bool disable_interleaved) :
+    bool disable_interleaved,
+    const AllocatorDependencies& dependencies) :
     buffer_type_(buffer_type),
     bank_id_to_bank_offset_(bank_id_to_bank_offset),
     interleaved_address_limit_(interleaved_address_limit),
-    alignment_bytes_(alignment_bytes) {
+    alignment_bytes_(alignment_bytes),
+    allocator_dependencies_(dependencies) {
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
-    this->init_allocator(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
+
+    // Initialize all allocators; sets up allocator-dependent members
+    this->init_allocators(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
 }
 
 uint32_t BankManager::num_banks() const { return bank_id_to_bank_offset_.size(); }
 
 DeviceAddr BankManager::bank_size() const {
-    TT_ASSERT(bool(allocator_), "Allocator not initialized!");
-    return allocator_->max_size_bytes();
+    const auto* alloc0 = this->get_allocator_from_id(AllocatorDependencies::AllocatorID{0});
+    TT_FATAL(alloc0, "Allocator not initialized!");
+    return alloc0->max_size_bytes();
 }
 
 int64_t BankManager::bank_offset(uint32_t bank_id) const {
@@ -100,12 +200,201 @@ void BankManager::validate_bank_id(uint32_t bank_id) const {
         bank_id_to_bank_offset_.size());
 }
 
+allocator::Algorithm* BankManager::get_allocator_from_id(BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    TT_FATAL(
+        allocator_id.get() < allocator_dependencies_.num_allocators(),
+        "Invalid allocator ID {} (num_allocators={})",
+        allocator_id.get(),
+        allocator_dependencies_.num_allocators());
+    return allocators_[allocator_id.get()] ? allocators_[allocator_id.get()].get() : nullptr;
+}
+
+const allocator::Algorithm* BankManager::get_allocator_from_id(
+    BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    return const_cast<BankManager*>(this)->get_allocator_from_id(allocator_id);
+}
+
+void BankManager::invalidate_allocated_ranges_cache_for_dependent_allocators(
+    BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    TT_FATAL(
+        allocator_id.get() < allocator_dependencies_.num_allocators(),
+        "Invalid allocator ID {} (num_allocators={})",
+        allocator_id.get(),
+        allocator_dependencies_.num_allocators());
+    const auto& dependent_allocators = allocator_dependencies_.dependencies[allocator_id.get()];
+    for (const auto dep_allocator_id : dependent_allocators) {
+        allocated_ranges_cache_[dep_allocator_id.get()].reset();
+    }
+}
+
+const std::vector<std::pair<DeviceAddr, DeviceAddr>>& BankManager::compute_merged_allocated_ranges(
+    BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    TT_FATAL(
+        allocator_id.get() < allocator_dependencies_.num_allocators(),
+        "Invalid allocator ID {} (num_allocators={})",
+        allocator_id.get(),
+        allocator_dependencies_.num_allocators());
+
+    // Return cached value if available
+    if (allocated_ranges_cache_[allocator_id.get()].has_value()) {
+        return allocated_ranges_cache_[allocator_id.get()].value();
+    }
+
+    // Collect allocated address ranges per dependent allocator (single pass)
+    const auto& dependent_allocators = allocator_dependencies_.dependencies[allocator_id.get()];
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> all_allocated_ranges;
+    for (const auto dep_allocator_id : dependent_allocators) {
+        auto* dep_alloc = this->get_allocator_from_id(dep_allocator_id);
+        TT_FATAL(dep_alloc, "Allocator not initialized!");
+        const auto allocated_addresses = dep_alloc->allocated_addresses();
+        all_allocated_ranges.reserve(all_allocated_ranges.size() + allocated_addresses.size());
+        for (const auto& [addr, end_addr] : allocated_addresses) {
+            if (end_addr > addr) {
+                all_allocated_ranges.emplace_back(addr, end_addr);
+            }
+        }
+    }
+
+    // Sort allocated ranges across all dependent allocators by start address
+    std::sort(all_allocated_ranges.begin(), all_allocated_ranges.end(), [](const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+
+    // Coalesce overlaps across all dependent allocators
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> coalesced_ranges;
+    coalesced_ranges.reserve(all_allocated_ranges.size());
+    for (const auto& r : all_allocated_ranges) {
+        if (coalesced_ranges.empty() || r.first > coalesced_ranges.back().second) {
+            coalesced_ranges.push_back(r);
+        } else {
+            coalesced_ranges.back().second = std::max(coalesced_ranges.back().second, r.second);
+        }
+    }
+
+    allocated_ranges_cache_[allocator_id.get()] = std::move(coalesced_ranges);
+    return allocated_ranges_cache_[allocator_id.get()].value();
+}
+
+std::vector<std::pair<DeviceAddr, DeviceAddr>> BankManager::compute_available_addresses(
+    BankManager::AllocatorDependencies::AllocatorID allocator_id, DeviceAddr size_per_bank, DeviceAddr address_limit) {
+    auto* alloc = this->get_allocator_from_id(allocator_id);
+    TT_FATAL(alloc, "Allocator not initialized!");
+
+    // Helper for clamping ranges in-place according to address_limit
+    // This is needed because the allocator's available_addresses method does not clamp to address_limit
+    auto clamp_ranges = [address_limit](std::vector<std::pair<DeviceAddr, DeviceAddr>>& ranges) {
+        if (address_limit == 0) {
+            return;
+        }
+
+        // First pass: clamp ranges in-place
+        for (auto& r : ranges) {
+            if (r.first < address_limit) {
+                r.first = address_limit;
+            }
+        }
+
+        // Second pass: remove empty ranges (where r.second <= r.first)
+        ranges.erase(
+            std::remove_if(ranges.begin(), ranges.end(), [](const auto& r) { return r.second <= r.first; }),
+            ranges.end());
+    };
+
+    // Current allocator's available ranges (clamped if needed)
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> available_ranges = alloc->available_addresses(size_per_bank);
+    clamp_ranges(available_ranges);
+    std::sort(available_ranges.begin(), available_ranges.end(), [](const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+
+    // Allocated ranges from dependent allocators; ranges are merged
+    const auto& allocated_ranges_in_dependent_allocators = this->compute_merged_allocated_ranges(allocator_id);
+
+    // Helper for subtracting allocated ranges from available ranges
+    // Ranges consist of half-open intervals throughout: [start, end)
+    // Assumptions:
+    // - Each of 'available_ranges' and 'allocated_ranges' is individually sorted by start and internally
+    // non-overlapping
+    // Strategy:
+    // - Two-pointer sweep: advance a single shared pointer 'j' through allocated ranges across all available ranges.
+    //   Complexity O(|available_ranges| + |allocated_ranges|).
+    // Example:
+    //   available_ranges = [(10, 30)], allocated_ranges = [(12, 15), (18, 25)]
+    //   result           = [(10, 12), (15, 18), (25, 30)]
+    auto subtract_ranges = [](const std::vector<std::pair<DeviceAddr, DeviceAddr>>& available_ranges,
+                              const std::vector<std::pair<DeviceAddr, DeviceAddr>>& allocated_ranges) {
+        std::vector<std::pair<DeviceAddr, DeviceAddr>> out;
+        out.reserve(available_ranges.size());
+
+        // Monotonic pointer to scan all allocated ranges; we don't reset the pointer after each available range
+        // This assumes available and allocated ranges are sorted and non-overlapping
+        size_t j = 0;
+        for (const auto& available : available_ranges) {
+            DeviceAddr available_start = available.first;
+            DeviceAddr available_end = available.second;
+            // 1) Skip allocated ranges that are completely to the left of available range
+            //    available:            [s --- e)
+            //    allocated: [s --- e)
+            while (j < allocated_ranges.size() && allocated_ranges[j].second <= available_start) {
+                j++;
+            }
+
+            DeviceAddr cur_available_start = available_start;
+            // 2) Scan allocated ranges that might overlap current available range
+            //    Loop until we hit allocated ranges that are to the right of available range
+            //    ie. stop until we hit ranges like this:
+            //    available: [s --- e)
+            //    allocated:            [s --- e)
+            while (j < allocated_ranges.size() && allocated_ranges[j].first < available_end) {
+                DeviceAddr allocated_start = allocated_ranges[j].first;
+                DeviceAddr allocated_end = allocated_ranges[j].second;
+                // Case A: Gap exists before the allocated range
+                //   available: [cur --- e)
+                //   allocated:   [s ---
+                //   -> Keep free gap: [cur, allocated_s)
+                if (allocated_start > cur_available_start) {
+                    out.emplace_back(cur_available_start, allocated_start);
+                }
+                // Case B: The allocated range overlaps with rest of available range
+                //   available: [cur ----- e)
+                //   allocated:     [s ----- e)
+                //   -> No remaining free space in [cur, e). Update cur_available_start to available_end and break
+                if (allocated_end >= available_end) {
+                    cur_available_start = available_end;
+                    break;
+                }
+                // Case C: The allocated range ends before the end of available range
+                //   available: [cur ----- e)
+                //   allocated:   [s --- e)
+                //   -> Update cur_available_start to the end of allocated range
+                //      We continue scanning the next allocated range and emit any remaining free space at the tail
+                cur_available_start = allocated_end;
+                j++;
+            }
+            // 3) Emit remaining tail (if any) after scanning all allocated ranges
+            if (cur_available_start < available_end) {
+                out.emplace_back(cur_available_start, available_end);
+            }
+        }
+        return out;
+    };
+
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> updated_available_ranges =
+        subtract_ranges(available_ranges, allocated_ranges_in_dependent_allocators);
+
+    return updated_available_ranges;
+}
+
 uint64_t BankManager::allocate_buffer(
     DeviceAddr size,
     DeviceAddr page_size,
     bool bottom_up,
     const CoreRangeSet& compute_grid,
-    std::optional<uint32_t> num_shards) {
+    std::optional<uint32_t> num_shards,
+    BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    auto* alloc = this->get_allocator_from_id(allocator_id);
+    TT_FATAL(alloc, "Allocator not initialized!");
+
     uint32_t num_banks = this->num_banks();
     bool is_sharded = false;
     if (num_shards.has_value()) {
@@ -124,10 +413,17 @@ uint64_t BankManager::allocate_buffer(
         address_limit = interleaved_address_limit_;
         TT_FATAL(address_limit > 0, "Address limit {} needs to be larger than zero.", address_limit);
     }
-    TT_ASSERT(bool(allocator_), "Allocator not initialized!");
-    auto address = allocator_->allocate(size_per_bank, bottom_up, address_limit);
-    if (not address.has_value()) {
-        TT_THROW(
+
+    // If there are no dependent allocators, fall back to allocator's single allocator strategy
+    const auto& dependent_allocators = allocator_dependencies_.dependencies[allocator_id.get()];
+
+    // If using single allocator strategy, Algorithm::allocate handles address limit, which means it can only be used
+    // with top-down allocation. Otherwise, address limit is used to clamp the available ranges regardless of bottom_up
+    // vs. top-down allocation
+    if (dependent_allocators.empty()) {
+        auto address = alloc->allocate(size_per_bank, bottom_up, address_limit);
+        TT_FATAL(
+            address.has_value(),
             "Out of Memory: Not enough space to allocate {} B {} buffer across {} banks, where each bank needs to "
             "store {} B, but bank size is only {} B",
             size,
@@ -135,47 +431,110 @@ uint64_t BankManager::allocate_buffer(
             num_banks,
             size_per_bank,
             bank_size());
+        allocated_buffers_[allocator_id.get()].insert(address.value());
+        // No neighbors, nothing to invalidate
+        return address.value();
     }
-    allocated_buffers_.insert(address.value());
+
+    // Get available address ranges after subtracting dependencies
+    // The pair represents (start, end) of the available address range(s)
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> available_ranges =
+        this->compute_available_addresses(allocator_id, size_per_bank, address_limit);
+
+    // Choose an address from the allowed ranges respecting alignment and direction
+    // Addresses should already be aligned to alignment_bytes_
+    std::optional<DeviceAddr> chosen;
+    if (bottom_up) {
+        for (const auto& r : available_ranges) {
+            DeviceAddr s = r.first;
+            if (s + size_per_bank <= r.second) {
+                chosen = s;
+                break;
+            }
+        }
+    } else {
+        for (ssize_t i = static_cast<ssize_t>(available_ranges.size()) - 1; i >= 0; --i) {
+            const auto& r = available_ranges[static_cast<size_t>(i)];
+            DeviceAddr s = r.second - size_per_bank;
+            if (s >= r.first) {
+                chosen = s;
+                break;
+            }
+        }
+    }
+
+    TT_FATAL(
+        chosen.has_value(),
+        "Out of Memory: Not enough space after considering dependencies to allocate {} B {} across {} banks ({} B "
+        "per bank)",
+        size,
+        enchantum::to_string(buffer_type_),
+        num_banks,
+        size_per_bank);
+    TT_FATAL(
+        chosen.value() % alignment_bytes_ == 0,
+        "Chosen address {} is not aligned to {} B",
+        chosen.value(),
+        alignment_bytes_);
+
+    auto address = alloc->allocate_at_address(chosen.value(), size_per_bank);
+    TT_FATAL(address.has_value(), "Allocator failed to place at chosen address {}", chosen.value());
+    allocated_buffers_[allocator_id.get()].insert(address.value());
+    // Allocation in this allocator invalidates caches in allocators that depend on this allocator
+    this->invalidate_allocated_ranges_cache_for_dependent_allocators(allocator_id);
     return address.value();
 }
 
-void BankManager::deallocate_buffer(DeviceAddr address) { allocator_->deallocate(address); }
+void BankManager::deallocate_buffer(DeviceAddr address, BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    auto* alloc = this->get_allocator_from_id(allocator_id);
+    TT_FATAL(alloc, "Allocator not initialized!");
+    alloc->deallocate(address);
+    allocated_buffers_[allocator_id.get()].erase(address);
+    // Deallocation in this allocator invalidates caches in allocators that depend on this allocator
+    this->invalidate_allocated_ranges_cache_for_dependent_allocators(allocator_id);
+}
 
 void BankManager::deallocate_all() {
-    for (DeviceAddr addr : allocated_buffers_) {
-        allocator_->deallocate(addr);
+    for (const auto allocator_id : allocator_dependencies_.allocator_ids()) {
+        auto* alloc = this->get_allocator_from_id(allocator_id);
+        TT_FATAL(alloc, "Allocator not initialized!");
+        for (DeviceAddr addr : allocated_buffers_[allocator_id.get()]) {
+            alloc->deallocate(addr);
+        }
+        allocated_buffers_[allocator_id.get()].clear();
+        allocated_ranges_cache_[allocator_id.get()].reset();
     }
 }
 
 void BankManager::clear() {
-    if (allocator_) {
-        allocator_->clear();
+    for (const auto allocator_id : allocator_dependencies_.allocator_ids()) {
+        if (allocators_[allocator_id.get()]) {
+            allocators_[allocator_id.get()]->clear();
+            allocated_buffers_[allocator_id.get()].clear();
+        }
+        allocated_ranges_cache_[allocator_id.get()].reset();
     }
 }
 
-BankManager::~BankManager() {
-    deallocate_all();
-    allocated_buffers_.clear();
-    bank_id_to_bank_offset_.clear();
-    allocator_.reset(nullptr);
-}
-
-BankManager&& BankManager::operator=(BankManager&& that) noexcept {
+BankManager& BankManager::operator=(BankManager&& that) noexcept {
     buffer_type_ = that.buffer_type_;
-    allocated_buffers_ = that.allocated_buffers_;
-    bank_id_to_bank_offset_ = that.bank_id_to_bank_offset_;
-    allocator_.reset(that.allocator_.release());
+    allocated_buffers_ = std::move(that.allocated_buffers_);
+    bank_id_to_bank_offset_ = std::move(that.bank_id_to_bank_offset_);
+    allocators_ = std::move(that.allocators_);
     interleaved_address_limit_ = that.interleaved_address_limit_;
     alignment_bytes_ = that.alignment_bytes_;
-    return std::move(*this);
+    allocator_dependencies_ = std::move(that.allocator_dependencies_);
+    allocated_ranges_cache_ = std::move(that.allocated_ranges_cache_);
+    return *this;
 }
 
-std::optional<DeviceAddr> BankManager::lowest_occupied_address(uint32_t bank_id) const {
-    if (not allocator_) {
+std::optional<DeviceAddr> BankManager::lowest_occupied_address(
+    uint32_t bank_id, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    const auto* alloc = this->get_allocator_from_id(allocator_id);
+    if (alloc == nullptr) {
         return std::nullopt;
     }
-    auto lowest_address = allocator_->lowest_occupied_address();
+    auto lowest_address = alloc->lowest_occupied_address();
     if (not lowest_address.has_value()) {
         return lowest_address;
     }
@@ -183,32 +542,43 @@ std::optional<DeviceAddr> BankManager::lowest_occupied_address(uint32_t bank_id)
     return adjusted_abs_addr;
 }
 
-Statistics BankManager::get_statistics() const { return allocator_ ? allocator_->get_statistics() : Statistics(); }
+Statistics BankManager::get_statistics(BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    const auto* alloc = this->get_allocator_from_id(allocator_id);
+    return alloc ? alloc->get_statistics() : Statistics();
+}
 
-void BankManager::dump_blocks(std::ofstream& out) const {
-    if (allocator_) {
-        allocator_->dump_blocks(out);
+void BankManager::dump_blocks(std::ofstream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    const auto* alloc = this->get_allocator_from_id(allocator_id);
+    if (alloc) {
+        alloc->dump_blocks(out);
     }
 }
 
-MemoryBlockTable BankManager::get_memory_block_table() const {
-    if (allocator_) {
-        return allocator_->get_memory_block_table();
+MemoryBlockTable BankManager::get_memory_block_table(
+    BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    const auto* alloc = this->get_allocator_from_id(allocator_id);
+    if (alloc) {
+        return alloc->get_memory_block_table();
     }
 
     log_warning(tt::LogAlways, "allocator is not initialized, cannot get block table for memory");
     return {};
 }
 
-void BankManager::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
-    if (allocator_) {
-        allocator_->shrink_size(shrink_size, bottom_up);
+void BankManager::shrink_size(
+    DeviceAddr shrink_size, bool bottom_up, BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    TT_FATAL(allocator_dependencies_.num_allocators() == 1, "Expected single allocator!");
+    auto* alloc = this->get_allocator_from_id(allocator_id);
+    if (alloc) {
+        alloc->shrink_size(shrink_size, bottom_up);
     }
 }
 
-void BankManager::reset_size() {
-    if (allocator_) {
-        allocator_->reset_size();
+void BankManager::reset_size(BankManager::AllocatorDependencies::AllocatorID allocator_id) {
+    TT_FATAL(allocator_dependencies_.num_allocators() == 1, "Expected single allocator!");
+    auto* alloc = this->get_allocator_from_id(allocator_id);
+    if (alloc) {
+        alloc->reset_size();
     }
 }
 

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -13,6 +13,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <algorithm>
+#include <functional>
+#include <tt_stl/small_vector.hpp>
+#include <tt_stl/strong_type.hpp>
 
 #include "algorithms/allocator_algorithm.hpp"
 #include "core_coord.hpp"
@@ -30,13 +34,48 @@ class BankManager {
 public:
     BankManager() = default;
 
+    /**
+     * @brief Describes dependencies between multiple allocators which share the same memory space.
+     *
+     * Allocator dependencies are bidirectional and are stored as undirected adjacency lists.
+     * Eg. If allocator A depends on allocator B, then A and B cannot allocate in regions occupied by the other.
+     * It is used by BankManager to differentiate between different allocators and query dependencies between them.
+
+     * AllocatorDependencies is created from an unordered map of allocator IDs with their dependencies.
+     * Some nuances:
+        - Default value (AllocatorDependencies() or AllocatorDependencies{}) represents a single independent allocator.
+        - The presence of alloctor IDs in keys or values implies the existence of previous allocator IDs.
+          Eg. 3: {0, 1} (read as: 3 depends on 0 and 1) implies that 0: {3}, 1: {3}, 2: {}, 3: {0, 1}.
+        - Undirected adjacency lists means that 0: 1 implies 1: 0 (as seen in the example above).
+          Eg. 0: {1}, 1: {2}, 2: {3} implies 0: {1}, 1: {0, 2}, 2: {1, 3}, 3: {2}.
+     */
+    struct AllocatorDependencies {
+        using AllocatorID = ttsl::StrongType<uint32_t, struct AllocatorIDTag>;
+        using AdjacencyList = ttsl::SmallVector<ttsl::SmallVector<AllocatorID>>;
+
+        // Position of each state in the adjacency list corresponds to the allocator ID of that state
+        // Dependencies per state are sorted in order of allocator IDs
+        AdjacencyList dependencies{{}};  // Default: single allocator (0) with no dependencies
+
+        AllocatorDependencies();
+        explicit AllocatorDependencies(
+            const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>>& dependencies_map);
+
+        uint32_t num_allocators() const;
+        ttsl::SmallVector<AllocatorID> allocator_ids() const;
+
+        bool operator==(const AllocatorDependencies& other) const noexcept;
+        bool operator!=(const AllocatorDependencies& other) const noexcept { return !(*this == other); }
+    };
+
     BankManager(
         const BufferType& buffer_type,
         const std::vector<int64_t>& bank_descriptors,
         DeviceAddr size_bytes,
         uint32_t alignment_bytes,
         DeviceAddr alloc_offset = 0,
-        bool disable_interleaved = false);
+        bool disable_interleaved = false,
+        const AllocatorDependencies& dependencies = AllocatorDependencies());
     BankManager(
         const BufferType& buffer_type,
         const std::unordered_map<uint32_t, int64_t>& bank_id_to_descriptor,
@@ -44,9 +83,9 @@ public:
         DeviceAddr interleaved_address_limit,
         uint32_t alignment_bytes,
         DeviceAddr alloc_offset = 0,
-        bool disable_interleaved = false);
-    BankManager&& operator=(BankManager&& that) noexcept;
-    ~BankManager();
+        bool disable_interleaved = false,
+        const AllocatorDependencies& dependencies = AllocatorDependencies());
+    BankManager& operator=(BankManager&& that) noexcept;
     uint32_t num_banks() const;
 
     DeviceAddr bank_size() const;
@@ -58,39 +97,85 @@ public:
         DeviceAddr page_size,
         bool bottom_up,
         const CoreRangeSet& compute_grid,
-        std::optional<uint32_t> num_shards);
+        std::optional<uint32_t> num_shards,
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
-    void deallocate_buffer(DeviceAddr address);
+    void deallocate_buffer(
+        DeviceAddr address, AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
     void deallocate_all();
 
     void clear();
 
-    std::optional<DeviceAddr> lowest_occupied_address(uint32_t bank_id) const;
+    std::optional<DeviceAddr> lowest_occupied_address(
+        uint32_t bank_id,
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0}) const;
 
-    Statistics get_statistics() const;
+    Statistics get_statistics(
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0}) const;
 
-    void dump_blocks(std::ofstream& out) const;
+    void dump_blocks(
+        std::ofstream& out,
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0}) const;
 
-    MemoryBlockTable get_memory_block_table() const;
+    MemoryBlockTable get_memory_block_table(
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0}) const;
 
-    void shrink_size(DeviceAddr shrink_size, bool bottom_up = true);
-    void reset_size();
+    void shrink_size(
+        DeviceAddr shrink_size,
+        bool bottom_up = true,
+        AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
+    void reset_size(AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
 private:
-    void deallocate_buffer_(DeviceAddr address);
-
-    // Types of buffers allocated in the banks
+    /*********************************
+     * Allocator-independent members *
+     *********************************/
+    // Type of buffers allocated in the banks (same across allocators)
     BufferType buffer_type_{0};
-    std::unordered_set<DeviceAddr> allocated_buffers_;
     // This is to store offsets for any banks that share a core or node (dram in wh/storage core), so we can view all
-    // banks using only bank_id Set to 0 for cores/nodes with only 1 bank
+    // banks using only bank_id. Set to 0 for cores/nodes with only 1 bank.
     std::unordered_map<uint32_t, int64_t> bank_id_to_bank_offset_;
-    std::unique_ptr<allocator::Algorithm> allocator_;
+
     DeviceAddr interleaved_address_limit_{};
     uint32_t alignment_bytes_{};
-    void validate_bank_id(uint32_t bank_id) const;
 
-    void init_allocator(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset);
+    /*******************************
+     * Allocator-dependent members *
+     *******************************/
+    // Dependencies between allocators (also encodes number of allocators)
+    AllocatorDependencies allocator_dependencies_{};
+
+    // Track allocations per allocator
+    ttsl::SmallVector<std::unordered_set<DeviceAddr>> allocated_buffers_{};
+    ttsl::SmallVector<std::unique_ptr<allocator::Algorithm>> allocators_{};
+
+    // Per-allocator cache of: merged allocated ranges of all other dependent allocators
+    ttsl::SmallVector<std::optional<std::vector<std::pair<DeviceAddr, DeviceAddr>>>> allocated_ranges_cache_{};
+
+    /*********************************
+     * Allocator-independent methods *
+     *********************************/
+    void validate_bank_id(uint32_t bank_id) const;
+    void init_allocators(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset);
+
+    /*******************************
+     * Allocator-dependent methods *
+     *******************************/
+    // Returns allocator for the given allocator ID; returns nullptr if allocator ID is invalid
+    allocator::Algorithm* get_allocator_from_id(AllocatorDependencies::AllocatorID allocator_id);
+    const allocator::Algorithm* get_allocator_from_id(AllocatorDependencies::AllocatorID allocator_id) const;
+
+    // Invalidate caches stored on allocators that depend on the given allocator
+    void invalidate_allocated_ranges_cache_for_dependent_allocators(AllocatorDependencies::AllocatorID allocator_id);
+
+    // Compute and cache the merged allocated ranges of all dependent allocators for the given allocator
+    const std::vector<std::pair<DeviceAddr, DeviceAddr>>& compute_merged_allocated_ranges(
+        AllocatorDependencies::AllocatorID allocator_id);
+
+    // Compute available address ranges for the given allocator and request, after subtracting merged neighbor
+    // allocations
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> compute_available_addresses(
+        AllocatorDependencies::AllocatorID allocator_id, DeviceAddr size_per_bank, DeviceAddr address_limit);
 };
 
 }  // namespace tt_metal


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28036)

### Problem description
Allocator today maintains a single independent state across all relevant concepts. A rough chain of dependencies looks like this: 
- Allocator -> BankManager -> AllocatorAlgo (eg. free list allocator)

To enable allocation where submeshes may overlap (see [issue](https://github.com/tenstorrent/tt-metal/issues/28036) for full picture), I want to augment our allocators to natively support maintaining multiple dependent states.

### What's changed
- Introduce `AllocatorDependencies` to capture dependencies between allocators
- Update `BankManager` ctor and APIs to support overlapped allocators
- Add `available_addresses` API to allocator algorithm
  * Add tests in `test_free_list_opt_allocator.cpp`
- Add tests for `AllocatorDependencies` and overlapped allocators
- Minor changes:
  * Change `TT_ASSERT` to `TT_FATAL` for uninitialized allocator check
  * Update `BankManager::deallocate_buffer/deallocate_all/clear` to also remove buffer address from `allocated_buffers_`
   * Switch back to default destructor for `BankManager`
   * Change move assignment operator to return lval

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17803878971
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes