### PR TITLE
[skip ci] Update clone_pybind.cpp, formatting change for consistency

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
@@ -13,7 +13,7 @@ void bind_clone_operation(py::module& module) {
 
     Clones the input, creating a copy with the specified `memory_config` and converting its data type to `dtype`.
     This operation does not alter the tensor's layout.
-    
+
     - ROW_MAJOR_LAYOUT: Returns the tensor unpadded in the last two dimensions.
 
     - TILE_LAYOUT: Pads the tensor to ensure its width and height are multiples of 32.

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
@@ -13,6 +13,7 @@ void bind_clone_operation(py::module& module) {
 
     Clones the input, creating a copy with the specified `memory_config` and converting its data type to `dtype`.
     This operation does not alter the tensor's layout.
+    
     - ROW_MAJOR_LAYOUT: Returns the tensor unpadded in the last two dimensions.
 
     - TILE_LAYOUT: Pads the tensor to ensure its width and height are multiples of 32.


### PR DESCRIPTION
### Ticket
[#25066](https://github.com/tenstorrent/tt-metal/issues/25066)

### Problem description
Formatting generated by Sphinx is inconsistency with other APIs.

### What's changed
Minor edit to formatting for consistency with other APIs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes