### PR TITLE
negative prompt enabled

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -23,6 +23,7 @@ def run_demo_inference(
     ttnn_device,
     is_ci_env,
     prompts,
+    negative_prompt,
     num_inference_steps,
     vae_on_device,
     encoders_on_device,
@@ -40,6 +41,8 @@ def run_demo_inference(
 
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
     prompts = prompts + [""] * needed_padding
+
+    assert isinstance(negative_prompt, str), "negative_prompt must be a string"
 
     # 1. Load components
     profiler.start("diffusion_pipeline_from_pretrained")
@@ -74,7 +77,7 @@ def run_demo_inference(
         negative_prompt_embeds_torch,
         pooled_prompt_embeds_torch,
         negative_pooled_prompt_embeds_torch,
-    ) = tt_sdxl.encode_prompts(prompts)
+    ) = tt_sdxl.encode_prompts(prompts, negative_prompt)
 
     tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
         prompt_embeds_torch,
@@ -155,6 +158,10 @@ def run_demo_inference(
     (("An astronaut riding a green horse"),),
 )
 @pytest.mark.parametrize(
+    "negative_prompt",
+    ((""),),
+)
+@pytest.mark.parametrize(
     "num_inference_steps",
     ((50),),
 )
@@ -190,6 +197,7 @@ def test_demo(
     mesh_device,
     is_ci_env,
     prompt,
+    negative_prompt,
     num_inference_steps,
     vae_on_device,
     encoders_on_device,
@@ -201,6 +209,7 @@ def test_demo(
         mesh_device,
         is_ci_env,
         prompt,
+        negative_prompt,
         num_inference_steps,
         vae_on_device,
         encoders_on_device,

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -23,7 +23,7 @@ def run_demo_inference(
     ttnn_device,
     is_ci_env,
     prompts,
-    negative_prompt,
+    negative_prompts,
     num_inference_steps,
     vae_on_device,
     encoders_on_device,
@@ -40,12 +40,12 @@ def run_demo_inference(
         prompts = [prompts]
 
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
-    if isinstance(negative_prompt, list):
-        assert len(negative_prompt) == len(prompts), "prompts and negative_prompt lists must be the same length"
+    if isinstance(negative_prompts, list):
+        assert len(negative_prompts) == len(prompts), "prompts and negative_prompt lists must be the same length"
 
     prompts = prompts + [""] * needed_padding
-    if isinstance(negative_prompt, list):
-        negative_prompt = negative_prompt + [""] * needed_padding
+    if isinstance(negative_prompts, list):
+        negative_prompts = negative_prompts + [""] * needed_padding
 
     # 1. Load components
     profiler.start("diffusion_pipeline_from_pretrained")
@@ -80,7 +80,7 @@ def run_demo_inference(
         negative_prompt_embeds_torch,
         pooled_prompt_embeds_torch,
         negative_pooled_prompt_embeds_torch,
-    ) = tt_sdxl.encode_prompts(prompts, negative_prompt)
+    ) = tt_sdxl.encode_prompts(prompts, negative_prompts)
 
     tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
         prompt_embeds_torch,

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -40,9 +40,12 @@ def run_demo_inference(
         prompts = [prompts]
 
     needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
-    prompts = prompts + [""] * needed_padding
+    if isinstance(negative_prompt, list):
+        assert len(negative_prompt) == len(prompts), "prompts and negative_prompt lists must be the same length"
 
-    assert isinstance(negative_prompt, str), "negative_prompt must be a string"
+    prompts = prompts + [""] * needed_padding
+    if isinstance(negative_prompt, list):
+        negative_prompt = negative_prompt + [""] * needed_padding
 
     # 1. Load components
     profiler.start("diffusion_pipeline_from_pretrained")
@@ -159,7 +162,7 @@ def run_demo_inference(
 )
 @pytest.mark.parametrize(
     "negative_prompt",
-    ((""),),
+    ((None),),
 )
 @pytest.mark.parametrize(
     "num_inference_steps",

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -179,7 +179,6 @@ def batch_encode_prompt_on_device(
     num_devices = ttnn_device.get_num_devices()
     assert len(prompt) == num_devices, "Prompt length must be equal to number of devices"
     assert prompt_2 is None, "Prompt 2 is not supported currently"
-    assert negative_prompt is None, "Negative prompt is not tested currently with on device text encoders"
     assert lora_scale is None, "Lora scale is not supported currently with on device text encoders"
     assert clip_skip is None, "Clip skip is not supported currently with on device text encoders"
     assert prompt_embeds is None, "Prompt embeds is not supported currently with on device text encoders"

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -33,6 +33,10 @@ OUT_ROOT, RESULTS_FILE_NAME = "test_reports", "sdxl_test_results.json"
     ((8.0),),
 )
 @pytest.mark.parametrize(
+    "negative_prompt",
+    (("normal quality, low quality, worst quality, low res, blurry, nsfw, nude"),),
+)
+@pytest.mark.parametrize(
     "vae_on_device",
     [
         (True),
@@ -69,6 +73,7 @@ def test_accuracy_sdxl(
     coco_statistics_path,
     evaluation_range,
     guidance_scale,
+    negative_prompt,
 ):
     start_from, num_prompts = evaluation_range
 
@@ -84,6 +89,7 @@ def test_accuracy_sdxl(
         mesh_device,
         is_ci_env,
         prompts,
+        negative_prompt,
         num_inference_steps,
         vae_on_device,
         encoders_on_device,
@@ -124,6 +130,8 @@ def test_accuracy_sdxl(
             "num_inference_steps": num_inference_steps,
             "start_from": start_from,
             "num_prompts": num_prompts,
+            "negative_prompt": negative_prompt,
+            "guidance_scale": guidance_scale,
             "model_name": "sdxl",
         },
         "benchmarks_summary": [

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -162,7 +162,7 @@ class TtSDXLPipeline(LightweightModule):
 
             self.image_processing_compiled = True
 
-    def encode_prompts(self, prompts):
+    def encode_prompts(self, prompts, negative_prompt):
         # Encode prompts using the text encoders.
 
         if self.pipeline_config.encoders_on_device:
@@ -184,7 +184,7 @@ class TtSDXLPipeline(LightweightModule):
                     device=self.cpu_device,
                     num_images_per_prompt=1,
                     do_classifier_free_guidance=True,
-                    negative_prompt=None,
+                    negative_prompt=negative_prompt,
                     negative_prompt_2=None,
                     prompt_embeds=None,
                     negative_prompt_embeds=None,
@@ -225,7 +225,7 @@ class TtSDXLPipeline(LightweightModule):
                 device=self.cpu_device,
                 num_images_per_prompt=1,
                 do_classifier_free_guidance=True,
-                negative_prompt=None,
+                negative_prompt=negative_prompt,
                 negative_prompt_2=None,
                 prompt_embeds=None,
                 negative_prompt_embeds=None,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -162,7 +162,7 @@ class TtSDXLPipeline(LightweightModule):
 
             self.image_processing_compiled = True
 
-    def encode_prompts(self, prompts, negative_prompt):
+    def encode_prompts(self, prompts, negative_prompts):
         # Encode prompts using the text encoders.
 
         if self.pipeline_config.encoders_on_device:
@@ -175,7 +175,9 @@ class TtSDXLPipeline(LightweightModule):
             for i in range(0, len(prompts), self.batch_size):
                 batch_prompts = prompts[i : i + self.batch_size]
                 current_negative_prompts = (
-                    negative_prompt[i : i + self.batch_size] if isinstance(negative_prompt, list) else negative_prompt
+                    negative_prompts[i : i + self.batch_size]
+                    if isinstance(negative_prompts, list)
+                    else negative_prompts
                 )
                 batch_embeds = batch_encode_prompt_on_device(
                     self.torch_pipeline,
@@ -228,7 +230,7 @@ class TtSDXLPipeline(LightweightModule):
                 device=self.cpu_device,
                 num_images_per_prompt=1,
                 do_classifier_free_guidance=True,
-                negative_prompt=negative_prompt,
+                negative_prompt=negative_prompts,
                 negative_prompt_2=None,
                 prompt_embeds=None,
                 negative_prompt_embeds=None,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -174,6 +174,9 @@ class TtSDXLPipeline(LightweightModule):
             all_embeds = []
             for i in range(0, len(prompts), self.batch_size):
                 batch_prompts = prompts[i : i + self.batch_size]
+                current_negative_prompts = (
+                    negative_prompt[i : i + self.batch_size] if isinstance(negative_prompt, list) else negative_prompt
+                )
                 batch_embeds = batch_encode_prompt_on_device(
                     self.torch_pipeline,
                     self.tt_text_encoder,
@@ -184,7 +187,7 @@ class TtSDXLPipeline(LightweightModule):
                     device=self.cpu_device,
                     num_images_per_prompt=1,
                     do_classifier_free_guidance=True,
-                    negative_prompt=negative_prompt,
+                    negative_prompt=current_negative_prompts,
                     negative_prompt_2=None,
                     prompt_embeds=None,
                     negative_prompt_embeds=None,


### PR DESCRIPTION
### Problem description
We need to enable negative prompt support

### What's changed
added support for negative prompt

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17397017987) passed
- [x] [N300 accuracy run (device_vae is only fixed)](https://github.com/tenstorrent/tt-shield/actions/runs/17396405651) passed
- [x] [N150 accuracy run (device_vae is only fixed)](https://github.com/tenstorrent/tt-shield/actions/runs/17396399020) passed
- [x] [Single card demo tests - sdxl only](https://github.com/tenstorrent/tt-metal/actions/runs/17397004419) passed
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17397013995) failed same fails as on main