### PR TITLE
#27364: Add support for Width Sharded Padded Slice

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -263,10 +263,13 @@ Result conv2d_DRAM(
         device);
 
     uint32_t slice_rounding_value = 1;
-    if (conv_config.output_layout == tt_metal::Layout::TILE) {
+    if (conv_config.output_layout == tt_metal::Layout::TILE &&
+        dram_slice_config.slice_type == Conv2dSliceConfig::SliceType::WIDTH) {
         // In Conv2d DRAM with Outputs in Tile layout, we need to round the slice size to a multiple of TILE_HEIGHT.
         slice_rounding_value = tt::constants::TILE_HEIGHT;
     }
+    uint32_t width_rounding_value =
+        (conv_config.output_layout == tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
 
     bool first_run = true;
     const uint32_t min_output_slice_size =
@@ -360,8 +363,8 @@ Result conv2d_DRAM(
         const uint32_t output_slice_height = output_slice_height_end - output_slice_height_start;
 
         uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
-        if (output_slice_width % slice_rounding_value != 0) {
-            additional_padded_width = slice_rounding_value - (output_slice_width % slice_rounding_value);
+        if (output_slice_width % width_rounding_value != 0) {
+            additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
             log_trace(
                 LogOp,
                 "Conv2d DRAM Slicing: Slice {}: Additional padding of {} added to the right side.",
@@ -409,35 +412,25 @@ Result conv2d_DRAM(
 
         TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
 
-        Tensor sliced_input_tensor;
-        if (conv_config.shard_layout.value() == TensorMemoryLayout::WIDTH_SHARDED) {
-            sliced_input_tensor = ttnn::slice(
-                queue_id,
-                input_tensor_on_device,
-                ttnn::SmallVector<uint32_t>{0, input_slice_height_start, input_slice_width_start, 0},  // Start
-                ttnn::SmallVector<uint32_t>{batch_size, input_slice_height_end, input_slice_width_end, in_channels},
-                ttnn::SmallVector<uint32_t>{1, 1, 1, 1}  // Step
-            );
-        } else {
-            auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
-                conv_config,
-                batch_size,
-                ttnn::Shape({batch_size, input_slice_height, input_slice_width, in_channels}),
-                ttnn::Shape({batch_size, output_slice_height, output_slice_width, out_channels}),
-                mm_conv,
-                compute_grid_size,
-                // Setting layout to TILE forces input_channels_alignment to 32.
-                //  The padded_slice op needs aligned reads from L1.
-                Layout::TILE));
+        auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
+            conv_config,
+            batch_size,
+            ttnn::Shape({batch_size, input_slice_height, input_slice_width, in_channels}),
+            ttnn::Shape({batch_size, output_slice_height, output_slice_width, out_channels}),
+            mm_conv,
+            compute_grid_size,
+            // Setting layout to TILE forces input_channels_alignment to 32.
+            //  The padded_slice op needs aligned reads from L1.
+            Layout::TILE));
 
-            sliced_input_tensor = ttnn::experimental::padded_slice(
-                queue_id,
-                input_tensor_on_device,
-                ttnn::SmallVector<uint32_t>{0, input_slice_height_start, input_slice_width_start, 0},  // Start
-                ttnn::SmallVector<uint32_t>{batch_size, input_slice_height_end, input_slice_width_end, in_channels},
-                ttnn::SmallVector<uint32_t>{1, 1, 1, 1},  // Step
-                sliced_input_tensor_memory_config);
-        }
+        Tensor sliced_input_tensor = ttnn::experimental::padded_slice(
+            queue_id,
+            input_tensor_on_device,
+            ttnn::SmallVector<uint32_t>{0, input_slice_height_start, input_slice_width_start, 0},  // Start
+            ttnn::SmallVector<uint32_t>{batch_size, input_slice_height_end, input_slice_width_end, in_channels},
+            ttnn::SmallVector<uint32_t>{1, 1, 1, 1},  // Step
+            sliced_input_tensor_memory_config);
+
         auto conv_config_l1 = conv_config;
         conv_config_l1.deallocate_activation = true;
         conv_config_l1.reallocate_halo_output = true;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_op.cpp
@@ -75,6 +75,9 @@ std::vector<ttnn::TensorSpec> PaddedSliceDeviceOperation::compute_output_specs(
     if (this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
         auto output_shard_shape = this->output_mem_config.shard_spec().value().shape;
         out_shape[out_shape.size() - 1] = output_shard_shape[1];
+    } else if (this->output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto output_shard_shape = this->output_mem_config.shard_spec().value().shape;
+        out_shape[out_shape.size() - 2] = output_shard_shape[0];
     }
 
     ttnn::Shape output_tensor_shape(std::move(out_shape));

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -68,6 +68,8 @@ get_padded_slice_runtime_args_rm_sharded_output(
 
     bool rm_orientation = output_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     bool is_block_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    bool is_width_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+
     uint32_t num_cores_channels = get_num_cores_channels_from_sharded_tensor(output_tensor);
     uint32_t input_page_size = input_shape[-1] * input_tensor.element_size();
     uint32_t input_row_size_bytes = tt::div_up(input_shape[-1], num_cores_channels) * input_tensor.element_size();
@@ -153,6 +155,9 @@ get_padded_slice_runtime_args_rm_sharded_output(
         if (is_block_sharded) {
             core_w_index = rm_orientation ? core.x : core.y;
             core_h_index = rm_orientation ? core.y : core.x;
+        } else if (is_width_sharded) {
+            core_h_index = 0;
+            core_w_index = core_index;
         }
 
         const uint32_t num_sticks_written = core_h_index * num_sticks_per_core;
@@ -366,16 +371,10 @@ get_padded_slice_runtime_args_tile_sharded_output(
 
     bool rm_orientation = output_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     bool is_block_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    uint32_t num_cores_channels = 1;
-    auto total_cores = output_shard_spec.grid;
-    if (is_block_sharded) {
-        if (rm_orientation) {
-            num_cores_channels = total_cores.bounding_box().grid_size().x;
-        } else {
-            num_cores_channels = total_cores.bounding_box().grid_size().y;
-        }
-    }
+    bool is_width_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
+    uint32_t num_cores_channels = get_num_cores_channels_from_sharded_tensor(output_tensor);
+    log_info(tt::LogOp, "Num Cores Channels = {}", num_cores_channels);
     uint32_t num_tiles_per_channel = tt::div_up(input_padded_shape[3], tt::constants::TILE_WIDTH);
     num_tiles_per_channel = tt::div_up(num_tiles_per_channel, num_cores_channels);
     TT_FATAL(
@@ -479,6 +478,9 @@ get_padded_slice_runtime_args_tile_sharded_output(
         if (is_block_sharded) {
             core_w_index = rm_orientation ? core.x : core.y;
             core_h_index = rm_orientation ? core.y : core.x;
+        } else if (is_width_sharded) {
+            core_h_index = 0;
+            core_w_index = core_index;
         }
 
         const uint32_t num_sticks_written_start = core_h_index * num_sticks_per_core;


### PR DESCRIPTION
### Ticket
#27364 

### Problem description
Padded slice doesn't support Width Sharded outputs. This causes the conv dram auto slicing to fail as it estimates L1 usage incorrectly.

### What's changed
Added support for Width Sharded outputs to padded_slice. This reduces L1 usage in Conv DRAM, and fixes auto slice OOM issues. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17407899259)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17323266716) (if applicable)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17425808064)
- [x] Frequent models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17425812995)
- [x] New/Existing tests provide coverage for changes