### PR TITLE
Fix the reversed assertion in addrgen_api that caused watcher errors when using the new APIs

### DIFF
--- a/tt_metal/fabric/hw/inc/linear/addrgen_api.h
+++ b/tt_metal/fabric/hw/inc/linear/addrgen_api.h
@@ -69,7 +69,7 @@ FORCE_INLINE uint64_t get_noc_address(const AddrGenType& d, const uint32_t id, u
 static constexpr uint32_t max_fabric_addrgen_payload_size = 4532;
 
 FORCE_INLINE void validate_max_payload_size(uint32_t payload_size) {
-    ASSERT((payload_size > max_fabric_addrgen_payload_size));
+    ASSERT((payload_size <= max_fabric_addrgen_payload_size));
     if ((payload_size > max_fabric_addrgen_payload_size)) {
         WAYPOINT("HUNG");
         // hang to prompt investigation


### PR DESCRIPTION
### Ticket
Fix the reversed assertion in addrgen_api that caused watcher errors when using the new APIs
### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes