### PR TITLE
Update vllm nightly to use 6U galaxy

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -86,10 +86,10 @@ jobs:
             model: "meta-llama/Llama-3.3-70B-Instruct",
             server-timeout: 35,
             benchmark-timeout: 10,
-            runner-label: config-tg,
+            runner-label: topology-6u,
             mesh-device: TG,
             tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
@@ -98,9 +98,9 @@ jobs:
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 10,
             benchmark-timeout: 5,
-            runner-label: config-tg,
+            runner-label: topology-6u,
             mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D\"}",
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
             tt-llama-text-ver: tt_transformers,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic


### PR DESCRIPTION
### Problem description
Since 4Us are getting deprecated we are having more and more stability issues with this pipeline. Now that more 6Us are available we can make a switch.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [vllm nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17399802997) (failing test is unrelated to these changes and is happening on main as well https://github.com/tenstorrent/tt-metal/actions/runs/17382234143)