### PR TITLE
Many mostly small fixes and DeepSeek

### DIFF
--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -14,6 +14,15 @@ This codebase was designed for the model: [deepseek-ai/DeepSeek-R1-0528](https:/
 - Installed: [TT-Metalium™ / TT-NN™](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
 
 ## How to Run
+
+If you are not running on Tenstorrent internal infrastructure, you need to set the following environment variables:
+
+- `DEEPSEEK_V3_CACHE`: Path to a directory where cached data such as converted weights and test inputs/outputs will be stored.
+
+- `DEEPSEEK_V3_HF_MODEL`: Path to a directory containing the DeepSeek-V3 Hugging Face model weights. Defaults to `models/demos/deepseek_v3/reference`. Download the model from Hugging Face set this to the model directory.
+
+These variables are used in scripts for generating test data and running tests.
+
 This codebase separates model execution into three distinct stages, each of which can be run independently:
 1. Convert PyTorch weights to TTNN tensor files and generate the WeightConfig
 2. Generate ModelConfigs for prefill and decode modes

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -282,7 +282,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
 
     @classmethod
     @abstractmethod
-    def forward_mlp_decode(cls, x: ttnn.Tensor, row_idx: int, cfg: RunPrefillConfig) -> ttnn.Tensor:
+    def forward_mlp_decode(cls, x: ttnn.Tensor, row_idx: int, cfg: RunDecodeConfig) -> ttnn.Tensor:
         """
         Forward pass for the MLP component during prefill.
         This method should be implemented by subclasses to handle specific MLP configurations.

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block.py
@@ -57,7 +57,7 @@ class MoEDecoderBlock(DecoderBlockBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
-        is_padding_layer: tuple[bool, ...],
+        is_padding_layer: tuple[bool, ...] | None,
     ) -> ModelPrefillConfig:
         assert mesh_device.shape[0] == len(
             is_padding_layer
@@ -89,7 +89,7 @@ class MoEDecoderBlock(DecoderBlockBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
-        is_padding_layer: tuple[bool, ...],
+        is_padding_layer: tuple[bool, ...] | None,
     ) -> ModelDecodeConfig:
         assert mesh_device.shape[0] == len(
             is_padding_layer

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -213,7 +213,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         }
 
     @classmethod
-    def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         x = ttnn.experimental.all_gather_async(x, **cfg["revert_tp"])
 
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
@@ -282,9 +282,9 @@ class MoE(SharedStateAddOn, AbstractModule):
         return post_combine_output_tensor
 
     @classmethod
-    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    def forward_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
         return cls.forward(x, cfg)
 
     @classmethod
-    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
         return cls.forward(x, cfg)

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -197,6 +197,6 @@ class DistributedRMSNorm(RMSNormBase):
             program_config=program_config,
             **cfg["rms_norm_post_all_gather"],
         )
-        ttnn.deallocate(tt_stats)
+        ttnn.deallocate(tt_gathered_stats)
 
         return tt_out

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -47,7 +47,7 @@ class DistributedRMSNorm(RMSNormBase):
     ) -> WeightConfig:
         torch_metaweight = get_state_dicts(state_dicts, "weight", shape=(hf_config.hidden_size,), dtype=torch.bfloat16)
         num_shards = torch_metaweight.shape[0]
-        assert num_shards == mesh_device.shape[0], "Number of state dictsdoes not match the number of rows."
+        assert num_shards == mesh_device.shape[0], "Number of state dicts does not match the number of rows."
 
         tt_weight = ttnn.as_tensor(
             torch_metaweight.reshape(

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -81,4 +81,4 @@ class RMSNorm(RMSNormBase):
             Output tensor after embedding lookup
         """
         pc = cls._get_pc(x.memory_config())
-        return ttnn.rms_norm(x, program_config=cls._get_pc(x.memory_config()), **cfg)
+        return ttnn.rms_norm(x, program_config=pc, **cfg)

--- a/models/demos/deepseek_v3/utils/composite_ops.py
+++ b/models/demos/deepseek_v3/utils/composite_ops.py
@@ -62,8 +62,8 @@ def mesh_scatter(
         for row_scatter_idx in range(num_mesh_rows):
             ttnn.point_to_point(
                 tensor,
-                ttnn.MeshCoordinate(to_col_scatter_idx, row_scatter_idx),
-                ttnn.MeshCoordinate(from_col_scatter_idx, row_scatter_idx),
+                ttnn.MeshCoordinate(row_scatter_idx, to_col_scatter_idx),
+                ttnn.MeshCoordinate(row_scatter_idx, from_col_scatter_idx),
                 ttnn.Topology.Linear,
                 per_row_semaphore,
                 optional_output_tensor=tensor,

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -122,7 +122,7 @@ class AllGatherAsyncConfig(OpConfigBase):
     memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None
     subdevice_id: ttnn._ttnn.device.SubDeviceId | None = None
     use_optimal_ccl_for_llama: bool | None = None
-    barrier_semaphore: ttnn._ttnn.global_semaphore.global_sempahore | None = None
+    barrier_semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
 
 
 @dataclass
@@ -147,7 +147,7 @@ class PointToPointConfig(OpConfigBase):
     receiver_coord: ttnn.MeshCoordinate | None = None
     sender_coord: ttnn.MeshCoordinate | None = None
     topology: ttnn.Topology = ttnn.Topology.Linear
-    semaphore: ttnn._ttnn.global_semaphore.global_sempahore | None = None
+    semaphore: ttnn._ttnn.global_semaphore.global_semaphore | None = None
     optional_output_tensor: ttnn.Tensor | None = None
 
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -594,7 +594,7 @@ def save_and_get_path(path, tensor):
     )  # TODO: bring regular tensor saving back once Issue #26763 is resolved
 
 
-def get_mesh_coords(mesh_shape: list[int], row: int = None, col: int = None) -> set[ttnn.MeshCoordinate]:
+def get_mesh_coords(mesh_shape: list[int], row: int = None, col: int = None) -> list[ttnn.MeshCoordinate]:
     """Get mesh coordinates for a given mesh shape and optional row and column indices."""
     if row:
         assert 0 <= row < mesh_shape[0], "Row index out of bounds"

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -6,6 +6,7 @@ from itertools import takewhile
 from typing import Any, Sequence
 
 import torch
+from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import fields, is_dataclass
 from enum import Enum
 from types import NoneType
-from typing import Any, Callable, overload
+from typing import Any, overload
 
 from loguru import logger
 

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -16,9 +16,9 @@ from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, Me
 MESH_DEVICE_STATE_DICT_KEY = "mesh_device"
 
 WeightConfig = (
-    dict[str, "WeightConfig | SavedTensor | None"]
-    | list["WeightConfig | SavedTensor | None"]
-    | tuple["WeightConfig | SavedTensor | None"]  # TODO: bring regular tensor saving back once Issue #26763 is resolved
+    dict[str, "WeightConfig | SavedWeight | None"]
+    | list["WeightConfig | SavedWeight | None"]
+    | tuple["WeightConfig | SavedWeight | None"]  # TODO: bring regular tensor saving back once Issue #26763 is resolved
 )
 
 _PRIMITIVE_COPYABLE_TYPES = bool | int | float | complex | str | bytes | None | Enum

--- a/models/experimental/stable_diffusion_35_large/tt/parallel_config.py
+++ b/models/experimental/stable_diffusion_35_large/tt/parallel_config.py
@@ -28,9 +28,9 @@ class VAEParallelConfig:
     def __init__(
         self,
         device: ttnn.MeshDevice,
-        new_gather_handles: list[ttnn._ttnn.global_semaphore.global_sempahore],
-        reduce_from_semaphore: ttnn._ttnn.global_semaphore.global_sempahore,
-        reduce_to_semaphore: ttnn._ttnn.global_semaphore.global_sempahore,
+        new_gather_handles: list[ttnn._ttnn.global_semaphore.global_semaphore],
+        reduce_from_semaphore: ttnn._ttnn.global_semaphore.global_semaphore,
+        reduce_to_semaphore: ttnn._ttnn.global_semaphore.global_semaphore,
         num_links: int,
     ):
         self.device = device

--- a/ttnn/cpp/ttnn-pybind/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn-pybind/global_semaphore.cpp
@@ -16,7 +16,7 @@
 namespace ttnn::global_semaphore {
 
 void py_module_types(py::module& module) {
-    py::class_<GlobalSemaphore, std::shared_ptr<GlobalSemaphore>>(module, "global_sempahore");
+    py::class_<GlobalSemaphore, std::shared_ptr<GlobalSemaphore>>(module, "global_semaphore");
 }
 
 void py_module(py::module& module) {


### PR DESCRIPTION
### What's changed
Global:
- Correct typo “global_sempahore” → “global_semaphore” in ttnn and downstream uses!

DeepSeek:
- utils/config_helpers.py: Add missing from loguru import logger to fix NameError in save_and_get_path.
- tt/rms_norm/distributed_rms_norm.py: Fix double-free by deallocating tt_gathered_stats (not tt_stats) after rms_norm_post_all_gather.
- utils/composite_ops.py: Correct MeshCoordinate row/col ordering in mesh_scatter’s column-scatter path.
- utils/run_config.py: Replace nonexistent SavedTensor with SavedWeight in WeightConfig typing.
- utils/run_config.py: Remove duplicate Callable import; use collections.abc.Callable consistently.
- tt/moe.py: Correct forward return type annotation to ttnn.Tensor (single tensor returned).
- tt/decoder_block/decoder_block_base.py: Fix forward_mlp_decode signature to accept RunDecodeConfig.
- tt/rms_norm/rms_norm.py: Remove unused pc and pass the computed program_config to ttnn.rms_norm.
- utils/config_helpers.py: Fix get_mesh_coords return type annotation to list[ttnn.MeshCoordinate] to match actual return.
- tt/rms_norm/distributed_rms_norm.py: Fix typo in assert message.
- tt/model_1d.py: Allow optional is_padding_layer in decode_model_config (or pass proper tuple) to match usage.

### Checklist
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yieldthought%2Fds-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yieldthought%2Fds-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml)
- [x] [![(TG) TG DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fds-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-deepseek-tests.yaml)