### PR TITLE
Added bh 1d and 2d mesh devices and updated the testing

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 10
+        default: 20
       build-artifact-name:
         required: true
         type: string
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-        timeout-minutes: 15
+        timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/conftest.py
+++ b/conftest.py
@@ -544,7 +544,11 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 
 
 @pytest.fixture(scope="function")
-def p150_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_params):
+def bh_1d_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_params):
+    # Generic blackhole configuration
+    # This creates a snake pattern on 2D meshes to appear as a long line or
+    # donut shaped ring in rackbox
+    # Not compatible with blackhole galaxy
     import ttnn
 
     if ttnn.get_num_devices() not in [1, 2, 4, 8]:
@@ -555,9 +559,43 @@ def p150_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_
     fabric_config = updated_device_params.pop("fabric_config", None)
     reliability_mode = updated_device_params.pop("reliability_mode", None)
     set_fabric(fabric_config)
+    mesh_device = ttnn.open_mesh_device(
+        mesh_shape=ttnn.MeshShape(ttnn.get_num_devices(), 1),
+        **updated_device_params,
+    )
+    logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
+    yield mesh_device
+
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
+
+    ttnn.close_mesh_device(mesh_device)
+    reset_fabric(fabric_config)
+    del mesh_device
+
+
+@pytest.fixture(scope="function")
+def bh_2d_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_params):
+    # Generic blackhole configuration
+    # This preserves the 2D mesh configuration in rackbox and galaxy
+    import ttnn
+
+    if ttnn.get_num_devices() not in [1, 2, 4, 8, 32]:
+        pytest.skip()
+
+    request.node.pci_ids = ttnn.get_pcie_device_ids()
+    updated_device_params = get_updated_device_params(device_params)
+    fabric_config = updated_device_params.pop("fabric_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
+    set_fabric(fabric_config)
     if ttnn.get_num_devices() == 8:
         mesh_device = ttnn.open_mesh_device(
             mesh_shape=ttnn.MeshShape(4, 2),
+            **updated_device_params,
+        )
+    elif ttnn.get_num_devices() == 32:
+        mesh_device = ttnn.open_mesh_device(
+            mesh_shape=ttnn.MeshShape(4, 8),
             **updated_device_params,
         )
     else:

--- a/conftest.py
+++ b/conftest.py
@@ -546,12 +546,11 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 @pytest.fixture(scope="function")
 def bh_1d_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device_params):
     # Generic blackhole configuration
-    # This creates a snake pattern on 2D meshes to appear as a long line or
-    # donut shaped ring in rackbox
-    # Not compatible with blackhole galaxy
+    # This configures an [m,n] blackhole mesh device to appear as a [1,m*n] line or ring
+    # Implements wraparound in rackboxes
     import ttnn
 
-    if ttnn.get_num_devices() not in [1, 2, 4, 8]:
+    if ttnn.get_num_devices() not in [1, 2, 4, 8, 32]:
         pytest.skip()
 
     request.node.pci_ids = ttnn.get_pcie_device_ids()

--- a/tests/ttnn/stress_tests/test_ccl.py
+++ b/tests/ttnn/stress_tests/test_ccl.py
@@ -88,7 +88,7 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
 def test_ccl_smoke_test(
-    p150_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     ag_output_shape,
     cluster_axis,
@@ -107,17 +107,17 @@ def test_ccl_smoke_test(
 ):
     if (8 == ttnn.get_num_devices()) and (all_gather_topology == ttnn.Topology.Ring):
         pytest.skip("Rackbox is a mesh not a torus so ring wouldn't work")
-    if p150_mesh_device.shape[cluster_axis] < num_devices:
+    if bh_2d_mesh_device.shape[cluster_axis] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform in this axis")
-    if (p150_mesh_device.shape[cluster_axis] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+    if (bh_2d_mesh_device.shape[cluster_axis] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
-    for i in range(p150_mesh_device.shape[(cluster_axis - 1) % 2]):
+    for i in range(bh_2d_mesh_device.shape[(cluster_axis - 1) % 2]):
         if cluster_axis == 0:
-            submesh_device = p150_mesh_device.create_submesh(
+            submesh_device = bh_2d_mesh_device.create_submesh(
                 ttnn.MeshShape((num_devices, 1)), offset=ttnn.MeshCoordinate(0, i)
             )
         else:
-            submesh_device = p150_mesh_device.create_submesh(
+            submesh_device = bh_2d_mesh_device.create_submesh(
                 ttnn.MeshShape((1, num_devices)), offset=ttnn.MeshCoordinate(i, 0)
             )
         run_all_gather_impl(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test.py
@@ -7,6 +7,7 @@ import ttnn
 
 from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl
 from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
@@ -87,7 +88,7 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
 def test_ccl_smoke_test(
-    p150_mesh_device,
+    bh_1d_mesh_device,
     num_devices,
     ag_output_shape,
     cluster_axis,
@@ -104,14 +105,11 @@ def test_ccl_smoke_test(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    if p150_mesh_device.shape[cluster_axis] < num_devices:
-        pytest.skip("Test requires more devices than are available on this platform in this axis")
-    if (p150_mesh_device.shape[cluster_axis] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
-        pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    validate_test(num_devices, all_gather_topology, bh_1d_mesh_device.shape, cluster_axis)
     if cluster_axis == 0:
-        submesh_device = p150_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     else:
-        submesh_device = p150_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
+        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
     run_all_gather_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
@@ -68,7 +68,7 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
 def test_all_gather_nightly(
-    p150_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     ag_output_shape,
     dim,
@@ -86,11 +86,11 @@ def test_all_gather_nightly(
 ):
     if (2 == num_devices) and (all_gather_topology == ttnn.Topology.Ring):
         pytest.skip("Ring configuration requires more than 2 devices")
-    if (p150_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+    if (bh_2d_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
-    if p150_mesh_device.shape[0] < num_devices:
+    if bh_2d_mesh_device.shape[0] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
-    submesh_device = p150_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     cluster_axis = 0
     run_all_gather_impl(
         submesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_reduce_scatter_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_reduce_scatter_apc.py
@@ -72,7 +72,7 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [8])
 def test_rs_row_nightly(
-    p150_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     num_links,
     rs_input_shape,
@@ -90,11 +90,11 @@ def test_rs_row_nightly(
 ):
     if (2 == num_devices) and (rs_topology == ttnn.Topology.Ring):
         pytest.skip("Ring configuration requires more than 2 devices")
-    if (p150_mesh_device.shape[0] != num_devices) and (rs_topology == ttnn.Topology.Ring):
+    if (bh_2d_mesh_device.shape[0] != num_devices) and (rs_topology == ttnn.Topology.Ring):
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
-    if p150_mesh_device.shape[0] < num_devices:
+    if bh_2d_mesh_device.shape[0] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
-    submesh_device = p150_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     cluster_axis = 0
     run_reduce_scatter_impl(
         submesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+from loguru import logger
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+
+
+def run_with_trace(
+    mesh_device,
+    all_to_all_topology,
+    input_tensor_mesh,
+    in_dim,
+    out_dim,
+    num_links,
+    output_mem_config,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_to_all_async(
+        input_tensor_mesh,
+        in_dim,
+        out_dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_to_all_topology,
+        subdevice_id=subdevice_id,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    output_tensors = []
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_to_all_async(
+            input_tensor_mesh,
+            in_dim,
+            out_dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_to_all_topology,
+            subdevice_id=subdevice_id,
+        )
+        output_tensors.append(tt_out_tensor)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return output_tensors
+
+
+def run_with_trace(
+    mesh_device,
+    topology,
+    input_tensor,
+    persistent_intermediate_buffer,
+    persistent_output_buffer,
+    in_dim,
+    out_dim,
+    num_links,
+    output_mem_config,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_to_all_async(
+        input_tensor,
+        in_dim=in_dim,
+        out_dim=out_dim,
+        persistent_intermediate_buffer=persistent_intermediate_buffer,
+        persistent_output_buffer=persistent_output_buffer,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=topology,
+        subdevice_id=subdevice_id,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_to_all_async(
+            input_tensor,
+            in_dim=in_dim,
+            out_dim=out_dim,
+            persistent_intermediate_buffer=persistent_intermediate_buffer,
+            persistent_output_buffer=persistent_output_buffer,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=topology,
+            subdevice_id=subdevice_id,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_all_to_all_impl(
+    mesh_device,
+    num_devices,
+    logical_shape,
+    in_dim,
+    out_dim,
+    num_links,
+    input_dtype,
+    layout,
+    topology,
+    num_iters=1,
+    trace_mode=False,
+    mem_config=None,
+    do_check=True,
+    reuse_inputs=False,
+):
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+    # create global semaphore handles
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
+
+    logger.info(f"Logical shape: {logical_shape}")
+    logger.info(f"in_dim: {in_dim}")
+    logger.info(f"out_dim: {out_dim}")
+
+    input_mem_config = mem_config
+    output_mem_config = mem_config
+    ###
+
+    ### Create persistent output buffers
+    logger.info("Creating persistent buffers")
+    output_shape = list(logical_shape)
+    output_shape[out_dim] //= num_devices
+    persistent_intermediate_buffers = [
+        ttnn.from_torch(
+            torch.zeros(output_shape),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=input_dtype,
+            memory_config=output_mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+    persistent_output_buffers = [
+        ttnn.from_torch(
+            torch.zeros(output_shape),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=input_dtype,
+            memory_config=output_mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+
+    logger.info("Done creating persistent buffers")
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters if not reuse_inputs else 1):
+        output_tensor = torch.rand(logical_shape).bfloat16()
+        output_tensor_goldens_list.append(torch.chunk(output_tensor, num_devices, out_dim))
+        input_tensor_mesh = ttnn.from_torch(
+            output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(in_dim)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            topology,
+            input_tensor_mesh_list[0],
+            persistent_intermediate_buffers[0],
+            persistent_output_buffers[0],
+            in_dim,
+            out_dim,
+            num_links,
+            output_mem_config,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_to_all_async(
+                input_tensor_mesh_list[i if not reuse_inputs else 0],
+                persistent_intermediate_buffer=persistent_intermediate_buffers[i],
+                persistent_output_buffer=persistent_output_buffers[i],
+                in_dim=in_dim,
+                out_dim=out_dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=topology,
+                subdevice_id=worker_sub_device_id,
+            )
+            tt_out_tensor_list.append(persistent_output_buffers[i])
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    if do_check:
+        for tensor_index in range(len(tt_out_tensor_list)):
+            tt_out_tensor = tt_out_tensor_list[tensor_index]
+            output_tensors = output_tensor_goldens_list[tensor_index if not reuse_inputs else 0]
+            for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+                tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+                output_tensor = output_tensors[i]
+                logger.info(f"Checking for device {t.device().id()}")
+                if input_dtype == ttnn.bfloat16:
+                    eq, output = comp_equal(tt_output_tensor, output_tensor)
+                else:
+                    eq, output = comp_pcc(tt_output_tensor, output_tensor)
+                if not eq:
+                    logger.error(f"output mismatch for tensor {i}")
+                    passed = False
+
+    assert (
+        mesh_device.num_program_cache_entries() == 1
+    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    if do_check and not passed:
+        assert eq, f"{i} FAILED: {output}"
+
+
+@pytest.mark.parametrize(
+    "num_devices, num_links, logical_shape, in_dim, out_dim, layout",
+    [
+        (4, 1, [1, 1, 44544, 3072 * 3], 2, 3, ttnn.TILE_LAYOUT),  # Pre-attn all-to-all
+        (4, 1, [1, 1, 44544, 3072], 3, 2, ttnn.TILE_LAYOUT),  # Post-attn all-to-all
+    ],
+    ids=["pre-attn", "post-attn"],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+    ],
+)
+@pytest.mark.parametrize(
+    "num_iters, do_check, reuse_inputs",
+    [(2, True, False), (6, False, True), (20, False, True)],
+    ids=["check", "perf", "stress"],
+)
+@pytest.mark.parametrize(
+    "enable_trace",
+    [True, False],
+    ids=["use_trace", "no_trace"],
+)
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True
+)
+def test_all_to_all(
+    bh_1d_mesh_device,
+    num_devices,
+    logical_shape,
+    in_dim,
+    out_dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    function_level_defaults,
+    do_check,
+    reuse_inputs,
+    enable_trace,
+    is_ci_env,
+):
+    topology = ttnn.Topology.Ring
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
+    run_all_to_all_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        logical_shape,
+        in_dim,
+        out_dim,
+        num_links,
+        input_dtype,
+        layout,
+        topology=topology,
+        num_iters=num_iters,
+        mem_config=mem_config,
+        do_check=do_check,
+        trace_mode=enable_trace,
+        reuse_inputs=reuse_inputs,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -1,0 +1,808 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import math
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal
+from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+
+
+def create_global_semaphores(mesh_device, cores, initial_value):
+    # create global semaphore handles
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(3)]
+    return ccl_semaphore_handles
+
+
+def run_reduce_scatter_impl(
+    bh_1d_mesh_device,
+    num_devices,
+    rs_input_shape,
+    dim,
+    num_links,
+    rs_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_rs,
+    rs_topology,
+    num_iters=1,
+    enable_trace=True,
+    ones_tensor=False,
+    mem_config_intermediate=None,
+    cluster_axis=None,
+    use_barrier=False,
+    use_persistent_buffers=True,
+    chunks_per_sync=None,
+    num_workers_per_link=None,
+    num_buffers_per_channel=None,
+):
+    torch.manual_seed(0)
+
+    tile = (32, 32)
+
+    # Set the default config
+    if mem_config_intermediate is None:
+        mem_config_intermediate = mem_config_rs
+
+    ##### Fabric setup #####
+    compute_grid_size = bh_1d_mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+
+    sub_device_manager = bh_1d_mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    bh_1d_mesh_device.load_sub_device_manager(sub_device_manager)
+    bh_1d_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphores(bh_1d_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    barrier_semaphore_handles = [
+        ttnn.create_global_semaphore(bh_1d_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### Create persistent output buffers
+    logger.info("Creating persistent buffers")
+    intermediate_shape = rs_input_shape[:]
+    if rs_topology == ttnn.Topology.Linear:
+        # Line RS requires double-sized input for forward/backward
+        intermediate_shape.insert(0, 2)
+    persistent_intermediate_buffers = [
+        ttnn.from_torch(
+            torch.zeros(intermediate_shape),
+            device=bh_1d_mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=rs_input_dtype,
+            memory_config=mem_config_intermediate,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(bh_1d_mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+    rs_output_shape = rs_input_shape[:]
+    rs_output_shape[dim] //= num_devices
+    persistent_output_buffers = [
+        ttnn.from_torch(
+            torch.zeros(rs_output_shape),
+            device=bh_1d_mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=rs_input_dtype,
+            memory_config=mem_config_rs,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(bh_1d_mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+
+    logger.info("Done creating persistent buffers")
+
+    ##### All gather input setup #####
+    logger.info(f"Reduce scatter shape: {rs_input_shape}")
+    logger.info(f"Reduce scatter dim: {dim}")
+    logger.info(f"input mem config: {mem_config_input}")
+    logger.info(f"Reduce input mem config: {mem_config_rs}")
+    logger.info(f"intermediate mem config: {mem_config_intermediate}")
+    logger.info(f"topology: {rs_topology}")
+
+    tt_input_tensor_mesh_list = []
+    torch_input_tensor_list = []
+
+    for i in range(num_iters):
+        rs_global_input_shape = rs_input_shape[:]
+        rs_global_input_shape[dim] *= num_devices
+        if ones_tensor:
+            rs_input_tensor = torch.ones(rs_global_input_shape).bfloat16()
+        else:
+            rs_input_tensor = torch.rand(rs_global_input_shape).bfloat16()
+        input_tensors = torch.chunk(rs_input_tensor, num_devices, dim)
+        torch_input_tensor_list.append(input_tensors)
+
+        input_tensor_mesh = ttnn.from_torch(
+            rs_input_tensor,
+            device=bh_1d_mesh_device,
+            layout=layout,
+            dtype=rs_input_dtype,
+            memory_config=mem_config_input,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                bh_1d_mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(dim)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
+
+        tt_input_tensor_mesh_list.append(input_tensor_mesh)
+
+    ##### Perform torch ops #####
+    torch_reduce_scatter_output_list = []
+    for i in range(num_iters):
+        reduce_output = torch.sum(torch.stack(torch_input_tensor_list[i]), dim=0)
+        scatter_output = torch.chunk(reduce_output, num_devices, dim)
+        torch_reduce_scatter_output_list.append(scatter_output)
+
+    ##### Perform the TT ops #####
+    tt_reduce_scatter_output_list = []
+
+    def run_op(i):
+        tt_reduce_scatter_output_tensor = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_input_tensor_mesh_list[i],
+            persistent_output_buffers=[persistent_intermediate_buffers[i], persistent_output_buffers[i]]
+            if use_persistent_buffers
+            else None,
+            dim=dim,
+            multi_device_global_semaphore=ccl_semaphore_handles[i],
+            barrier_semaphore=barrier_semaphore_handles[i] if use_barrier else None,
+            num_links=num_links,
+            memory_config=mem_config_rs,
+            intermediate_memory_config=mem_config_intermediate,
+            topology=rs_topology,
+            subdevice_id=worker_sub_device_id,
+            cluster_axis=cluster_axis,
+            chunks_per_sync=chunks_per_sync,
+            num_workers_per_link=num_workers_per_link,
+            num_buffers_per_channel=num_buffers_per_channel,
+        )
+
+        return tt_reduce_scatter_output_tensor
+
+    if enable_trace:
+        # Compile the op
+        tt_reduce_scatter_output_trace_list = []
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+        logger.info(f"Done compiling Op")
+
+        # Capture the trace
+        trace_id = ttnn.begin_trace_capture(bh_1d_mesh_device, cq_id=0)
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+            tt_reduce_scatter_output_trace_list.append(tt_reduce_scatter_output_tensor)
+        ttnn.end_trace_capture(bh_1d_mesh_device, trace_id, cq_id=0)
+        logger.info(f"Done capturing trace")
+
+        # Execute trace
+        ttnn.execute_trace(bh_1d_mesh_device, trace_id, cq_id=0, blocking=False)
+        logger.info(f"Done executing trace")
+
+        # Synchronize the devices
+        ttnn.synchronize_device(bh_1d_mesh_device, sub_device_ids=sub_device_stall_group)
+        for tt_tensor in tt_reduce_scatter_output_trace_list:
+            tt_rs_out = ttnn.from_device(tt_tensor)
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(bh_1d_mesh_device, dim=dim))
+            tt_tensor.deallocate(True)
+            tt_reduce_scatter_output_list.append(tt_rs_out)
+    else:
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+            tt_rs_out = ttnn.from_device(tt_reduce_scatter_output_tensor)
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(bh_1d_mesh_device, dim=dim))
+            tt_reduce_scatter_output_tensor.deallocate(True)
+            tt_reduce_scatter_output_list.append(tt_rs_out)
+
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(bh_1d_mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
+
+            logger.info(f"Done iteration {i}")
+
+    for i in range(num_iters):
+        tt_rs_out = tt_reduce_scatter_output_list[i]
+        torch_rs_out_tensor = torch_reduce_scatter_output_list[i]
+
+        torch_rs_out = torch.cat(torch_rs_out_tensor, dim)
+
+        if ones_tensor:
+            eq, output = comp_equal(tt_rs_out, torch_rs_out)
+        else:
+            eq, output = comp_pcc(tt_rs_out, torch_rs_out)
+
+        logger.info(f"{output}, iteration {i}")
+        assert eq, f"{i} FAILED ag: {output}"
+
+    bh_1d_mesh_device.reset_sub_device_stall_group()
+    bh_1d_mesh_device.clear_loaded_sub_device_manager()
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
+    [
+        (4, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        # Composite-RS tests
+        (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
+        # (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True), #Issue 27619
+    ],
+    ids=[
+        "padded_dim_2_test_one",
+        "padded_dim_2_test_two",
+        "batch_8",
+        "batch_4",
+        "batch_1_sd35_spatial",
+        "batch_1_sd35_prompt",
+        "batch_2",
+        "batch_1",
+        "composite_rs_test_one",
+        "composite_rs_test_two",
+        # "composite_rs_test_three",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_rs",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+    ids=["ones", "random"],
+)
+@pytest.mark.parametrize(
+    "use_barrier, use_persistent_buffers",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+    ],
+    ids=["barrier_with_persistent_buffers", "barrier_without_persistent_buffers", "no_barrier_with_persistent_buffers"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_reduce_scatter_async(
+    bh_1d_mesh_device,
+    num_devices,
+    num_links,
+    rs_input_shape,
+    dim,
+    layout,
+    rs_input_dtype,
+    is_training_shape,
+    mem_config_input,
+    mem_config_rs,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    use_barrier,
+    use_persistent_buffers,
+    rs_topology,
+):
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
+
+    if is_training_shape and enable_trace:
+        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
+
+    run_reduce_scatter_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        use_barrier=use_barrier,
+        use_persistent_buffers=use_persistent_buffers,
+    )
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
+    [
+        # Scatter on dim 0
+        # (4, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # Scatter on dim 1
+        # (4, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # Scatter on dim 2
+        # (4, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # # Scatter on dim 3
+        (4, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (4, [16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (4, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_rs",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace,num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+    ids=["ones", "random"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_reduce_scatter_async_training_shapes(
+    bh_1d_mesh_device,
+    num_devices,
+    rs_input_shape,
+    dim,
+    num_links,
+    rs_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_rs,
+    enable_trace,
+    rs_topology,
+    num_iters,
+    ones_tensor,
+):
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
+    if enable_trace:
+        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
+
+    run_reduce_scatter_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        use_barrier=True,
+        use_persistent_buffers=False,
+    )
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, layout, rs_input_dtype",
+    [
+        (4, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout, intermediate_shard_shape, intermediate_shard_grid, intermediate_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [1, 1, 32, 3072],
+            3,
+            [32, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            [32, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            [32, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            [512, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            [512, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            [512, 256],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            [4, 1, 384, 3072],
+            3,
+            [512, 3072],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            [1536, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            [1536, 128],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+    ids=["ones", "random"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_reduce_scatter_async_sharded_to_sharded(
+    bh_1d_mesh_device,
+    num_links,
+    num_devices,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    intermediate_shard_shape,
+    intermediate_shard_grid,
+    intermediate_mem_layout,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
+    adjusted_intermediate_shard_shape = intermediate_shard_shape[:]
+    if rs_topology == ttnn.Topology.Linear:
+        adjusted_intermediate_shard_shape[0] *= 2
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    intermediate_shard_spec = ttnn.ShardSpec(
+        intermediate_shard_grid,
+        adjusted_intermediate_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_intermediate = ttnn.MemoryConfig(
+        intermediate_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=intermediate_shard_spec
+    )
+    mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_reduce_scatter_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
+    )
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, layout, rs_input_dtype",
+    [
+        (4, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, intermediate_shard_shape, intermediate_shard_grid, intermediate_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [4, 1, 256, 3072],
+            3,
+            [1024, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            [1024, 128],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            [512, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            [256, 256],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+    ids=["ones", "random"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_reduce_scatter_async_interleaved_to_sharded(
+    bh_1d_mesh_device,
+    num_links,
+    num_devices,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    intermediate_shard_shape,
+    intermediate_shard_grid,
+    intermediate_mem_layout,
+    output_shard_shape,
+    output_shard_grid,
+    output_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
+    adjusted_intermediate_shard_shape = intermediate_shard_shape[:]
+    if rs_topology == ttnn.Topology.Linear:
+        adjusted_intermediate_shard_shape[0] *= 2
+
+    intermediate_shard_spec = ttnn.ShardSpec(
+        intermediate_shard_grid,
+        adjusted_intermediate_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    mem_config_intermediate = ttnn.MemoryConfig(
+        intermediate_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=intermediate_shard_spec
+    )
+    mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
+
+    run_reduce_scatter_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
+    )
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices, layout, rs_input_dtype",
+    [
+        (4, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "rs_input_shape, dim, input_shard_shape, input_shard_grid, input_mem_layout",
+    [
+        (
+            [4, 1, 256, 3072],
+            3,
+            [1024, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [4, 1, 384, 1024],
+            3,
+            [512, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 1),
+    ],
+    ids=["perf", "check"],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        True,
+        False,
+    ],
+    ids=["ones", "random"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
+)
+def test_reduce_scatter_async_sharded_to_interleaved(
+    bh_1d_mesh_device,
+    num_links,
+    num_devices,
+    rs_input_dtype,
+    layout,
+    rs_input_shape,
+    dim,
+    input_shard_shape,
+    input_shard_grid,
+    input_mem_layout,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    rs_topology,
+):
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    mem_config_input = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    mem_config_intermediate = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    mem_config_rs = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    run_reduce_scatter_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        mem_config_intermediate=mem_config_intermediate,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_new_all_broadcast.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+
+
+def run_with_trace(
+    mesh_device,
+    all_broadcast_topology,
+    input_tensor_mesh,
+    num_links,
+    output_mem_config,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_broadcast_async(
+        input_tensor_mesh,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_broadcast_topology,
+        subdevice_id=subdevice_id,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_broadcast_async(
+            input_tensor_mesh,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_broadcast_topology,
+            subdevice_id=subdevice_id,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_all_broadcast_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    num_links,
+    input_dtype,
+    layout,
+    function_level_defaults,
+    all_broadcast_topology,
+    num_iters=1,
+    trace_mode=False,
+    rand_tensor=True,
+    mem_config=None,
+    input_shard_shape=None,
+    input_shard_grid=None,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+    cluster_axis=None,
+):
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    logger.info(f"Output shape: {output_shape}")
+    logger.info(f"input_shard_shape: {input_shard_shape}")
+    logger.info(f"input_shard_grid: {input_shard_grid}")
+
+    ### For sharded all broadcast only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = input_shard_shape
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    else:
+        assert mem_config is not None
+        input_mem_config = mem_config
+        output_mem_config = mem_config
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensors = []
+        for k in range(num_devices):
+            if rand_tensor:
+                output_tensor = torch.rand(output_shape).bfloat16()
+            else:
+                output_tensor = torch.zeros(output_shape)
+                row_id = 1
+                # Fix indices for tensors with ranks 2 or 3
+                for w in range(output_shape[0]):
+                    for z in range(output_shape[1]):
+                        for y in range(0, output_shape[2], 32):
+                            for x in range(0, output_shape[3], 32):
+                                output_tensor[w, z, y, :] = row_id
+                                row_id += 1
+            output_tensors.append(output_tensor)
+
+        output_tensor_goldens_list.append(output_tensors)
+        temp_output_tensor = torch.cat(output_tensors, -1)
+
+        input_tensor_mesh = ttnn.from_torch(
+            temp_output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            all_broadcast_topology,
+            input_tensor_mesh_list[0],
+            num_links,
+            output_mem_config,
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensors = ttnn.experimental.all_broadcast_async(
+                input_tensor_mesh_list[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_broadcast_topology,
+                subdevice_id=worker_sub_device_id,
+            )
+            tt_out_tensor_list.append(tt_out_tensors)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensors = tt_out_tensor_list[tensor_index]
+        output_tensors = output_tensor_goldens_list[tensor_index]
+        for k in range(num_devices):
+            output_tensor = output_tensors[k]
+            for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensors[k])):
+                tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+                logger.info(f"Checking for device {t.device().id()}")
+                if input_dtype == ttnn.bfloat16:
+                    eq, output = comp_equal(tt_output_tensor, output_tensor)
+                else:
+                    eq, output = comp_pcc(tt_output_tensor, output_tensor)
+                if not eq:
+                    logger.error(f"output mismatch for tensor {i}")
+                    passed = False
+                    assert eq, f"{i} FAILED: {output}"
+    assert (
+        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
+    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, output_shape, layout, input_dtype",
+    [
+        (2, 1, [2, 30], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (2, 1, [3, 122, 2042], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (2, 1, [1, 1, 1, 32, 1024], ttnn.TILE_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("num_iters", [3])
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_all_broadcast(
+    bh_1d_mesh_device,
+    # pcie_mesh_device,
+    num_devices,
+    output_shape,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    function_level_defaults,
+):
+    topology = ttnn.Topology.Linear
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
+    if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported for row-major")
+
+    run_all_broadcast_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        output_shape,
+        num_links,
+        input_dtype,
+        layout,
+        function_level_defaults,
+        all_broadcast_topology=topology,
+        num_iters=num_iters,
+        rand_tensor=True,
+        mem_config=mem_config,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@pytest.mark.parametrize(
+    "num_devices, num_links, output_shape, layout, input_dtype",
+    [
+        (2, 1, [256, 3328], ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
+        (2, 1, [1, 69, 4000], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("num_iters", [3])
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10000}], indirect=True
+)
+def test_all_broadcast_trace(
+    bh_1d_mesh_device,
+    # pcie_mesh_device,
+    num_devices,
+    output_shape,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    function_level_defaults,
+):
+    topology = ttnn.Topology.Linear
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
+    if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported for row-major")
+
+    run_all_broadcast_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        output_shape,
+        num_links,
+        input_dtype,
+        layout,
+        function_level_defaults,
+        all_broadcast_topology=topology,
+        num_iters=num_iters,
+        rand_tensor=True,
+        mem_config=mem_config,
+        trace_mode=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_devices, output_shape, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        (
+            2,
+            [2, 3, 64, 1024],
+            (384, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(4, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 1)),
+                }
+            ),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [1])
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_all_broadcast_sharded(
+    bh_1d_mesh_device,
+    num_devices,
+    output_shape,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    topology = ttnn.Topology.Linear
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
+    pytest.skip("This is currently not functional")
+    if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported for row-major")
+
+    run_all_broadcast_impl(
+        bh_1d_mesh_device,
+        num_devices,
+        output_shape,
+        num_links,
+        input_dtype,
+        layout,
+        function_level_defaults,
+        all_broadcast_topology=topology,
+        num_iters=num_iters,
+        rand_tensor=True,
+        input_shard_shape=input_shard_shape,
+        input_shard_grid=input_shard_grid,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_reduce_scatter_nightly.py
@@ -6,6 +6,7 @@ import pytest
 import ttnn
 from tests.nightly.t3000.ccl.test_minimal_reduce_scatter_async import run_reduce_scatter_impl
 from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
@@ -82,7 +83,7 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [8])
 def test_rs_row_nightly(
-    p150_mesh_device,
+    bh_1d_mesh_device,
     num_devices,
     num_links,
     rs_input_shape,
@@ -98,14 +99,9 @@ def test_rs_row_nightly(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    if (2 == num_devices) and (rs_topology == ttnn.Topology.Ring):
-        pytest.skip("Ring configuration requires more than 2 devices")
-    if (p150_mesh_device.shape[0] != num_devices) and (rs_topology == ttnn.Topology.Ring):
-        pytest.skip("Ring configuration requires the entire row or column so it loops around")
-    if p150_mesh_device.shape[0] < num_devices:
-        pytest.skip("Test requires more devices than are available on this platform")
-    submesh_device = p150_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     cluster_axis = 0
+    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, cluster_axis)
+    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     run_reduce_scatter_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -443,7 +443,7 @@ def test_all_gather_only(
     indirect=True,
 )
 def test_bh_trace_ag(
-    p150_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     output_shape,
     dim,
@@ -460,13 +460,13 @@ def test_bh_trace_ag(
     output_shard_grid,
     tensor_mem_layout,
 ):
-    if p150_mesh_device.shape[0] != num_devices:
+    if bh_2d_mesh_device.shape[0] != num_devices:
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
     if ttnn.get_num_devices() == 8:
         pytest.skip("Test requires a torus but rackbox is a mesh")
     profiler = BenchmarkProfiler()
     run_all_gather_impl(
-        p150_mesh_device,
+        bh_2d_mesh_device,
         num_devices,
         output_shape,
         dim,


### PR DESCRIPTION
### Ticket
Removed the p150_mesh_device and replaced it with

bh_1d_mesh_device = doesn't work in torus, creates a wrap around snake or donut pattern by linearizing the 2D mesh similar to t3k_mesh_device
bh_2d_mesh_device = works in torus and maintains the 2D nature of the mesh or torus

Added nightly testing to the CCL ops currently supported by blackhole

These work generally for all BH configurations.
### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/17333992155

BH Nightly
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/17334006219
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes