### PR TITLE
Add internal validation to PhysicalSystemDescriptor

### DIFF
--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -38,19 +38,19 @@ const std::unordered_map<tt::ARCH, std::vector<std ::uint16_t>> ubb_bus_ids = {
     {tt::ARCH::BLACKHOLE, {0x00, 0x40, 0xC0, 0x80}},
 };
 
-std::pair<TrayID, NID> get_ubb_id(chip_id_t chip_id) {
+std::pair<TrayID, ASICLocation> get_ubb_id(chip_id_t chip_id) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& tray_bus_ids = ubb_bus_ids.at(cluster.arch());
     const auto bus_id = cluster.get_bus_id(chip_id);
     auto tray_bus_id_it = std::find(tray_bus_ids.begin(), tray_bus_ids.end(), bus_id & 0xF0);
     if (tray_bus_id_it != tray_bus_ids.end()) {
-        auto ubb_nid = bus_id & 0x0F;
-        return {TrayID{tray_bus_id_it - tray_bus_ids.begin() + 1}, NID{ubb_nid}};
+        auto ubb_asic_location = bus_id & 0x0F;
+        return {TrayID{tray_bus_id_it - tray_bus_ids.begin() + 1}, ASICLocation{ubb_asic_location}};
     }
     return {};
 }
 
-std::pair<TrayID, NID> get_asic_position(
+std::pair<TrayID, ASICLocation> get_asic_position(
     chip_id_t chip_id, const std::set<uint32_t, std::greater<uint32_t>>& sorted_pcie_slots) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto cluster_desc = cluster.get_cluster_desc();
@@ -60,19 +60,19 @@ std::pair<TrayID, NID> get_asic_position(
         // Derive NID based on the tunnel depth for N300 systems
         auto mmio_device = cluster.get_associated_mmio_device(chip_id);
         auto tunnels = cluster.get_tunnels_from_mmio_device(mmio_device);
-        NID n_id;
+        ASICLocation asic_location;
         for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
             const auto& devices_on_tunnel = tunnels[tunnel];
             auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
             if (device_it != devices_on_tunnel.end()) {
-                n_id = NID{device_it - devices_on_tunnel.begin() + 1};
+                asic_location = ASICLocation{device_it - devices_on_tunnel.begin()};
             }
         }
         // Derive Tray ID based on the Physical PCIe slot for N300 systems
         uint32_t tray_id =
             1 + std::distance(
                     sorted_pcie_slots.begin(), sorted_pcie_slots.find(cluster.get_physical_slot(chip_id).value()));
-        return {TrayID{tray_id}, n_id};
+        return {TrayID{tray_id}, asic_location};
     } else {
         TT_THROW("Unrecognized board type. Cannot determine asic position.");
     }
@@ -187,9 +187,9 @@ void PhysicalSystemDescriptor::run_local_discovery() {
     for (const auto& [src, conn] : eth_connections) {
         auto src_unique_id = AsicID{chip_unique_ids.at(src)};
         // Populate ASIC Descriptor with Physical Information
-        auto [tray_id, n_id] = get_asic_position(src, sorted_pcie_slots);
+        auto [tray_id, asic_location] = get_asic_position(src, sorted_pcie_slots);
         asic_descriptors_[src_unique_id] =
-            ASICDescriptor{TrayID{tray_id}, n_id, cluster_desc->get_board_type(src), src_unique_id, hostname};
+            ASICDescriptor{TrayID{tray_id}, asic_location, cluster_desc->get_board_type(src), src_unique_id, hostname};
 
         std::unordered_map<chip_id_t, size_t> visited_dst;
         // Populate ASIC Graph for Current Host
@@ -398,13 +398,13 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
             tray_group["board_type"] = enchantum::to_string(group.second.front().board_type);
             std::vector<ASICDescriptor> sorted_asics = group.second;
             std::sort(sorted_asics.begin(), sorted_asics.end(), [](const ASICDescriptor& a, const ASICDescriptor& b) {
-                return a.n_id < b.n_id;
+                return a.asic_location < b.asic_location;
             });
             // Create asics array
             YAML::Node asics_array;
             for (const auto& asic : sorted_asics) {
                 YAML::Node asic_node;
-                asic_node["nid"] = *(asic.n_id);
+                asic_node["asic_location"] = *(asic.asic_location);
                 asic_node["asic_id"] = *(asic.unique_id);
                 asics_array.push_back(asic_node);
             }
@@ -437,9 +437,9 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
                     src_conn_node["host_name"] = src_asic_desc.host_name;
                     dst_conn_node["host_name"] = dst_asic_desc.host_name;
                     src_conn_node["tray_id"] = *(src_asic_desc.tray_id);
-                    src_conn_node["nid"] = *(src_asic_desc.n_id);
+                    src_conn_node["asic_location"] = *(src_asic_desc.asic_location);
                     dst_conn_node["tray_id"] = *(dst_asic_desc.tray_id);
-                    dst_conn_node["nid"] = *(dst_asic_desc.n_id);
+                    dst_conn_node["asic_location"] = *(dst_asic_desc.asic_location);
                     src_conn_node["chan_id"] = +eth_conn.src_chan;
                     dst_conn_node["chan_id"] = +eth_conn.dst_chan;
 
@@ -589,10 +589,10 @@ TrayID PhysicalSystemDescriptor::get_tray_id(AsicID asic_id) const {
     return asic_descriptors_.at(asic_id).tray_id;
 }
 
-NID PhysicalSystemDescriptor::get_n_id(AsicID asic_id) const {
+ASICLocation PhysicalSystemDescriptor::get_asic_location(AsicID asic_id) const {
     TT_FATAL(
         asic_descriptors_.find(asic_id) != asic_descriptors_.end(), "No ASIC descriptor found for asic_id {}", asic_id);
-    return asic_descriptors_.at(asic_id).n_id;
+    return asic_descriptors_.at(asic_id).asic_location;
 }
 
 std::vector<AsicID> PhysicalSystemDescriptor::get_asics_connected_to_host(std::string hostname) const {

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -31,7 +31,8 @@ std::string get_mobo_name() {
 
     return motherboard;
 }
-
+// TODO: Once ASIC Location is exposed through a UMD API, code generating the asic location
+// here can be removed.
 // TODO: UBB specific code here is duplicated. This needs to be exposed as a UMD API.
 const std::unordered_map<tt::ARCH, std::vector<std ::uint16_t>> ubb_bus_ids = {
     {tt::ARCH::WORMHOLE_B0, {0xC0, 0x80, 0x00, 0x40}},

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -489,7 +489,7 @@ void PhysicalSystemDescriptor::validate_graphs() {
                 // All connections on this edge must be local or global.
                 TT_FATAL(
                     all_connections_local || all_connections_global,
-                    "Physical Discover Error: All ethernet connections should either be local or global. Please reset "
+                    "Physical Discovery Error: All ethernet connections should either be local or global. Please reset "
                     "the system and try again.");
                 // If all connections are local, then the src_host and dst_host should be the same
                 if (all_connections_local) {

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -475,75 +475,69 @@ void PhysicalSystemDescriptor::validate_graphs() {
         for (const auto& [src_asic, edges] : asic_group) {
             const auto& src_host = asic_descriptors_.at(src_asic).host_name;
             const auto& src_host_edges = system_graph_.host_connectivity_graph.at(src_host);
-            for (const auto& edge : edges) {
-                auto dst_asic = edge.first;
+
+            for (const auto& [dst_asic, eth_conns] : edges) {
                 const auto& dst_host = asic_descriptors_.at(dst_asic).host_name;
-                const auto& eth_conns = edge.second;
-                bool all_connections_local =
-                    std::all_of(eth_conns.begin(), eth_conns.end(), [&](const EthConnection& eth_conn) {
-                        return eth_conn.is_local;
-                    });
-                bool all_connections_global =
-                    std::all_of(eth_conns.begin(), eth_conns.end(), [&](const EthConnection& eth_conn) {
-                        return !eth_conn.is_local;
-                    });
-                // All connections on this edge must be local or global.
+
+                bool all_local = std::all_of(
+                    eth_conns.begin(), eth_conns.end(), [](const EthConnection& conn) { return conn.is_local; });
+
+                bool all_global = std::all_of(
+                    eth_conns.begin(), eth_conns.end(), [](const EthConnection& conn) { return !conn.is_local; });
+
+                // All connections must be uniformly local or global.
                 TT_FATAL(
-                    all_connections_local || all_connections_global,
-                    "Physical Discovery Error: All ethernet connections should either be local or global. Please reset "
-                    "the system and try again.");
-                // If all connections are local, then the src_host and dst_host should be the same
-                if (all_connections_local) {
-                    // If connections are local, then the src_host and dst_host should be the same.
-                    for (const auto& eth_conn : eth_conns) {
-                        TT_FATAL(
-                            src_host == dst_host,
-                            "Physical Discovery Error: Local Connection between {} and {} is not on the same host. "
-                            "Please reset the system and try again.",
-                            src_host,
-                            dst_host);
-                    }
-                } else {
-                    // If connections are global, then the src_host and dst_host should be different.
+                    all_local || all_global,
+                    "Physical Discovery Error: All ethernet connections should either be local or global. "
+                    "Please reset the system and try again.");
+
+                if (all_local) {
+                    // Local connections must remain within the same host.
                     TT_FATAL(
-                        src_host != dst_host,
-                        "Physical Discovery Error: Hostnames for connections marked as global should be different. "
-                        "Please reset the system and try again.");
-                    for (const auto& eth_conn : eth_conns) {
-                        bool host_neighbor_found = false;
-                        for (const auto& src_host_edge : src_host_edges) {
-                            if (src_host_edge.first == dst_host) {
-                                host_neighbor_found = true;
-                                const auto& exit_node_conns = src_host_edge.second;
-                                bool exit_node_conn_found =
-                                    std::find_if(
-                                        exit_node_conns.begin(),
-                                        exit_node_conns.end(),
-                                        [&](const ExitNodeConnection& exit_node_conn) {
-                                            return exit_node_conn.src_exit_node == src_asic &&
-                                                   exit_node_conn.dst_exit_node == dst_asic &&
-                                                   exit_node_conn.eth_conn.src_chan == eth_conn.src_chan &&
-                                                   exit_node_conn.eth_conn.dst_chan == eth_conn.dst_chan;
-                                        }) != exit_node_conns.end();
-                                // A global connection should be visible as an exit node from the src_host to the
-                                // dst_host.
-                                TT_FATAL(
-                                    exit_node_conn_found,
-                                    "Physical Discovery Error: Global Connection between {} and {} is not found in the "
-                                    "host connectivity graph. Please reset the system and try again.",
-                                    src_host,
-                                    dst_host);
-                                break;
-                            }
-                        }
-                        // A global connection should be visible as an exit node from the src_host to the dst_host.
-                        TT_FATAL(
-                            host_neighbor_found,
-                            "Physical Discovery Error: Global Connection between {} and {} is not found in the host "
-                            "connectivity graph. Please reset the system and try again.",
-                            src_host,
-                            dst_host);
-                    }
+                        src_host == dst_host,
+                        "Physical Discovery Error: Local Connection between {} and {} is not on the same host. "
+                        "Please reset the system and try again.",
+                        src_host,
+                        dst_host);
+                    continue;  // no need to check further
+                }
+
+                // Global connections must cross hosts.
+                TT_FATAL(
+                    src_host != dst_host,
+                    "Physical Discovery Error: Hostnames for connections marked as global should be different. "
+                    "Please reset the system and try again.");
+
+                // Validate each global ethernet connection.
+                for (const auto& eth_conn : eth_conns) {
+                    // Look for a host edge matching dst_host.
+                    auto host_edge_it =
+                        std::find_if(src_host_edges.begin(), src_host_edges.end(), [&](const auto& host_edge) {
+                            return host_edge.first == dst_host;
+                        });
+
+                    TT_FATAL(
+                        host_edge_it != src_host_edges.end(),
+                        "Physical Discovery Error: Global Connection between {} and {} is not found in the host "
+                        "connectivity graph. Please reset the system and try again.",
+                        src_host,
+                        dst_host);
+
+                    const auto& exit_node_conns = host_edge_it->second;
+                    bool exit_conn_found = std::any_of(
+                        exit_node_conns.begin(), exit_node_conns.end(), [&](const ExitNodeConnection& exit_node_conn) {
+                            return exit_node_conn.src_exit_node == src_asic &&
+                                   exit_node_conn.dst_exit_node == dst_asic &&
+                                   exit_node_conn.eth_conn.src_chan == eth_conn.src_chan &&
+                                   exit_node_conn.eth_conn.dst_chan == eth_conn.dst_chan;
+                        });
+
+                    TT_FATAL(
+                        exit_conn_found,
+                        "Physical Discovery Error: Global Connection between {} and {} is not found in the "
+                        "host connectivity graph. Please reset the system and try again.",
+                        src_host,
+                        dst_host);
                 }
             }
         }

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -135,7 +135,7 @@ private:
     void generate_cross_host_connections();
     void remove_unresolved_nodes();
     void resolve_hostname_uniqueness();
-
+    void validate_graphs();
     PhysicalConnectivityGraph system_graph_;
     std::unordered_map<AsicID, ASICDescriptor> asic_descriptors_;
     std::unordered_map<std::string, std::string> host_to_mobo_name_;

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -17,7 +17,7 @@ namespace tt::tt_metal {
 
 using AsicID = tt::stl::StrongType<uint64_t, struct AsicIDTag>;
 using TrayID = tt::stl::StrongType<uint32_t, struct TrayIDTag>;
-using NID = tt::stl::StrongType<uint32_t, struct NIDTag>;
+using ASICLocation = tt::stl::StrongType<uint32_t, struct ASICLocationTag>;
 using RackID = tt::stl::StrongType<uint32_t, struct RackIDTag>;
 using UID = tt::stl::StrongType<uint32_t, struct UIDTag>;
 using HallID = tt::stl::StrongType<uint32_t, struct HallIDTag>;
@@ -26,7 +26,7 @@ using AisleID = tt::stl::StrongType<uint32_t, struct AisleIDTag>;
 // Specify Physical ASIC Attributes
 struct ASICDescriptor {
     TrayID tray_id;
-    NID n_id;
+    ASICLocation asic_location;
     BoardType board_type = BoardType::UNKNOWN;
     AsicID unique_id;
     std::string host_name;
@@ -98,7 +98,7 @@ public:
     std::vector<EthConnection> get_eth_connections(AsicID src_asic_id, AsicID dst_asic_id) const;
     const AsicTopology& get_asic_topology(const std::string& hostname) const;
     TrayID get_tray_id(AsicID asic_id) const;
-    NID get_n_id(AsicID asic_id) const;
+    ASICLocation get_asic_location(AsicID asic_id) const;
     std::vector<AsicID> get_asics_connected_to_host(std::string hostname) const;
 
     // Host Topology Query APIs

--- a/tt_metal/fabric/serialization/physical_desc.cpp
+++ b/tt_metal/fabric/serialization/physical_desc.cpp
@@ -30,7 +30,7 @@ std::vector<uint8_t> serialize_physical_descriptor_to_bytes(
         auto asic_desc = tt::tt_metal::flatbuffer::CreateAsicDescriptor(
             builder,
             *(descriptor.tray_id),
-            *(descriptor.n_id),
+            *(descriptor.asic_location),
             descriptor.board_type,
             *(descriptor.unique_id),
             builder.CreateString(descriptor.host_name));
@@ -161,7 +161,7 @@ tt_metal::PhysicalSystemDescriptor deserialize_physical_descriptor_from_bytes(co
         for (auto fb_asic_desc : *fb_desc->asic_descriptors()) {
             tt_metal::ASICDescriptor desc;
             desc.tray_id = TrayID{fb_asic_desc->descriptor()->tray_id()};
-            desc.n_id = NID{fb_asic_desc->descriptor()->n_id()};
+            desc.asic_location = ASICLocation{fb_asic_desc->descriptor()->asic_location()};
             desc.board_type = static_cast<BoardType>(fb_asic_desc->descriptor()->board_type());
             desc.unique_id = AsicID{fb_asic_desc->descriptor()->unique_id()};
             desc.host_name = fb_asic_desc->descriptor()->host_name()->str();

--- a/tt_metal/fabric/serialization/physical_desc.fbs
+++ b/tt_metal/fabric/serialization/physical_desc.fbs
@@ -47,7 +47,7 @@ table PhysicalConnectivityGraph {
 
 table AsicDescriptor {
     tray_id: uint32;
-    n_id: uint32;
+    asic_location: uint32;
     board_type: uint32;
     unique_id: uint64;
     host_name: string;


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- `PhysicalSystemDescriptor` is missing validation to ensure that the ASIC and Host Graphs + Descriptors are internally consistent.
- When the system is in an unusable state, this can lead to users seeing incorrect information, instead of error messages.

### What's changed
- Add a validation step to ensure that all graphs are consistent

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes