### PR TITLE
Stable diffusion L1_small size in tests unification

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 18944
+SD_L1_SMALL_SIZE = 19616

--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# L1 Small Size Constants
+SD_L1_SMALL_SIZE = 11 * 8192  # 90112 - L1 small size for Stable Diffusion

--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 11 * 8192  # 90112 - L1 small size for Stable Diffusion
+SD_L1_SMALL_SIZE = 18944

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -19,6 +19,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import compile_trace_sd
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -521,7 +522,7 @@ def run_demo_inference_diffusiondb(
 
 @pytest.mark.parametrize(
     "device_params",
-    [{"l1_small_size": 11 * 8192, "trace_region_size": 789835776}],
+    [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -14,6 +14,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import compile_trace_sd
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -178,7 +179,7 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
 def warmup_model():
     # create device, these constants are specific to n150 & n300
     device_id = 0
-    device_params = {"l1_small_size": 11 * 8192, "trace_region_size": 789835776}
+    device_params = {"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}
     device = ttnn.CreateDevice(device_id=device_id, **device_params)
     num_inference_steps = 50
     image_size = (512, 512)

--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -9,6 +9,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_basic_transformer_block import basic_transformer_block
@@ -20,7 +21,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention import cross_attention
@@ -19,7 +20,7 @@ from tests.ttnn.utils_for_testing import comp_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize("has_encoder_hidden_states", (True, False))
 @pytest.mark.parametrize(

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
@@ -9,6 +9,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention_down_block_2d_new_conv import (
     cross_attention_down_block_2d,
@@ -23,7 +24,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "block_index, hidden_states, shard_layout, shard_end_core, shard_shape, out_channels",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -9,6 +9,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_mid_block_2d_cross_attn_new_conv import (
@@ -24,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
 )

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attn_upblock_new_conv import (
     cross_attention_upblock2d,
@@ -27,7 +28,7 @@ def ttnn_to_torch(input):
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "hidden_states, res_hidden_states_tuple, index, prev_output_channel, in_channels, out_channels, shard_end_core, shard_shape",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -6,6 +6,7 @@ import pytest
 import torchvision.transforms as transforms
 from diffusers import StableDiffusionPipeline
 
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.demo.demo import load_inputs
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference as demo
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_diffusiondb as demo_db
@@ -13,7 +14,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192, "trace_region_size": 789321728}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789321728}], indirect=True
+)
 @pytest.mark.parametrize(
     "num_prompts",
     ((1),),
@@ -33,7 +36,9 @@ def test_demo_sd_db(device, reset_seeds, input_path, num_prompts, num_inference_
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192, "trace_region_size": 789835776}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}], indirect=True
+)
 @pytest.mark.parametrize(
     "input_path",
     (("models/demos/wormhole/stable_diffusion/demo/input_data.json"),),

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downblock_2d_new_conv import downblock2d
@@ -21,7 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
 )

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downsample_2d_new_conv import downsample_2d
@@ -21,7 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "hidden_states, shard_layout, shard_end_core, shard_shape, block_index",
     (

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -8,11 +8,12 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_embeddings import TtTimestepEmbedding
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_embeddings(device):
     torch.manual_seed(0)
     # setup pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -8,6 +8,7 @@ from diffusers import UNet2DConditionModel
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward import feedforward
@@ -19,7 +20,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -8,6 +8,7 @@ from diffusers import UNet2DConditionModel
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_geglu import geglu
@@ -19,7 +20,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -11,6 +11,7 @@ from loguru import logger
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import run
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -45,7 +46,9 @@ def unsqueeze_all_params_to_4d(params):
     return params
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 15659008}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 15659008}], indirect=True
+)
 def test_stable_diffusion_unet_trace(device):
     assert is_wormhole_b0() or is_blackhole(), "SD 1.4 runs on Wormhole B0 or Blackhole"
 
@@ -171,7 +174,9 @@ def test_stable_diffusion_unet_trace(device):
     print(f"SD1.4 is running at {fps} FPS")
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192, "trace_region_size": 6458368}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 6458368}], indirect=True
+)
 def test_stable_diffusion_vae_trace(device):
     if is_wormhole_b0():
         os.environ["TT_MM_THROTTLE_PERF"] = "5"
