### PR TITLE
[tt-train] Add dummy NoOp optimizer

### DIFF
--- a/tt-train/configs/training_shakespeare_nanollama3_no_op.yaml
+++ b/tt-train/configs/training_shakespeare_nanollama3_no_op.yaml
@@ -1,0 +1,30 @@
+training_config:
+  project_name: "tt_train_nano_gpt" # not really nanogpt, but want to use the same wandb project name for now
+  model_type: "llama"
+  seed: 5489
+  model_save_interval: 500
+  batch_size: 32
+  num_epochs: 1
+  max_steps: 1000
+  learning_rate: 0.0003
+  weight_decay: 0.01
+  use_no_op: true
+  use_moreh_adamw: false
+  use_kahan_summation: false
+  use_clip_grad_norm: false
+  clip_grad_norm_max_norm: 1.0
+  transformer_config:
+    num_heads: 6
+    num_groups: 3
+    embedding_dim: 384
+    dropout_prob: 0.0
+    num_blocks: 6
+    vocab_size: 96
+    max_sequence_length: 256
+    runner_type: default
+    theta: 500000.0
+eval_config:
+  repetition_penalty: 1.0
+  temperature: 0.7
+  top_k: 50
+  top_p: 1.0

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -136,6 +136,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/optimizer_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/no_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/no_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/lambda_scheduler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/lambda_scheduler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/linear_scheduler.cpp

--- a/tt-train/sources/ttml/optimizers/no_op.cpp
+++ b/tt-train/sources/ttml/optimizers/no_op.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "no_op.hpp"
+
+#include <fmt/format.h>
+
+#include "core/tt_tensor_utils.hpp"
+#include "serialization/serializable.hpp"
+
+namespace ttml::optimizers {
+
+NoOp::NoOp(ttml::serialization::NamedParameters parameters) : OptimizerBase(std::move(parameters)) {
+}
+
+void NoOp::zero_grad() {
+    for (auto& [name, tensor_ptr] : m_parameters) {
+        if (tensor_ptr->get_requires_grad() && tensor_ptr->is_grad_initialized()) {
+            tensor_ptr->set_grad(core::zeros_like(tensor_ptr->get_value()));
+        }
+    }
+}
+
+void NoOp::step() {
+    m_steps++;
+}
+
+serialization::StateDict NoOp::get_state_dict() const {
+    serialization::StateDict dict;
+    dict["steps"] = m_steps;
+    return dict;
+}
+
+void NoOp::set_state_dict(const serialization::StateDict& dict) {
+    m_steps = serialization::get_value_type<size_t>(dict, "steps");
+}
+
+size_t NoOp::get_steps() const {
+    return m_steps;
+}
+
+void NoOp::set_steps(size_t steps) {
+    this->m_steps = steps;
+}
+
+}  // namespace ttml::optimizers

--- a/tt-train/sources/ttml/optimizers/no_op.cpp
+++ b/tt-train/sources/ttml/optimizers/no_op.cpp
@@ -42,4 +42,11 @@ void NoOp::set_steps(size_t steps) {
     this->m_steps = steps;
 }
 
+float NoOp::get_lr() const {
+    return 0.0f;
+}
+
+void NoOp::set_lr(float lr) {
+}
+
 }  // namespace ttml::optimizers

--- a/tt-train/sources/ttml/optimizers/no_op.cpp
+++ b/tt-train/sources/ttml/optimizers/no_op.cpp
@@ -4,8 +4,6 @@
 
 #include "no_op.hpp"
 
-#include <fmt/format.h>
-
 #include "core/tt_tensor_utils.hpp"
 #include "serialization/serializable.hpp"
 

--- a/tt-train/sources/ttml/optimizers/no_op.hpp
+++ b/tt-train/sources/ttml/optimizers/no_op.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "optimizers/optimizer_base.hpp"
+#include "serialization/serializable.hpp"
+
+namespace ttml::optimizers {
+
+class NoOp : public OptimizerBase {
+public:
+    explicit NoOp(ttml::serialization::NamedParameters parameters);
+
+    void zero_grad() override;
+
+    void step() override;
+
+    [[nodiscard]] serialization::StateDict get_state_dict() const override;
+    void set_state_dict(const serialization::StateDict& dict) override;
+
+    [[nodiscard]] size_t get_steps() const override;
+    void set_steps(size_t steps) override;
+
+    [[nodiscard]] float get_lr() const override {
+        return 0.0f;
+    }
+
+    void set_lr(float lr) override {
+    }
+
+private:
+    size_t m_steps{0};
+};
+
+}  // namespace ttml::optimizers

--- a/tt-train/sources/ttml/optimizers/no_op.hpp
+++ b/tt-train/sources/ttml/optimizers/no_op.hpp
@@ -23,12 +23,9 @@ public:
     [[nodiscard]] size_t get_steps() const override;
     void set_steps(size_t steps) override;
 
-    [[nodiscard]] float get_lr() const override {
-        return 0.0f;
-    }
+    [[nodiscard]] float get_lr() const override;
 
-    void set_lr(float lr) override {
-    }
+    void set_lr(float lr) override;
 
 private:
     size_t m_steps{0};

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     datasets/generators_test.cpp
     datasets/dataloader_test.cpp
     optimizers/adamw_test.cpp
+    optimizers/no_op_test.cpp
     modules/distributed/linear_test.cpp
     serialization/model_serializer_test.cpp
     serialization/msgpack_serializer_test.cpp

--- a/tt-train/tests/optimizers/no_op_test.cpp
+++ b/tt-train/tests/optimizers/no_op_test.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "optimizers/no_op.hpp"
+
+#include <gtest/gtest.h>
+
+#include <core/ttnn_all_includes.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "modules/linear_module.hpp"
+#include "ops/losses.hpp"
+
+class NoOpFullTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ttml::autograd::ctx().open_device();
+    }
+
+    void TearDown() override {
+        ttml::autograd::ctx().reset_graph();
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+TEST_F(NoOpFullTest, NoOpTest) {
+    using namespace ttml::ops;
+    ttml::autograd::ctx().set_seed(123);
+    auto* device = &ttml::autograd::ctx().get_device();
+    const size_t batch_size = 32;
+    const size_t num_features = 64;
+    std::vector<float> features;
+    features.reserve(batch_size * num_features);
+
+    for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t j = 0; j < num_features; ++j) {
+            features.push_back(static_cast<float>(i) * 0.1F);
+        }
+    }
+
+    std::vector<float> targets;
+    for (size_t i = 0; i < batch_size; ++i) {
+        targets.push_back(static_cast<float>(i) * 0.1F);
+    }
+
+    auto data_tensor = ttml::autograd::create_tensor(
+        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1, 1, num_features}), device));
+
+    auto targets_tensor =
+        ttml::autograd::create_tensor(ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, 1}), device));
+
+    auto model = ttml::modules::LinearLayer(num_features, 1);
+    auto initial_weight = model.get_weight();
+    auto initial_weight_values = ttml::core::to_vector(initial_weight->get_value());
+
+    auto optimizer = ttml::optimizers::NoOp(model.parameters());
+
+    const size_t steps = 100;
+    std::vector<float> losses;
+    losses.reserve(steps);
+    for (size_t step = 0; step < steps; ++step) {
+        optimizer.zero_grad();
+        auto prediction = model(data_tensor);
+        auto loss = ttml::ops::mse_loss(prediction, targets_tensor);
+        auto loss_value = ttml::core::to_vector(loss->get_value())[0];
+        losses.emplace_back(loss_value);
+        loss->backward();
+        optimizer.step();
+        ttml::autograd::ctx().reset_graph();
+    }
+
+    auto current_weight_values = ttml::core::to_vector(model.get_weight()->get_value());
+
+    EXPECT_EQ(initial_weight_values, current_weight_values);
+    EXPECT_EQ(losses.back(), losses.front());
+}

--- a/tt-train/tests/optimizers/no_op_test.cpp
+++ b/tt-train/tests/optimizers/no_op_test.cpp
@@ -27,10 +27,10 @@ protected:
 
 TEST_F(NoOpFullTest, NoOpTest) {
     using namespace ttml::ops;
-    ttml::autograd::ctx().set_seed(123);
+    ttml::autograd::ctx().set_seed(123U);
     auto* device = &ttml::autograd::ctx().get_device();
-    const size_t batch_size = 32;
-    const size_t num_features = 64;
+    const size_t batch_size = 32U;
+    const size_t num_features = 64U;
     std::vector<float> features;
     features.reserve(batch_size * num_features);
 
@@ -46,18 +46,18 @@ TEST_F(NoOpFullTest, NoOpTest) {
     }
 
     auto data_tensor = ttml::autograd::create_tensor(
-        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1, 1, num_features}), device));
+        ttml::core::from_vector(features, ttnn::Shape({batch_size, 1U, 1U, num_features}), device));
 
     auto targets_tensor =
-        ttml::autograd::create_tensor(ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1, 1, 1}), device));
+        ttml::autograd::create_tensor(ttml::core::from_vector(targets, ttnn::Shape({batch_size, 1U, 1U, 1U}), device));
 
-    auto model = ttml::modules::LinearLayer(num_features, 1);
+    auto model = ttml::modules::LinearLayer(num_features, 1U);
     auto initial_weight = model.get_weight();
     auto initial_weight_values = ttml::core::to_vector(initial_weight->get_value());
 
     auto optimizer = ttml::optimizers::NoOp(model.parameters());
 
-    const size_t steps = 100;
+    const size_t steps = 100U;
     std::vector<float> losses;
     losses.reserve(steps);
     for (size_t step = 0; step < steps; ++step) {


### PR DESCRIPTION
### Problem description
Introduces NoOp (No Operation) optimizer. The purpose of this optimizer is to serve as a dummy for testing and debugging training pipelines. 

### What's changed
- **Added NoOp optimizer** in`tt-train/sources/ttml/optimizers/`
- **Updated the build system** to include `no_op.hpp` and `no_op.cpp`
- **Added tests** in `tt-train/tests/optimizers/no_op_test.cpp`
- **Added option to use NoOp optimizer in nanoGPT** in `tt-train/sources/examples/nano_gpt/main.cpp` and added sample configuration file in `tt-train/configs/training_shakespeare_nanollama3_no_op.yaml`

### Results
Loss comparison of NoOp optimizer with AdamW (batch size = 32)
<img width="1610" height="933" alt="image" src="https://github.com/user-attachments/assets/1441f6c9-47b4-4b29-a5d0-2e0f52b97756" />

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes