### PR TITLE
Stable diffusion moved to DRAM layernorm

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -400,7 +400,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((11.30),),
+    ((11.10),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"


### PR DESCRIPTION
### Problem description
SD ND hang occured due to layernorm_sharded
[tt-triage report](https://github.com/user-attachments/files/22073554/stable_diffusion_hang.txt)

### What's changed
- switched to using layernorm DRAM implementation
- stress tested on n150 and n300, 6h later no hang


### Checklist
- [X] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17371276631)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17370905304)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) Ci [stable_diffusion passes](https://github.com/tenstorrent/tt-metal/actions/runs/17370891191)