@@ -240,7 +245,9 @@ def test_stable_diffusion_vae_trace(device):
 
 
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 21 * 4096, "trace_region_size": 789321728}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789321728}], indirect=True
+)
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_resnetblock2d_new_conv import resnetBlock2D
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -25,7 +26,7 @@ def ttnn_to_torch(input):
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, in_channels, input_height, input_width, memory_layout, buffer_type, shard_end_core, shard_shape, out_channels, use_in_shortcut, block_name, block_index, resnet_index",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_transformer_2d_new_conv import transformer_2d_model
@@ -25,7 +26,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     TRANSFORMER_PARAMETERIZATIONS,
 )
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_transformer_2d_model_512x512(
     device,
     model_name,

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -10,6 +10,7 @@ from tqdm.auto import tqdm
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
@@ -47,7 +48,7 @@ def unsqueeze_all_params_to_4d(params):
 
 
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768}], ids=["device_params=l1_small_size_24576"], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], ids=["device_params=l1_small_size_24576"], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, in_channels, input_height, input_width",

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upblock_2d_new_conv import upblock_2d
@@ -21,7 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("res_hidden_states_tuple", [([2, 1280, 8, 8], [2, 1280, 8, 8], [2, 1280, 8, 8])])
 @pytest.mark.parametrize(
     "hidden_states, shard_layout, shard_end_core, shard_shape", [DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO]

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -8,6 +8,7 @@ from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import (
     CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
@@ -38,7 +39,7 @@ def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
         CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[1] + (2,),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_upsample2d_512x512(device, input_shape, shard_layout, shard_end_core, shard_shape, index):
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_nearest_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_nearest_2d.py
@@ -6,13 +6,14 @@ import pytest
 import torch
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upsample_nearest_2d import upsample_nearest2d
 from models.utility_functions import skip_for_grayskull, torch_random
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("input_shape", [(2, 1280, 8, 8), (2, 1280, 16, 16), (2, 640, 32, 32)])
 @pytest.mark.parametrize("scale_factor", [2])
 def test_upsample_nearest2d_512x512(reset_seeds, device, input_shape, scale_factor):

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     get_default_compute_config,
     get_default_conv_config,
@@ -18,7 +19,7 @@ from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "in_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -7,11 +7,12 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     """input_channels, input_height, input_width, out_channels, output_height, output_width""",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -7,6 +7,7 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     GROUPNORM_DECODER_NUM_BLOCKS,
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
@@ -19,7 +20,7 @@ from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_decoder import VaeDe
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     """input_channels, input_height, input_width, out_channels, output_height, output_width,
     midblock_in_channels, midblock_resnet_norm_blocks, midblock_conv_channel_split_factors,

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -7,6 +7,7 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -17,7 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_blackhole("Blackhole PCC bad until GN issues fixed (#20760)")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "input_channels, input_height, input_width, norm_num_blocks, conv_in_channel_split_factors",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
@@ -7,6 +7,7 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -19,7 +20,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_blackhole("Blackhole PCC bad until GN issues fixed (#20760)")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "input_channels, input_height, input_width, out_channels, norm_num_blocks, conv_channel_split_factors, block, block_id, resnet_block_id",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
@@ -7,6 +7,7 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     UPBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -18,7 +19,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_blackhole("Blackhole PCC bad until GN issues fixed (#20760)")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "input_channels, input_height, input_width, out_channels, output_height, output_width, resnet_norm_blocks, resnet_conv_in_channel_split_factors, upsample_conv_channel_split_factors, block_id",
     [

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -7,12 +7,13 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "input_channels, input_height, input_width, out_channels, output_height, output_width, conv_channel_split_factor, block_id",
     [


### PR DESCRIPTION
### Problem description
Stable diffusion model has L1_small size which differs from test to test.
Value for L1_Small needs to be unified

### What's changed
- added L1_Small variable and used it across the stable_diffusion codebase
### Checklist
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [stable_diffusion passes](https://github.com/tenstorrent/tt-metal/actions/runs/17317980956)