### PR TITLE
Clear PhysicalSystemDescriptor state before running discovery

### DIFF
--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -28,7 +28,8 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
     auto physical_system_desc = tt::tt_metal::PhysicalSystemDescriptor();
-
+    // Run discovery again to ensure that state is cleared before re-discovery
+    physical_system_desc.run_discovery();
     auto hostnames = physical_system_desc.get_all_hostnames();
     // Validate number of hosts discovered
     EXPECT_EQ(hostnames.size(), *(distributed_context.size()));

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -163,7 +163,18 @@ void PhysicalSystemDescriptor::run_discovery(bool run_global_discovery) {
     }
 }
 
+void PhysicalSystemDescriptor::clear() {
+    // Erase all contents in all data structures
+    system_graph_.asic_connectivity_graph.clear();
+    system_graph_.host_connectivity_graph.clear();
+    asic_descriptors_.clear();
+    host_to_mobo_name_.clear();
+    host_to_rank_.clear();
+    exit_node_connection_table_.clear();
+}
+
 void PhysicalSystemDescriptor::run_local_discovery() {
+    this->clear();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
 

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -130,6 +130,7 @@ public:
 private:
     void run_local_discovery();
     void run_global_discovery();
+    void clear();
     void merge(PhysicalSystemDescriptor&& other);
     void exchange_metadata(bool issue_gather);
     void generate_cross_host_connections();


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- `PhysicalSystemDescriptor` state is not cleared between calls to `run_dsicovery()`
- This can lead to stale or duplicated information in the data-structure

### What's changed
- Clear state before running discovery

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes