### PR TITLE
[DM]: Adjusting bounds for failing test in perf pipelines

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -408,7 +408,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
     CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    unit_tests::dm::all_from_all::packet_sizes_test(
+    unit_tests::dm::all_from_all::directed_ideal_test(
         mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -417,7 +417,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
     CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
     CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    unit_tests::dm::all_to_all::packet_sizes_test(
+    unit_tests::dm::all_to_all::directed_ideal_test(
         mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 
@@ -436,7 +436,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
     CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
     CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    unit_tests::dm::all_to_all::directed_ideal_test(
+    unit_tests::dm::all_to_all::packet_sizes_test(
         mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size);
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -177,7 +177,7 @@
 "Loopback Directed Ideal":
   wormhole_b0:
     riscv_0:
-      bandwidth: 30
+      bandwidth: 28
   blackhole:
     riscv_0:
       bandwidth: 60


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27038)

### Problem description
`metal - Run microbenchmarks` pipeline is failing on main for our WH data movement regressions. It seems to have started failing on the `One to All Multicast Directed Ideal` primitive with `test id 53` and now is failing on the primitive with `test id 55`.

### What's changed
Failure seems to be related to a mix of noise and the change of BW due to removal of sharded buffer usage in the `Loopback` primitive. Updated the test bounds to accommodate this change for the relevant test case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17319722003) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17319724322) CI passes
- [x] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/17319305695)