### PR TITLE
[skip ci] bugprone-parent-virtual-call

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,6 @@ Checks: >
   -bugprone-narrowing-conversions,
   -bugprone-nondeterministic-pointer-iteration-order,
   -bugprone-optional-value-conversion,
-  -bugprone-parent-virtual-call,
   -bugprone-sizeof-expression,
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-switch-missing-default-case,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -112,7 +112,8 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     }
 
     // Close devices/context to trigger watcher check on teardown.
-    DebugToolsFixture::TearDown();  // Call parent teardown so we don't disable watcher
+    DebugToolsFixture::TearDown();  // NOLINT(bugprone-parent-virtual-call) Call parent teardown so we don't disable
+                                    // watcher
     MetalContext::instance().teardown();
     EXPECT_TRUE(FileContainsAllStrings(this->log_file_name, expected_strings));
 }


### PR DESCRIPTION
### Ticket
#22758 
Closes #27641 

### Problem description
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/parent-virtual-call.html

### What's changed
- Enable check globally
- Disable the check on the one line where we appear to intentionally call a parent virtual function (PLEASE CHECK)