### PR TITLE
use multi-thread api for tile and dtype conversion

### DIFF
--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -108,12 +108,11 @@ class Experts(AbstractModule):
             The converted TTNN tensor.
         """
         multi_dev_host_weights = ttnn.from_host_shards(
-            [
-                ttnn.from_torch(e.unsqueeze(0), dtype=ttnn.bfloat4_b, layout=ttnn.TILE_LAYOUT)
-                for e in wx_per_device_state_dict_group
-            ],
+            [ttnn.from_torch(e.unsqueeze(0), layout=ttnn.ROW_MAJOR_LAYOUT) for e in wx_per_device_state_dict_group],
             mesh_device.shape,
         )
+        # This is a solution to fasten the conversion to tile layout and bfloat4_b with multi-threading
+        multi_dev_host_weights = ttnn.to_dtype(multi_dev_host_weights, ttnn.bfloat4_b)
 
         multi_dev_weights = ttnn.to_device(
             multi_dev_host_weights,


### PR DESCRIPTION
This pull request updates the `_convert_weight` function in `experts.py` to optimize the conversion of weight tensors to the desired data type and layout. The main improvement is a change in the conversion process to use multi-threading for faster performance.

Tensor conversion optimization:

* Changed the initial conversion of tensors from using `ttnn.bfloat4_b` and `ttnn.TILE_LAYOUT` to `ttnn.ROW_MAJOR_LAYOUT`, followed by a separate conversion to `ttnn.bfloat4_b` using `ttnn.to_dtype`, which allows for multi-threaded processing and speeds up the overall conversion.### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes