### PR TITLE
#26109: Provide option to place config tensors for Conv2D in DRAM instead of L1_SMALL.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4576,6 +4576,7 @@ def test_conv_bs_grid(
 # fmt: off
 @pytest.mark.parametrize("enable_activation_reuse", [False, True])
 @pytest.mark.parametrize("enable_split_reader", [False, True])
+@pytest.mark.parametrize("config_in_dram", [False, True])
 @pytest.mark.parametrize(
     "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, input_dtype, input_layout, groups, kernel, stride, padding, dilation, auto_shard, act_block_h_override, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc",
     (
@@ -4616,6 +4617,7 @@ def test_conv2d_activation_reuse(
     input_layout,
     enable_split_reader,
     enable_activation_reuse,
+    config_in_dram
 ):
     if batch == 16 and is_wormhole_b0():
         # not enough memory on WH for this case
@@ -4660,7 +4662,8 @@ def test_conv2d_activation_reuse(
         activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
         enable_act_double_buffer=True,  # will be disabled if activation reuse is enabled
         input_dtype = input_dtype,
-        enable_activation_reuse=enable_activation_reuse
+        enable_activation_reuse=enable_activation_reuse,
+        config_tensors_in_dram=config_in_dram
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -125,6 +125,7 @@ def run_conv(
     sharded_cfg=None,
     throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
     enable_activation_reuse=False,
+    config_tensors_in_dram=False,
 ):
     if isinstance(device, ttnn.MeshDevice) and len(device.get_device_ids()) > 1:
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when running on multiple devices"
@@ -254,6 +255,7 @@ def run_conv(
         enable_kernel_stride_folding=enable_kernel_stride_folding,
         full_inner_dim=bs_full_inner_dim,
         enable_activation_reuse=enable_activation_reuse,
+        config_tensors_in_dram=config_tensors_in_dram,
     )
 
     compute_config = ttnn.init_device_compute_kernel_config(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -745,7 +745,8 @@ Result conv2d_L1(
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
                 input_tensor_post_tm.memory_config(),
                 true,
-                conv_config.in_place);
+                conv_config.in_place,
+                conv_config.config_tensors_in_dram);
 
             if (conv_config.deallocate_activation) {
                 input_tensor_post_tm.deallocate(/*force*/ true);
@@ -787,7 +788,8 @@ Result conv2d_L1(
             conv_config.enable_weights_double_buffer,
             conv_config.full_inner_dim,
             enable_split_reader,
-            conv_config.enable_activation_reuse);
+            conv_config.enable_activation_reuse,
+            conv_config.config_tensors_in_dram);
 
         if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
             conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -46,6 +46,7 @@ std::vector<CBInfo> get_cb_info(
     const OptimizedConvParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> input_shape,
     const Conv2dConfig& conv_config,
     DataType input_datatype,
     DataType output_datatype,
@@ -151,6 +152,8 @@ std::vector<CBInfo> get_cb_info(
         packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : output_datatype;
     const tt::DataFormat partial_df = datatype_to_dataformat_converter(partial_dtype);
     const uint32_t partial_tile_size = tt::tile_size(partial_df);
+
+    const bool is_1d_conv = input_shape[0] != 1 && input_shape[1] == 1;
 
     {
         // Weights CB
@@ -261,8 +264,10 @@ std::vector<CBInfo> get_cb_info(
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::READER_INDICES,
         .num_pages = 1,
-        .page_size = pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per indexß
-        .is_globally_allocated = true,
+        .page_size = is_1d_conv && conv_config.config_tensors_in_dram
+                         ? pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 6
+                         : pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per indexß
+        .is_globally_allocated = conv_config.config_tensors_in_dram == false,
         .data_format = tt::DataFormat::UInt16});
 
     // L1 scratchpad CB
@@ -316,7 +321,7 @@ void allocate_cbs(
 
         std::tie(cb.index, cb.handle) =
             tt::tt_metal::create_cb(cb_index++, program, all_cores, cb.page_size, cb.num_pages, cb.data_format, buffer);
-        log_debug(
+        log_trace(
             tt::LogOp,
             "Allocated circular buffer {} with index {}, num pages {}, page size {}, globally allocated: {}",
             enchantum::to_string(cb.name),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -265,9 +265,10 @@ std::vector<CBInfo> get_cb_info(
         .name = Conv2dCb::READER_INDICES,
         .num_pages = 1,
         .page_size = is_1d_conv && conv_config.config_tensors_in_dram
-                         ? pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 6
-                         : pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per indexß
-        .is_globally_allocated = conv_config.config_tensors_in_dram == false,
+                         ? pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT *
+                               6  // 3 indices per output, 2B per index
+                         : pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per index
+        .is_globally_allocated = !conv_config.config_tensors_in_dram,
         .data_format = tt::DataFormat::UInt16});
 
     // L1 scratchpad CB

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -66,6 +66,7 @@ std::vector<CBInfo> get_cb_info(
     const OptimizedConvParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> input_shape,
     const Conv2dConfig& conv_config,
     DataType input_datatype,
     DataType output_datatype,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -305,6 +305,7 @@ void py_bind_conv2d(py::module& module) {
             std::optional<ttnn::operations::unary::UnaryWithParam>,
             bool,
             bool,
+            bool,
             uint32_t,
             uint32_t,
             bool,
@@ -325,6 +326,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("activation") = std::nullopt,
         py::arg("deallocate_activation") = false,
         py::arg("reallocate_halo_output") = true,
+        py::arg("config_tensors_in_dram") = false,
         py::arg("act_block_h_override") = 0,
         py::arg("act_block_w_div") = 1,
         py::arg("reshard_if_not_optimal") = false,
@@ -363,7 +365,10 @@ void py_bind_conv2d(py::module& module) {
     py_conv_config.def_readwrite("reallocate_halo_output", &Conv2dConfig::reallocate_halo_output, R"doc(
         reallocate_halo_output is a boolean that indicates whether the halo output tensor should be moved to reduce memory fragmentation, before the conv micro-op is called.
         This is ideally used with deallocate_activation = true, when facing OOM issues in the conv micro-op.
-
+    )doc");
+    py_conv_config.def_readwrite("config_tensors_in_dram", &Conv2dConfig::config_tensors_in_dram, R"doc(
+        Boolean that determines where config tensors should be stored. Setting it to true stores them in DRAM. False stores them in L1_SMALL.
+        Config tensors are used by Conv2D, Pooling and other 2D ops to store how data should be loaded, instead of computing on device RISC-cores.
     )doc");
     py_conv_config.def_readwrite("act_block_h_override", &Conv2dConfig::act_block_h_override, R"doc(
             Controls the size of the activation block height.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -33,6 +33,10 @@ struct Conv2dConfig {
     // the output tensor of halo will be reallocated.
     bool reallocate_halo_output = true;
 
+    // If true, config tensors for Conv2D are stored in DRAM instead of L1_SMALL. L1_SMALL is persistent storage and
+    // get's quickly used up for large CNNs.
+    bool config_tensors_in_dram = false;
+
     // Has to be a multiple of 32.
     //  Smaller -> Smaller CBs, Lower L1 Usage, Lower perf.
     uint32_t act_block_h_override = 0;
@@ -115,6 +119,7 @@ struct Conv2dConfig {
         "activation",
         "deallocate_activation",
         "reallocate_halo_output",
+        "config_tensors_in_dram",
         "act_block_h_override",
         "act_block_w_div",
         "reshard_if_not_optimal",
@@ -136,6 +141,7 @@ struct Conv2dConfig {
             std::cref(this->activation),
             std::cref(this->deallocate_activation),
             std::cref(this->reallocate_halo_output),
+            std::cref(this->config_tensors_in_dram),
             std::cref(this->act_block_h_override),
             std::cref(this->act_block_w_div),
             std::cref(this->reshard_if_not_optimal),
@@ -209,7 +215,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
-    bool enable_weights_double_buffer);
+    bool enable_weights_double_buffer,
+    bool config_tensors_in_dram);
 
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     tt::tt_metal::Program& program,
@@ -235,7 +242,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool full_inner_dim,
-    bool enable_activation_reuse);
+    bool enable_activation_reuse,
+    bool config_tensors_in_dram);
 
 // new micro op
 struct OptimizedConvNew {
@@ -255,6 +263,7 @@ struct OptimizedConvNew {
     bool full_inner_dim;
     bool enable_split_reader;
     bool enable_activation_reuse;
+    bool config_tensors_in_dram;
     uint32_t pre_op_l1_allocation_size_bytes{};
     OptimizedConvNew(
         const sliding_window::SlidingWindowConfig& sliding_window_config,
@@ -273,7 +282,8 @@ struct OptimizedConvNew {
         bool enable_weights_double_buffer,
         bool full_inner_dim,
         bool enable_split_reader,
-        bool enable_activation_reuse) :
+        bool enable_activation_reuse,
+        bool config_tensors_in_dram) :
         output_channels(output_channels),
         groups(groups),
         sliding_window_config(sliding_window_config),
@@ -290,10 +300,9 @@ struct OptimizedConvNew {
         enable_weights_double_buffer(enable_weights_double_buffer),
         full_inner_dim(full_inner_dim),
         enable_split_reader(enable_split_reader),
-        enable_activation_reuse(enable_activation_reuse) {}
-
+        enable_activation_reuse(enable_activation_reuse),
+        config_tensors_in_dram(config_tensors_in_dram) {};
     void validate(
-        const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
@@ -321,7 +330,8 @@ struct OptimizedConvNew {
         "enable_act_double_buffer",
         "enable_weights_double_buffer",
         "enable_split_reader",
-        "enable_activation_reuse");
+        "enable_activation_reuse",
+        "config_tensors_in_dram");
     auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->parallelization_config),
@@ -338,7 +348,8 @@ struct OptimizedConvNew {
             std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_weights_double_buffer),
             std::cref(this->enable_split_reader),
-            std::cref(this->enable_activation_reuse));
+            std::cref(this->enable_activation_reuse),
+            std::cref(this->config_tensors_in_dram));
     }
 };
 
@@ -361,7 +372,8 @@ Tensor optimized_conv_new(
     bool enable_weights_double_buffer = false,
     bool full_inner_dim = false,
     bool enable_split_reader = false,
-    bool enable_activation_reuse = false);
+    bool enable_activation_reuse = false,
+    bool config_tensors_in_dram = false);
 
 // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
 // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
@@ -373,17 +385,14 @@ bool determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_
 struct conv_op_l1_usage {
     uint32_t tensor_allocation_size;
     uint32_t CB_allocation_size;
-};
 
-// This function calculates how much L1 will be allocated by the conv2d op.
 // L1 allocation is either for the output tensor or for Circular Buffers.
-// This doesn't include Circular Buffers that use globally allocated addresses, as these don't need memory allocation.
 conv_op_l1_usage calculate_L1_usage(
     const DeviceComputeKernelConfig& compute_kernel_config,
     const OptimizedConvBlockConfig& block_config,
     const OptimizedConvParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
-    std::array<uint32_t, 2> kernel_size,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     const Conv2dConfig& conv_config,
     tt::tt_metal::DataType input_datatype,
     tt::tt_metal::DataType output_datatype,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -303,6 +303,7 @@ struct OptimizedConvNew {
         enable_activation_reuse(enable_activation_reuse),
         config_tensors_in_dram(config_tensors_in_dram) {};
     void validate(
+        const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
@@ -385,6 +386,7 @@ bool determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_
 struct conv_op_l1_usage {
     uint32_t tensor_allocation_size;
     uint32_t CB_allocation_size;
+};
 
 // L1 allocation is either for the output tensor or for Circular Buffers.
 conv_op_l1_usage calculate_L1_usage(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -178,7 +178,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool full_inner_dim,
-    bool enable_activation_reuse) {
+    bool enable_activation_reuse,
+    bool config_tensors_in_dram) {
     distributed::MeshDevice* device = a.device();
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
@@ -522,10 +523,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     };
 
     Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, input_parallel_config);
+        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device());
+        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
 
+
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
     const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
     TT_FATAL(act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0, "Error");
@@ -613,6 +616,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     Conv2dConfig conv_config = Conv2dConfig{
         .weights_dtype = b.dtype(),
+        .config_tensors_in_dram = config_tensors_in_dram,
         .shard_layout = a.memory_config().memory_layout(),
         .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
         .enable_act_double_buffer = enable_act_double_buffer,
@@ -625,6 +629,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         parallelization_config,
         b.padded_shape(),
         {filter_h, filter_w},
+        {sliding_window_config.input_hw.first, sliding_window_config.input_hw.second},
         conv_config,
         a.dtype(),
         output.dtype(),
@@ -634,8 +639,19 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         is_conv_1d_depthwise_conv,
         skip_activation_mcast);
 
-    access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size = conv_sharded_input_top_left_indices[0].size();
-
+    if (config_tensors_in_dram) {
+        // The actual CB reader size is difficult to calculate in calculate_L1_size. So instead keep the CB size as the
+        // maximum possible size.
+        TT_FATAL(
+            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size >=
+                conv_reader_indices_storage.get_buffer()->page_size(),
+            "CB page size {} should be greater than the config tensor page size {}",
+            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size,
+            conv_reader_indices_storage.get_buffer()->page_size());
+    } else {
+        access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size =
+            conv_reader_indices_storage.get_buffer()->page_size();
+    }
     // call function to allocate circular buffers
     allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
 
@@ -752,6 +768,16 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     std::map<std::string, std::string> writer_defines;
     std::map<std::string, std::string> writer_mcast_sender_defines;
     std::map<std::string, std::string> compute_defines;
+
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
+        writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
+        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->address());
+        reader_compile_time_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer()).append_to(reader_compile_time_args);
+    }
+
     if (skip_activation_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
     }
@@ -797,7 +823,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         device->arch(), total_num_cores, compute_defines, ttnn::get_throttle_level(compute_kernel_config));
 
     for (auto elem : compute_defines) {
-        log_debug(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+        log_trace(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
     }
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -1012,23 +1038,29 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                 }
                 reader_rt_args.push_back(static_cast<uint32_t>(is_receiver_core));  // is_receiver_core
                 reader_rt_args.push_back(static_cast<uint32_t>(is_sender_core));    // is_receiver_core
+                reader_rt_args.push_back(transpose_mcast ? core.x : core.y);        // dram config reader index
                 reader_rt_args.insert(reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
                 SetRuntimeArgs(program, reader_id, core, reader_rt_args);
             }
         }
-    } else if (enable_activation_reuse) {
+    } else {
+        uint32_t core_index = 0;
         for (const CoreRange& core_range : input_cores.ranges()) {
             for (const CoreCoord& core : core_range) {
-                uint32_t reader_remaining_tiles_to_push = 0;
-                if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
-                    reader_remaining_tiles_to_push = activation_reuse_config.partial_core_reader_tiles_to_push;
-                } else if (
-                    activation_reuse_config.cores_with_non_meaningful_work.find(core) !=
-                    activation_reuse_config.cores_with_non_meaningful_work.end()) {
-                    reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
-                }
-                std::vector<uint32_t> reader_rt_args{reader_remaining_tiles_to_push};
+                std::vector<uint32_t> reader_rt_args{core_index};
+                if (enable_activation_reuse) {
+                    uint32_t reader_remaining_tiles_to_push = 0;
+                    if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
+                        reader_remaining_tiles_to_push = activation_reuse_config.partial_core_reader_tiles_to_push;
+                    } else if (
+                        activation_reuse_config.cores_with_non_meaningful_work.find(core) !=
+                        activation_reuse_config.cores_with_non_meaningful_work.end()) {
+                        reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
+                    }
+                } 
+                reader_rt_args.push_back(reader_remaining_tiles_to_push);
                 SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+                core_index++;
             }
         }
     }
@@ -1047,7 +1079,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             "bias_tile_offset {} should be less than bias_ntiles {}",
             bias_tile_offset,
             bias_ntiles);
-
         std::vector<uint32_t> sender_rt_args = {
             weight_dram_addr, bias_dram_addr, out_start_tile_id_w, bias_tile_offset};
         if (block_sharded) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -61,7 +61,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
-    bool enable_weights_double_buffer) {
+    bool enable_weights_double_buffer,
+    bool config_tensors_in_dram) {
     tt::tt_metal::IDevice* device = a.device();
     TT_FATAL(a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
@@ -367,6 +368,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     Conv2dConfig conv_config = Conv2dConfig{
         .weights_dtype = b.dtype(),
+        .config_tensors_in_dram = config_tensors_in_dram,
         .shard_layout = a.memory_config().memory_layout(),
         .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
         .enable_act_double_buffer = enable_act_double_buffer,
@@ -377,6 +379,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         p_config,
         b.padded_shape(),
         {filter_h, filter_w},
+        {sliding_window_config.input_hw.first, sliding_window_config.input_hw.second},
         conv_config,
         a.dtype(),
         output.dtype(),
@@ -392,13 +395,26 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     // create sharded ttnn config tensors
     Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, parallel_config);
+        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
     conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, false, a.device());
+        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
 
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
     const tt::tt_metal::DeviceStorage& conv_reader_indices_storage = conv_reader_indices_tensor.device_storage();
 
-    access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size = conv_sharded_input_top_left_indices[0].size();
+    if (config_tensors_in_dram) {
+        // The actual CB reader size is difficult to calculate in calculate_L1_size. So instead keep the CB size as the
+        // maximum possible size.
+        TT_FATAL(
+            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size >=
+                conv_reader_indices_storage.get_buffer()->page_size(),
+            "CB page size {} should be greater than the config tensor page size {}",
+            access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size,
+            conv_reader_indices_storage.get_buffer()->page_size());
+    } else {
+        access_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).page_size =
+            conv_reader_indices_storage.get_buffer()->page_size();
+    }
 
     // call function to allocate circular buffers
     allocate_cbs(cb_info, program, all_reader_cores, a, output, conv_reader_indices_tensor);
@@ -487,6 +503,19 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         per_core_num_blocks_act_w,  // this_core_weight_height_blocks
         num_blocks_act_h_per_core,
         get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index};
+
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->address());
+        activation_kernel_compile_args.push_back(conv_reader_indices_storage.get_buffer()->page_size());
+        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_storage.get_buffer())
+            .append_to(activation_kernel_compile_args);
+    }
+
+    for (uint32_t index = 0; index < activation_kernel_compile_args.size(); index++) {
+        log_debug(tt::LogOp, "activation_kernel_compile_args[{}] = {}", index, activation_kernel_compile_args[index]);
+    }
+
     tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
     tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "height_sharded_reader_common.hpp"
+
 #define ENABLE_DEBUG 0
 
 #if ENABLE_DEBUG
@@ -92,6 +94,9 @@ void kernel_main() {
     if (this_core_id >= num_mcast_cores) {
         return;
     }
+
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(0);
+
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -98,8 +98,11 @@ void kernel_main() {
     uint32_t act_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
     const bool is_receiver_core = get_arg_val<uint32_t>(i++) > 0;
     const bool is_sender_core = get_arg_val<uint32_t>(i++) > 0;
+    uint32_t dram_config_reader_index = get_arg_val<uint32_t>(i++);
 
     tt_l1_ptr uint32_t* act_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
+
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(dram_config_reader_index);
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -25,17 +25,24 @@ void kernel_main() {
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
 
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+
+    uint32_t core_index = get_arg_val<uint32_t>(0);
+    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(core_index);
+
 #ifdef ACTIVATION_REUSE
-    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(28);
-    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(29) == 1;
-    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(30);
-    constexpr uint32_t output_image_width = get_compile_time_arg_val(31);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(32);
-    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(31);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(32) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(33);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(34);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(36) == 1;
 
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(0);
 #endif
+
 
     if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act>();
@@ -44,8 +51,6 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
 
     // LOOP TO FILL READER INDICES
-    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
     uint32_t reader_idx = 0;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -70,6 +70,9 @@ void kernel_main() {
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
 #ifdef SPLIT_READER
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_wait_front(cb_reader_indices, 1);
+#endif
 #ifdef ACTIVATION_REUSE
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
 #endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -82,6 +82,9 @@ void kernel_main() {
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
 
 #ifdef SPLIT_READER
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_wait_front(cb_reader_indices, 1);
+#endif
 #ifdef ACTIVATION_REUSE
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
 #endif

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -153,18 +153,19 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         const auto& remote_config1 = std::get<0>(kernel_config)[4];
         const auto& max_ref_size = std::get<1>(kernel_config);
 
-        auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(pad_config1, this->parallel_config_);
-        auto local_config_tensor1 =
-            sliding_window::construct_on_host_config_tensor(local_config1, this->parallel_config_);
-        auto remote_config_tensor1 =
-            sliding_window::construct_on_host_config_tensor(remote_config1, this->parallel_config_);
+        auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            pad_config1, this->parallel_config_, config_tensors_in_dram_);
+        auto local_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            local_config1, this->parallel_config_, config_tensors_in_dram_);
+        auto remote_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            remote_config1, this->parallel_config_, config_tensors_in_dram_);
 
         auto pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-            pad_config_tensor1, parallel_config_, is_block_sharded, device);
+            pad_config_tensor1, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
         auto local_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-            local_config_tensor1, parallel_config_, is_block_sharded, device);
+            local_config_tensor1, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
         auto remote_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-            remote_config_tensor1, parallel_config_, is_block_sharded, device);
+            remote_config_tensor1, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
 
         int pad_h = config_.get_pad_h() + config_.get_ceil_pad_h();
         int pad_w = config_.get_pad_w() + config_.get_ceil_pad_w();
@@ -186,7 +187,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
             remote_read_,
             transpose_mcast_,
             output_tensor,
-            /*capture_buffers=*/true)};
+            config_tensors_in_dram_)};
 
     } else {
         auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
@@ -204,23 +205,23 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         const auto& gather_config0 = kernel_config.gather_config0;
         const auto& gather_config1 = kernel_config.gather_config1;
 
-        const auto pad_config_tensor0 =
-            sliding_window::construct_on_host_config_tensor(pad_config0, this->parallel_config_);
-        const auto pad_config_tensor1 =
-            sliding_window::construct_on_host_config_tensor(pad_config1, this->parallel_config_);
-        const auto gather_config_tensor0 =
-            sliding_window::construct_on_host_config_tensor(gather_config0, this->parallel_config_);
-        const auto gather_config_tensor1 =
-            sliding_window::construct_on_host_config_tensor(gather_config1, this->parallel_config_);
+        const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+            pad_config0, this->parallel_config_, config_tensors_in_dram_);
+        const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            pad_config1, this->parallel_config_, config_tensors_in_dram_);
+        const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+            gather_config0, this->parallel_config_, config_tensors_in_dram_);
+        const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            gather_config1, this->parallel_config_, config_tensors_in_dram_);
 
-        auto pad_config_device_tensor0 =
-            sliding_window::move_config_tensor_to_device(pad_config_tensor0, parallel_config_, is_block_sharded, device);
-        auto pad_config_device_tensor1 =
-            sliding_window::move_config_tensor_to_device(pad_config_tensor1, parallel_config_, is_block_sharded, device);
+        auto pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor0, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
+        auto pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor1, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
         auto gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-            gather_config_tensor0, parallel_config_, is_block_sharded, device);
+            gather_config_tensor0, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
         auto gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-            gather_config_tensor1, parallel_config_, is_block_sharded, device);
+            gather_config_tensor1, parallel_config_, is_block_sharded, device, config_tensors_in_dram_);
 
         const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
             kernel_config.number_of_blocks_per_core, this->parallel_config_);
@@ -242,7 +243,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
             transpose_mcast_,
             output_tensor,
             UNTILIZE_BLOCK_SIZE,
-            /*capture_buffers=*/true)};
+            config_tensors_in_dram_)};
     }
 }
 
@@ -254,7 +255,8 @@ Tensor halo_op(
     bool transpose_mcast,
     const MemoryConfig& output_memory_config,
     bool is_out_tiled,
-    bool in_place) {
+    bool in_place,
+    bool config_tensors_in_dram) {
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Halo expects sharded input tensor");
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
@@ -300,7 +302,8 @@ Tensor halo_op(
                    .in_nsticks_per_core_ = in_nsticks_per_core,
                    .output_memory_config_ = output_memory_config,
                    .is_out_tiled_ = is_out_tiled,
-                   .in_place_ = in_place},
+                   .in_place_ = in_place,
+                   .config_tensors_in_dram_ = config_tensors_in_dram},
                {input_tensor})
         .at(0);
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -25,6 +25,7 @@ struct HaloDeviceOperation {
     tt::tt_metal::MemoryConfig output_memory_config_;
     bool is_out_tiled_;
     bool in_place_;
+    bool config_tensors_in_dram_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
@@ -41,7 +42,8 @@ struct HaloDeviceOperation {
         "max_out_nsticks_per_core_",
         "output_memory_config_",
         "is_out_tiled_",
-        "in_place_");
+        "in_place_",
+        "config_tensors_in_dram_");
     auto attribute_values() const {
         return std::make_tuple(
             std::cref(config_),
@@ -52,7 +54,8 @@ struct HaloDeviceOperation {
             std::cref(max_out_nsticks_per_core_),
             std::cref(output_memory_config_),
             std::cref(is_out_tiled_),
-            std::cref(in_place_));
+            std::cref(in_place_),
+            std::cref(config_tensors_in_dram_));
     }
 };
 
@@ -64,7 +67,8 @@ Tensor halo_op(
     bool transpose_mcast = true,
     const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     bool is_out_tiled = true,
-    bool in_place = false);
+    bool in_place = false,
+    bool config_tensors_in_dram = false);
 
 }  // namespace halo
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/common/constants.hpp"
@@ -72,7 +73,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     const bool transpose_mcast,
     Tensor& output_tensor,
     const int block_size,
-    const bool capture_buffers) {
+    bool config_tensors_in_dram) {
     Buffer* src_buffer = input_tensor.buffer();
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -143,6 +144,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
 
     uint32_t input_to_writer_cb_id0 = cb_indices.src_cb_id;
     uint32_t input_to_writer_cb_id1 = cb_indices.src_cb_id;
+    const bool is_rm_orientation = shard_orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_orientation);
+
     if (!skip_untilize) {
         cb_indices.untilize_out_cb_id0 = cb_indices.get_next_cb_id();
         cb_indices.untilize_out_cb_id1 = cb_indices.get_next_cb_id();
@@ -168,12 +172,18 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         KernelHandle untilize_kernel_id =
             CreateKernel(program, compute_kernel_name, all_cores, ComputeConfig{.compile_args = compute_ct_args});
 
-        const bool is_rm_orientation = shard_orientation == ShardOrientation::ROW_MAJOR;
-        const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_orientation);
         for (int core_id = 0; core_id < cores.size(); core_id++) {
             SetRuntimeArgs(program, untilize_kernel_id, cores[core_id], {number_of_blocks_per_core[core_id]});
         }
     }
+
+    log_debug(
+        tt::LogOp,
+        "\n\n Halo Config Tensors: Padding: \n\t {} \n\t {} \nGather \n\t {} \n\t {}",
+        padding_config0,
+        padding_config1,
+        gather_config0,
+        gather_config1);
 
     TT_ASSERT(padding_config0.dtype() == DataType::UINT16);
     TT_ASSERT(padding_config1.dtype() == DataType::UINT16);
@@ -182,7 +192,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
 
     const uint32_t num_cores = all_cores.num_cores();
 
-    auto padding_config_storage0 = padding_config0.device_storage();
+    const auto& padding_config_storage0 = padding_config0.device_storage();
     auto padding_config_buffer0 = padding_config_storage0.get_buffer();
     cb_indices.padding_config0 = cb_indices.get_next_cb_id();
     auto padding_config_cb0 = create_circular_buffer(
@@ -191,10 +201,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         cb_indices.padding_config0,
         kernel_config_df,
         1,
-        padding_config_buffer0->size() / num_cores,
-        padding_config_buffer0);
+        padding_config_buffer0->page_size(),
+        config_tensors_in_dram ? nullptr : padding_config_buffer0);
 
-    auto padding_config_storage1 = padding_config1.device_storage();
+    const auto& padding_config_storage1 = padding_config1.device_storage();
     auto padding_config_buffer1 = padding_config_storage1.get_buffer();
     cb_indices.padding_config1 = cb_indices.get_next_cb_id();
     auto padding_config_cb1 = create_circular_buffer(
@@ -203,10 +213,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         cb_indices.padding_config1,
         kernel_config_df,
         1,
-        padding_config_buffer1->size() / num_cores,
-        padding_config_buffer1);
+        padding_config_buffer1->page_size(),
+        config_tensors_in_dram ? nullptr : padding_config_buffer1);
 
-    auto gather_config_storage0 = gather_config0.device_storage();
+    const auto& gather_config_storage0 = gather_config0.device_storage();
     auto gather_config_buffer0 = gather_config_storage0.get_buffer();
     cb_indices.gather_config0 = cb_indices.get_next_cb_id();
     auto gather_config_cb0 = create_circular_buffer(
@@ -215,10 +225,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         cb_indices.gather_config0,
         kernel_config_df,
         1,
-        gather_config_buffer0->size() / num_cores,
-        gather_config_buffer0);
+        gather_config_buffer0->page_size(),
+        config_tensors_in_dram ? nullptr : gather_config_buffer0);
 
-    auto gather_config_storage1 = gather_config1.device_storage();
+    const auto& gather_config_storage1 = gather_config1.device_storage();
     auto gather_config_buffer1 = gather_config_storage1.get_buffer();
     cb_indices.gather_config1 = cb_indices.get_next_cb_id();
     auto gather_config_cb1 = create_circular_buffer(
@@ -227,9 +237,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         cb_indices.gather_config1,
         kernel_config_df,
         1,
-        gather_config_buffer1->size() / num_cores,
-        gather_config_buffer1);
+        gather_config_buffer1->page_size(),
+        config_tensors_in_dram ? nullptr : gather_config_buffer1);
 
+    const bool is_height_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
@@ -241,7 +252,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     const uint32_t block_stride = 2;  // Skip every 2nd block because of split reader
     const std::string reader_kernel_name =
         "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp";
-    std::vector<uint32_t> reader_ct_args = {
+    std::vector<uint32_t> common_reader_ct_args = {
         0,  // padding config cb
         0,  // gather config cb
         cb_indices.src_cb_id,
@@ -262,39 +273,81 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         0,            // Block start offset
         block_stride  // Block stride
     };
+    std::map<std::string, std::string> reader_defines;
+    std::vector<uint32_t> core_0_reader_ct_args = common_reader_ct_args;
+    std::vector<uint32_t> core_1_reader_ct_args = common_reader_ct_args;
 
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        core_0_reader_ct_args.push_back(padding_config_storage0.get_buffer()->address());
+        core_0_reader_ct_args.push_back(padding_config_storage0.get_buffer()->page_size());
+
+        core_0_reader_ct_args.push_back(gather_config_storage0.get_buffer()->address());
+        core_0_reader_ct_args.push_back(gather_config_storage0.get_buffer()->page_size());
+
+        core_1_reader_ct_args.push_back(padding_config_storage1.get_buffer()->address());
+        core_1_reader_ct_args.push_back(padding_config_storage1.get_buffer()->page_size());
+
+        core_1_reader_ct_args.push_back(gather_config_storage1.get_buffer()->address());
+        core_1_reader_ct_args.push_back(gather_config_storage1.get_buffer()->page_size());
+
+        tt::tt_metal::TensorAccessorArgs(padding_config_storage0.get_buffer()).append_to(core_0_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_storage0.get_buffer()).append_to(core_0_reader_ct_args);
+
+        tt::tt_metal::TensorAccessorArgs(padding_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(gather_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
+    }
     const uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
-    const bool enable_padding = padding_config_buffer0->size() / num_cores != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
-                                padding_config_buffer1->size() / num_cores != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
+    const bool enable_padding = config_tensors_in_dram ||
+                                padding_config_buffer0->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
+                                padding_config_buffer1->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
 
-    reader_ct_args[0] = enable_padding ? cb_indices.padding_config0 : 0;
-    reader_ct_args[1] = cb_indices.gather_config0;
-    reader_ct_args[5] = cb_indices.pad_cb_id0;
-    CreateKernel(
+    core_0_reader_ct_args[0] = enable_padding ? cb_indices.padding_config0 : 0;
+    core_0_reader_ct_args[1] = cb_indices.gather_config0;
+    core_0_reader_ct_args[5] = cb_indices.pad_cb_id0;
+
+    core_1_reader_ct_args[0] = enable_padding ? cb_indices.padding_config1 : 0;
+    core_1_reader_ct_args[1] = cb_indices.gather_config1;
+    core_1_reader_ct_args[3] = input_to_writer_cb_id1;
+    core_1_reader_ct_args[5] = cb_indices.pad_cb_id1;
+    core_1_reader_ct_args[17] = 1;  // Block start offset
+
+    auto reader_0_kernel_id = CreateKernel(
         program,
         reader_kernel_name,
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_ct_args});
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = core_0_reader_ct_args,
+            .defines = reader_defines});
 
-    reader_ct_args[0] = enable_padding ? cb_indices.padding_config1 : 0;
-    reader_ct_args[1] = cb_indices.gather_config1;
-    reader_ct_args[3] = input_to_writer_cb_id1;
-    reader_ct_args[5] = cb_indices.pad_cb_id1;
-    reader_ct_args[17] = 1;  // Block start offset
-    CreateKernel(
+    auto reader_1_kernel_id = CreateKernel(
         program,
         reader_kernel_name,
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_ct_args});
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = core_1_reader_ct_args,
+            .defines = reader_defines});
 
-    // Capture padding_config_buffer, local_config_buffer, remote_config_buffer to cache this with the program
-    if (!capture_buffers) {
-        padding_config_storage0 = {};
-        padding_config_storage1 = {};
-        gather_config_storage0 = {};
-        gather_config_storage1 = {};
+    if (config_tensors_in_dram) {
+        uint32_t core_index = 0;
+        for (auto core : cores) {
+            if (is_height_sharded) {
+                SetRuntimeArgs(program, reader_0_kernel_id, core, {core_index});
+                SetRuntimeArgs(program, reader_1_kernel_id, core, {core_index});
+            } else if (is_width_sharded) {
+                SetRuntimeArgs(program, reader_0_kernel_id, core, {0});
+                SetRuntimeArgs(program, reader_1_kernel_id, core, {0});
+            } else if (is_block_sharded) {
+                auto nhw_index = is_rm_orientation ? core.y : core.x;
+                SetRuntimeArgs(program, reader_0_kernel_id, core, {nhw_index});
+                SetRuntimeArgs(program, reader_1_kernel_id, core, {nhw_index});
+            }
+            core_index++;
+        }
     }
     auto override_runtime_arguments_callback = [src_cb,
                                                 out_cb,
@@ -351,7 +404,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const bool remote_read,
     const bool transpose_mcast,
     Tensor& output_tensor,
-    const bool capture_buffers) {
+    bool config_tensors_in_dram) {
     IDevice* device = input_tensor.device();
     Buffer* src_buffer = input_tensor.buffer();
     Buffer* dst_buffer = output_tensor.buffer();
@@ -452,7 +505,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
 
     const uint32_t num_cores = all_cores.num_cores();
 
-    auto padding_config_storage = padding_config.device_storage();
+    const auto& padding_config_storage = padding_config.device_storage();
     auto padding_config_buffer = padding_config_storage.get_buffer();
     cb_indices.padding_config_cb_id = cb_indices.get_next_cb_id();
     auto padding_config_cb = create_circular_buffer(
@@ -461,10 +514,10 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         cb_indices.padding_config_cb_id,
         kernel_config_df,
         1,
-        padding_config_buffer->size() / num_cores,
-        padding_config_buffer);
+        padding_config_buffer->page_size(),
+        config_tensors_in_dram ? nullptr : padding_config_buffer);
 
-    auto local_config_storage = local_config.device_storage();
+    const auto& local_config_storage = local_config.device_storage();
     auto local_config_buffer = local_config_storage.get_buffer();
     cb_indices.local_config_cb_id = cb_indices.get_next_cb_id();
     auto local_config_cb = create_circular_buffer(
@@ -473,10 +526,10 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         cb_indices.local_config_cb_id,
         kernel_config_df,
         1,
-        local_config_buffer->size() / num_cores,
-        local_config_buffer);
+        local_config_buffer->page_size(),
+        config_tensors_in_dram ? nullptr : local_config_buffer);
 
-    auto remote_config_storage = remote_config.device_storage();
+    const auto& remote_config_storage = remote_config.device_storage();
     auto remote_config_buffer = remote_config_storage.get_buffer();
     cb_indices.remote_config_cb_id = cb_indices.get_next_cb_id();
     auto remote_config_cb = create_circular_buffer(
@@ -485,9 +538,10 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         cb_indices.remote_config_cb_id,
         kernel_config_df,
         1,
-        remote_config_buffer->size() / num_cores,
-        remote_config_buffer);
+        remote_config_buffer->page_size(),
+        config_tensors_in_dram ? nullptr : remote_config_buffer);
 
+    const bool is_height_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
@@ -600,12 +654,33 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         sync_cb_id1,
         sync_cb_id2};
 
+    std::map<std::string, std::string> reader_defines;
+
+    if (config_tensors_in_dram) {
+        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
+        reader_ct_args.push_back(padding_config_storage.get_buffer()->address());
+        reader_ct_args.push_back(padding_config_storage.get_buffer()->page_size());
+
+        reader_ct_args.push_back(local_config_storage.get_buffer()->address());
+        reader_ct_args.push_back(local_config_storage.get_buffer()->page_size());
+
+        reader_ct_args.push_back(remote_config_storage.get_buffer()->address());
+        reader_ct_args.push_back(remote_config_storage.get_buffer()->page_size());
+
+        tt::tt_metal::TensorAccessorArgs(padding_config_storage.get_buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(local_config_storage.get_buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(remote_config_storage.get_buffer()).append_to(reader_ct_args);
+    }
+
     KernelHandle reader_kernel_id0 = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp",
         rectangular_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_ct_args});
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = reader_ct_args,
+            .defines = reader_defines});
 
     reader_ct_args[0] = false;  // secondary thread
     KernelHandle reader_kernel_id1 = CreateKernel(
@@ -613,7 +688,10 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
         "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp",
         rectangular_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_ct_args});
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_ct_args,
+            .defines = reader_defines});
 
     for (uint32_t core_i = 0; core_i < num_cores_rectangular; core_i++) {
         uint32_t core_x_i = core_i % rectangular_x;
@@ -624,16 +702,19 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
 
         std::vector<uint32_t> reader_rt_args0 = {(uint32_t)noop_core, (uint32_t)cast_core};
         std::vector<uint32_t> reader_rt_args1 = {(uint32_t)noop_core, (uint32_t)false};
+
+        if (is_height_sharded) {
+            reader_rt_args0.push_back(core_i);
+        } else if (is_width_sharded) {
+            reader_rt_args0.push_back(0);
+        } else if (is_block_sharded) {
+            auto nhw_index = is_rm_orientation ? core_y_i : core_x_i;
+            reader_rt_args0.push_back(nhw_index);
+        }
         SetRuntimeArgs(program, reader_kernel_id0, core, reader_rt_args0);
         SetRuntimeArgs(program, reader_kernel_id1, core, reader_rt_args1);
     }
 
-    if (!capture_buffers) {
-        padding_config_storage = {};
-        local_config_storage = {};
-        remote_config_storage = {};
-    }
-    // Capture padding_config_storage, local_config_storage, remote_config_storage to cache this with the program
     auto override_runtime_arguments_callback = [src_cb,
                                                 out_cb,
                                                 padding_config_cb,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -16,8 +16,9 @@ Tensor HaloOperation::invoke(
     bool transpose_mcast,
     const MemoryConfig& output_memory_config,
     bool is_out_tiled,
-    bool in_place) {
+    bool in_place,
+    bool config_tensors_in_dram) {
     return halo_op(
-        input_tensor, config, pad_val, remote_read, transpose_mcast, output_memory_config, is_out_tiled, in_place);
+        input_tensor, config, pad_val, remote_read, transpose_mcast, output_memory_config, is_out_tiled, in_place, config_tensors_in_dram);
 }
 };  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -20,7 +20,8 @@ struct HaloOperation {
         bool transpose_mcast = true,
         const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         bool is_out_tiled = true,
-        bool in_place = false);
+        bool in_place = false,
+        bool config_tensors_in_dram = false);
 
     // invoke can be overloaded as many times as needed to provide all desired APIs
 };

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -173,13 +173,14 @@ std::vector<uint16_t> remap_nhw_scalar_argument_across_full_grid(
     const std::vector<uint16_t>& config, const ParallelConfig& parallel_config);
 
 Tensor construct_on_host_config_tensor(
-    const std::vector<std::vector<uint16_t>>& config, const ParallelConfig& p_config);
+    const std::vector<std::vector<uint16_t>>& config, const ParallelConfig& p_config, bool store_in_dram = false);
 
 Tensor move_config_tensor_to_device(
     const Tensor& config_tensor,
     const ParallelConfig& p_config,
     bool is_block_sharded,
-    tt::tt_metal::distributed::MeshDevice* device);
+    tt::tt_metal::distributed::MeshDevice* device,
+    bool store_in_dram = false);
 
 uint32_t align_buffer(uint32_t size);
 


### PR DESCRIPTION
### Ticket
#26109 

### Problem description
Placing config tensors in L1_SMALL leads to a lot of L1 memory being used, especially in large CNNs with DRAM Slicing.

### What's changed
Provide option to place the config tensors of the Conv & Halo kernels in DRAM instead of L1_SMALL. 
Use Conv2DConfig to enable this feature. When enabled L1_SMALL is no longer needed.  
This is helpful for large CNNs with many layers where L1_SMALL allocation becomes big. Conv DRAM Slicing also splits a single layer into upto 4 unique different convs, further increasing L1_SMALL size.

For Conv1D, Config Tensors end up being 3 * per_core_out_nhw in size, as the current compression for config tensors doesn't work well with Conv1D. Resize the CBs to account for this. 

#### Usage Example
```
    conv_config = ttnn.Conv2dConfig(
        config_tensors_in_dram=True,
    )
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17641767206)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17616259576)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17607210190)
- [x] Nightly L2 with forced config in dram [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17611832889)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17616253474)
- [x] Frequent Models with forced config in dram [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17611865842)
- [x] New/Existing tests provide coverage for changes