### PR TITLE
Remove context switching when checking wh eth link up

### DIFF
--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -299,7 +299,7 @@ struct debug_stack_usage_t {
 };
 
 struct debug_eth_link_t {
-    uint8_t link_down;
+    volatile uint8_t link_down;
 };
 
 enum watcher_enable_msg_t {

--- a/tt_metal/hw/inc/wormhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/wormhole/eth_fw_api.h
@@ -58,7 +58,7 @@ struct boot_results_t {
 #include "ethernet/erisc.h"
 
 FORCE_INLINE bool is_link_up() {
-    internal_::risc_context_switch_without_noc_sync();
+    // Collected when FW/Fabric is idle and context switches to base FW
     volatile boot_results_t* link_stats = (volatile boot_results_t*)(MEM_SYSENG_BOOT_RESULTS_BASE);
     return link_stats->link_status == 0x6;
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27596

### Problem description
Extra context switch in link check causes WH initialization to fail. Safe to remove it because metal fw will context switch which periodically collects liink stats

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17315028494) CI passes
- [x] [T3K unit](https://github.com/tenstorrent/tt-metal/actions/runs/17325590651)