### PR TITLE
Support tiled output for pool ops

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -123,9 +123,6 @@ def run_avg_pool2d(
     if (out_dtype == ttnn.bfloat8_b or out_dtype == ttnn.bfloat4_b) and output_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("BFLOAT8_B/BFLOAT4_B output data format is not supported with ROW_MAJOR layout")
 
-    if is_blackhole() and output_layout == ttnn.TILE_LAYOUT:
-        pytest.skip("Blackhole does not support tiled output for pool operations")
-
     if skips_enabled:
         # skips to avoid unimportant combinations
         if divisor_override is not None:

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -76,9 +76,6 @@ def run_max_pool(
     if (out_dtype == ttnn.bfloat8_b or out_dtype == ttnn.bfloat4_b) and output_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("BFLOAT8_B/BFLOAT4_B output data format is not supported with ROW_MAJOR layout")
 
-    if is_blackhole() and output_layout == ttnn.TILE_LAYOUT:
-        pytest.skip("Blackhole does not support tiled output for pool operations")
-
     # skips to avoid unimportant combinations
     if ceil_mode:
         if stride == (1, 1):

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -75,8 +75,15 @@ def tensor_map():
     ],
 )
 @pytest.mark.parametrize(
-    "dtype",
+    "in_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize(
+    "out_layout",
+    [
+        ttnn.ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.ttnn.TILE_LAYOUT,
+    ],
 )
 def test_avg_pool2d_post_commit(
     device,
@@ -89,15 +96,18 @@ def test_avg_pool2d_post_commit(
     divisor_override,
     count_include_pad,
     shard_scheme,
-    dtype,
+    in_dtype,
+    out_layout,
 ):
     # we only want to test the largest kernel size with a specific input shape
     # to test otherwise untouched paths in the large kernel, other shapes run OOM
     # or will just slow the test down doing redundant work
     if kernel_size == (36, 36) and input_shape != [1, 320, 48, 48] and input_shape != [1, 290, 47, 47]:
         pytest.skip("Skipping, only run shapes [1, 320, 48, 48] and [1, 290, 47, 47] with kernel size (36, 36)")
-    if dtype == ttnn.bfloat8_b and input_shape != [1, 320, 48, 48] and input_shape != [1, 512, 112, 32]:
-        pytest.skip("Skipping, only run shape [1, 320, 48, 48] with bfloat8_b dtype")
+    if in_dtype == ttnn.bfloat8_b and input_shape != [1, 320, 48, 48] and input_shape != [1, 512, 112, 32]:
+        pytest.skip("Skipping, only run shape [1, 320, 48, 48] with bfloat8_b input dtype")
+    if out_layout == ttnn.ttnn.TILE_LAYOUT and kernel_size == (36, 36):
+        pytest.skip("Skipping, OOMs with tiled output and kernel size (36, 36)")
     run_avg_pool2d(
         device=device,
         tensor_map=tensor_map,
@@ -109,6 +119,8 @@ def test_avg_pool2d_post_commit(
         divisor_override=divisor_override,
         count_include_pad=count_include_pad,
         shard_scheme=shard_scheme,
-        dtype=dtype,
+        in_dtype=in_dtype,
         nightly_skips=False,
+        output_layout=out_layout,
+        out_dtype=ttnn.bfloat16 if out_layout == ttnn.ROW_MAJOR_LAYOUT else ttnn.bfloat8_b,
     )

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -78,13 +78,6 @@ def tensor_map():
     "in_dtype",
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
-@pytest.mark.parametrize(
-    "out_layout",
-    [
-        ttnn.ttnn.ROW_MAJOR_LAYOUT,
-        ttnn.ttnn.TILE_LAYOUT,
-    ],
-)
 def test_avg_pool2d_post_commit(
     device,
     tensor_map,
@@ -97,7 +90,6 @@ def test_avg_pool2d_post_commit(
     count_include_pad,
     shard_scheme,
     in_dtype,
-    out_layout,
 ):
     # we only want to test the largest kernel size with a specific input shape
     # to test otherwise untouched paths in the large kernel, other shapes run OOM
@@ -106,8 +98,6 @@ def test_avg_pool2d_post_commit(
         pytest.skip("Skipping, only run shapes [1, 320, 48, 48] and [1, 290, 47, 47] with kernel size (36, 36)")
     if in_dtype == ttnn.bfloat8_b and input_shape != [1, 320, 48, 48] and input_shape != [1, 512, 112, 32]:
         pytest.skip("Skipping, only run shape [1, 320, 48, 48] with bfloat8_b input dtype")
-    if out_layout == ttnn.ttnn.TILE_LAYOUT and kernel_size == (36, 36):
-        pytest.skip("Skipping, OOMs with tiled output and kernel size (36, 36)")
     run_avg_pool2d(
         device=device,
         tensor_map=tensor_map,
@@ -121,6 +111,4 @@ def test_avg_pool2d_post_commit(
         shard_scheme=shard_scheme,
         in_dtype=in_dtype,
         nightly_skips=False,
-        output_layout=out_layout,
-        out_dtype=ttnn.bfloat16 if out_layout == ttnn.ROW_MAJOR_LAYOUT else ttnn.bfloat8_b,
     )

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -211,11 +211,9 @@ void MAIN {
                         PACK((pack_untilize_uninit(tmp_cb_id)));
 
                         // Workaround until #27504 is not closed
-                        if constexpr (is_output_block_format || window_size_hw > FACE_HEIGHT) {
-                            tensix_sync();
-                            unary_op_init_common(tmp_cb_id, out_cb_id);
-                            tensix_sync();
-                        }
+                        tensix_sync();
+                        unary_op_init_common(tmp_cb_id, out_cb_id);
+                        tensix_sync();
 
                         tilize_init(tmp_cb_id, in_ntiles_c, out_cb_id);
                         tilize_block(tmp_cb_id, in_ntiles_c, out_cb_id);
@@ -223,7 +221,7 @@ void MAIN {
                         cb_push_back(out_cb_id, in_ntiles_c);
                         tilize_uninit(tmp_cb_id, out_cb_id);
 
-                        if constexpr (is_output_block_format || window_size_hw > FACE_HEIGHT) {
+                        if constexpr (is_output_block_format) {
                             tensix_sync();
                             unary_op_init_common(in_cb_id_0, tmp_cb_id);
                             tensix_sync();

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -10,6 +10,7 @@
 #include "compute_kernel_api/pack.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
 #define DEBUG_PRINT 0
 
@@ -19,9 +20,10 @@
 #include "debug/dprint_tensix.h"
 #endif
 
-#define TILE_WIDTH 32
-#define FACE_WIDTH 16
 #define FACE_HEIGHT 16
+#define FACE_WIDTH 16
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
 
 namespace NAMESPACE {
 
@@ -50,6 +52,10 @@ void MAIN {
     constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(16);
     constexpr bool one_scalar_per_core = get_compile_time_arg_val(17);
     constexpr bool return_indices = (bool)get_compile_time_arg_val(18);
+    constexpr uint32_t tmp_cb_id = get_compile_time_arg_val(19);
+    constexpr bool is_output_tiled = get_compile_time_arg_val(20);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(21);
+
 
     constexpr uint32_t topk_output_tiles = 1;
     constexpr uint32_t topk_cb_tile_idx = 0;
@@ -86,9 +92,10 @@ void MAIN {
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
     constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
     if constexpr (!return_indices) {
+        constexpr uint32_t cb_for_init = is_output_tiled ? tmp_cb_id : out_cb_id;
         tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-            in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, out_cb_id, num_faces_in_input_tile, face_r_dim);
-        pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, num_out_sticks, num_faces_in_output_tile);
+            in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, cb_for_init, num_faces_in_input_tile, face_r_dim);
+        pack_untilize_dest_init<max_tiles_per_iter>(cb_for_init, num_out_sticks, num_faces_in_output_tile);
     } else {
         unary_op_init_common(in_cb_id_0, in_cb_id_0);
         tilize_init_no_pack(in_cb_id_0, topk_output_tiles);
@@ -112,6 +119,8 @@ void MAIN {
         cb_wait_front(in_scalar_cb_id_0, 1);
     }
 
+    uint32_t tilize_stick_counter = 0;
+    uint32_t temp_cb_row_offset = 0;
     for (uint32_t n = 0; n < nsticks_per_core_by_nblocks; ++n) {
         const bool reader0 = !(split_reader && (n & 0x1));
         const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
@@ -119,6 +128,9 @@ void MAIN {
         const uint32_t curr_in_idx_cb_id = !reader0 ? in_idx_cb_id_1 : in_idx_cb_id_0;
         if constexpr (!one_scalar_per_core) {
             cb_wait_front(curr_scalar_cb_id, 1);
+        }
+        if (is_output_tiled && !tilize_stick_counter) {
+            cb_reserve_back(out_cb_id, in_ntiles_c);
         }
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             const bool last_c_block = c_i == in_nblocks_c - 1;
@@ -130,11 +142,26 @@ void MAIN {
                 (last_tile_is_partial && last_c_block)
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
-            cb_reserve_back(out_cb_id, output_faces);
-            if constexpr (tilize_reconfig) {
+            if constexpr (!is_output_tiled) {
+                cb_reserve_back(out_cb_id, output_faces);
+            }
+            if constexpr (tilize_reconfig || is_output_tiled) {
                 if (first_c_block || last_c_block) {
                     UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
+                }
+            }
+            if constexpr (is_output_tiled) {
+                if (last_c_block) {
+                    PACK((llk_pack_untilize_init<
+                          partial_iter_output_tiles,
+                          partial_iter_output_tiles,
+                          false,
+                          false,
+                          TILE_C_DIM>(tmp_cb_id, 1, num_faces_in_output_tile)));
+                } else if (first_c_block) {
+                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                        tmp_cb_id, 1, num_faces_in_output_tile)));
                 }
             }
             tile_regs_acquire();
@@ -170,13 +197,52 @@ void MAIN {
             tile_regs_commit();
             tile_regs_wait();
             if constexpr (!return_indices) {
-                // for non-return index version we only have 1 output tensor therefore we can let pack_untilize_dest
-                // overflow by always packing num_faces_in_output_tile even for the last tile which may have less
-                if (last_c_block) {
-                    pack_untilize_dest<partial_iter_output_tiles>(
-                        out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                 if constexpr (is_output_tiled) {
+                    // TILED output: accumulate sticks and perform tilization when needed
+                    pack_untilize_dest<1>(tmp_cb_id, 1, temp_cb_row_offset, num_out_sticks, num_faces_in_output_tile);
+                    temp_cb_row_offset += last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
+                    if (last_c_block) {
+                        tilize_stick_counter++;
+
+                    }
+                    tile_regs_release();
+
+                    if (tilize_stick_counter == TILE_HEIGHT) {
+                        PACK((pack_untilize_uninit(tmp_cb_id)));
+
+                        // Workaround until #27504 is not closed
+                        if constexpr (is_output_block_format || window_size_hw > FACE_HEIGHT) {
+                            tensix_sync();
+                            unary_op_init_common(tmp_cb_id, out_cb_id);
+                            tensix_sync();
+                        }
+
+                        tilize_init(tmp_cb_id, in_ntiles_c, out_cb_id);
+                        tilize_block(tmp_cb_id, in_ntiles_c, out_cb_id);
+
+                        cb_push_back(out_cb_id, in_ntiles_c);
+                        tilize_uninit(tmp_cb_id, out_cb_id);
+
+                        if constexpr (is_output_block_format || window_size_hw > FACE_HEIGHT) {
+                            tensix_sync();
+                            unary_op_init_common(in_cb_id_0, tmp_cb_id);
+                            tensix_sync();
+                        }
+
+                        MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
+                        tilize_stick_counter = 0;
+                        temp_cb_row_offset = 0;
+                    }
                 } else {
-                    pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                    // ROW_MAJOR output: pack directly to output CB
+                    if (last_c_block) {
+                        pack_untilize_dest<partial_iter_output_tiles>(
+                            out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                    } else {
+                        pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                    }
+                    cb_push_back(out_cb_id, output_faces);
+                    tile_regs_release();
                 }
             } else {
                 if constexpr (pack_untilize_reinit) {
@@ -197,12 +263,12 @@ void MAIN {
                     pack_untilize_uninit(out_cb_id);
                     tensix_sync();
                 }
+                cb_push_back(out_cb_id, output_faces);
+                if constexpr (return_indices) {
+                    cb_push_back(out_idx_cb_id, output_faces);
+                }
+                tile_regs_release();
             }
-            cb_push_back(out_cb_id, output_faces);
-            if constexpr (return_indices) {
-                cb_push_back(out_idx_cb_id, output_faces);
-            }
-            tile_regs_release();
         }
         if constexpr (!one_scalar_per_core) {
             cb_pop_front(curr_scalar_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -155,7 +155,7 @@ void MAIN {
                 if (last_c_block) {
 #ifdef ARCH_BLACKHOLE
                     pack_untilize_dest_init<partial_iter_output_tiles>(
-                        tmp_cb_id, num_out_sticks, num_faces_in_output_tile);
+                        pre_tilize_cb_id, num_out_sticks, num_faces_in_output_tile);
 #else
                     PACK((llk_pack_untilize_init<
                           partial_iter_output_tiles,
@@ -166,7 +166,8 @@ void MAIN {
 #endif
                 } else if (first_c_block) {
 #ifdef ARCH_BLACKHOLE
-                    pack_untilize_dest_init<max_tiles_per_iter>(tmp_cb_id, num_out_sticks, num_faces_in_output_tile);
+                    pack_untilize_dest_init<max_tiles_per_iter>(
+                        pre_tilize_cb_id, num_out_sticks, num_faces_in_output_tile);
 #else
                     PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
                         pre_tilize_cb_id, 1, num_faces_in_output_tile)));

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -20,6 +20,22 @@
 #define FACE_WIDTH 16
 #define FACE_HEIGHT 16
 
+// Zero out a single page (where wr ptr points) for a given circular buffer.
+template <uint32_t cb_id>
+ALWI void zero_out_page() {
+    uint32_t page_size = get_local_cb_interface(cb_id).fifo_page_size;
+    const uint32_t num_zeros_reads = page_size / MEM_ZEROS_SIZE;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id);
+
+    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+}
+
 // Fill an L1 buffer with the given val
 // WARNING: Use with caution as there's no memory protection. Make sure size is within limits
 ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val, bool unconditionally = true) {
@@ -93,7 +109,7 @@ ALWI void read_window_with_top_left_index(
     // return_indices requires 1 tile at a time, otherwise we can reduce 8 tiles at a time.
     constexpr uint32_t MAX_TILES_PER_REDUCTION = return_indices ? 1 : (is_avg_pool && is_large_kernel) ? 4 : 8;
     constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
-    constexpr uint32_t in_ntiles_c = in_c / TILE_WIDTH;
+    constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      (window_h * window_w) <= 16 && !last_tile_is_partial;
     uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
@@ -122,6 +138,9 @@ ALWI void read_window_with_top_left_index(
             cb_reserve_back(in_idx_cb_id, 1);
         }
         uint32_t processed_sticks = 0;
+        if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
+            zero_out_page<in_cb_id>();
+        }
         for (uint32_t h = 0; h < window_h; ++h) {
             auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
                 const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
@@ -285,12 +304,6 @@ void kernel_main() {
     constexpr uint32_t dilation_w = get_compile_time_arg_val(35);
     constexpr bool return_indices = (bool)get_compile_time_arg_val(36);
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
-
-    // TODO this should go in the initialization condition below
-    if constexpr (last_tile_is_partial) {
-        clear_out_tiles<in_cb_id, clear_value_cb_id>();
-    }
-
     constexpr uint32_t in_scalar_cb_id =
         split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -423,8 +423,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     if (is_output_tiled) {
         pre_tilize_cb_id = next_cb_index++;
-        const uint32_t pre_tilize_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
-        const uint32_t pre_tilize_cb_npages = 1;
+        const uint32_t pre_tilize_cb_pagesize = tt::constants::TILE_WIDTH * params.nbytes;
+        const uint32_t pre_tilize_cb_npages = tt::constants::TILE_HEIGHT * params.in_ntiles_c;
         tt::tt_metal::create_cb(
             pre_tilize_cb_id, program, all_cores, pre_tilize_cb_pagesize, pre_tilize_cb_npages, params.data_format);
         log_debug(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -3,10 +3,13 @@
 
 #include "pool_op.hpp"
 #include "tt-metalium/circular_buffer_config.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/pool/pool_utils.hpp"
 #include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/buffer.hpp"
+#include "ttnn/tensor/types.hpp"
 #include <cstdint>
 #include <optional>
 #include <vector>
@@ -235,7 +238,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t num_shards_c,
     const MemoryConfig& out_mem_config,
     std::optional<int32_t> divisor_override,
-    uint32_t memory_used) {
+    uint32_t memory_used,
+    const Layout& output_layout) {
     distributed::MeshDevice* device = inputs[0].device();
 
     const tt::tt_metal::DeviceStorage& reader_indices_storage = reader_indices.device_storage();
@@ -247,8 +251,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
     const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
-    FactoryParameters params =
-        get_factory_parameters(num_shards_c, inputs[0], kernel_h, kernel_w, in_c, pool_type, return_indices);
+    FactoryParameters params = get_factory_parameters(
+        num_shards_c, inputs[0].dtype(), outputs[0].dtype(), kernel_h, kernel_w, in_c, pool_type, return_indices, output_layout);
     uint32_t pad_h = pad_t + pad_b;
     uint32_t pad_w = pad_l + pad_r;
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
@@ -411,17 +415,43 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", tile_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
     }
 
-    // output of reduce == writer to write
-    // output rows in RM
-    // after reduction
-    const uint32_t out_cb_pagesize =
-        std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
-        params.nbytes;  // there is just one row of channels after each reduction (or 1
-                        // block of c if its greater than 8 tiles)
-    const uint32_t out_cb_npages = outputs[0].shard_spec().value().shape[0] * params.out_ntiles_c;
+    const bool is_output_tiled = output_layout == Layout::TILE;
+    const bool is_output_block_format = is_block_float(outputs[0].dtype());
+
+    // Conditionally allocate temporary CB - only needed for TILED output
+    uint32_t temp_cb_id = 32;  // default invalid CB ID
+
+    if (is_output_tiled) {
+        temp_cb_id = next_cb_index++;
+        const uint32_t temp_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
+        const uint32_t temp_cb_npages = 1;
+        tt::tt_metal::create_cb(temp_cb_id, program, all_cores, temp_cb_pagesize, temp_cb_npages, params.data_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", temp_cb_id, temp_cb_pagesize, temp_cb_npages);
+    }
+
+    uint32_t out_cb_pagesize;
+    uint32_t out_cb_npages;
+
+    if (is_output_tiled) {
+        out_cb_pagesize = tt::tile_size(params.output_data_format);
+        out_cb_npages =
+            outputs[0].shard_spec().value().shape[0] * outputs[0].shard_spec().value().shape[1] / tt::constants::TILE_HW;
+    } else {
+        out_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
+            params.nbytes;  // there is just one row of channels after each reduction (or 1
+                            // block of c if its greater than 8 tiles)
+        out_cb_npages = outputs[0].shard_spec().value().shape[0] * params.out_ntiles_c;
+    }
 
     const auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, params.data_format, outputs[0].buffer());
+        next_cb_index++,
+        program,
+        all_cores,
+        out_cb_pagesize,
+        out_cb_npages,
+        params.output_data_format,
+        outputs[0].buffer());
 
     uint32_t out_idx_cb_id = 32;
     tt::tt_metal::CBHandle out_idx_cb = 0;
@@ -582,7 +612,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         out_cb_id,                      // 15
         out_idx_cb_id,                  // 16
         one_scalar_per_core,            // 17
-        (uint32_t)return_indices};      // 18
+        (uint32_t)return_indices,       // 18
+        temp_cb_id,                     // 19
+        is_output_tiled,                // 20
+        is_output_block_format};        // 21
 
     auto compute_config = tt::tt_metal::ComputeConfig{
         .math_fidelity = MathFidelity::HiFi4,
@@ -619,7 +652,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         outputs[0].memory_config(),
         pool_type,
         count_include_pad,
-        divisor_override);
+        divisor_override,
+        output_layout,
+        outputs[0].dtype());
+
     uint32_t output_cb_size = post_allocate_size - memory_used;
 
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
@@ -693,6 +729,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     const auto& pool_type = op_attr.pool_type_;
     const auto& out_mem_config = op_attr.memory_config_;
+    const auto& output_layout = op_attr.output_layout_;
     bool count_include_pad = op_attr.count_include_pad_;
     std::optional<int32_t> divisor_override = op_attr.divisor_override_;
     bool return_indices = op_attr.return_indices_;
@@ -771,7 +808,8 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         num_shards_c,
         out_mem_config,
         divisor_override,
-        op_attr.memory_used);
+        op_attr.memory_used,
+        output_layout);
 }
 
 void Pool2D::MultiCore::override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -419,14 +419,16 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const bool is_output_block_format = is_block_float(outputs[0].dtype());
 
     // Conditionally allocate temporary CB - only needed for TILED output
-    uint32_t temp_cb_id = 32;  // default invalid CB ID
+    uint32_t pre_tilize_cb_id = 32;  // default invalid CB ID
 
     if (is_output_tiled) {
-        temp_cb_id = next_cb_index++;
-        const uint32_t temp_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
-        const uint32_t temp_cb_npages = 1;
-        tt::tt_metal::create_cb(temp_cb_id, program, all_cores, temp_cb_pagesize, temp_cb_npages, params.data_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", temp_cb_id, temp_cb_pagesize, temp_cb_npages);
+        pre_tilize_cb_id = next_cb_index++;
+        const uint32_t pre_tilize_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
+        const uint32_t pre_tilize_cb_npages = 1;
+        tt::tt_metal::create_cb(
+            pre_tilize_cb_id, program, all_cores, pre_tilize_cb_pagesize, pre_tilize_cb_npages, params.data_format);
+        log_debug(
+            tt::LogOp, "CB {} :: PS = {}, NP = {}", pre_tilize_cb_id, pre_tilize_cb_pagesize, pre_tilize_cb_npages);
     }
 
     uint32_t out_cb_pagesize;
@@ -613,7 +615,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         out_idx_cb_id,                  // 16
         one_scalar_per_core,            // 17
         (uint32_t)return_indices,       // 18
-        temp_cb_id,                     // 19
+        pre_tilize_cb_id,               // 19
         is_output_tiled,                // 20
         is_output_block_format};        // 21
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -23,13 +23,20 @@ void validate_pool2d(
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     const MemoryConfig& out_mem_config,
     const std::optional<const int32_t> divisor_override,
-    const bool return_indices) {
+    const bool return_indices,
+    const Layout& output_layout) {
     // check the input tensor
     const Tensor& input = input_tensors[0];
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input.buffer() != nullptr, "Operands to reshape need to be allocated in buffers on device!");
     TT_FATAL(input.dtype() == DataType::BFLOAT16, "Only BFLOAT16 supported for now");
     TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR supported for now. Tracked by issue #23338");
+
+    // Blackhole does not support tiled output for pool operations
+    if (input.device()->arch() == tt::ARCH::BLACKHOLE) {
+        TT_FATAL(output_layout == Layout::ROW_MAJOR, "Blackhole does not support tiled output for pool operations");
+    }
+
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
 
     if (return_indices) {
@@ -99,7 +106,8 @@ void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_att
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
         op_attr.divisor_override_,
-        op_attr.return_indices_);
+        op_attr.return_indices_,
+        op_attr.output_layout_);
 }
 
 void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
@@ -109,7 +117,8 @@ void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
         op_attr.divisor_override_,
-        op_attr.return_indices_);
+        op_attr.return_indices_,
+        op_attr.output_layout_);
 }
 
 Pool2D::spec_return_value_t Pool2D::compute_output_specs(
@@ -125,7 +134,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     uint32_t batch_size = sliding_window_config.batch_size;
     uint32_t out_nhw = batch_size * out_h * out_w;
 
-    bool is_out_tiled = output_dtype == DataType::BFLOAT8_B;
+    bool is_out_tiled = op_attr.output_layout_ == Layout::TILE;
     uint32_t tile_rows = is_out_tiled ? tt::constants::TILE_HEIGHT : 1;
 
     uint32_t num_cores_nhw = sliding_window_config.num_cores_nhw;
@@ -144,17 +153,18 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
         }
     }
 
+    if (is_out_tiled) {
+        out_c_padded = tt::round_up(out_c, tt::constants::TILE_WIDTH * sliding_window_config.num_cores_c);
+        out_nhw_padded = tt::round_up(out_nhw_padded, tt::constants::TILE_HEIGHT * sliding_window_config.num_cores_nhw);
+    }
+
     ttnn::Shape padded_output_shape({1, 1, out_nhw_padded, out_c_padded});
     ttnn::Shape output_shape({1, 1, out_nhw, out_c});
 
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout::fromPaddedShape(
-            output_dtype,
-            tt::tt_metal::PageConfig(input.layout()),  // Preserve layout from input
-            mem_config,
-            output_shape,
-            padded_output_shape));
+            output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
 }
 
 Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
@@ -233,6 +243,7 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     Pool2DType pool_type,
     DataType output_dtype,
+    Layout output_layout,
     MemoryConfig memory_config,
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
@@ -243,6 +254,7 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
             .sliding_window_config_ = sliding_window_config,
             .pool_type_ = pool_type,
             .output_dtype_ = output_dtype,
+            .output_layout_ = output_layout,
             .memory_config_ = std::move(memory_config),
             .count_include_pad_ = count_include_pad,
             .divisor_override_ = divisor_override,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -25,6 +25,7 @@ struct Pool2D {
         sliding_window::SlidingWindowConfig sliding_window_config_;
         Pool2DType pool_type_;
         DataType output_dtype_;
+        Layout output_layout_;
         MemoryConfig memory_config_;
         bool count_include_pad_;
         std::optional<int32_t> divisor_override_;
@@ -82,6 +83,7 @@ struct Pool2D {
         const sliding_window::SlidingWindowConfig& sliding_window_config,
         Pool2DType pool_type,
         DataType output_dtype,
+        Layout output_layout,
         MemoryConfig memory_config,
         bool count_include_pad,
         std::optional<int32_t> divisor_override,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -161,7 +161,8 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         uint32_t input_channels = input_tensor_shape[3];
         uint32_t padding_needed = input_tensor_width_snapped_to_channels_alignment - input_channels;
 
-        // Apply zero padding to channels if needed
+        // Apply zero padding to channels if needed - we need it in case when output dtype is block float because if we
+        // have random values it would affect common exponent calculation
         Tensor input_tensor_padded;
         if (padding_needed > 0 && is_block_float(dtype)) {
             ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -18,6 +18,7 @@
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/math.hpp>
 
@@ -47,10 +48,18 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
     bool in_place_halo = false,
     bool deallocate_input = false,
     bool reallocate_halo_output = true,
-    bool return_indices = false) {
+    bool return_indices = false,
+    const DataType dtype = DataType::BFLOAT16,
+    const Layout output_layout = Layout::ROW_MAJOR) {
     std::array<uint32_t, 4> padding_4d = sliding_window::get_pair_n4_padding(padding);
-    bool is_out_tiled = false;  // pool output is row major
+    bool is_out_tiled = output_layout == Layout::TILE;
     bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
+    TT_FATAL(
+        dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B,
+        "Currently only BFLOAT16, BFLOAT8_B, and BFLOAT4_B output data formats are supported");
+    TT_FATAL(
+        !((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && output_layout == Layout::ROW_MAJOR),
+        "BFLOAT8_B/BFLOAT4_B output data format is not supported with ROW_MAJOR layout");
     validate_input_params(
         input_tensor,
         batch_size,
@@ -107,9 +116,9 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
                 input_tensor.device()->compute_with_storage_grid_size(),
                 ShardOrientation::ROW_MAJOR,
                 false,
-                false,
-                is_in_tiled,  // if input is tiled we need to choose num_cores_c to make the shard width to be a tile
-                              // multiple, it cannot be 16
+                is_out_tiled,
+                is_in_tiled || is_out_tiled,  // if input/output is tiled we need to choose num_cores_c to make the
+                                              // shard width to be a tile multiple, it cannot be 16
                 0);
         } else {  // auto-sharding
             std::optional<sliding_window::ParallelConfig> sw_parallel_config =
@@ -120,7 +129,9 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
                     pool_type,
                     count_include_pad,
                     divisor_override,
-                    return_indices);
+                    return_indices,
+                    output_layout,
+                    dtype);
             TT_FATAL(
                 sw_parallel_config.has_value(),
                 "autosharding could not determine valid shard scheme, please check tensor dimensions");
@@ -146,17 +157,31 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         uint32_t input_tensor_width_snapped_to_channels_alignment =
             tt::round_up(input_tensor_shape[3], num_cores_c * input_channels_alignment);
 
+        // Calculate padding needed for channels dimension
+        uint32_t input_channels = input_tensor_shape[3];
+        uint32_t padding_needed = input_tensor_width_snapped_to_channels_alignment - input_channels;
+
+        // Apply zero padding to channels if needed
+        Tensor input_tensor_padded;
+        if (padding_needed > 0 && is_block_float(dtype)) {
+            ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
+
+            input_tensor_padded = ttnn::pad(ttnn::DefaultQueueId, input_tensor, pad_spec, 0.0f);
+        } else {
+            input_tensor_padded = input_tensor;
+        }
+
+        // Create target shape and apply sharding
         ttnn::Shape input_padded_shape = ttnn::Shape(
             {input_tensor_shape[0],
              input_tensor_shape[1],
              input_tensor_shape[2],
              input_tensor_width_snapped_to_channels_alignment});
 
-        input_tensor_sharded = input_tensor.reshape(input_tensor_shape, input_padded_shape);
-
         auto sharded_mem_config = conv::create_sharded_memory_config_from_parallel_config(
             input_padded_shape, parallel_config, is_in_tiled ? tt::constants::TILE_HEIGHT : 1);
-        input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt);
+
+        input_tensor_sharded = ttnn::to_memory_config(input_tensor_padded, sharded_mem_config, std::nullopt);
         out_memory_config = input_tensor_sharded.memory_config();
     } else {
         TT_FATAL(
@@ -181,10 +206,8 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
     uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
     uint32_t output_c = channels;
-    uint32_t output_c_padded = tt::round_up(output_c, tt::constants::TILE_WIDTH / 2);
-    if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED || shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        output_c_padded = tt::round_up(output_c, num_cores_c * tt::constants::TILE_WIDTH / 2);
-    }
+    uint32_t output_c_padded = tt::round_up(
+        output_c, num_cores_c * (is_out_tiled ? tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH / 2));
     uint32_t output_shard_width_padded = output_c_padded / num_cores_c;
     log_debug(
         tt::LogOp,
@@ -206,7 +229,7 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         .num_cores_nhw = num_cores_nhw,
         .num_cores_c = num_cores_c,
         .core_range_set = parallel_config.grid,
-        .snap_to_tile = false,
+        .snap_to_tile = is_out_tiled,
         .ceil_mode = ceil_mode,
         .is_avg_pool = pool_type == Pool2DType::AVG_POOL2D,
     };
@@ -300,7 +323,8 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         haloed_tensors,
         sliding_window_config,
         pool_type,
-        DataType::BFLOAT16,  // input_tensor.dtype(), // currently only bfp16 output is supported
+        dtype,
+        output_layout,
         out_memory_config,
         count_include_pad,
         divisor_override,
@@ -343,7 +367,9 @@ std::variant<Tensor, MaxPoolWithIndicesResult> MaxPool2DOp::invoke(
     bool in_place_halo,
     bool deallocate_input,
     bool reallocate_halo_output,
-    bool return_indices) {
+    bool return_indices,
+    const DataType dtype,
+    const Layout output_layout) {
     return pool2d_invoke(
         queue_id,
         input_tensor,
@@ -364,7 +390,9 @@ std::variant<Tensor, MaxPoolWithIndicesResult> MaxPool2DOp::invoke(
         in_place_halo,
         deallocate_input,
         reallocate_halo_output,
-        return_indices);
+        return_indices,
+        dtype,
+        output_layout);
 }
 
 Tensor AvgPool2DOp::invoke(
@@ -384,7 +412,9 @@ Tensor AvgPool2DOp::invoke(
     const std::optional<const TensorMemoryLayout> applied_shard_scheme,
     bool in_place_halo,
     bool deallocate_input,
-    bool reallocate_halo_output) {
+    bool reallocate_halo_output,
+    const DataType dtype,
+    const Layout output_layout) {
     auto result = pool2d_invoke(
         queue_id,
         input_tensor,
@@ -405,8 +435,9 @@ Tensor AvgPool2DOp::invoke(
         in_place_halo,
         deallocate_input,
         reallocate_halo_output,
-        false  // return_indices
-    );
+        false,  // return_indices
+        dtype,
+        output_layout);
 
     // Average pool always returns just the tensor, never indices
     return std::get<Tensor>(result);

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -37,7 +37,9 @@ struct MaxPool2DOp {
         bool in_place_halo = false,
         bool deallocate_input = false,
         bool reallocate_halo_output = true,
-        bool return_indices = false);
+        bool return_indices = false,
+        const DataType dtype = DataType::BFLOAT16,
+        const Layout output_layout = Layout::ROW_MAJOR);
 };
 struct AvgPool2DOp {
     static Tensor invoke(
@@ -57,7 +59,9 @@ struct AvgPool2DOp {
         std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
         bool in_place_halo = false,
         bool deallocate_input = false,
-        bool reallocate_halo_output = true);
+        bool reallocate_halo_output = true,
+        const DataType dtype = DataType::BFLOAT16,
+        const Layout output_layout = Layout::ROW_MAJOR);
 };
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -38,8 +38,8 @@ struct MaxPool2DOp {
         bool deallocate_input = false,
         bool reallocate_halo_output = true,
         bool return_indices = false,
-        const DataType dtype = DataType::BFLOAT16,
-        const Layout output_layout = Layout::ROW_MAJOR);
+        DataType dtype = DataType::BFLOAT16,
+        Layout output_layout = Layout::ROW_MAJOR);
 };
 struct AvgPool2DOp {
     static Tensor invoke(
@@ -60,8 +60,8 @@ struct AvgPool2DOp {
         bool in_place_halo = false,
         bool deallocate_input = false,
         bool reallocate_halo_output = true,
-        const DataType dtype = DataType::BFLOAT16,
-        const Layout output_layout = Layout::ROW_MAJOR);
+        DataType dtype = DataType::BFLOAT16,
+        Layout output_layout = Layout::ROW_MAJOR);
 };
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -45,6 +45,8 @@ void bind_max_pool2d_operation(py::module& module) {
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
             return_indices (bool, optional): whether to return both values and indices. When True, returns a tuple (values, indices). Defaults to `False`.
+            dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
             queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
@@ -82,6 +84,8 @@ void bind_max_pool2d_operation(py::module& module) {
                                 in_place_halo=False,
                                 deallocate_input=False,
                                 reallocate_halo_output=True,
+                                dtype=ttnn.bfloat16,
+                                output_layout=ttnn.ROW_MAJOR_LAYOUT,
                             )
 
         )doc",
@@ -103,6 +107,8 @@ void bind_max_pool2d_operation(py::module& module) {
                bool deallocate_input,
                bool reallocate_halo_output,
                bool return_indices,
+               const DataType dtype,
+               const Layout output_layout,
                QueueId queue_id) -> py::object {
                 auto result = self(
                     queue_id,
@@ -121,7 +127,9 @@ void bind_max_pool2d_operation(py::module& module) {
                     in_place_halo,
                     deallocate_input,
                     reallocate_halo_output,
-                    return_indices);
+                    return_indices,
+                    dtype,
+                    output_layout);
 
                 // Handle variant return type
                 if (std::holds_alternative<MaxPoolWithIndicesResult>(result)) {
@@ -130,6 +138,7 @@ void bind_max_pool2d_operation(py::module& module) {
                 } else {
                     return py::cast(std::get<ttnn::Tensor>(result));
                 }
+
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -148,6 +157,8 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("deallocate_input") = false,
             py::arg("reallocate_halo_output") = true,
             py::arg("return_indices") = false,
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("output_layout") = Layout::ROW_MAJOR,
             py::arg("queue_id") = DefaultQueueId});
 }
 
@@ -179,6 +190,8 @@ void bind_avg_pool2d_operation(py::module& module) {
             in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
+            dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
             queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
@@ -216,6 +229,8 @@ void bind_avg_pool2d_operation(py::module& module) {
                             in_place_halo=False,
                             deallocate_input=False,
                             reallocate_halo_output=True,
+                            dtype=ttnn.bfloat16,
+                            output_layout=ttnn.ROW_MAJOR_LAYOUT,
                         )
         )doc",
         ttnn::pybind_overload_t{
@@ -236,6 +251,8 @@ void bind_avg_pool2d_operation(py::module& module) {
                bool in_place_halo,
                bool deallocate_input,
                bool reallocate_halo_output,
+               const DataType dtype,
+               const Layout output_layout,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
                     queue_id,
@@ -254,7 +271,9 @@ void bind_avg_pool2d_operation(py::module& module) {
                     applied_shard_scheme,
                     in_place_halo,
                     deallocate_input,
-                    reallocate_halo_output);
+                    reallocate_halo_output,
+                    dtype,
+                    output_layout);
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -273,6 +292,8 @@ void bind_avg_pool2d_operation(py::module& module) {
             py::arg("in_place_halo") = false,
             py::arg("deallocate_input") = false,
             py::arg("reallocate_halo_output") = true,
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("output_layout") = Layout::ROW_MAJOR,
             py::arg("queue_id") = 0});
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -161,7 +161,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
 
     const bool is_output_tiled = false;
     const bool is_output_block_format = false;
-    const uint32_t tmp_cb_id =
+    const uint32_t pre_tilize_cb_id =
         32;  // Unused CB for pool compute kernel for grid sample, we don't have tiled output in gridsample
 
     // Kernel for core group 1
@@ -186,8 +186,8 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
-            tmp_cb_id,                                           // 19: Temp CB (unused)
-            is_output_tiled,                                               // 20: is_output_tiled (unused)
+            pre_tilize_cb_id,                                    // 19: Pre-tilize CB (unused)
+            is_output_tiled,                                     // 20: is_output_tiled (unused)
             is_output_block_format                               // 21: is_output_block_format (unused)
         };
 
@@ -225,7 +225,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
-            tmp_cb_id,                                           // 19: Temp CB (unused)
+            pre_tilize_cb_id,                                    // 19: Pre-tilize CB (unused)
             is_output_tiled,                                     // 20: is_output_tiled (unused)
             is_output_block_format                               // 21: is_output_block_format (unused)
         };

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -159,6 +159,11 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     tt::tt_metal::KernelHandle compute_kernel_group_1 = 0;
     tt::tt_metal::KernelHandle compute_kernel_group_2 = 0;
 
+    const bool is_output_tiled = false;
+    const bool is_output_block_format = false;
+    const uint32_t tmp_cb_id =
+        32;  // Unused CB for pool compute kernel for grid sample, we don't have tiled output in gridsample
+
     // Kernel for core group 1
     if (core_group_1.num_cores() > 0) {
         std::vector<uint32_t> compute_compile_time_args_1 = {
@@ -181,6 +186,9 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
+            tmp_cb_id,                                           // 19: Temp CB (unused)
+            is_output_tiled,                                               // 20: is_output_tiled (unused)
+            is_output_block_format                               // 21: is_output_block_format (unused)
         };
 
         compute_kernel_group_1 = tt::tt_metal::CreateKernel(
@@ -217,6 +225,9 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                                         // 16: Index Output CB (unused)
             one_scalar_per_core,                                 // 17: Scalar mode
             false,                                               // 18: Return Indices (unused)
+            tmp_cb_id,                                           // 19: Temp CB (unused)
+            is_output_tiled,                                     // 20: is_output_tiled (unused)
+            is_output_block_format                               // 21: is_output_block_format (unused)
         };
 
         compute_kernel_group_2 = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -277,12 +277,12 @@ uint32_t calculate_L1_usage(
     }
     uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
 
-    uint32_t temp_cb_size = 0;
+    uint32_t pre_tilize_cb_size = 0;
 
     if (is_output_tiled) {
-        const uint32_t temp_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
-        const uint32_t temp_cb_npages = 1;
-        temp_cb_size = temp_cb_pagesize * temp_cb_npages;
+        const uint32_t pre_tilize_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
+        const uint32_t pre_tilize_cb_npages = 1;
+        pre_tilize_cb_size = pre_tilize_cb_pagesize * pre_tilize_cb_npages;
     }
 
     uint32_t out_idx_cb_config_size = 0;
@@ -294,8 +294,9 @@ uint32_t calculate_L1_usage(
     }
 
     return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size + temp_cb_size +
-           sliding_window::align_buffer(out_cb_config_size) + sliding_window::align_buffer(out_idx_cb_config_size);
+           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size +
+           pre_tilize_cb_size + sliding_window::align_buffer(out_cb_config_size) +
+           sliding_window::align_buffer(out_idx_cb_config_size);
 }
 
 std::optional<ParallelConfig> determine_pool_config_for_auto_shard(

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -109,18 +109,21 @@ std::optional<ParallelConfig> determine_valid_parallel_config(
 
 FactoryParameters get_factory_parameters(
     uint32_t num_shards_c,
-    const Tensor& input,
+    const DataType& input_dtype,
+    const DataType& output_dtype,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t in_channels,
     Pool2DType pool_type,
-    bool return_indices) {
+    bool return_indices,
+    const Layout& output_layout) {
     uint32_t multi_buffering_factor = 2;
     bool split_reader = true;
 
-    auto dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
+    auto dtype = input_dtype == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_dtype;
     tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
     tt::DataFormat index_format = datatype_to_dataformat_converter(DataType::UINT16);
+    tt::DataFormat output_data_format = datatype_to_dataformat_converter(output_dtype);
     uint32_t nbytes = datum_size(data_format);
     uint32_t index_nbytes = datum_size(index_format);
 
@@ -131,7 +134,10 @@ FactoryParameters get_factory_parameters(
     uint32_t num_tilized_rows =
         kernel_size_hw <= tt::constants::FACE_WIDTH ? kernel_size_hw : tt::constants::TILE_HEIGHT;
     uint32_t in_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / tt::constants::TILE_WIDTH);
-    uint32_t out_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / tt::constants::FACE_WIDTH);
+    // For TILE_LAYOUT output, we need to align to TILE_WIDTH instead of FACE_WIDTH
+    uint32_t effective_tile_width_for_output =
+        (output_layout == Layout::TILE) ? tt::constants::TILE_WIDTH : tt::constants::FACE_WIDTH;
+    uint32_t out_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / effective_tile_width_for_output);
 
     bool is_avg_pool = pool_type == Pool2DType::AVG_POOL2D;
     const bool last_tile_is_partial =
@@ -155,6 +161,7 @@ FactoryParameters get_factory_parameters(
         .index_nbytes = index_nbytes,
         .data_format = data_format,
         .index_format = index_format,
+        .output_data_format = output_data_format,
         .in_ntiles_c = in_ntiles_c,
         .out_ntiles_c = out_ntiles_c,
         .is_avg_pool = is_avg_pool,
@@ -183,7 +190,9 @@ uint32_t calculate_L1_usage(
     const MemoryConfig& output_memory,
     Pool2DType pool_type,
     bool count_include_pad,
-    std::optional<int32_t> divisor_override) {
+    std::optional<int32_t> divisor_override,
+    const Layout& output_layout,
+    const DataType& output_dtype) {
     const auto grid_size = input_memory.shard_spec().value().grid.bounding_box().grid_size();
     uint32_t num_shards_c = 0;
     if (input_memory.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
@@ -196,8 +205,8 @@ uint32_t calculate_L1_usage(
         num_shards_c = grid_size.x;
     }
 
-    FactoryParameters params =
-        get_factory_parameters(num_shards_c, input, kernel_h, kernel_w, in_channels, pool_type, return_indices);
+    FactoryParameters params = get_factory_parameters(
+        num_shards_c, input.dtype(), output_dtype, kernel_h, kernel_w, in_channels, pool_type, return_indices, output_layout);
 
     bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
@@ -252,12 +261,29 @@ uint32_t calculate_L1_usage(
         tile_idx_tmp_cb_size = params.index_nbytes * tile_elems * 1;  // 1 page
     }
 
-    // after reduction
-    uint32_t out_cb_pagesize =
-        std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
-        params.nbytes;
-    uint32_t out_cb_npages = output_memory.shard_spec().value().shape[0] * params.out_ntiles_c;
+    uint32_t out_cb_pagesize;
+    uint32_t out_cb_npages;
+    const bool is_output_tiled = output_layout == Layout::TILE;
+
+    if (is_output_tiled) {
+        out_cb_pagesize = tt::tile_size(datatype_to_dataformat_converter(output_dtype));
+        out_cb_npages = output_memory.shard_spec().value().shape[0] * output_memory.shard_spec().value().shape[1] /
+                        tt::constants::TILE_HW;
+    } else {
+        out_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
+            params.nbytes;
+        out_cb_npages = output_memory.shard_spec().value().shape[0] * params.out_ntiles_c;
+    }
     uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
+
+    uint32_t temp_cb_size = 0;
+
+    if (is_output_tiled) {
+        const uint32_t temp_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
+        const uint32_t temp_cb_npages = 1;
+        temp_cb_size = temp_cb_pagesize * temp_cb_npages;
+    }
 
     uint32_t out_idx_cb_config_size = 0;
     if (return_indices) {
@@ -268,7 +294,7 @@ uint32_t calculate_L1_usage(
     }
 
     return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size +
+           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size + temp_cb_size +
            sliding_window::align_buffer(out_cb_config_size) + sliding_window::align_buffer(out_idx_cb_config_size);
 }
 
@@ -279,7 +305,9 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     Pool2DType pool_type,
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
-    bool return_indices) {
+    bool return_indices,
+    const Layout& output_layout,
+    const DataType& output_dtype) {
     uint32_t batch_size = sliding_window_config.batch_size;
     auto output_shape = sliding_window_config.get_output_shape();
     auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
@@ -298,6 +326,7 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     };
 
     bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
+    bool is_out_tiled = output_layout == ttnn::TILE_LAYOUT;
 
     auto calc_l1_usage_inner = [&](TensorMemoryLayout layout, ShardOrientation orientation) -> l1_usage_config {
         auto input_parallel_config = pool::determine_valid_parallel_config(
@@ -309,8 +338,8 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
             compute_grid_size,
             orientation,
             false,
-            false,
-            is_in_tiled,  // if input is tiled we need the shard width to be a tile multiple,
+            is_out_tiled,
+            is_in_tiled || is_out_tiled,  // if input/output is tiled we need the shard width to be a tile multiple,
             0);
 
         if (!input_parallel_config.has_value()) {
@@ -333,7 +362,9 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
             get_memconfig(input_parallel_config.value()),
             pool_type,
             count_include_pad,
-            divisor_override);
+            divisor_override,
+            output_layout,
+            output_dtype);
 
         return {.l1_usage = l1_usage, .config = input_parallel_config};
     };

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttnn::operations::pool {
 
@@ -46,6 +47,7 @@ struct FactoryParameters {
     uint32_t index_nbytes;
     tt::DataFormat data_format;
     tt::DataFormat index_format;
+    tt::DataFormat output_data_format;
     uint32_t in_ntiles_c;
     uint32_t out_ntiles_c;
     bool is_avg_pool;
@@ -91,16 +93,20 @@ std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_sha
     Pool2DType pool_type,
     bool count_include_pad,
     std::optional<int32_t> divisor_override,
-    bool return_indices);
+    bool return_indices,
+    const Layout& output_layout,
+    const DataType& output_dtype);
 
 FactoryParameters get_factory_parameters(
     uint32_t num_shards_c,
-    const Tensor& input,
+    const DataType& input_dtype,
+    const DataType& output_dtype,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t in_channels,
     Pool2DType pool_type,
-    bool return_indices);
+    bool return_indices,
+    const Layout& output_layout);
 
 uint32_t calculate_L1_usage(
     const Tensor& input,
@@ -119,7 +125,9 @@ uint32_t calculate_L1_usage(
     const tt::tt_metal::MemoryConfig& output_memory,
     Pool2DType pool_type,
     bool count_include_pad,
-    std::optional<int32_t> divisor_override);
+    std::optional<int32_t> divisor_override,
+    const Layout& output_layout,
+    const DataType& output_dtype);
 
 // pool specific validations are done in validate_pool2d, but we want to validate basic inputs to ensure
 // they are sensical to avoid problems in sliding window config, halo and other setup procedures


### PR DESCRIPTION
### Ticket
[#16058](https://github.com/tenstorrent/tt-metal/issues/16058)

### Problem description
Pool ops currently provide only row-major output. If we had the ability to produce tiled output, we could skip the tilizing step in cases where an operation requires tiled input but pool ops provide row-major output. This would also save L1 memory, since block formats could be used for pool outputs.

### What's Changed

- Added 2 optional parameters to maxpool and avgpool:

  - `dtype` (data type of the output), defaulting to `BFLOAT16`
  
  - `output_layout`, defaulting to `ROW_MAJOR` (to maintain current behavior)

- Added support for tiled output: introduced a path where sticks are stored in a temporary CB instead of being directly packed to the output, followed by tilizing.

- Added tiled output cases to all existing maxpool and avgpool tests.

#### Disadvantages

- Workaround required for packing to black format, which has a performance impact. (LLK issue raised: #27504)

- ~~Not yet supported on Blackhole.~~ Blackhole has full inits for `pack_untilize_dest` in every iteration. (LLK issue raised: #27314)


### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17628755562) ✅
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17628766908) ✅ (llama test is failing on main, not related to this change)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17628775045) ✅
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17628782226) ✅