### PR TITLE
#27676 Implicit row broadcast causes accuracy drop

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2608,12 +2608,12 @@ def test_small_fp32_multiply(device):
     b = ttnn.from_torch(0.01 * torch.randn((4, 32, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
 
     out_torch = torch.multiply(ttnn.to_torch(a), ttnn.to_torch(b))
-    print("Torch multiply result:")
-    print(out_torch)
+    # print("Torch multiply result:")
+    # print(out_torch)
 
     out = ttnn.multiply(a, b)
-    print("TTNN multiply result:")
-    print(out)
+    # print("TTNN multiply result:")
+    # print(out)
 
     # assert_allclose(out_torch, ttnn.to_torch(out))
     assert_with_pcc(out_torch, ttnn.to_torch(out))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2600,3 +2600,20 @@ def test_remainder_implicit_broadcast(device, shapes, torch_dtype, ttnn_dtype):
     output_tensor = ttnn.remainder(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+def test_small_fp32_multiply(device):
+    # Scaling with 0.01 to get realistic values that appear during training.
+    a = ttnn.from_torch(0.01 * torch.randn((1, 1, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(0.01 * torch.randn((4, 32, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
+
+    out_torch = torch.multiply(ttnn.to_torch(a), ttnn.to_torch(b))
+    print("Torch multiply result:")
+    print(out_torch)
+
+    out = ttnn.multiply(a, b)
+    print("TTNN multiply result:")
+    print(out)
+
+    # assert_allclose(out_torch, ttnn.to_torch(out))
+    assert_with_pcc(out_torch, ttnn.to_torch(out))

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -191,6 +191,11 @@ inline auto any_non_llk_row_broadcasted(const Tensor& a, const auto& b) {
             if (a_dtype == DataType::BFLOAT16 && b_dtype == DataType::BFLOAT16) {
                 return false;
             }
+            // for float32 to use SFPU, go with binary_ng
+            if (a_dtype == DataType::FLOAT32 and b_dtype == DataType::FLOAT32) {
+                return false;
+            }
+
             return true;
         }
     }
@@ -312,11 +317,6 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
         if (a.dtype() == DataType::INT32 or b.dtype() == DataType::INT32 or a.dtype() == DataType::UINT32 or
             b.dtype() == DataType::UINT32 or a.dtype() == DataType::UINT16 or b.dtype() == DataType::UINT16 or
             a.dtype() == DataType::UINT8 or b.dtype() == DataType::UINT8) {
-            return true;
-        }
-
-        // for float32 to use SFPU, go with binary_ng
-        if (a.dtype() == DataType::FLOAT32 and b.dtype() == DataType::FLOAT32) {
             return true;
         }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -315,6 +315,11 @@ inline auto is_binary_ng_only(const Tensor& a, const auto& b, BinaryOpType binar
             return true;
         }
 
+        // for float32 to use SFPU, go with binary_ng
+        if (a.dtype() == DataType::FLOAT32 and b.dtype() == DataType::FLOAT32) {
+            return true;
+        }
+
         if (a.logical_shape().rank() > 4 or b.logical_shape().rank() > 4) {
             return true;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -17,12 +17,13 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::binary {
 
 namespace utils {
-    bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
+bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
     switch (val) {
         case BinaryOpType::ADD:
         case BinaryOpType::SUB:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
-                || (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
+                (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MUL:
         case BinaryOpType::EQ:
         case BinaryOpType::NE:
@@ -30,8 +31,9 @@ namespace utils {
         case BinaryOpType::LOGICAL_OR:
         case BinaryOpType::LOGICAL_XOR:
         case BinaryOpType::SQUARED_DIFFERENCE:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
-                || (a == DataType::UINT16 && b == DataType::UINT16));
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
+                (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::DIV:
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
@@ -41,15 +43,19 @@ namespace utils {
         case BinaryOpType::GT:
         case BinaryOpType::LT:
         case BinaryOpType::GE:
-        case BinaryOpType::LE:return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
+        case BinaryOpType::LE:
+            return (
+                (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
         case BinaryOpType::GCD:
         case BinaryOpType::LCM:
         case BinaryOpType::LEFT_SHIFT:
         case BinaryOpType::RIGHT_SHIFT:
-        case BinaryOpType::LOGICAL_RIGHT_SHIFT: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT32 && b == DataType::UINT32));
+        case BinaryOpType::LOGICAL_RIGHT_SHIFT:
+            return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT32 && b == DataType::UINT32));
         case BinaryOpType::BITWISE_XOR:
         case BinaryOpType::BITWISE_OR:
-        case BinaryOpType::BITWISE_AND: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
+        case BinaryOpType::BITWISE_AND:
+            return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MAXIMUM:
         case BinaryOpType::MINIMUM:
         case BinaryOpType::XLOGY:
@@ -58,7 +64,7 @@ namespace utils {
     }
     return false;
 }
-} // utils
+}  // namespace utils
 
 BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
@@ -82,7 +88,7 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
         DataType dtype1 = tensor_args.input_tensor_a.dtype();
         DataType dtype2 = tensor_args.input_tensor_b->dtype();
         bool sfpu_op_check = utils::is_binary_sfpu_op(op, dtype1, dtype2);
-        if(sfpu_op_check){
+        if (sfpu_op_check) {
             return ElementWiseMultiCoreSfpu{};
         } else {
             return ElementWiseMultiCore{};
@@ -94,8 +100,7 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
         }
         if (height_b == 1) {
             if (tensor_args.input_tensor_a.is_sharded()) {
-                if (tensor_args.input_tensor_a.padded_shape()[0] ==
-                        tensor_args.input_tensor_b->padded_shape()[0] ||
+                if (tensor_args.input_tensor_a.padded_shape()[0] == tensor_args.input_tensor_b->padded_shape()[0] ||
                     tensor_args.input_tensor_a.padded_shape()[0] > 1 and
                         tensor_args.input_tensor_b->padded_shape()[0] == 1) {
                     return BroadcastHeightMultiCoreShardedOptimized{};
@@ -117,7 +122,20 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_FATAL(input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(
+            input_tensor_b->storage_type() == StorageType::DEVICE,
+            "Input tensor B must be on device, got storage type: {}",
+            input_tensor_b->storage_type());
+    }
+
+    TT_FATAL(
+        input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
 
     BinaryDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
 
@@ -138,18 +156,21 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     if (input_tensor_a.memory_config().is_sharded()) {
         if (tensor_b_sharded) {
             TT_FATAL(
-                input_tensor_a.memory_config().memory_layout() == input_tensor_b->memory_config().memory_layout(), "Error");
+                input_tensor_a.memory_config().memory_layout() == input_tensor_b->memory_config().memory_layout(),
+                "Error");
             TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b->shard_spec().value(), "Error");
         }
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+            TT_FATAL(
+                input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
         } else {
             TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         }
     } else if (tensor_b_sharded) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+            TT_FATAL(
+                input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
         } else {
             TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
         }
@@ -203,8 +224,12 @@ void BinaryDeviceOperation::validate_on_program_cache_hit(
             "ttnn::operations::binary::BinaryDeviceOperation: batch size mismatch");
     }
 
-    TT_FATAL(height_a == height_b || height_a == 1 || height_b == 1, "ttnn::operations::binary::BinaryDeviceOperation: height mismatch");
-    TT_FATAL(width_a == width_b || width_a == 1 || width_b == 1, "ttnn::operations::binary::BinaryDeviceOperation: width mismatch");
+    TT_FATAL(
+        height_a == height_b || height_a == 1 || height_b == 1,
+        "ttnn::operations::binary::BinaryDeviceOperation: height mismatch");
+    TT_FATAL(
+        width_a == width_b || width_a == 1 || width_b == 1,
+        "ttnn::operations::binary::BinaryDeviceOperation: width mismatch");
 }
 
 BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output_specs(
@@ -247,7 +272,8 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
     auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
 
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
-    if (std::holds_alternative<ElementWiseMultiCore>(program_factory) or std::holds_alternative<ElementWiseMultiCoreSfpu>(program_factory)) {
+    if (std::holds_alternative<ElementWiseMultiCore>(program_factory) or
+        std::holds_alternative<ElementWiseMultiCoreSfpu>(program_factory)) {
         const auto& input_tensor_b = *tensor_args.input_tensor_b;
         if (operation_attributes.memory_config.is_sharded()) {
             ShardSpec shard_spec{CoreRangeSet(), {0, 0}};
@@ -259,7 +285,8 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
                 shard_spec = operation_attributes.memory_config.shard_spec().value();
             }
             auto memory_config = operation_attributes.memory_config.with_shard_spec(shard_spec);
-            return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
+            return TensorSpec(
+                output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
         }
     } else {
         if (operation_attributes.memory_config.is_sharded()) {
@@ -269,10 +296,13 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
                 shard_spec = input_tensor_a.shard_spec().value();
             }
             auto memory_config = operation_attributes.memory_config.with_shard_spec(shard_spec);
-            return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
+            return TensorSpec(
+                output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
         }
     }
-    return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
+    return TensorSpec(
+        output_shape,
+        TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_output_tensors(
@@ -280,7 +310,8 @@ BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_outpu
     if (tensor_args.output_tensor.has_value()) {
         return *tensor_args.output_tensor;
     }
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
 tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
@@ -310,13 +341,11 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
     }
 
     return operation::hash_operation<BinaryDeviceOperation>(
-        attributes,
-        program_factory.index(),
-        input_tensor_a.dtype(),
-        input_tensor_a.memory_config());
+        attributes, program_factory.index(), input_tensor_a.dtype(), input_tensor_a.memory_config());
 }
 
-operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t> BinaryDeviceOperation::create_op_performance_model(
+operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t>
+BinaryDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -338,7 +367,8 @@ operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_
     uint32_t ideal_eltwise_cycles = total_bytes / 80 / num_cores;
 
     // TODO: update OpPerformanceModel to work on variadic arguments
-    operation::OpPerformanceModelGeneral<tensor_return_value_t> result(input_tensors, output_tensor, ideal_eltwise_cycles);
+    operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        input_tensors, output_tensor, ideal_eltwise_cycles);
 #if 0
         log_info(tt::LogOp, "BinaryDeviceOperation PerfModel:");
         log_info(tt::LogOp, "\t Data (Bytes): {}", total_bytes);
@@ -369,6 +399,17 @@ BinaryDeviceOperation::invoke(
             output_dtype.value() == optional_output_tensor.value().dtype(),
             "If both output dtype and output tensor provided dtype should match");
     }
+
+    TT_FATAL(
+        input_tensor_a_arg.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a_arg.storage_type());
+
+    TT_FATAL(
+        input_tensor_b_arg.storage_type() == StorageType::DEVICE,
+        "Input tensor B must be on device, got storage type: {}",
+        input_tensor_b_arg.storage_type());
+
     CoreRangeSet worker_grid;
     // We assert all shard specs are the same if sharded, so only need to check the first shard spec
     // This will create the worker grid based on the used sub-devices when sharded
@@ -415,7 +456,9 @@ BinaryDeviceOperation::invoke(
             std::move(activations),
             std::move(input_tensor_a_activation),
             std::nullopt,
-            memory_config.value_or(optional_output_tensor.has_value() ? optional_output_tensor->memory_config() : input_tensor_a_arg.memory_config()),
+            memory_config.value_or(
+                optional_output_tensor.has_value() ? optional_output_tensor->memory_config()
+                                                   : input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.dtype()),
             std::move(worker_grid),
             std::nullopt},

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -178,6 +178,19 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
 
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(
+            input_tensor_b->storage_type() == StorageType::DEVICE,
+            "Input tensor B must be on device, got storage type: {}",
+            input_tensor_b->storage_type());
+    }
+
     TT_FATAL(
         input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
 
@@ -453,6 +466,17 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
+    // Validate storage type for input tensors
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE,
+        "Input tensor A must be on device, got storage type: {}",
+        input_tensor_a.storage_type());
+
+    TT_FATAL(
+        input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Input tensor B must be on device, got storage type: {}",
+        input_tensor_b.storage_type());
+
     auto subtile_broadcast_type = get_subtile_broadcast_type(
         input_tensor_a.logical_shape()[-2],
         input_tensor_a.logical_shape()[-1],


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27676)

### Problem description
For fp32 row broadcasting, it is directed to legacy because of performance. However, legacy has problem with FPU accuracy for fp32.

### What's changed
For fp32, now directed to binary_ng using SFPU. Accuracy takes precedence over performance.
It also piggy back the change of (https://github.com/tenstorrent/tt-metal/issues/27455) so that I will close that PR.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes