### PR TITLE
Replaced torch grid_sample and nonzero with respective ttnn ops in VADv2 and addressed the OOM issue.

### DIFF
--- a/models/experimental/vadv2/tests/pcc/test_tt_transformer.py
+++ b/models/experimental/vadv2/tests/pcc/test_tt_transformer.py
@@ -208,7 +208,7 @@ def create_vadv2_model_parameters_tramsformer(model: ResNet, device=None):
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_vadv2_encoder(
+def test_vadv2_transformer(
     device,
     reset_seeds,
     model_location_generator,

--- a/models/experimental/vadv2/tests/pcc/test_tt_vad.py
+++ b/models/experimental/vadv2/tests/pcc/test_tt_vad.py
@@ -17,7 +17,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.vadv2.common import load_torch_model
 
 
-@pytest.mark.skip("#27009: Failure about banks")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 10 * 1024}], indirect=True)
 def test_vadv2(
     device,

--- a/models/experimental/vadv2/tests/pcc/test_tt_vad.py
+++ b/models/experimental/vadv2/tests/pcc/test_tt_vad.py
@@ -17,7 +17,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.vadv2.common import load_torch_model
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 10 * 1024}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 20 * 1024}], indirect=True)
 def test_vadv2(
     device,
     reset_seeds,

--- a/models/experimental/vadv2/tt/tt_backbone.py
+++ b/models/experimental/vadv2/tt/tt_backbone.py
@@ -12,7 +12,13 @@ class TtResnet50:
         self.maxpool_args = conv_args.maxpool
         self.device = device
 
-        self.conv1 = TtConv2D(conv_args.conv1, conv_pth.conv1, device=self.device, activation="relu", act_block_h=32)
+        self.conv1 = TtConv2D(
+            conv_args.conv1,
+            conv_pth.conv1,
+            device=self.device,
+            activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+            act_block_h=32,
+        )
 
         # Layer 1
         self.layer1_0 = TtBottleneck(

--- a/models/experimental/vadv2/tt/tt_decoder.py
+++ b/models/experimental/vadv2/tt/tt_decoder.py
@@ -77,6 +77,7 @@ class TtDetectionTransformerDecoder:
                 spatial_shapes=spatial_shapes,
             )
             output = ttnn.permute(output, (1, 0, 2))
+            ttnn.ReadDeviceProfiler(self.device)
 
             if reg_branches is not None:
                 # Select reg_branch layers for current lid

--- a/models/experimental/vadv2/tt/tt_encoder.py
+++ b/models/experimental/vadv2/tt/tt_encoder.py
@@ -275,6 +275,7 @@ class TtBEVFormerEncoder:
                 prev_bev=prev_bev,
                 **kwargs,
             )
+            ttnn.ReadDeviceProfiler(self.device)
 
             bev_query = output
             if self.return_intermediate:

--- a/models/experimental/vadv2/tt/tt_encoder.py
+++ b/models/experimental/vadv2/tt/tt_encoder.py
@@ -99,6 +99,9 @@ class TtBEVFormerEncoder:
             ref = ttnn.reshape(ref, (1, num_points_in_pillar, H * W, 3))
 
             ref = ttnn.repeat(ref, (bs, 1, 1, 1))  # [B, P, HW, 3]
+            ttnn.deallocate(x_vals)
+            ttnn.deallocate(y_vals)
+            ttnn.deallocate(z_vals)
             return ref
 
         elif dim == "2d":
@@ -126,6 +129,8 @@ class TtBEVFormerEncoder:
 
             ref = ttnn.repeat(ref, (bs, 1, 1))  # [bs, H*W, 2]
             ref = ttnn.reshape(ref, (bs, H * W, 1, 2))  # [bs, H*W, 1, 2]
+            ttnn.deallocate(x_vals)
+            ttnn.deallocate(y_vals)
 
             return ref
 
@@ -201,6 +206,16 @@ class TtBEVFormerEncoder:
         reference_points_cam = ttnn.permute(reference_points_cam, [2, 1, 3, 0, 4])
         bev_mask = ttnn.permute(bev_mask, [2, 1, 3, 0, 4])
         bev_mask = ttnn.squeeze(bev_mask, dim=-1)
+        ttnn.deallocate(y_gt_0)
+        ttnn.deallocate(y_lt_1)
+        ttnn.deallocate(x_gt_0)
+        ttnn.deallocate(x_lt_1)
+        ttnn.deallocate(a)
+        ttnn.deallocate(b)
+        ttnn.deallocate(x)
+        ttnn.deallocate(y)
+        ttnn.deallocate(lidar2img)
+        ttnn.deallocate(reference_points)
 
         return reference_points_cam, bev_mask
 

--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -72,7 +72,7 @@ class TtSpatialCrossAttention:
             index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
             index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
             index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
-            output_tensor = ttnn.nonzero(index_query_per_img, queue_id=0)
+            output_tensor = ttnn.nonzero(index_query_per_img, queue_id=0, memory_config=ttnn.L1_MEMORY_CONFIG)
             no_of_non_zero_indices = output_tensor[0][..., 0].item()
             index_query_per_img = output_tensor[1][:, :, :, :no_of_non_zero_indices]
 
@@ -247,11 +247,12 @@ class TtMSDeformableAttention3D:
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
         )
-        attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
-        attention_weights = attention_weights.softmax(dim=-1)
-        attention_weights = ttnn.from_torch(
-            attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
-        )
+        # attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
+        # attention_weights = attention_weights.softmax(dim=-1)
+        # attention_weights = ttnn.from_torch(
+        #     attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+        # )
+        attention_weights = ttnn.softmax(attention_weights, -1)
 
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)

--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -245,21 +245,15 @@ class TtMSDeformableAttention3D:
         sampling_offsets = ttnn.reshape(
             sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
         )
-        ttnn.reallocate(sampling_offsets)
         attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
         ttnn.deallocate(params.attention_weights.weight)
         ttnn.deallocate(params.attention_weights.bias)
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels * self.num_points)
         )
-        # attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
-        # attention_weights = attention_weights.softmax(dim=-1)
-        # attention_weights = ttnn.from_torch(
-        #     attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
-        # )
 
         attention_weights = ttnn.softmax(attention_weights, -1)
-
+        attention_weights = ttnn.reallocate(attention_weights)
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_levels, self.num_points)
         )

--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -69,18 +69,18 @@ class TtSpatialCrossAttention:
         for i, mask_per_img in enumerate(bev_mask):
             index_query_per_img = ttnn.sum(mask_per_img[0], -1)
             index_query_per_img = ttnn.to_layout(index_query_per_img, ttnn.ROW_MAJOR_LAYOUT)
-            index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
-            index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
-            index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
+            for _ in range(3):  # unsqueeze 3 times
+                index_query_per_img = ttnn.unsqueeze(index_query_per_img, 0)
             output_tensor = ttnn.nonzero(index_query_per_img, queue_id=0, memory_config=ttnn.L1_MEMORY_CONFIG)
+            ttnn.deallocate(index_query_per_img)
+
             no_of_non_zero_indices = output_tensor[0][..., 0].item()
             index_query_per_img = output_tensor[1][:, :, :, :no_of_non_zero_indices]
 
-            index_query_per_img = ttnn.squeeze(index_query_per_img, 0)
-            index_query_per_img = ttnn.squeeze(index_query_per_img, 0)
-            index_query_per_img = ttnn.squeeze(index_query_per_img, 0)
-
+            for _ in range(3):  # squeeze back
+                index_query_per_img = ttnn.squeeze(index_query_per_img, 0)
             indexes.append(index_query_per_img)
+            ttnn.deallocate(output_tensor[0])
 
         max_len = max([each.shape[0] for each in indexes])
         query = ttnn.to_torch(query)
@@ -96,6 +96,7 @@ class TtSpatialCrossAttention:
                 reference_points_rebatch[j, i, : len(index_query_per_img)] = reference_points_per_img[
                     j, index_query_per_img
                 ]
+
         queries_rebatch = ttnn.from_torch(queries_rebatch, dtype=ttnn.bfloat16, device=self.device)
         reference_points_rebatch = ttnn.from_torch(reference_points_rebatch, dtype=ttnn.bfloat16, device=self.device)
         num_cams, l, bs, embed_dims = key.shape
@@ -114,6 +115,9 @@ class TtSpatialCrossAttention:
             spatial_shapes=spatial_shapes,
             level_start_index=level_start_index,
         )
+        ttnn.deallocate(queries_rebatch)
+        ttnn.deallocate(reference_points_rebatch)
+
         queries = ttnn.reshape(queries, (bs, self.num_cams, max_len, self.embed_dims))
 
         queries = ttnn.to_torch(queries)
@@ -241,6 +245,7 @@ class TtMSDeformableAttention3D:
         sampling_offsets = ttnn.reshape(
             sampling_offsets, (bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
         )
+        ttnn.reallocate(sampling_offsets)
         attention_weights = ttnn.linear(query, params.attention_weights.weight, bias=params.attention_weights.bias)
         ttnn.deallocate(params.attention_weights.weight)
         ttnn.deallocate(params.attention_weights.bias)
@@ -252,6 +257,7 @@ class TtMSDeformableAttention3D:
         # attention_weights = ttnn.from_torch(
         #     attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
         # )
+
         attention_weights = ttnn.softmax(attention_weights, -1)
 
         attention_weights = ttnn.reshape(

--- a/models/experimental/vadv2/tt/tt_temporal_self_attention.py
+++ b/models/experimental/vadv2/tt/tt_temporal_self_attention.py
@@ -109,7 +109,11 @@ class TtTemporalSelfAttention:
             attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels * self.num_points)
         )
 
-        attention_weights = ttnn.softmax(attention_weights, -1)
+        attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
+        attention_weights = attention_weights.softmax(dim=-1)
+        attention_weights = ttnn.from_torch(
+            attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+        )
 
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points)

--- a/models/experimental/vadv2/tt/tt_temporal_self_attention.py
+++ b/models/experimental/vadv2/tt/tt_temporal_self_attention.py
@@ -109,11 +109,12 @@ class TtTemporalSelfAttention:
             attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels * self.num_points)
         )
 
-        attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
-        attention_weights = attention_weights.softmax(dim=-1)
-        attention_weights = ttnn.from_torch(
-            attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
-        )
+        # attention_weights = ttnn.to_torch(attention_weights)  # OOM ISSUE
+        # attention_weights = attention_weights.softmax(dim=-1)
+        # attention_weights = ttnn.from_torch(
+        #     attention_weights, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+        # )
+        attention_weights = ttnn.softmax(attention_weights, -1)
 
         attention_weights = ttnn.reshape(
             attention_weights, (bs, num_query, self.num_heads, self.num_bev_queue, self.num_levels, self.num_points)

--- a/models/experimental/vadv2/tt/tt_utils.py
+++ b/models/experimental/vadv2/tt/tt_utils.py
@@ -53,6 +53,7 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
     )
 
     output = output * attention_weights
+    ttnn.reallocate(output)
     output = ttnn.sum(output, 3)
     output = ttnn.reshape(output, [bs, num_heads * embed_dims, num_queries])
     output = ttnn.permute(output, (0, 2, 1))

--- a/models/experimental/vadv2/tt/tt_utils.py
+++ b/models/experimental/vadv2/tt/tt_utils.py
@@ -38,6 +38,7 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
         value_l_ = ttnn.to_layout(value_l_, layout=ttnn.ROW_MAJOR_LAYOUT)
         sampling_value_l_ = ttnn.grid_sample(value_l_, sampling_grid_l_)
         ttnn.deallocate(value_l_)
+        ttnn.deallocate(sampling_grid_l_)
         sampling_value_l_ = ttnn.permute(sampling_value_l_, (0, 3, 1, 2))
 
         sampling_value_list.append(sampling_value_l_)
@@ -47,22 +48,20 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
         attention_weights = ttnn.reshape(attention_weights, [bs * num_heads, 1, num_queries, num_levels * num_points])
 
     output = ttnn.stack(sampling_value_list, -2)
-
+    ttnn.deallocate(sampling_grids)
     output = ttnn.reshape(
         output, [output.shape[0], output.shape[1], output.shape[2], output.shape[3] * output.shape[4]]
     )
 
     output = output * attention_weights
     ttnn.reallocate(output)
+    for val in sampling_value_list:
+        ttnn.deallocate(val)
     output = ttnn.sum(output, 3)
     output = ttnn.reshape(output, [bs, num_heads * embed_dims, num_queries])
     output = ttnn.permute(output, (0, 2, 1))
 
-    for level, (H_, W_) in enumerate(value_spatial_shapes):
-        ttnn.deallocate(sampling_value_list[level])
-
     ttnn.deallocate(attention_weights)
-    ttnn.deallocate(sampling_grids)
     ttnn.deallocate(sampling_value_l_)
     ttnn.deallocate(value)
 

--- a/models/experimental/vadv2/tt/tt_utils.py
+++ b/models/experimental/vadv2/tt/tt_utils.py
@@ -54,11 +54,13 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
     )
 
     output = output * attention_weights
-    ttnn.reallocate(output)
+    output = ttnn.reallocate(output)
     for val in sampling_value_list:
         ttnn.deallocate(val)
     output = ttnn.sum(output, 3)
+    output = ttnn.reallocate(output)
     output = ttnn.reshape(output, [bs, num_heads * embed_dims, num_queries])
+    output = ttnn.reallocate(output)
     output = ttnn.permute(output, (0, 2, 1))
 
     ttnn.deallocate(attention_weights)

--- a/models/experimental/vadv2/tt/tt_utils.py
+++ b/models/experimental/vadv2/tt/tt_utils.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-import torch.nn.functional as F
 
 
 def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations, attention_weights, device):
@@ -34,12 +33,14 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
                 sampling_grid_l_.shape[4],
             ],
         )
-        value_l_ = ttnn.to_torch(value_l_).float()
-        sampling_grid_l_ = ttnn.to_torch(sampling_grid_l_).float()
-        sampling_value_l_ = F.grid_sample(
-            value_l_, sampling_grid_l_, mode="bilinear", padding_mode="zeros", align_corners=False
-        )
-        sampling_value_l_ = ttnn.from_torch(sampling_value_l_, device=device, dtype=ttnn.bfloat16)
+
+        value_l_ = ttnn.permute(value_l_, (0, 2, 3, 1))
+        value_l_ = ttnn.to_layout(value_l_, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        sampling_value_l_ = ttnn.grid_sample(value_l_, sampling_grid_l_)
+        ttnn.deallocate(value_l_)
+        sampling_value_l_ = ttnn.permute(sampling_value_l_, (0, 3, 1, 2))
+
         sampling_value_list.append(sampling_value_l_)
 
         attention_weights = ttnn.permute(attention_weights, (0, 2, 1, 3, 4))
@@ -47,14 +48,19 @@ def multi_scale_deformable_attn(value, value_spatial_shapes, sampling_locations,
         attention_weights = ttnn.reshape(attention_weights, [bs * num_heads, 1, num_queries, num_levels * num_points])
 
     output = ttnn.stack(sampling_value_list, -2)
+
+    for level, (H_, W_) in enumerate(value_spatial_shapes):
+        ttnn.deallocate(sampling_value_list[level])
+
     output = ttnn.reshape(
         output, [output.shape[0], output.shape[1], output.shape[2], output.shape[3] * output.shape[4]]
     )
+
     output = output * attention_weights
     output = ttnn.sum(output, 3)
     output = ttnn.reshape(output, [bs, num_heads * embed_dims, num_queries])
     output = ttnn.permute(output, (0, 2, 1))
-    # ttnn.deallocate(attention_weights)
+    ttnn.deallocate(attention_weights)
     ttnn.deallocate(sampling_grids)
     ttnn.deallocate(sampling_value_l_)
     ttnn.deallocate(value)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21608

### Problem description

- OOM issue observed with the latest main.
- Usage of torch.grid_sample in the model.

### What's Changed

- Resolved the OOM issue.
- Replaced torch.grid_sample with ttnn.grid_sample.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/17539978476)