### PR TITLE
Update pytest markers for performance tests

### DIFF
--- a/models/demos/classification_eval/classification_eval.py
+++ b/models/demos/classification_eval/classification_eval.py
@@ -10,7 +10,7 @@ from loguru import logger
 from transformers import AutoImageProcessor
 
 import ttnn
-from models.demos.mobilenetv2.tests.perf.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
+from models.demos.mobilenetv2.common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.utils.common_demo_utils import get_data_loader, load_imagenet_dataset
 from models.experimental.efficientnetb0.common import EFFICIENTNETB0_L1_SMALL_SIZE
 from models.experimental.swin_s.common import SWIN_S_L1_SMALL_SIZE

--- a/models/demos/mobilenetv2/common.py
+++ b/models/demos/mobilenetv2/common.py
@@ -6,6 +6,9 @@ import os
 
 import torch
 
+MOBILENETV2_L1_SMALL_SIZE = 8 * 1024  # 8 KiB
+MOBILENETV2_BATCH_SIZE = 10
+
 
 def load_torch_model(torch_model, model_location_generator=None):
     if model_location_generator == None or "TT_GH_CI_INFRA" not in os.environ:

--- a/models/demos/mobilenetv2/demo/demo.py
+++ b/models/demos/mobilenetv2/demo/demo.py
@@ -10,9 +10,8 @@ from tqdm import tqdm
 
 import ttnn
 from models.common.utility_functions import profiler, run_for_wormhole_b0
-from models.demos.mobilenetv2.common import load_torch_model
+from models.demos.mobilenetv2.common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE, load_torch_model
 from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
-from models.demos.mobilenetv2.tests.perf.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tt import ttnn_mobilenetv2
 from models.demos.mobilenetv2.tt.model_preprocessing import (
     create_mobilenetv2_input_tensors,

--- a/models/demos/mobilenetv2/tests/pcc/test_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/pcc/test_mobilenetv2.py
@@ -6,9 +6,8 @@
 import pytest
 
 import ttnn
-from models.demos.mobilenetv2.common import load_torch_model
+from models.demos.mobilenetv2.common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE, load_torch_model
 from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
-from models.demos.mobilenetv2.tests.perf.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tt import ttnn_mobilenetv2
 from models.demos.mobilenetv2.tt.model_preprocessing import (
     create_mobilenetv2_input_tensors,

--- a/models/demos/mobilenetv2/tests/perf/mobilenetv2_common.py
+++ b/models/demos/mobilenetv2/tests/perf/mobilenetv2_common.py
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-
-# SPDX-License-Identifier: Apache-2.0
-
-MOBILENETV2_L1_SMALL_SIZE = 8 * 1024  # 8 KiB
-MOBILENETV2_BATCH_SIZE = 10

--- a/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py
@@ -9,9 +9,8 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import run_for_wormhole_b0
-from models.demos.mobilenetv2.common import load_torch_model
+from models.demos.mobilenetv2.common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE, load_torch_model
 from models.demos.mobilenetv2.reference.mobilenetv2 import Mobilenetv2
-from models.demos.mobilenetv2.tests.perf.mobilenetv2_common import MOBILENETV2_BATCH_SIZE, MOBILENETV2_L1_SMALL_SIZE
 from models.demos.mobilenetv2.tt import ttnn_mobilenetv2
 from models.demos.mobilenetv2.tt.model_preprocessing import (
     create_mobilenetv2_input_tensors,

--- a/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
@@ -6,7 +6,7 @@
 import pytest
 from loguru import logger
 
-from models.demos.mobilenetv2.tests.pcc.test_mobilenetv2 import MOBILENETV2_BATCH_SIZE
+from models.demos.mobilenetv2.common import MOBILENETV2_BATCH_SIZE
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 
 

--- a/models/demos/segformer/tests/perf/test_e2e_performant.py
+++ b/models/demos/segformer/tests/perf/test_e2e_performant.py
@@ -58,5 +58,6 @@ def test_segformer_e2e(device, batch_size, model_location_generator):
     ((1),),
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_segformer_e2e_dp(mesh_device, device_batch_size, model_location_generator):
     run_segformer_trace_2cqs_inference(mesh_device, device_batch_size, model_location_generator)

--- a/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
@@ -65,5 +65,6 @@ def test_ufldv2_e2e_performant(device, batch_size, model_location_generator):
     ((1),),
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_ufldv2_e2e_performant_dp(mesh_device, batch_size_per_device, model_location_generator):
     run_ufldv2_e2e(mesh_device, batch_size_per_device, model_location_generator)

--- a/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
+++ b/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
@@ -111,6 +111,7 @@ def test_e2e_performant(
     ],
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_dp(
     mesh_device,
     device_batch_size,

--- a/models/demos/wormhole/vit/README.md
+++ b/models/demos/wormhole/vit/README.md
@@ -27,7 +27,7 @@ pytest --disable-warnings tests/nightly/single_card/vit/test_ttnn_optimized_shar
 To run the demo for ViT model, follow these instructions:
 -  For overall runtime inference (end-2-end), use the following command to run the demo:
 ```sh
-pytest --disable-warnings models/demos/wormhole/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+pytest --disable-warnings models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
 ```
 
 -  For inference device OPs analysis, use the following command to run the demo:

--- a/models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -126,7 +126,7 @@ def test_vit(device, batch_size, is_single_card_n300):
     # Test is ran either on n300 or n150
     # If it's n300, there's a problem with eth dispatch, hence lower perf
     if is_single_card_n300:
-        expected_samples_per_sec = 1255
+        expected_samples_per_sec = 1323
     else:  # n150
         expected_samples_per_sec = 1377
     torch.manual_seed(0)

--- a/models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -117,6 +117,7 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
 
 @pytest.mark.skipif(is_blackhole(), reason="Unsupported on BH")
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1753088}], indirect=True
 )

--- a/models/demos/yolov10x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov10x/tests/perf/test_e2e_performant.py
@@ -107,6 +107,8 @@ def test_e2e_performant(
         (640, 640),
     ],
 )
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_dp(
     mesh_device,
     batch_size_per_device,

--- a/models/demos/yolov11/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov11/tests/perf/test_e2e_performant.py
@@ -66,7 +66,6 @@ def run_yolov11_inference(
         (640, 640),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "device_params",
@@ -103,6 +102,7 @@ def test_e2e_performant(
     ],
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "device_params",

--- a/models/demos/yolov12x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov12x/tests/perf/test_e2e_performant.py
@@ -57,7 +57,6 @@ def run_yolov12x_inference(
         ),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "device_params",
@@ -86,6 +85,7 @@ def test_e2e_performant(
     ],
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "device_params",

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -132,7 +132,6 @@ def run_perf_e2e_yolov4(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV4_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
@@ -168,6 +167,7 @@ def test_e2e_performant(
 
 @run_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV4_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],

--- a/models/demos/yolov6l/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov6l/tests/perf/test_e2e_performant.py
@@ -96,7 +96,6 @@ def run_yolov6_inference(
         (640, 640),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 def test_perf_yolov6l(
     device,
     batch_size_per_device,
@@ -132,6 +131,7 @@ def test_perf_yolov6l(
     ],
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_perf_yolov6l_dp(
     mesh_device,
     batch_size_per_device,

--- a/models/demos/yolov7/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov7/tests/perf/test_e2e_performant.py
@@ -119,7 +119,6 @@ def run_perf_e2e_yolov7(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV7_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
@@ -155,6 +154,7 @@ def test_e2e_performant(
 
 @run_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV7_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],

--- a/models/demos/yolov8s/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8s/tests/perf/test_e2e_performant.py
@@ -50,7 +50,6 @@ def run_yolov8s(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV8S_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],

--- a/models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py
+++ b/models/demos/yolov8s_world/tests/perf/test_perf_yolov8s_world.py
@@ -97,7 +97,6 @@ def run_yolov8s_world_inference(
         (640, 640),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 def test_perf_yolov8s_world(
     device,
     batch_size_per_device,
@@ -133,6 +132,7 @@ def test_perf_yolov8s_world(
     ],
 )
 @pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 def test_perf_yolov8s_world_dp(
     mesh_device,
     batch_size_per_device,

--- a/models/demos/yolov8x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8x/tests/perf/test_e2e_performant.py
@@ -113,7 +113,6 @@ def run_perf_e2e_yolov8x(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": YOLOV8X_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
@@ -74,7 +74,6 @@ def run_yolov9c_inference(
         ),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 def test_e2e_performant(
     model_location_generator,
     device,

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
@@ -25,7 +25,6 @@ from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov
         ),
     ],
 )
-@pytest.mark.models_performance_bare_metal
 def test_e2e_performant(
     model_location_generator,
     device,


### PR DESCRIPTION
### Ticket
Link to Github Issue - https://github.com/tenstorrent/tt-metal/issues/27745

### Problem description
pytest markers are not consistent for all the models.

### What's changed
Enabled "models_performance_bare_metal" for DP performant test alone. Removed this marker for other tests.
Enabled "models_performance_virtual_machine" for DP performant tests. It was not consistent.

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17763204779)
- [x] Model Perf [yolos - ([v6l ,v7, v8s,v8x,v10x, v11 , v12x, v9c), vanilla_unet, ufldv2, segformer,](https://github.com/tenstorrent/tt-metal/actions/runs/17773077344),[ViT](https://github.com/tenstorrent/tt-metal/actions/runs/17774774347),[yolov4](https://github.com/tenstorrent/tt-metal/actions/runs/17773096189/workflow), yolov8s_world
- [x] Tests for MobilenetV2 [[Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/17772953352),[Model Perf, PCC test](https://github.com/tenstorrent/tt-metal/actions/runs/17772929784/workflow),[Demo](https://github.com/tenstorrent/tt-metal/actions/runs/17772985438)]. - Passed