### PR TITLE
#27736: Create fused sfpu op tutorial

### DIFF
--- a/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
+++ b/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
@@ -1,0 +1,282 @@
+# SFPU Eltwise Chain
+
+In this example, we build a TT-Metal program that demonstrates how to create **fused SFPU (Special Function Processing Unit) operations**, where the output of one SFPU operation is directly reused as input for the next operation. This technique enables efficient computation of complex mathematical functions by chaining multiple elementary operations without intermediate memory transfers.
+
+You can find the full example in
+[`sfpu_eltwise_chain.cpp`](/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp).
+
+## Building and Running the Example
+
+To build and execute, you may use the following commands:
+```bash
+export TT_METAL_HOME=$(pwd)
+./build_metal.sh --build-programming-examples
+./build/programming_examples/metal_example_sfpu_eltwise_chain
+```
+
+## Main Program Overview
+
+This example demonstrates **SFPU operation fusion** by implementing the **softplus activation function**: `softplus(x) = log(1 + exp(x))`. Instead of computing each operation separately and storing intermediate results in memory, we chain three SFPU operations together:
+
+1. **exp(x)** - Exponential function
+2. **exp(x) + 1** - Add constant (1) to the result
+3. **log(exp(x) + 1)** - Natural logarithm of the result
+
+The data pipeline is:
+1. Input data is read from DRAM into a circular buffer
+2. A tile of ones is created in L1 memory for the addition operation
+3. The compute kernel performs the fused SFPU operations on a single tile
+4. The result is written back to DRAM
+
+---
+
+### Device and Program Setup
+
+```cpp
+IDevice* device = CreateDevice(0);
+CommandQueue& cq = device->command_queue();
+Program program = CreateProgram();
+```
+
+---
+
+### Core Configuration
+
+This example uses a single core for computation:
+
+```cpp
+constexpr CoreCoord core = {0, 0};
+```
+
+---
+
+### Input Data Preparation
+
+We generate random input data and calculate the expected golden results on the CPU for validation (we will produce one tile 32x32 of data for this example):
+
+```cpp
+std::mt19937 rng(std::random_device{}());
+std::uniform_real_distribution<float> dist(0.f, 1.0f);
+
+std::vector<bfloat16> src_vec(constants::TILE_HW);
+for (bfloat16& v : src_vec) {
+    v = bfloat16(dist(rng));
+}
+
+std::vector<bfloat16> golden_vec(constants::TILE_HW, 0);
+golden_softplus(src_vec, golden_vec);
+```
+
+The input data is then tilized to match the hardware's expected tiled layout from flat structure of CPU's vector:
+
+```cpp
+src_vec = tilize_nfaces(src_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
+```
+
+---
+
+### Memory Buffers
+
+We create input and output DRAM buffers to store our data:
+
+```cpp
+constexpr uint32_t single_tile_size = sizeof(bfloat16) * constants::TILE_HEIGHT * constants::TILE_WIDTH;
+tt_metal::InterleavedBufferConfig dram_config{
+    .device = device,
+    .size = sizeof(bfloat16) * src_vec.size(),
+    .page_size = single_tile_size,
+    .buffer_type = tt_metal::BufferType::DRAM};
+
+std::shared_ptr<Buffer> src_dram_buffer = CreateBuffer(dram_config);
+std::shared_ptr<Buffer> dst_dram_buffer = CreateBuffer(dram_config);
+
+EnqueueWriteBuffer(cq, src_dram_buffer, src_vec.data(), false);
+```
+
+---
+
+### Circular Buffers
+
+Three circular buffers are created for the computation:
+
+```cpp
+// Input data buffer
+constexpr uint32_t src_cb_index = CBIndex::c_0;
+CircularBufferConfig cb_src_config =
+    CircularBufferConfig(single_tile_size, {{src_cb_index, tt::DataFormat::Float16_b}})
+        .set_page_size(src_cb_index, single_tile_size);
+tt_metal::CreateCircularBuffer(program, core, cb_src_config);
+
+// Ones buffer (for addition operation)
+constexpr uint32_t ones_cb_index = CBIndex::c_1;
+CircularBufferConfig cb_ones_config =
+    CircularBufferConfig(single_tile_size, {{ones_cb_index, tt::DataFormat::Float16_b}})
+        .set_page_size(ones_cb_index, single_tile_size);
+tt_metal::CreateCircularBuffer(program, core, cb_ones_config);
+
+// Result buffer
+constexpr uint32_t result_cb_index = CBIndex::c_2;
+CircularBufferConfig cb_result_config =
+    CircularBufferConfig(single_tile_size, {{result_cb_index, tt::DataFormat::Float16_b}})
+        .set_page_size(result_cb_index, single_tile_size);
+tt_metal::CreateCircularBuffer(program, core, cb_result_config);
+```
+
+---
+
+### Kernel Setup
+
+Three kernels are created for this example:
+
+```cpp
+// Reader kernel - reads input data and creates ones tile
+KernelHandle reader_kernel_id = CreateKernel(
+    program,
+    "sfpu_eltwise_chain/kernels/dataflow/reader.cpp",
+    core,
+    tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
+
+// Writer kernel - writes result back to DRAM
+KernelHandle writer_kernel_id = CreateKernel(
+    program,
+    "sfpu_eltwise_chain/kernels/dataflow/writer.cpp",
+    core,
+    tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+
+// Compute kernel - performs fused SFPU operations
+KernelHandle compute_kernel_id = CreateKernel(
+    program,
+    "sfpu_eltwise_chain/kernels/compute/compute.cpp",
+    core,
+    tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+```
+
+---
+
+### Running and Validation
+
+After executing the program, we validate the results using Pearson Correlation Coefficient:
+
+```cpp
+EnqueueProgram(cq, program, false);
+Finish(cq);
+
+std::vector<bfloat16> result_vec(constants::TILE_HW, 0);
+EnqueueReadBuffer(cq, dst_dram_buffer, result_vec, true);
+
+result_vec = untilize_nfaces(result_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
+
+const float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
+fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
+TT_FATAL(pearson > 0.999, "PCC not high enough. Result PCC: {}, Expected PCC: 0.999", pearson);
+```
+
+---
+
+## Kernel Descriptions
+
+### Reader Kernel
+
+The reader kernel performs two main tasks:
+1. **Reads input data** from DRAM into the source circular buffer
+2. **Creates a tile of ones** in L1 memory for the addition operation
+
+```cpp
+// Read input data
+cb_reserve_back(src_cb_index, one_tile);
+const uint32_t l1_write_addr = get_write_ptr(src_cb_index);
+noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+noc_async_read_barrier();
+cb_push_back(src_cb_index, one_tile);
+
+// Create tile with ones
+cb_reserve_back(ones_cb_index, one_tile);
+const uint32_t ones_l1_write_addr = get_write_ptr(ones_cb_index);
+volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(ones_l1_write_addr);
+for (uint32_t i = 0; i < tt::constants::TILE_HW; i++) {
+    ptr[i] = float_to_bfloat16(1.0f);
+}
+cb_push_back(ones_cb_index, one_tile);
+```
+
+Nota additional `float_to_bfloat16` function. Since `bfloat16` is not native C++ type we obtain `uint16_t` pointer (the same size as `bfloat16`) and save converted values.
+
+---
+
+### Writer Kernel
+
+The writer kernel reads the computed result from the result circular buffer and writes it back to DRAM:
+
+```cpp
+cb_wait_front(result_cb_index, one_tile);
+const uint32_t l1_read_addr = get_read_ptr(result_cb_index);
+noc_async_write_tile(0, interleaved_accessor, l1_read_addr);
+noc_async_write_barrier();
+cb_pop_front(result_cb_index, one_tile);
+```
+
+---
+
+### Compute Kernel - The SFPU Fusion Core
+
+This is the heart of the example, demonstrating **SFPU operation chaining**:
+
+```cpp
+// Initialize SFPU and acquire tile registers
+init_sfpu(src_cb_index, result_cb_index);
+tile_regs_acquire();
+
+// Load data into registers
+cb_wait_front(src_cb_index, one_tile);
+cb_wait_front(ones_cb_index, one_tile);
+copy_tile(src_cb_index, 0, 0);      // Input data → register 0
+copy_tile(ones_cb_index, 0, 1);     // Ones tile → register 1
+
+// Fused SFPU operations chain
+exp_tile_init();
+exp_tile(0);                        // register 0 = exp(input)
+
+add_binary_tile_init();
+add_binary_tile(0, 1, 0);          // register 0 = exp(input) + 1
+
+log_tile_init();
+log_tile(0);                       // register 0 = log(exp(input) + 1)
+
+// Store result and cleanup
+tile_regs_commit();
+tile_regs_wait();
+cb_reserve_back(result_cb_index, one_tile);
+pack_tile(0, result_cb_index);
+```
+
+### Key SFPU Fusion Concepts
+
+1. **Register Reuse**: The output of each operation stays in the same register and becomes input for the next operation
+2. **No Intermediate Memory**: Results don't need to be stored back to circular buffers between operations
+3. **Operation Initialization**: Each SFPU operation requires initialization (`*_init()`) before use
+4. **Efficient Chaining**: Multiple complex functions can be computed in a single pass through the data
+
+---
+
+## Expected Output
+
+```console
+Metalium vs Golden -- PCC = 0.999847
+```
+
+The high Pearson Correlation Coefficient (>0.999) indicates that the SFPU fused operations produce results nearly identical to the CPU golden reference, demonstrating both the correctness and precision of the hardware implementation.
+
+---
+
+## Benefits of SFPU Fusion
+
+1. **Memory Bandwidth Reduction**: Eliminates intermediate memory transfers
+2. **Lower Latency**: Reduces the number of memory access cycles
+3. **Higher Throughput**: Enables computation of complex functions in fewer kernel invocations
+4. **Power Efficiency**: Reduces memory I/O operations which are typically power-intensive
+
+This pattern can be extended to implement more complex mathematical functions by chaining additional SFPU operations together.
+
+---
+
+© Tenstorrent AI ULC 2025

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/shard_data_rm)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vecadd_sharding)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vecadd_multi_core)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NoC_tile_transfer)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfpu_eltwise_chain)
 
 add_custom_target(
     programming_examples
@@ -44,6 +45,7 @@ install(
         matmul
         shard_data_rm
         NoC_tile_transfer
+        sfpu_eltwise_chain
     # DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
     # FIXME(afuller): Something funky is happening when installing files into
     # /usr/share/doc on a default Docker image. Speculation: some dependency for
@@ -68,6 +70,7 @@ install(
         matmul
         shard_data_rm
         NoC_tile_transfer
+        sfpu_eltwise_chain
     DESTINATION "${CMAKE_INSTALL_DATADIR}/tenstorrent/kernels"
     COMPONENT metalium-examples
     FILES_MATCHING

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/CMakeLists.txt
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.22...3.30)
+project(metal_example_sfpu_eltwise_chain)
+
+add_executable(metal_example_sfpu_eltwise_chain)
+target_sources(metal_example_sfpu_eltwise_chain PRIVATE sfpu_eltwise_chain.cpp)
+
+if(NOT TARGET TT::Metalium)
+    find_package(TT-Metalium REQUIRED)
+endif()
+target_link_libraries(metal_example_sfpu_eltwise_chain PUBLIC TT::Metalium)

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/compute/compute.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/compute/compute.cpp
@@ -30,18 +30,18 @@ void MAIN {
     // the circular buffer to registers so the SFPU can use it.
     // the first 0 in copy_tile is the index into the circular buffer
     // and the second 0 is the offset into the registers. This case
-    // we are copying the 0th tile from the circular buffer to the 0th tile
-    // in the registers.
+    // we are copying the 0th tile from the source data circular buffer to the 0th tile
+    // in the registers and 0th tile from the ones tile to the 1st tile in the registers.
     cb_wait_front(src_cb_index, one_tile);
     cb_wait_front(ones_cb_index, one_tile);
     copy_tile(src_cb_index, /*offset*/ 0, /*register_offset*/ 0);
     copy_tile(ones_cb_index, /*offset*/ 0, /*register_offset*/ 1);
 
-    // Compute the exponential of the tile using the SFPU. This
-    // operation is in-place. It takes data from tile 0 in the
-    // registers and writes the result back to tile 0 in the
-    // registers.
-    // Telling the SFPU to perform exponential. This is required each time we
+    //
+    // Fused operations
+    //
+    // Compute the softplus of the tile using the SFPU.
+    // *_init() - Telling the SFPU to perform given operation. This is required each time we
     // switch to a different SFPU operation.
     exp_tile_init();
     exp_tile(0);  // exp(input)

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/compute/compute.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/compute/compute.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/exp.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+
+namespace NAMESPACE {
+void MAIN {
+    // Compile time args
+    constexpr uint32_t src_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t ones_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t result_cb_index = get_compile_time_arg_val(2);
+
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Initialize the SFPU
+    init_sfpu(src_cb_index, result_cb_index);
+
+    // Wait for the SFPU to have registers available for us to use during
+    // the computation.
+    tile_regs_acquire();
+
+    // Wait for data to show up in the circular buffer and copy it from
+    // the circular buffer to registers so the SFPU can use it.
+    // the first 0 in copy_tile is the index into the circular buffer
+    // and the second 0 is the offset into the registers. This case
+    // we are copying the 0th tile from the circular buffer to the 0th tile
+    // in the registers.
+    cb_wait_front(src_cb_index, one_tile);
+    cb_wait_front(ones_cb_index, one_tile);
+    copy_tile(src_cb_index, /*offset*/ 0, /*register_offset*/ 0);
+    copy_tile(ones_cb_index, /*offset*/ 0, /*register_offset*/ 1);
+
+    // Compute the exponential of the tile using the SFPU. This
+    // operation is in-place. It takes data from tile 0 in the
+    // registers and writes the result back to tile 0 in the
+    // registers.
+    // Telling the SFPU to perform exponential. This is required each time we
+    // switch to a different SFPU operation.
+    exp_tile_init();
+    exp_tile(0);  // exp(input)
+
+    add_binary_tile_init();
+    add_binary_tile(0, 1, 0);  // exp(input) + 1
+
+    log_tile_init();
+    log_tile(0);  // log(exp(input) + 1)
+
+    // Wait for result to be done and data stored back to the circular buffer
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // Reserve output tile
+    cb_reserve_back(result_cb_index, one_tile);
+
+    pack_tile(0, result_cb_index);  // copy tile 0 from the registers to the CB
+
+    // We don't need the input tile anymore, mark it as consumed
+    cb_pop_front(src_cb_index, one_tile);
+    cb_pop_front(ones_cb_index, one_tile);
+
+    // Done with the registers, we can release them for the next SFPU operation
+    tile_regs_release();
+
+    // Mark the tile as ready for the writer kernel to write to DRAM
+    cb_push_back(result_cb_index, one_tile);
+}
+}  // namespace NAMESPACE

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt-metalium/constants.hpp"
+
+#include <cstdint>
+#include <cstring>
+
+/**
+ * @brief Converts a 32-bit IEEE 754 float to 16-bit bfloat16 format.
+ *
+ * This function performs a simple truncation conversion from float32 to bfloat16
+ * by extracting the upper 16 bits (sign, exponent, and upper 7 bits of mantissa)
+ * of the IEEE 754 float representation. The lower 16 bits of the mantissa are
+ * discarded, which may result in precision loss but maintains the same range
+ * as float32.
+ *
+ * @param value The input 32-bit floating point value to convert
+ * @return uint16_t The resulting 16-bit bfloat16 value in its binary representation
+ *
+ * @note This implementation uses simple truncation without rounding, which may
+ *       introduce quantization errors for values that cannot be exactly
+ *       represented in bfloat16 format - it is sufficient for this example.
+ */
+inline uint16_t float_to_bfloat16(float value) {
+    uint32_t tmp;
+    std::memcpy(&tmp, &value, sizeof(tmp));
+    return static_cast<uint16_t>(tmp >> 16);
+}
+
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_buffer_addr = get_arg_val<uint32_t>(0);
+
+    // Compile time args
+    constexpr uint32_t src_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t ones_cb_index = get_compile_time_arg_val(1);
+
+    // Input data config
+    const uint32_t input_data_tile_size_bytes = get_tile_size(src_cb_index);
+    constexpr auto interleaved_accessor_args = TensorAccessorArgs<2>();
+    const auto interleaved_accessor =
+        TensorAccessor(interleaved_accessor_args, input_buffer_addr, input_data_tile_size_bytes);
+
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Read input value data
+    cb_reserve_back(src_cb_index, one_tile);
+    const uint32_t l1_write_addr = get_write_ptr(src_cb_index);
+    noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+    noc_async_read_barrier();
+    cb_push_back(src_cb_index, one_tile);
+
+    // Create tile with ones
+    cb_reserve_back(ones_cb_index, one_tile);
+    const uint32_t ones_l1_write_addr = get_write_ptr(ones_cb_index);
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(ones_l1_write_addr);
+    for (uint32_t i = 0; i < tt::constants::TILE_HW; i++) {
+        ptr[i] = float_to_bfloat16(1.0f);
+    }
+    cb_push_back(ones_cb_index, one_tile);
+}

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/writer.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/writer.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include <cstdint>
+
+void kernel_main() {
+    // Runtime args
+    const uint32_t output_buffer_addr = get_arg_val<uint32_t>(0);
+
+    // Compile time args
+    constexpr uint32_t result_cb_index = get_compile_time_arg_val(0);
+
+    // Input data config
+    const uint32_t output_data_tile_size_bytes = get_tile_size(result_cb_index);
+    constexpr auto interleaved_accessor_args = TensorAccessorArgs<1>();
+    const auto interleaved_accessor =
+        TensorAccessor(interleaved_accessor_args, output_buffer_addr, output_data_tile_size_bytes);
+
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Save output data
+    cb_wait_front(result_cb_index, one_tile);
+    const uint32_t l1_read_addr = get_read_ptr(result_cb_index);
+    noc_async_write_tile(0, interleaved_accessor, l1_read_addr);
+    noc_async_write_barrier();
+    cb_pop_front(result_cb_index, one_tile);
+}

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -4,7 +4,11 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/constants.hpp>
 
+#include <cmath>
+#include <random>
 #include <cstdint>
 #include <vector>
 
@@ -15,6 +19,82 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
+/**
+ * @brief Computes the softplus activation function element-wise on input vector
+ *
+ * The softplus function is defined as: softplus(x) = log(1 + exp(x))
+ * This is a smooth approximation to the ReLU function that outputs positive values.
+ *
+ * @param src_vec Input vector containing bfloat16 values to apply softplus to
+ * @param result_vec Output vector where computed softplus values will be stored
+ *                   Must be the same size as src_vec
+ *
+ * @throws TT_FATAL if input and output vectors have different sizes
+ *
+ * @note This is a reference implementation used for validation/testing purposes
+ * @note The function uses std::log1p for numerical stability
+ */
+void golden_softplus(const std::vector<bfloat16>& src_vec, std::vector<bfloat16>& result_vec) {
+    TT_FATAL(src_vec.size() == result_vec.size(), "Input and output vectors must be the same size");
+    for (size_t i = 0; i < src_vec.size(); ++i) {
+        result_vec[i] = bfloat16(std::log1p(std::exp(src_vec[i].to_float())));  // Softplus function
+    }
+}
+
+/**
+ * @brief Calculates the Pearson Correlation Coefficient (PCC) between two bfloat16 vectors.
+ *
+ * This function computes the linear correlation coefficient between two vectors of bfloat16 values,
+ * which measures the strength and direction of the linear relationship between the two datasets.
+ * The PCC value ranges from -1 to 1, where:
+ * - 1 indicates a perfect positive linear relationship
+ * - 0 indicates no linear relationship
+ * - -1 indicates a perfect negative linear relationship
+ *
+ * @param vec_a First input vector of bfloat16 values
+ * @param vec_b Second input vector of bfloat16 values (must be same size as vec_a)
+ *
+ * @return float The Pearson correlation coefficient between the two input vectors
+ *
+ * @note The function assumes both input vectors have the same size
+ * @note bfloat16 values are converted to float for calculations to maintain precision
+ */
+inline float check_bfloat16_vector_pcc(const std::vector<bfloat16>& vec_a, const std::vector<bfloat16>& vec_b) {
+    // Calculate the mean of x and y values
+    float x_mean = 0.0f;
+    float y_mean = 0.0f;
+
+    for (size_t i = 0; i < vec_a.size(); i++) {
+        x_mean += vec_a[i].to_float();
+        y_mean += vec_b[i].to_float();
+    }
+
+    x_mean /= vec_a.size();
+    y_mean /= vec_b.size();
+
+    // Calculate the covariance and standard deviation of x and y values
+    float covariance = 0.0f;
+    float x_stddev = 0.0f;
+    float y_stddev = 0.0f;
+
+    for (size_t i = 0; i < vec_a.size(); i++) {
+        float x_diff = vec_a[i].to_float() - x_mean;
+        float y_diff = vec_b[i].to_float() - y_mean;
+
+        covariance += x_diff * y_diff;
+        x_stddev += x_diff * x_diff;
+        y_stddev += y_diff * y_diff;
+    }
+
+    covariance /= vec_a.size();
+    x_stddev /= vec_a.size();
+    y_stddev /= vec_b.size();
+
+    // Calculate the correlation coefficient
+    float correlation_coefficient_ = covariance / (std::sqrt(x_stddev) * std::sqrt(y_stddev));
+    return correlation_coefficient_;
+}
+
 int main() {
     // Device setup
     IDevice* device = CreateDevice(0);
@@ -22,6 +102,111 @@ int main() {
     // Device command queue and program setup
     CommandQueue& cq = device->command_queue();
     Program program = CreateProgram();
+
+    // Core range setup
+    constexpr CoreCoord core = {0, 0};
+
+    // Input data preparation
+    std::mt19937 rng(std::random_device{}());
+    std::uniform_real_distribution<float> dist(0.f, 1.0f);
+
+    // Fill the source vector with random values
+    std::vector<bfloat16> src_vec(constants::TILE_HW);
+    for (bfloat16& v : src_vec) {
+        v = bfloat16(dist(rng));
+    }
+
+    // Calculate golden function results on CPU
+    std::vector<bfloat16> golden_vec(constants::TILE_HW, 0);
+    golden_softplus(src_vec, golden_vec);
+
+    // Tilize the input vectors to match the expected tiled layout for the device
+    // The Tenstorrent hardware operates on data in 32x32 tiles rather than standard row-major format.
+    // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by the device.
+    // This transformation groups elements into 32x32 blocks and reorders them in memory so that each tile
+    // (32x32 elements) is stored contiguously. This matches the native data access patterns of the matrix engine
+    // and enables efficient operations on the accelerator.
+    src_vec = tilize_nfaces(src_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
+
+    constexpr uint32_t single_tile_size = sizeof(bfloat16) * constants::TILE_HEIGHT * constants::TILE_WIDTH;
+    tt_metal::InterleavedBufferConfig dram_config{
+        .device = device,
+        .size = sizeof(bfloat16) * src_vec.size(),
+        .page_size = single_tile_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
+    std::shared_ptr<Buffer> src_dram_buffer = CreateBuffer(dram_config);  // Input buffer
+    std::shared_ptr<Buffer> dst_dram_buffer = CreateBuffer(dram_config);  // Output buffer
+
+    // DRAM transfer
+    EnqueueWriteBuffer(cq, src_dram_buffer, src_vec.data(), false);
+
+    // L1 circular buffer setup
+    constexpr uint32_t src_cb_index = CBIndex::c_0;
+    CircularBufferConfig cb_src_config =
+        CircularBufferConfig(single_tile_size, {{src_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src_cb_index, single_tile_size);
+    tt_metal::CreateCircularBuffer(program, core, cb_src_config);
+
+    constexpr uint32_t ones_cb_index = CBIndex::c_1;
+    CircularBufferConfig cb_ones_config =
+        CircularBufferConfig(single_tile_size, {{ones_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(ones_cb_index, single_tile_size);
+    tt_metal::CreateCircularBuffer(program, core, cb_ones_config);
+
+    constexpr uint32_t result_cb_index = CBIndex::c_2;
+    CircularBufferConfig cb_result_config =
+        CircularBufferConfig(single_tile_size, {{result_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(result_cb_index, single_tile_size);
+    tt_metal::CreateCircularBuffer(program, core, cb_result_config);
+
+    // Kernels setup
+    // Data movement kernels
+    std::vector<uint32_t> reader_compile_time_args = {src_cb_index, ones_cb_index};
+    TensorAccessorArgs(*src_dram_buffer).append_to(reader_compile_time_args);
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/reader.cpp",
+        core,
+        tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
+    std::vector<uint32_t> writer_compile_time_args = {result_cb_index};
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/writer.cpp",
+        core,
+        tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+
+    // Compute kernel
+    std::vector<uint32_t> compute_compile_time_args = {src_cb_index, ones_cb_index, result_cb_index};
+    KernelHandle compute_kernel_id = CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/compute/compute.cpp",
+        core,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+
+    // Runtime args setup
+    SetRuntimeArgs(program, reader_kernel_id, core, {src_dram_buffer->address()});
+    SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer->address()});
+
+    // Program enqueue
+    EnqueueProgram(cq, program, false);
+    Finish(cq);
+
+    // Data transfer back to host machine
+    std::vector<bfloat16> result_vec(constants::TILE_HW, 0);
+    EnqueueReadBuffer(cq, dst_dram_buffer, result_vec, true);  // Blocking call to ensure data is read before proceeding
+
+    // Reverse the tilization to get the result in the row-major format that the CPU expects
+    result_vec = untilize_nfaces(result_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
+
+    fmt::print("Output vector of size {}\n", result_vec.size());
+
+    // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector
+    // This is a measure of how similar the two vectors are.
+    // A PCC close to 1 indicates that the two vectors are very similar.
+    float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
+    fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
+    TT_FATAL(pearson > 0.999, "PCC not high enough. Result PCC: {}, Expected PCC: 0.999", pearson);
 
     CloseDevice(device);
 }

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    // Device setup
+    IDevice* device = CreateDevice(0);
+
+    // Device command queue and program setup
+    CommandQueue& cq = device->command_queue();
+    Program program = CreateProgram();
+
+    CloseDevice(device);
+}

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -128,6 +128,7 @@ int main() {
     // and enables efficient operations on the accelerator.
     src_vec = tilize_nfaces(src_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
 
+    // Dram buffer config
     constexpr uint32_t single_tile_size = sizeof(bfloat16) * constants::TILE_HEIGHT * constants::TILE_WIDTH;
     tt_metal::InterleavedBufferConfig dram_config{
         .device = device,
@@ -199,12 +200,10 @@ int main() {
     // Reverse the tilization to get the result in the row-major format that the CPU expects
     result_vec = untilize_nfaces(result_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
 
-    fmt::print("Output vector of size {}\n", result_vec.size());
-
     // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector
     // This is a measure of how similar the two vectors are.
     // A PCC close to 1 indicates that the two vectors are very similar.
-    float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
+    const float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
     fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
     TT_FATAL(pearson > 0.999, "PCC not high enough. Result PCC: {}, Expected PCC: 0.999", pearson);
 


### PR DESCRIPTION
### Ticket
[#27736](https://github.com/tenstorrent/tt-metal/issues/27736)

### Problem description
This tutorial is based on customer request about fused sfpu operations.

### What's changed
- Fused SFPU operation example added implementing `softplus(x) = log(1 + exp(x))` function.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17400643176
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes