### PR TITLE
Add infra to run with 1x32 Mesh on Galaxy

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -122,7 +122,8 @@ jobs:
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
-          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="EdmFabric.RingDeadlockStabilityTest"
+          TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+          TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+
+Board: [
+  { name: Galaxy,
+    type: Mesh,
+    topology: [1, 32]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: Galaxy,
+  device_topology: [1, 32],
+  host_topology: [1, 1],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -21,6 +21,13 @@
 #include <vector>
 
 namespace tt::tt_fabric {
+// TODO: remove this once UMD provides API for UBB ID
+ struct UbbId {
+     std::uint32_t tray_id;
+     std::uint32_t asic_id;
+ };
+
+ UbbId get_ubb_id(chip_id_t chip_id);
 
 class FabricContext;
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -366,6 +366,29 @@ std::pair<std::unordered_map<chip_id_t, std::vector<chip_id_t>>, chip_id_t> sort
     return {adjacency_map, min_eth_chip->first};
 }
 
+std::pair<std::unordered_map<chip_id_t, std::vector<chip_id_t>>, chip_id_t> sort_adjacency_map_by_ubb_id(
+    const IntraMeshAdjacencyMap& topology_info) {
+    auto adjacency_map = topology_info.adjacency_map;
+    chip_id_t first_chip = 0;
+    for (auto& [chip_id, neighbors] : adjacency_map) {
+        auto ubb_id = tt::tt_fabric::get_ubb_id(chip_id);
+        if (ubb_id.tray_id == 1 && ubb_id.asic_id == 1) {
+            first_chip = chip_id;
+            break;
+        }
+    }
+
+    for (auto& [chip_id, neighbors] : adjacency_map) {
+        std::sort(neighbors.begin(), neighbors.end(), [&](chip_id_t a, chip_id_t b) {
+            auto ubb_id_a = tt::tt_fabric::get_ubb_id(a);
+            auto ubb_id_b = tt::tt_fabric::get_ubb_id(b);
+            return ubb_id_a.tray_id < ubb_id_b.tray_id ||
+                   (ubb_id_a.tray_id == ubb_id_b.tray_id && ubb_id_a.asic_id < ubb_id_b.asic_id);
+        });
+    }
+    return {adjacency_map, first_chip};
+}
+
 std::vector<chip_id_t> convert_1d_mesh_adjacency_to_row_major_vector(
     const IntraMeshAdjacencyMap& topology_info,
     std::optional<std::function<std::pair<AdjacencyMap, chip_id_t>(const IntraMeshAdjacencyMap&)>> graph_sorter) {
@@ -382,6 +405,14 @@ std::vector<chip_id_t> convert_1d_mesh_adjacency_to_row_major_vector(
         if (!graph_sorter.has_value()) {
             // Default behavior: sort adjacency map by Ethernet coordinates
             std::tie(adj_map, first_chip) = sort_adjacency_map_by_eth_coords(topology_info);
+        } else {
+            // User provided a sorting function. This is primarily done for testing.
+            std::tie(adj_map, first_chip) = graph_sorter.value()(topology_info);
+        }
+    } else if (cluster.get_board_type(0) == BoardType::UBB) {
+        if (!graph_sorter.has_value()) {
+            // Default behavior: sort adjacency map by Ethernet coordinates
+            std::tie(adj_map, first_chip) = sort_adjacency_map_by_ubb_id(topology_info);
         } else {
             // User provided a sorting function. This is primarily done for testing.
             std::tie(adj_map, first_chip) = graph_sorter.value()(topology_info);


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/27701

### Ticket
Link to Github Issue

### Problem description
Missing infra to run 1x32 Mesh on Galaxy

### What's changed
- add mesh graph descriptor for 1x32
- add sorting for UBBs by ubb_id
- consolidate get_ubb_id api to control_plane
- add tests and cleanup tests in tg-quick

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes