### PR TITLE
#0: Reduce L1 small on SDXL

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -22,7 +22,7 @@ import ttnn
 
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 
-SDXL_L1_SMALL_SIZE = 47000
+SDXL_L1_SMALL_SIZE = 42000
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 


### PR DESCRIPTION
### Ticket
-

### Problem description
Noticed L1_SMALL can be reduced on SDXL.

### What's changed
Reduce SDXL L1_SMALL to 42k

### Checklist
- [x] [Frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/17373232309) unrelated failures
- [x] [Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/17373227080) passing