### PR TITLE
Semaphore barriers added do ttnn.sort

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -103,6 +103,7 @@ void kernel_main() {
 
         // Set signal to start processing
         noc_semaphore_set_multicast(coordinator_to_cores_semaphore_id, semaphore_global_multicast_addr, number_of_dest);
+        noc_async_atomic_barrier();
 
         // Calculate sorting stages
         uint32_t stages = 0;
@@ -115,6 +116,7 @@ void kernel_main() {
                 // Set signal to start processing next sub-stage
                 noc_semaphore_set_multicast(
                     coordinator_to_cores_semaphore_id, semaphore_global_multicast_addr, number_of_dest);
+                noc_async_atomic_barrier();
 
                 // Wait until cores will process and save data
                 noc_semaphore_wait(semaphore_ptr, number_of_confirmations);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
@@ -69,6 +69,7 @@ void sort_noc_exchange_Wt_tiles(
 
         // Handshake for tile exchange
         noc_semaphore_inc(sem_noc_addr, 1);
+        noc_async_atomic_barrier();
         noc_semaphore_wait(sem_self_ptr, sem_counter);
 
         // Send local indices and values to peer
@@ -88,6 +89,7 @@ void sort_noc_exchange_Wt_tiles(
 
         // Indicate finish reading and wait for other core to finish
         noc_semaphore_inc(sem_noc_addr, 1);
+        noc_async_atomic_barrier();
         noc_semaphore_wait(sem_self_ptr, sem_counter + 1);
 
         // Push incoming tiles to compute buffers
@@ -183,6 +185,7 @@ void sort_barrier(
             uint64_t sem_barrier_noc_addr =
                 get_noc_addr(remote_core_physical.first, remote_core_physical.second, sem_barrier_addr);
             noc_semaphore_inc(sem_barrier_noc_addr, 1);
+            noc_async_atomic_barrier();
         }
     } else {
         // Indicate finish reading and wait for leader core to signal
@@ -191,6 +194,7 @@ void sort_barrier(
         uint64_t sem_barrier_noc_addr =
             get_noc_addr(remote_core_physical.first, remote_core_physical.second, sem_barrier_addr);
         noc_semaphore_inc(sem_barrier_noc_addr, 1);
+        noc_async_atomic_barrier();
         noc_semaphore_wait(sem_self_barrier_ptr, 1);
         noc_semaphore_set(sem_self_barrier_ptr, 0);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
@@ -53,6 +53,7 @@ void kernel_main() {
 
         // Indicate to the coordinator that the core is ready
         noc_semaphore_inc(coordinator_core_addr, 1);
+        noc_async_atomic_barrier();
         noc_semaphore_wait(semaphore_ptr, 0);     // Wait for coordinator to signal to start
         noc_semaphore_set(semaphore_ptr, VALID);  // Reset the semaphore
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
@@ -103,6 +103,7 @@ void kernel_main() {
 
                             // Signalize readiness to the coordinator
                             noc_semaphore_inc(coordinator_core_addr, 1);
+                            noc_async_atomic_barrier();
 
                             processing_pair_id += number_of_available_cores;
                         }  // if pair_id == processing_pair_id
@@ -112,4 +113,5 @@ void kernel_main() {
             }  // sub loop
         }  // stage loop
     }  // h loop
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION
### Ticket

#27726 

### Problem description

While working on updating the kernel compiler version, a potential data race condition was noticed in `ttnn.sort`. Upon inspection, it was determined that a barrier was missing after incrementing the semaphores for communication between cores.

### What's changed
- Added barriers after semaphore increment.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17370097859
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17370114201
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes