### PR TITLE
Softmax - Enable FP32 Reduction

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 from models.utility_functions import skip_for_wormhole_b0, is_grayskull
 from models.utility_functions import torch_random
 
@@ -457,3 +457,39 @@ def test_softmax_dtypes(device, shape, dim, dtype):
     ttnn_output = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_output, ttnn_output, 0.997)
+
+
+@pytest.mark.parametrize(
+    "accuracy_config",
+    [
+        (True, False, 3),
+        (False, True, 11),
+        (True, True, 9),
+        (False, False, 7),
+    ],
+)
+@pytest.mark.parametrize("shape", [(1, 1, 16384, 256)])
+def test_softmax_accuracy(device, shape, accuracy_config):
+    torch.manual_seed(0)
+
+    # Reference output
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    torch_output = torch.ops.aten._softmax.default(torch_tensor, dim=-1, half_to_float=False)
+
+    # TTNN Softmax
+    fp32_acc_en, math_approx_mode, expected_ulp = accuracy_config
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=math_approx_mode,
+        fp32_dest_acc_en=fp32_acc_en,
+        packer_l1_acc=True,
+    )
+
+    ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_output = ttnn.softmax(ttnn_tensor, dim=-1, compute_kernel_config=compute_kernel_config)
+
+    ttnn_output = ttnn.to_layout(ttnn_output, ttnn.ROW_MAJOR_LAYOUT)
+    output_torch = ttnn_output.cpu().to_torch()
+
+    assert_with_ulp(torch_output, output_torch, expected_ulp)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -106,7 +106,6 @@ void MAIN {
     bool wait_mask = true;
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
 #if FUSED_SCALE_MASK
-        DPRINT << "DOING FUSED_SCALE_MASK" << ENDL();
         reconfig_data_format(cb_in0, cb_fused_scale);
         pack_reconfig_data_format(cb_scale_mask);
         mul_tiles_bcast_scalar_init_short(cb_in0, cb_fused_scale);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp
@@ -441,12 +441,12 @@ void reduce_cb(
 
     reconfig_data_format(cb_in, cb_scaler);
     pack_reconfig_data_format(cb_out);
-    reduce_init<reduce_type, ReduceDim::REDUCE_ROW>(cb_in, cb_scaler, cb_out);
+    reduce_init<reduce_type, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_in, cb_scaler, cb_out);
     tile_regs_acquire();
     cb_reserve_back(cb_out, 1);
     for (uint32_t cur_tile = 0; cur_tile < cb_length_t; cur_tile++) {
         cb_wait_front(cb_in, 1);
-        reduce_tile<reduce_type, ReduceDim::REDUCE_ROW>(cb_in, cb_scaler, 0, 0, 0);
+        reduce_tile<reduce_type, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_in, cb_scaler, 0, 0, 0);
         cb_pop_front(cb_in, 1);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -201,13 +201,13 @@ void MAIN {
 
         // sum(exp(x))
         ACQ();
-        reduce_init(cb_exps, cb_bcast_scaler, cb_recipsumexps);
+        reduce_init<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_exps, cb_bcast_scaler, cb_recipsumexps);
         cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);
         for (uint32_t w = 0; w < block_w; w++) {
             constexpr uint32_t bcast_scaler0 = 0;
-            reduce_tile(cb_exps, cb_bcast_scaler, w, bcast_scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, ENABLE_FP32_DEST_ACC>(cb_exps, cb_bcast_scaler, w, bcast_scaler0, dst0);
         }
         reduce_uninit();
         recip_tile_init();

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -776,6 +776,8 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_c
         softmax_defines["NUMERIC_STABLE"] = "1";
     }
     softmax_defines["EXP_APPROX"] = math_approx_mode ? "1" : "0";
+    softmax_defines["ENABLE_FP32_DEST_ACC"] = fp32_dest_acc_en ? "1" : "0";
+
     auto softmax_kernels_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp",

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -222,6 +222,8 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     // if wtpc >= Ht then tpc should be a multiple of Ht
 
     softmax_defines["EXP_APPROX"] = math_approx_mode ? "1" : "0";
+    softmax_defines["ENABLE_FP32_DEST_ACC"] = fp32_dest_acc_en ? "1" : "0";
+
     std::string softmax_kernel_path =
         use_large_kernel
             ? "ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_large_tensor.cpp"

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -198,20 +198,6 @@ tt::tt_metal::operation::ProgramWithCallbacks Softmax::create_program(
         this->program_config);
 }
 
-tt::tt_metal::operation::Hash Softmax::compute_program_hash(
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    return tt::tt_metal::operation::hash_operation<Softmax>(
-        input_tensors.at(0).memory_config(),
-        input_tensors.at(0).dtype(),
-        input_tensors.at(0).padded_shape(),
-        optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().memory_config()}
-                                                 : std::nullopt,
-        optional_input_tensors.at(0).has_value() ? std::optional{optional_input_tensors.at(0).value().dtype()}
-                                                 : std::nullopt,
-        this->output_mem_config);
-}
-
 Tensor softmax_in_place(
     Tensor& input_tensor,
     const SoftmaxProgramConfig& program_config,

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.hpp
@@ -36,10 +36,6 @@ struct Softmax {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
-
-    tt::tt_metal::operation::Hash compute_program_hash(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
 };
 
 tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(


### PR DESCRIPTION
### Ticket
#25282

### Problem description
Computing softmax requires a reduction step, to sum up all the exp values. This step contributes error to the output of the op, which is causing noise within certain models.

Softmax still has a hashing implementation that needs to be cleaned out, as a follow up to #24311.

### What's changed
Adds the ability to force FP32 accumulation on this reduction. This adds the ability to improve accuracy at the expense of performance, as shown below.

| **FP32 Acc** | **Math Approx** | **FW Time (us)** | **Max ULP** | **Mean ULP** |
|:---:|:---:|:---:|:---:|:---:|
| No  | Yes | 98 | 18.0 | 2.92 |
| No  | No  | 223 | 7.0 | 0.95 |
| Yes | Yes | 96 | 18.0 | 2.77 |
| Yes | No  | 214 | 3.0 | 0.64 |

Manual hashing for softmax was removed as the default hashing is sufficient.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17408000619)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17332893836)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17406968218) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17406970622) 
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes