### PR TITLE
hash mesh_coords in paged update cache Op

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -400,7 +400,7 @@ operation::Hash PagedUpdateCacheDeviceOperation::compute_program_hash(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     return operation::hash_operation<PagedUpdateCacheDeviceOperation>(
-        this->op_type, input_tensors, optional_input_tensors);
+        this->op_type, input_tensors, optional_input_tensors, this->mesh_coords);
 }
 
 }  // namespace ttnn::operations::experimental::paged_cache

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.hpp
@@ -49,11 +49,17 @@ struct PagedUpdateCacheDeviceOperation {
         std::vector<Tensor>& output_tensors) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
-        "batch_idx_fallback", "update_idxs", "batch_offset", "op_type", "compute_kernel_config", "share_cache");
+        "batch_idx_fallback",
+        "update_idxs",
+        "batch_offset",
+        "op_type",
+        "compute_kernel_config",
+        "share_cache",
+        "mesh_coords");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
-            batch_idx_fallback, update_idxs, batch_offset, op_type, compute_kernel_config, share_cache);
+            batch_idx_fallback, update_idxs, batch_offset, op_type, compute_kernel_config, share_cache, mesh_coords);
     }
 
     tt::tt_metal::operation::Hash compute_program_hash(


### PR DESCRIPTION
### Problem description

This pull request updates the `PagedUpdateCacheDeviceOperation` to include the `mesh_coords` attribute in both its metadata and hashing logic. This ensures that the operation's hash computation and attribute handling are aware of mesh coordinates, which may be important for correct caching and operation identification.

Enhancements to operation attributes and hashing:

* Added `mesh_coords` to the list of attribute names and values in `PagedUpdateCacheDeviceOperation`, ensuring it is tracked as part of the operation's metadata.
* Updated the `compute_program_hash` method to include `mesh_coords` in the hash calculation, improving cache key accuracy.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17334096445) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes