### PR TITLE
[skip ci] Update INSTALLING.md, Galaxy 4U system reqs added

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -23,6 +23,13 @@ curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/
 chmod +x install.sh
 ./install.sh --no-install-podman --no-install-metalium-container
 ```
+
+> [!WARNING]
+> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U systems require the following versions:
+> | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
+> |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
+> | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
+
 - For more information visit Tenstorrent's [TT-Installer GitHub repository](https://github.com/tenstorrent/tt-installer).
 
 #### Option 2: Manual Installation

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -25,13 +25,17 @@ chmod +x install.sh
 ```
 
 > [!WARNING]
-> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U and Blackhole systems require the following example versions:
+> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U and Blackhole systems require the following versions:
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
 > | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
 > | Blackhole            | Ubuntu 22.04    | 3.10     | v2.1.0 or above    | fw_pack-18.7.0.fwbundle (v18.7.0)          | v3.0.20 or above      | N/A                            |
 
 - If required, add the following flags for specifying dependencies versions:
+
+> [!NOTE]
+> The following dependencies versions are examples. Install the versions above depending on your device.
+
 ```
 ./install.sh \
   --smi-version=v3.0.17 \

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -29,6 +29,7 @@ chmod +x install.sh
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
 > | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.1.0 or above    | fw_pack-18.5.0.fwbundle (v18.5.0)          | v3.0.20 or above      | N/A                            |
 
 - If required, add the following flags for specifying dependencies versions:
 ```

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -25,11 +25,11 @@ chmod +x install.sh
 ```
 
 > [!WARNING]
-> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U systems require the following versions:
+> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U and Blackhole systems require the following example versions:
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
 > | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
-> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.1.0 or above    | fw_pack-18.5.0.fwbundle (v18.5.0)          | v3.0.20 or above      | N/A                            |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.1.0 or above    | fw_pack-18.7.0.fwbundle (v18.7.0)          | v3.0.20 or above      | N/A                            |
 
 - If required, add the following flags for specifying dependencies versions:
 ```

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -30,6 +30,16 @@ chmod +x install.sh
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
 > | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
 
+- If required, add the following flags for specifying dependencies versions:
+```
+./install.sh \
+  --smi-version=v3.0.17 \
+  --fw-version=18.3.0 \
+  --kmd-version=1.34 \
+  --no-install-podman \
+  --no-install-metalium-container
+```
+
 - For more information visit Tenstorrent's [TT-Installer GitHub repository](https://github.com/tenstorrent/tt-installer).
 
 #### Option 2: Manual Installation


### PR DESCRIPTION
### Ticket
[PR#27200](https://github.com/tenstorrent/tt-metal/pull/27200)

### Problem description
Galaxy 4U systems have specific reqs for firmware and tt-smi versions.

### What's changed
Warning has been added for specific Galaxy 4U system reqs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes