### PR TITLE
fix segformer device perf 

### DIFF
--- a/models/demos/segformer/tests/perf/test_perf_segformer.py
+++ b/models/demos/segformer/tests/perf/test_perf_segformer.py
@@ -21,8 +21,8 @@ from models.demos.segformer.tests.pcc.test_segformer_decode_head import (
 from models.demos.segformer.tests.pcc.test_segformer_model import (
     create_custom_mesh_preprocessor as create_custom_preprocessor_model,
 )
-from models.demos.segformer.tt.common import get_mesh_mappers
 from models.demos.segformer.tt.ttnn_segformer_for_semantic_segmentation import TtSegformerForSemanticSegmentation
+from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.perf.perf_utils import prep_perf_report
 from models.utility_functions import profiler, skip_for_grayskull
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Segformer device perf fails with import error. as the common utils were moved to `demos/utils /common_demo_utils.py`

### What's changed
Modified the path

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17403177564/workflow) - In progress
- [x] [Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/17403098755/workflow) - passed