### PR TITLE
#28006: Improve expm1 accuracy

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import math
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def test_expm1_arange_masking(device):
+    # Expm1 Working range - Overflow from 88.5(inf) as in exp
+    low = -math.inf
+    high = 88.5
+
+    # Generate all possible bit patterns for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # masking to working range
+    mask = (input_tensor >= low) & (input_tensor <= high)
+    input_tensor = input_tensor[mask]
+
+    # Mask range where expm1 has ULP>1 (Covered in atol test below).
+    mask_failed = (input_tensor >= -0.28515625) & (input_tensor <= 0.69140625)
+    input_tensor[mask_failed] = 1.0
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.expm1)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.expm1(tt_in)
+    result = ttnn.to_torch(tt_result)
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize(
+    "low, high, expected_atol, expected_rtol",
+    [
+        (-1.6 * 10**38, -0.28515625, 0.001, 0.004),
+        (-0.28515625, 0.69140625, 0.004, 0.02),
+        (0.69140625, 88.5, 0.001, 0.01),
+    ],
+)
+def test_expm1_allclose(low, high, expected_atol, expected_rtol, device):
+    num_elements = math.prod([1, 3, 320, 320])
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))
+
+    golden_function = ttnn.get_golden_function(ttnn.expm1)
+    golden = golden_function(torch_input, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.expm1(tt_in)
+    result = ttnn.to_torch(tt_result)
+
+    assert torch.allclose(golden, result, atol=expected_atol, rtol=expected_rtol)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,31 +4,86 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_exp.h"
-
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_expm1() {
-    const bool SCALE_EN = false;             // Expm1 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
-    const uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+/*
+ * This function implements the exponential function using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ *
+ * @return sfpi::vFloat Result of exp(val)
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
+template <bool is_fp32_dest_acc_en = false>
+sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
+    sfpi::vFloat y = sfpi::vConstNeg1;
+    v_if(sfpi::abs(val) < sfpi::vFloat(1e-3f)) {
+        // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
+        // expm1(x) = x + (x^2/2) + (x^3/3^2)
+        // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)
+        y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
 
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+            // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+            // rather than 81 (which would have been correct).
+            // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        }
+    }
+    v_elseif(val > -88.0f) {
+        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+        // z = (bias + x * factor * N_m; where:
+        // factor = 0x00b8aa3b (computed through log(e))
+        // bias = 0x3f800000
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
+        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
+
+        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
+        d2 = d1 * d2;
+        zif = sfpu::_float_to_int32_(d2 * d3);
+
+        // Restore exponent
+        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+
+        y = sfpi::reinterpret<sfpi::vFloat>(zii) - sfpi::vConst1;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+            // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+            // rather than 81 (which would have been correct).
+            // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        }
+    }
+    v_endif;
+    return y;
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_expm1() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        v = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(
-            v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = v - 1.0f;
+        sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    const uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    _init_exponential_<APPROXIMATION_MODE, false /*fast_mode*/, EXP_BASE_SCALE_FACTOR>();
+    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+    sfpi::vConstIntPrgm1 = 0xf94ee7;
+    sfpi::vConstIntPrgm2 = 0x560e;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,10 +17,10 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,31 +4,87 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_exp.h"
-
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_expm1() {
-    const bool SCALE_EN = false;             // Expm1 does not use scale.
-    const bool SKIP_POSITIVE_CHECK = false;  // Expm1 does not skip positive check.
-    const uint16_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B;
+/*
+ * This function implements the exponential function using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ *
+ * @return sfpi::vFloat Result of exp(val)
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
+template <bool is_fp32_dest_acc_en = false>
+sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
+    sfpi::vFloat y = sfpi::vConstNeg1;
+    v_if(sfpi::abs(val) < sfpi::vFloat(1e-3f)) {
+        // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
+        // expm1(x) = x + (x^2/2) + (x^3/3^2)
+        // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)
+        y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
 
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+            // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+            // rather than 81 (which would have been correct).
+            // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        }
+    }
+    v_elseif(val > -88.0f) {
+        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+        // z = (bias + x * factor * N_m; where:
+        // factor = 0x00b8aa3b (computed through log(e))
+        // bias = 0x3f800000
+        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
+        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
+
+        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
+        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
+        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
+        d2 = d1 * d2;
+        zif = sfpu::_float_to_int32_(d2 * d3);
+
+        // Restore exponent
+        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
+
+        y = sfpi::reinterpret<sfpi::vFloat>(zii) - sfpi::vConst1;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+            // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+            // rather than 81 (which would have been correct).
+            // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        }
+    }
+    v_endif;
+    return y;
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_expm1() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        v = _calculate_exponential_piecewise_<APPROXIMATION_MODE, SCALE_EN, SKIP_POSITIVE_CHECK>(
-            v, exp_base_scale_factor);
-        sfpi::dst_reg[0] = v - 1.0f;
+        sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    const uint32_t EXP_BASE_SCALE_FACTOR = 0x3F800000;
-    _init_exponential_<APPROXIMATION_MODE, false /*fast_mode*/, EXP_BASE_SCALE_FACTOR>();
+    // Polynomial coefficients for approximation of exp on [1; 2]
+    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+    sfpi::vConstIntPrgm1 = 0xf94ee7;
+    sfpi::vConstIntPrgm2 = 0x560e;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -17,10 +17,10 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -419,7 +419,7 @@ ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_in
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-ALWI void expm1_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_expm1<true>(idst))); }
+ALWI void expm1_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_expm1<true, DST_ACCUM_MODE>(idst))); }
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
#28006 , #26993

### Problem description
Provide context for the problem.

### What's changed
- Tested in WH, BH
- **ULP Data** : 
  - Tested for the entire 16-bit range of bfloat16 (0 through 2¹⁶), covering all possible values. Test passes with ULP 1
  - Below listed are the failing cases
    - With exp21f , for range (-0.28515625, 0.69140625) , 
      - Max ULP is 221.093994140625 : List of values with ULP>1 ([File](https://github.com/user-attachments/files/22116782/expm1_ULP.txt)) 
      - Max ATOL = 0.00390625
    - With main, Max ULP is 333.99951171875 with values covering upto -4.5 (minimum) to 88.5 (maximum): List of values with ULP>1 ([File](https://github.com/user-attachments/files/22116836/expm1_ULP_Main.txt))
    - Excluding range ( -0.28515625, 0.69140625), still give ULP 253.99366760253906
  - Attached ULP Graphs, TTNN vs Torch, Values causing higher ULP : [Graphs](https://docs.google.com/document/d/1jSSbH0YpiJtgrWaiOrpEkK_lmz5TyilARTx8QhAnJFA/edit?tab=t.0#heading=h.sy95ujcnswla)
- **Edge case behaviour** : 

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
**INPUT** | **TORCH RESULT** | **TT RESULT (Main)** | **TT RESULT (Updated)**
-- | -- | -- | --
inf | inf | inf | inf
-inf | -1 | -1 | -1
nan | nan | inf | inf
-0.0 | -0.0 | 0 | 0
0 | 0 | 0 | 0


- **Single tile Performance analysis** : Kernel duration has increased (113.47% with Taylor and 108.05% with Hornor -Updated branch)
  - Main branch : [expm1_main.csv](https://github.com/user-attachments/files/22117714/expm1_main.csv)
  - Updated branch with taylor expansion: [expm1_perf_updated.csv](https://github.com/user-attachments/files/22117718/expm1_perf_updated.csv)
  - Updated branch with Hornor form : [expm1_updates.csv](https://github.com/user-attachments/files/22317501/expm1_updates.csv)

<img width="422" height="195" alt="Image" src="https://github.com/user-attachments/assets/1618c44e-4882-48c1-9c92-ab75010fcf2c" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17848222364)
- [x] [Blackhole Post commit (watcher enabled)](https://github.com/tenstorrent/tt-metal/actions/runs/17848083205) - Fails as in main
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17853501108)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17848084812)  - Fails as in [main](https://github.com/tenstorrent/tt-metal/actions/runs/17846738239)
- [x] [Single card pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17848308489)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17848191549)
- [x] [T3K pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17848190136)- Fails as in main
- [x] New/Existing tests provide coverage for changes