### PR TITLE
Remove conftest relation from SDXL class

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -65,7 +65,7 @@ def run_demo_inference(
             encoders_on_device=encoders_on_device,
             num_inference_steps=num_inference_steps,
             guidance_scale=guidance_scale,
-            is_galaxy=is_galaxy,
+            is_galaxy=is_galaxy(),
         ),
     )
 

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -14,6 +14,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
 )
 import os
 from models.utility_functions import profiler
+from conftest import is_galaxy
 
 from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 
@@ -64,6 +65,7 @@ def run_demo_inference(
             encoders_on_device=encoders_on_device,
             num_inference_steps=num_inference_steps,
             guidance_scale=guidance_scale,
+            is_galaxy=is_galaxy,
         ),
     )
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -33,7 +33,7 @@ class TtSDXLPipelineConfig:
     capture_trace: bool = True
     vae_on_device: bool = True
     encoders_on_device: bool = True
-    is_galaxy: bool = False
+    is_galaxy: bool
 
 
 class TtSDXLPipeline(LightweightModule):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 
 from diffusers import StableDiffusionXLPipeline
 from loguru import logger
-from conftest import is_galaxy
 import ttnn
 
 from models.common.lightweightmodule import LightweightModule
@@ -34,6 +33,7 @@ class TtSDXLPipelineConfig:
     capture_trace: bool = True
     vae_on_device: bool = True
     encoders_on_device: bool = True
+    is_galaxy: bool = False
 
 
 class TtSDXLPipeline(LightweightModule):
@@ -65,7 +65,7 @@ class TtSDXLPipeline(LightweightModule):
         self.allocated_device_tensors = False
         self.generated_input_tensors = False
 
-        if is_galaxy():
+        if pipeline_config.is_galaxy():
             logger.info("Setting TT_MM_THROTTLE_PERF for Galaxy")
             os.environ["TT_MM_THROTTLE_PERF"] = "5"
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -65,7 +65,7 @@ class TtSDXLPipeline(LightweightModule):
         self.allocated_device_tensors = False
         self.generated_input_tensors = False
 
-        if pipeline_config.is_galaxy():
+        if pipeline_config.is_galaxy:
             logger.info("Setting TT_MM_THROTTLE_PERF for Galaxy")
             os.environ["TT_MM_THROTTLE_PERF"] = "5"
 


### PR DESCRIPTION
Conftest is removed from SDXL class.
Otherwise the whole conftest was pulled in to SDXL class causing random errors (i.e. tests.scripts is not exported)