### PR TITLE
Switch to ReduceScatterMinimal and use barrier semaphores across DeepSeekv3 

### DIFF
--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -64,9 +64,6 @@ def test_forward_pass(
     # Set less layers and shorter max length for the sake of testing
     hf_config_short.num_hidden_layers = 8
 
-    # CCL workaround (remove once persistent buffers are added)
-    mesh_device.disable_and_clear_program_cache()
-
     # Check params
     if mode == "prefill":
         assert batch_size == 1, "Prefill only supports a batch size of 1"

--- a/models/demos/deepseek_v3/tt/ccl.py
+++ b/models/demos/deepseek_v3/tt/ccl.py
@@ -19,10 +19,14 @@ class CCL:
         self.gather_sems = []
         self.from_sems = []
         self.to_sems = []
+        self.reduce_scatter_sems = []
+        self.barrier_sems = []
         for _ in range(len(list(mesh_device.shape))):
             self.gather_sems.append([])
             self.from_sems.append([])
             self.to_sems.append([])
+            self.reduce_scatter_sems.append([])
+            self.barrier_sems.append([])
             for _ in range(2):
                 self.gather_sems[-1].append(
                     [
@@ -32,6 +36,14 @@ class CCL:
                 )  # use two semaphores to use minimal version of all_gather_async
                 self.from_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
                 self.to_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
+                self.reduce_scatter_sems[-1].append(
+                    [
+                        ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
+                        ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
+                        ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
+                    ]
+                )
+                self.barrier_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
 
         self.sem_cnt = [0, 0]
 
@@ -80,3 +92,19 @@ class CCL:
         buffer = None
 
         return buffer
+
+    def get_reduce_scatter_sem(self, axis):
+        """
+        Get a semaphore for the given axis.
+        """
+        sem = self.reduce_scatter_sems[axis][self.sem_cnt[axis]]
+        self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
+        return sem
+
+    def get_barrier_sem(self, axis):
+        """
+        Get a semaphore for the given axis.
+        """
+        sem = self.barrier_sems[axis][self.sem_cnt[axis]]
+        self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
+        return sem

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
@@ -132,6 +132,7 @@ class MoEDecoderBlock(DecoderBlockBase):
             "shared_expert": SharedExpert.create_state(hf_config, mesh_device, ccl),
             "revert_dp": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(0),
+                "barrier_semaphore": ccl.get_barrier_sem(1),
             },
         }
 

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
@@ -132,7 +132,7 @@ class MoEDecoderBlock(DecoderBlockBase):
             "shared_expert": SharedExpert.create_state(hf_config, mesh_device, ccl),
             "revert_dp": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(0),
-                "barrier_semaphore": ccl.get_barrier_sem(1),
+                "barrier_semaphore": ccl.get_barrier_sem(0),
             },
         }
 

--- a/models/demos/deepseek_v3/tt/embedding.py
+++ b/models/demos/deepseek_v3/tt/embedding.py
@@ -155,6 +155,7 @@ class Embedding(AbstractModule):
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "all_gather": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(0),
+                "barrier_semaphore": ccl.get_barrier_sem(0),
                 "num_links": ccl.get_max_links(0),
             },
         }

--- a/models/demos/deepseek_v3/tt/mla.py
+++ b/models/demos/deepseek_v3/tt/mla.py
@@ -20,7 +20,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     FromWeightConfig,
     LinearConfig,
     MeshDeviceStub,
-    ReduceScatterAsyncConfig,
+    ReduceScatterAsyncMinimalConfig,
     ReshardConfig,
     SavedWeight,
 )
@@ -300,11 +300,9 @@ class MLA(AbstractModule):
         # Set up CCLs
 
         # Q
-        wq_a_rs_config = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_device.shape),
+        wq_a_rs_config = ReduceScatterAsyncMinimalConfig(
             cluster_axis=1,
             dim=3,
-            math_op=ttnn.ReduceType.Sum,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -566,11 +564,9 @@ class MLA(AbstractModule):
         # Set up CCLs
 
         # Q
-        wq_a_rs_config = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        wq_a_rs_config = ReduceScatterAsyncMinimalConfig(
             cluster_axis=1,
             dim=3,
-            math_op=ttnn.ReduceType.Sum,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -590,11 +586,9 @@ class MLA(AbstractModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
-        wq_a2a_rs_config = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        wq_a2a_rs_config = ReduceScatterAsyncMinimalConfig(
             cluster_axis=1,
             dim=1,
-            math_op=ttnn.ReduceType.Sum,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -617,11 +611,9 @@ class MLA(AbstractModule):
                 packer_l1_acc=True,
             ),
         }
-        wkv_a_rs_config = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        wkv_a_rs_config = ReduceScatterAsyncMinimalConfig(
             cluster_axis=1,
             dim=1,
-            math_op=ttnn.ReduceType.Sum,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -634,11 +626,9 @@ class MLA(AbstractModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
-        flash_mla_rs_config = ReduceScatterAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        flash_mla_rs_config = ReduceScatterAsyncMinimalConfig(
             cluster_axis=1,
             dim=1,
-            math_op=ttnn.ReduceType.Sum,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -786,12 +776,13 @@ class MLA(AbstractModule):
 
         # CCL states setup (Must be in order of execution)
         get_rs_params = lambda axis: {
-            "from_remote_multi_device_global_semaphore": ccl.get_from_sem(axis=axis),
-            "to_remote_multi_device_global_semaphore": ccl.get_to_sem(axis=axis),
+            "multi_device_global_semaphore": ccl.get_reduce_scatter_sem(axis=axis),
+            "barrier_semaphore": ccl.get_barrier_sem(axis=axis),
             "num_links": ccl.get_max_links(axis=axis),
         }
         get_ag_params = lambda axis: {
             "multi_device_global_semaphore": ccl.get_gather_sem(axis=axis),
+            "barrier_semaphore": ccl.get_barrier_sem(axis=axis),
             "num_links": ccl.get_max_links(axis=axis),
         }
         ccl_states_prefill = {
@@ -859,8 +850,7 @@ class MLA(AbstractModule):
 
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
-
-        tt_q = ttnn.experimental.reduce_scatter_async(tt_q, **cfg["wq_a_rs_decode"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a_rs_decode"])
         tt_q = ttnn.experimental.all_gather_async(tt_q, **cfg["wq_a_ag_decode"])
 
         tt_q = RMSNorm.forward_decode(tt_q, cfg["q_norm"])
@@ -901,7 +891,7 @@ class MLA(AbstractModule):
             tt_q, **cfg["wq_a2a_ag_decode"]
         )  # [1, num_heads, bsz_local, kv_lora_rank + qk_rope_head_dim]
         tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, bsz_local, num_heads, kv_lora_rank + qk_rope_head_dim]
-        tt_q = ttnn.experimental.reduce_scatter_async(tt_q, **cfg["wq_a2a_rs_decode"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a2a_rs_decode"])
         tt_q = tt_q * scale  # Scale the input tensor
 
         # KVPE Stuff
@@ -942,7 +932,7 @@ class MLA(AbstractModule):
         # FIXME: Reduce-Scatter here!! (tt_kvpe)
         tt_kvpe = ttnn.pad(tt_kvpe, [(0, 0), (0, ttnn.TILE_SIZE - 1), (0, 0), (0, 0)], 0)
         tt_kvpe = ttnn.permute(tt_kvpe, (0, 2, 1, 3))  # [1, bsz, ttnn.TILE_SIZE, kv_lora_rank + qk_rope_head_dim]
-        tt_kvpe = ttnn.experimental.reduce_scatter_async(tt_kvpe, **cfg["wkv_a_rs_decode"])
+        tt_kvpe = ttnn.experimental.reduce_scatter_minimal_async(tt_kvpe, **cfg["wkv_a_rs_decode"])
         tt_kvpe = tt_kvpe[:, :, :1, :]  # [1, bsz_local, 1, kv_lora_rank + qk_rope_head_dim]
         tt_kvpe = tt_kvpe * scale  # Scale the input tensor
 
@@ -977,7 +967,7 @@ class MLA(AbstractModule):
             attn_out, **cfg["flash_mla_ag_decode"]
         )  # [1, bsz, num_heads, kv_lora_rank]
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, num_heads, bsz, kv_lora_rank]
-        attn_out = ttnn.experimental.reduce_scatter_async(
+        attn_out = ttnn.experimental.reduce_scatter_minimal_async(
             attn_out, **cfg["flash_mla_rs_decode"]
         )  # [1, num_heads_local, bsz, kv_lora_rank]
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, bsz, num_heads_local, kv_lora_rank]
@@ -1037,7 +1027,7 @@ class MLA(AbstractModule):
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
 
-        tt_q = ttnn.experimental.reduce_scatter_async(tt_q, **cfg["wq_a_rs_prefill"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a_rs_prefill"])
         tt_q = ttnn.experimental.all_gather_async(tt_q, **cfg["wq_a_ag_prefill"])
 
         tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -18,7 +18,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     MeshDeviceStub,
     MulConfig,
     OpConfigBase,
-    ReduceScatterAsyncConfig,
+    ReduceScatterAsyncMinimalConfig,
     ReshardConfig,
     SavedWeight,
 )
@@ -203,11 +203,9 @@ class MLP(AbstractModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
             ),
-            "reduce_scatter_async": ReduceScatterAsyncConfig(
-                dim=-1,  # We are scattering across the feature dimension (last one)
+            "reduce_scatter_async": ReduceScatterAsyncMinimalConfig(
+                dim=3,  # We are scattering across the feature dimension (last one)
                 cluster_axis=1,  # Reduce-scatter across the mesh rows
-                mesh_device=MeshDeviceStub(mesh_device.shape),
-                math_op=ttnn.ReduceType.Sum,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
             ),
@@ -310,11 +308,9 @@ class MLP(AbstractModule):
                 memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
                 input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
             ),
-            "reduce_scatter_async": ReduceScatterAsyncConfig(
-                mesh_device=MeshDeviceStub(mesh_device.shape),
+            "reduce_scatter_async": ReduceScatterAsyncMinimalConfig(
                 cluster_axis=1,  # Reduce-scatter across the mesh rows
-                dim=-1,  # We are scattering across the feature dimension (last one)
-                math_op=ttnn.ReduceType.Sum,
+                dim=3,  # We are scattering across the feature dimension (last one)
                 topology=ttnn.Topology.Linear,  # One row of Galaxy does not form a ring
                 memory_config=output_memory_config,
             ),
@@ -373,11 +369,12 @@ class MLP(AbstractModule):
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "all_gather": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(1),
+                "barrier_semaphore": ccl.get_barrier_sem(1),
                 "num_links": ccl.get_max_links(1),
             },
             "reduce_scatter_async": {
-                "from_remote_multi_device_global_semaphore": ccl.get_from_sem(1),
-                "to_remote_multi_device_global_semaphore": ccl.get_to_sem(1),
+                "multi_device_global_semaphore": ccl.get_reduce_scatter_sem(1),
+                "barrier_semaphore": ccl.get_barrier_sem(1),
                 "num_links": ccl.get_max_links(1),
             },
         }
@@ -478,7 +475,7 @@ class MLP(AbstractModule):
         ttnn.deallocate(activated)
 
         # Reduce-scatter across devices to sum partial results
-        output = ttnn.experimental.reduce_scatter_async(output, **cfg["reduce_scatter_async"])
+        output = ttnn.experimental.reduce_scatter_minimal_async(output, **cfg["reduce_scatter_async"])
 
         # De-chunk the output if the input was chunked
         _, num_chunks, _, output_dim = output.shape
@@ -514,7 +511,9 @@ class MLP(AbstractModule):
         ttnn.deallocate(activated)
 
         # Add reduce-scatter
-        output = ttnn.experimental.reduce_scatter_async(w2_out, **cfg["reduce_scatter_async"])
+        w2_out = ttnn.to_memory_config(w2_out, ttnn.DRAM_MEMORY_CONFIG)
+        # TODO: File issue on RS not being able to run sharded memory config
+        output = ttnn.experimental.reduce_scatter_minimal_async(w2_out, **cfg["reduce_scatter_async"])
         ttnn.deallocate(w2_out)
 
         assert output.memory_config() == cfg["output_memory_config"]

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     AllToAllDispatchConfig,
     MeshDeviceStub,
     MulConfig,
-    ReduceScatterAsyncConfig,
+    ReduceScatterAsyncMinimalConfig,
     RepeatConfig,
 )
 from models.demos.deepseek_v3.utils.run_config import (
@@ -101,8 +101,8 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "num_links": 1,
             },
             "final_output_reduce_scatter": {
-                "from_remote_multi_device_global_semaphore": ccl.get_from_sem(1),
-                "to_remote_multi_device_global_semaphore": ccl.get_to_sem(1),
+                "multi_device_global_semaphore": ccl.get_reduce_scatter_sem(1),
+                "barrier_semaphore": ccl.get_barrier_sem(1),
                 "num_links": ccl.get_max_links(1),
             },
             "revert_tp": {
@@ -154,11 +154,9 @@ class MoE(SharedStateAddOn, AbstractModule):
             "output_memory_config": memory_config,
             "all_to_all_dispatch": AllToAllDispatchConfig(cluster_axis=0, memory_config=memory_config),
             "all_to_all_combine": AllToAllCombineConfig(axis=0, memory_config=memory_config),
-            "final_output_reduce_scatter": ReduceScatterAsyncConfig(
-                mesh_device=MeshDeviceStub(mesh_device.shape),
+            "final_output_reduce_scatter": ReduceScatterAsyncMinimalConfig(
                 cluster_axis=1,
                 dim=3,
-                math_op=ttnn.ReduceType.Sum,
                 memory_config=memory_config,
                 topology=ttnn.Topology.Linear,
             ),
@@ -235,7 +233,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             post_combine_output_tensor, topk_experts_weights, **cfg["mul_experts_output_with_weights"]
         )
         post_combine_output_tensor = ttnn.sum(post_combine_output_tensor, dim=0, keepdim=True)
-        post_combine_output_tensor = ttnn.experimental.reduce_scatter_async(
+        post_combine_output_tensor = ttnn.experimental.reduce_scatter_minimal_async(
             post_combine_output_tensor, **cfg["final_output_reduce_scatter"]
         )
 

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -160,6 +160,7 @@ class DistributedRMSNorm(RMSNormBase):
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "all_gather": {
                 "multi_device_global_semaphore": ccl.get_gather_sem(1),
+                "barrier_semaphore": ccl.get_barrier_sem(1),
             },
         }
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -141,6 +141,25 @@ class ReduceScatterAsyncConfig(OpConfigBase):
 
 
 @dataclass
+class ReduceScatterAsyncMinimalConfig(OpConfigBase):
+    """Common parameters for a ttnn.experimental.reduce_scatter_minimal_async op"""
+
+    dim: int
+    multi_device_global_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
+    num_links: int | None = None
+    persistent_output_buffers: ttnn.Tensor | None = None
+    barrier_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
+    memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None
+    intermediate_memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None
+    topology: ttnn.Topology = ttnn.Topology.Ring
+    subdevice_id: ttnn._ttnn.device.SubDeviceId | None = None
+    cluster_axis: int | None = None
+    chunks_per_sync: int | None = None
+    num_workers_per_link: int | None = None
+    num_buffers_per_channel: int | None = None
+
+
+@dataclass
 class PointToPointConfig(OpConfigBase):
     """Common parameters for a ttnn.point_to_point op"""
 


### PR DESCRIPTION
### Problem description
This pull request refactors the collective communication logic across several model modules to use a new minimal implementation of reduce-scatter operations, introduces barrier semaphores for improved synchronization, and updates related configuration and state management. The changes improve consistency, simplify the codebase, and enhance synchronization primitives for distributed execution.

**Collective Communication Refactoring:**

* Replaced all uses of `ReduceScatterAsyncConfig` and `ttnn.experimental.reduce_scatter_async` with `ReduceScatterAsyncMinimalConfig` and `ttnn.experimental.reduce_scatter_minimal_async` across `mla_1d.py`, `mlp_1d.py`, and `moe.py`, updating all relevant model configuration and forward methods. 

**Synchronization Improvements:**

* Added `barrier_sems` and `reduce_scatter_sems` to the `CCL1D` class, along with corresponding getter methods (`get_barrier_sem`, `get_reduce_scatter_sem`), and updated state creation in all modules to use these new synchronization primitives for both reduce-scatter and all-gather operations.

**Enabled Program Caching:**
* Removed `mesh_device.disable_and_clear_program_cache()` in `test_model.py`.

These changes collectively modernize and streamline the distributed communication and synchronization logic used throughout the DeepSeek V3 model codebase.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI 
- [x] [TG DeepSeek](https://github.com/tenstorrent/tt-metal/actions/runs/17956324852) CI