### PR TITLE
[skip ci] Skipping galaxy distributed runtime tests Temporarily

### DIFF
--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -83,7 +83,7 @@ jobs:
           { name: "Galaxy Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 30, owner_id: U053W15B6JF, mlperf: true}, # Djordje Ivanovic
           { name: "Galaxy DRAM Prefetcher unit tests", arch: wormhole_b0, model: prefetcher, timeout: 30, owner_id: U071CKL4AFK}, # Ammar Vora, Yu Gao
           { name: "Galaxy distributed ops tests", arch: wormhole_b0, model: distributed-ops, timeout: 15, owner_id: U044T8U8DEF},  # Johanna Rock
-          { name: "Galaxy distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7},  # Aditya Saigal
+          #{ name: "Galaxy distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7}, # Aditya Saigal #See issue #26105
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:


### PR DESCRIPTION
### Ticket
#26105

### Problem description
Galaxy Distributed Runtime tests are being temporarily skipped to solve a ND hang in RandomizedMeshWorkloadMultiThread

### What's changed
Just skipped the test in the impl file

### Checklist
- [x] [TG Unit Tests] (https://github.com/tenstorrent/tt-metal/actions/runs/17301885212)
- [x] [Galaxy Unit Tests] (https://github.com/tenstorrent/tt-metal/actions/runs/17301554094)