### PR TITLE
Move global variables in tt_metal_profiler.cpp into a ProfilerStateManager class that is owned by MetalContext

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -55,6 +55,7 @@ void MetalContext::initialize(
     const BankMapping& l1_bank_remap,
     size_t worker_l1_size,
     bool minimal) {
+    ZoneScoped;
 
     if (cluster_->get_target_device_type() == tt::TargetDevice::Mock) {
         TT_THROW(
@@ -199,6 +200,8 @@ void MetalContext::initialize(
 }
 
 void MetalContext::teardown() {
+    ZoneScoped;
+
     if (!initialized_) {
         return;
     }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -18,6 +18,7 @@
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/profiler/profiler_state_manager.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/llrt/get_platform_architecture.hpp"
 #include "tt_metal/llrt/llrt.hpp"
@@ -122,6 +123,10 @@ void MetalContext::initialize(
     watcher_server_ =
         std::make_unique<WatcherServer>();  // Watcher server always created, since we use it to register kernels
 
+    if (rtoptions_.get_profiler_enabled()) {
+        profiler_state_manager_ = std::make_unique<ProfilerStateManager>();
+    }
+
     // Minimal setup, don't initialize FW/Dispatch/etc.
     if (minimal) {
         return;
@@ -216,6 +221,8 @@ void MetalContext::teardown() {
 
         cluster_->l1_barrier(device_id);
     }
+
+    profiler_state_manager_.reset();
 
     for (auto& mem_map : dispatch_mem_map_) {
         if (mem_map) {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -30,6 +30,7 @@ class ControlPlane;
 }  // namespace tt::tt_fabric
 
 namespace tt::tt_metal {
+class ProfilerStateManager;
 
 namespace inspector {
 class Data;
@@ -61,6 +62,8 @@ public:
     }
     std::unique_ptr<DPrintServer>& dprint_server() { return dprint_server_; }
     std::unique_ptr<WatcherServer>& watcher_server() { return watcher_server_; }
+
+    std::unique_ptr<ProfilerStateManager>& profiler_state_manager() { return profiler_state_manager_; }
 
     void initialize(
         const DispatchCoreConfig& dispatch_core_config,
@@ -155,6 +158,7 @@ private:
     std::unique_ptr<inspector::Data> inspector_data_;
     std::unique_ptr<DPrintServer> dprint_server_;
     std::unique_ptr<WatcherServer> watcher_server_;
+    std::unique_ptr<ProfilerStateManager> profiler_state_manager_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;

--- a/tt_metal/impl/profiler/profiler_state_manager.hpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <unordered_set>
+
+#include "core_coord.hpp"
+#include "profiler.hpp"
+
+namespace tt {
+
+namespace tt_metal {
+
+struct ProfilerStateManager {
+public:
+    ProfilerStateManager() {
+        this->device_profiler_map = {};
+        this->device_host_time_pair = {};
+        this->device_device_time_pair = {};
+        this->smallest_host_time = {};
+        this->do_sync_on_close = true;
+        this->sync_set_devices = {};
+    };
+    ~ProfilerStateManager() {
+        this->device_profiler_map.clear();
+        this->device_host_time_pair.clear();
+        this->device_device_time_pair.clear();
+        this->smallest_host_time.clear();
+        this->do_sync_on_close = false;
+        this->sync_set_devices.clear();
+    };
+
+    ProfilerStateManager& operator=(const ProfilerStateManager&) = delete;
+    ProfilerStateManager& operator=(ProfilerStateManager&&) = delete;
+    ProfilerStateManager(const ProfilerStateManager&) = delete;
+    ProfilerStateManager(ProfilerStateManager&&) = delete;
+
+    static constexpr CoreCoord SYNC_CORE = {0, 0};
+
+    std::unordered_map<chip_id_t, DeviceProfiler> device_profiler_map{};
+
+    std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>> device_host_time_pair{};
+    std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>>>
+        device_device_time_pair{};
+    std::unordered_map<chip_id_t, uint64_t> smallest_host_time{};
+
+    bool do_sync_on_close = false;
+
+    std::unordered_set<chip_id_t> sync_set_devices{};
+};
+
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -25,7 +25,6 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -47,6 +46,7 @@
 #include "profiler_paths.hpp"
 #include "profiler_state.hpp"
 #include "profiler_types.hpp"
+#include "profiler_state_manager.hpp"
 #include "tt-metalium/program.hpp"
 #include <tt-metalium/device_pool.hpp>
 #include "rtoptions.hpp"
@@ -62,18 +62,6 @@ namespace tt {
 namespace tt_metal {
 
 namespace detail {
-
-std::unordered_map<chip_id_t, DeviceProfiler> tt_metal_device_profiler_map;
-
-std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>> deviceHostTimePair;
-std::unordered_map<chip_id_t, uint64_t> smallestHostime;
-
-std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>>>
-    deviceDeviceTimePair;
-
-bool do_sync_on_close = true;
-std::unordered_set<chip_id_t> sync_set_devices;
-constexpr CoreCoord SYNC_CORE = {0, 0};
 
 void setControlBuffer(IDevice* device, std::vector<uint32_t>& control_buffer) {
 #if defined(TRACY_ENABLE)
@@ -103,8 +91,11 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
 
-    deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
-    smallestHostime.emplace(device_id, 0);
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+
+    profiler_state_manager->device_host_time_pair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
+    profiler_state_manager->smallest_host_time.emplace(device_id, 0);
 
     constexpr uint16_t sampleCount = 249;
     // TODO(MO): Always recreate a new program until subdevice
@@ -153,14 +144,15 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     }
     tt_metal::detail::WaitProgramDone(device, sync_program, false);
     std::vector<CoreCoord> cores = {core};
-    tt_metal_device_profiler_map.at(device_id).readResults(
+    profiler_state_manager->device_profiler_map.at(device_id).readResults(
         device, cores, ProfilerReadState::NORMAL, ProfilerDataBufferSource::L1);
-    tt_metal_device_profiler_map.at(device_id).processResults(
+    profiler_state_manager->device_profiler_map.at(device_id).processResults(
         device, cores, ProfilerReadState::NORMAL, ProfilerDataBufferSource::L1);
 
     log_info(tt::LogMetal, "SYNC PROGRAM FINISH IS DONE ON {}", device_id);
-    if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime)) {
-        smallestHostime[device_id] = hostStartTime;
+    if ((profiler_state_manager->smallest_host_time.at(device_id) == 0) ||
+        (profiler_state_manager->smallest_host_time.at(device_id) > hostStartTime)) {
+        profiler_state_manager->smallest_host_time.at(device_id) = hostStartTime;
     }
 
     constexpr uint32_t briscIndex = 0;
@@ -192,10 +184,11 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
             hostStartTime_H++;
         }
         preHostTime = hostTime;
-        uint64_t hostTimeLarge =
-            hostStartTime - smallestHostime[device_id] + ((uint64_t(hostStartTime_H) << 32) | hostTime);
+        uint64_t hostTimeLarge = hostStartTime - profiler_state_manager->smallest_host_time.at(device_id) +
+                                 ((uint64_t(hostStartTime_H) << 32) | hostTime);
 
-        deviceHostTimePair[device_id].push_back(std::pair<uint64_t, uint64_t>{deviceTimeLarge, hostTimeLarge});
+        profiler_state_manager->device_host_time_pair.at(device_id).push_back(
+            std::pair<uint64_t, uint64_t>{deviceTimeLarge, hostTimeLarge});
 
         if (firstSample) {
             firstSample = false;
@@ -207,7 +200,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     double hostSquaredSum = 0;
     double hostDeviceProductSum = 0;
 
-    for (auto& deviceHostTime : deviceHostTimePair[device_id]) {
+    for (auto& deviceHostTime : profiler_state_manager->device_host_time_pair.at(device_id)) {
         double deviceTime = deviceHostTime.first;
         double hostTime = deviceHostTime.second;
 
@@ -217,7 +210,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         hostDeviceProductSum += (hostTime * deviceTime);
     }
 
-    uint16_t accumulateSampleCount = deviceHostTimePair[device_id].size();
+    uint16_t accumulateSampleCount = profiler_state_manager->device_host_time_pair.at(device_id).size();
 
     double frequencyFit = (hostDeviceProductSum * accumulateSampleCount - hostSum * deviceSum) /
                           ((hostSquaredSum * accumulateSampleCount - hostSum * hostSum) * tracyToSecRatio);
@@ -235,18 +228,18 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         log_file.open(log_path, std::ios_base::app);
     }
 
-    int init = deviceHostTimePair[device_id].size() - sampleCount;
-    for (int i = init; i < deviceHostTimePair[device_id].size(); i++) {
+    int init = profiler_state_manager->device_host_time_pair.at(device_id).size() - sampleCount;
+    for (int i = init; i < profiler_state_manager->device_host_time_pair.at(device_id).size(); i++) {
         log_file << fmt::format(
                         "{:5},{:5},{:5},{:20},{:20},{:20.2f},{:20},{:20},{:20.2f},{:20.15f},{:20.15f},{:20},1.0,0",
                         device_id,
                         phys_core.x,
                         phys_core.y,
-                        deviceHostTimePair[device_id][i].first,
-                        deviceHostTimePair[device_id][i].second,
-                        (double)deviceHostTimePair[device_id][i].second * tracyToSecRatio,
+                        profiler_state_manager->device_host_time_pair.at(device_id)[i].first,
+                        profiler_state_manager->device_host_time_pair.at(device_id)[i].second,
+                        (double)profiler_state_manager->device_host_time_pair.at(device_id)[i].second * tracyToSecRatio,
                         writeTimes[i - init],
-                        smallestHostime[device_id],
+                        profiler_state_manager->smallest_host_time.at(device_id),
                         delay,
                         frequencyFit,
                         tracyToSecRatio,
@@ -258,15 +251,16 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         tt::LogMetal,
         "Host sync data for device: {}, cpu_start:{}, delay:{}, freq:{} Hz",
         device_id,
-        smallestHostime[device_id],
+        profiler_state_manager->smallest_host_time.at(device_id),
         delay,
         frequencyFit);
 
     double host_timestamp = hostStartTime;
-    double device_timestamp = delay + (host_timestamp - smallestHostime[device_id]) * frequencyFit * tracyToSecRatio;
+    double device_timestamp = delay + (host_timestamp - profiler_state_manager->smallest_host_time.at(device_id)) *
+                                          frequencyFit * tracyToSecRatio;
     // disable linting here; slicing is __intended__
     // NOLINTBEGIN
-    tt_metal_device_profiler_map.at(device_id).device_core_sync_info.emplace(
+    profiler_state_manager->device_profiler_map.at(device_id).device_core_sync_info.emplace(
         CoreCoord(phys_core), SyncInfo(host_timestamp, device_timestamp, frequencyFit));
     // NOLINTEND
 }
@@ -283,8 +277,11 @@ void setShift(int device_id, int64_t shift, double scale, const SyncInfo& root_s
             "do not use tracy mid-run data dumping for sensitive device-device event analysis.");
     }
 
-    auto device_profiler_it = tt_metal_device_profiler_map.find(device_id);
-    if (device_profiler_it != tt_metal_device_profiler_map.end()) {
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+
+    auto device_profiler_it = profiler_state_manager->device_profiler_map.find(device_id);
+    if (device_profiler_it != profiler_state_manager->device_profiler_map.end()) {
         device_profiler_it->second.freq_scale = scale;
         device_profiler_it->second.shift = shift;
         device_profiler_it->second.setSyncInfo(root_sync_info);
@@ -303,8 +300,10 @@ void peekDeviceData(IDevice* device, std::vector<CoreCoord>& worker_cores) {
     auto device_id = device->id();
     std::string zoneName = fmt::format("peek {}", device_id);
     ZoneName(zoneName.c_str(), zoneName.size());
-    const auto& device_profiler_it = tt_metal_device_profiler_map.find(device_id);
-    if (device_profiler_it != tt_metal_device_profiler_map.end()) {
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+    const auto& device_profiler_it = profiler_state_manager->device_profiler_map.find(device_id);
+    if (device_profiler_it != profiler_state_manager->device_profiler_map.end()) {
         DeviceProfiler& device_profiler = device_profiler_it->second;
         device_profiler.device_sync_new_markers.clear();
         device_profiler.readResults(device, worker_cores, ProfilerReadState::NORMAL, ProfilerDataBufferSource::L1);
@@ -422,17 +421,24 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
         peekDeviceData(device_sender, sender_cores);
         peekDeviceData(device_receiver, receiver_cores);
 
+        const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+            tt::tt_metal::MetalContext::instance().profiler_state_manager();
         TT_ASSERT(
-            tt_metal_device_profiler_map.at(device_id_sender).device_sync_new_markers.size() ==
-            tt_metal_device_profiler_map.at(device_id_receiver).device_sync_new_markers.size());
+            profiler_state_manager->device_profiler_map.at(device_id_sender).device_sync_new_markers.size() ==
+            profiler_state_manager->device_profiler_map.at(device_id_receiver).device_sync_new_markers.size());
 
-        auto event_receiver = tt_metal_device_profiler_map.at(device_id_receiver).device_sync_new_markers.begin();
+        auto event_receiver =
+            profiler_state_manager->device_profiler_map.at(device_id_receiver).device_sync_new_markers.begin();
 
-        for (auto event_sender = tt_metal_device_profiler_map.at(device_id_sender).device_sync_new_markers.begin();
-             event_sender != tt_metal_device_profiler_map.at(device_id_sender).device_sync_new_markers.end();
+        for (auto event_sender =
+                 profiler_state_manager->device_profiler_map.at(device_id_sender).device_sync_new_markers.begin();
+             event_sender !=
+             profiler_state_manager->device_profiler_map.at(device_id_sender).device_sync_new_markers.end();
              event_sender++) {
-            TT_ASSERT(event_receiver != tt_metal_device_profiler_map.at(device_id_receiver).device_sync_markers.end());
-            deviceDeviceTimePair.at(device_id_sender)
+            TT_ASSERT(
+                event_receiver !=
+                profiler_state_manager->device_profiler_map.at(device_id_receiver).device_sync_markers.end());
+            profiler_state_manager->device_device_time_pair.at(device_id_sender)
                 .at(device_id_receiver)
                 .push_back({event_sender->timestamp, event_receiver->timestamp});
             event_receiver++;
@@ -447,8 +453,10 @@ void setSyncInfo(
     std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::pair<double, int64_t>>>& deviceDeviceSyncInfo,
     const std::string& parentInfo = "") {
     ZoneScoped;
-    if (sync_set_devices.find(device_id) == sync_set_devices.end()) {
-        sync_set_devices.insert(device_id);
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+    if (profiler_state_manager->sync_set_devices.find(device_id) == profiler_state_manager->sync_set_devices.end()) {
+        profiler_state_manager->sync_set_devices.insert(device_id);
         if (deviceDeviceSyncInfo.find(device_id) != deviceDeviceSyncInfo.end()) {
             std::string parentInfoNew =
                 parentInfo + fmt::format("->{}: ({},{})", device_id, syncInfo.second, syncInfo.first);
@@ -466,15 +474,18 @@ void setSyncInfo(
 
 void syncAllDevices(chip_id_t host_connected_device) {
     // Check if profiler on host connected device is initilized
-    if (tt_metal_device_profiler_map.find(host_connected_device) == tt_metal_device_profiler_map.end()) {
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+    if (profiler_state_manager->device_profiler_map.find(host_connected_device) ==
+        profiler_state_manager->device_profiler_map.end()) {
         return;
     }
 
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
         return;
     }
-    // Update deviceDeviceTimePair
-    for (const auto& sender : deviceDeviceTimePair) {
+    // Update device_device_time_pair
+    for (const auto& sender : profiler_state_manager->device_device_time_pair) {
         for (const auto& receiver : sender.second) {
             syncDeviceDevice(sender.first, receiver.first);
         }
@@ -483,7 +494,7 @@ void syncAllDevices(chip_id_t host_connected_device) {
     // Run linear regression to calculate scale and bias between devices
     // deviceDeviceSyncInfo[dev0][dev1] = {scale, bias} of dev0 over dev1
     std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::pair<double, int64_t>>> deviceDeviceSyncInfo;
-    for (auto& sender : deviceDeviceTimePair) {
+    for (auto& sender : profiler_state_manager->device_device_time_pair) {
         for (auto& receiver : sender.second) {
             std::vector<std::pair<uint64_t, uint64_t>> timePairs;
             for (int i = 0; i < receiver.second.size(); i += 2) {
@@ -534,13 +545,14 @@ void syncAllDevices(chip_id_t host_connected_device) {
     // Find any sync info from root device
     // Currently, sync info only exists for SYNC_CORE
     SyncInfo root_sync_info;
-    for (auto& [core, info] : tt_metal_device_profiler_map.at(host_connected_device).device_core_sync_info) {
+    for (auto& [core, info] :
+         profiler_state_manager->device_profiler_map.at(host_connected_device).device_core_sync_info) {
         root_sync_info = info;
         break;
     }
 
     // Propagate sync info with DFS through sync tree
-    sync_set_devices.clear();
+    profiler_state_manager->sync_set_devices.clear();
     setSyncInfo(host_connected_device, (std::pair<double, int64_t>){1.0, 0}, root_sync_info, deviceDeviceSyncInfo);
 }
 
@@ -553,12 +565,16 @@ void ProfilerSync(ProfilerSyncState state) {
     if (!getDeviceProfilerState()) {
         return;
     }
+
     TT_ASSERT(
         !tt::DevicePool::instance().is_dispatch_firmware_active(),
         "Profiler sync is not supported with fast dispatch enabled!");
+
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
     static chip_id_t first_connected_device_id = -1;
     if (state == ProfilerSyncState::INIT) {
-        do_sync_on_close = true;
+        profiler_state_manager->do_sync_on_close = true;
         auto ethernet_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
         std::unordered_set<chip_id_t> visited_devices = {};
         constexpr int TOTAL_DEVICE_COUNT = 36;
@@ -584,10 +600,10 @@ void ProfilerSync(ProfilerSyncState state) {
                         visited_devices.insert(sender_device_id);
                         visited_devices.insert(receiver_device_id);
 
-                        deviceDeviceTimePair.emplace(
+                        profiler_state_manager->device_device_time_pair.emplace(
                             sender_device_id,
                             (std::unordered_map<chip_id_t, std::vector<std::pair<uint64_t, uint64_t>>>){});
-                        deviceDeviceTimePair.at(sender_device_id)
+                        profiler_state_manager->device_device_time_pair.at(sender_device_id)
                             .emplace(receiver_device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
                     }
                 }
@@ -595,7 +611,7 @@ void ProfilerSync(ProfilerSyncState state) {
                     if (first_connected_device_id == -1 and !doSync) {
                         first_connected_device_id = sender_device_id;
                     }
-                    syncDeviceHost(sender_device, SYNC_CORE, true);
+                    syncDeviceHost(sender_device, ProfilerStateManager::SYNC_CORE, true);
                 }
             }
         }
@@ -605,11 +621,11 @@ void ProfilerSync(ProfilerSyncState state) {
         }
     }
 
-    if (state == ProfilerSyncState::CLOSE_DEVICE and do_sync_on_close) {
-        do_sync_on_close = false;
-        for (const auto& synced_with_host_device : deviceHostTimePair) {
+    if (state == ProfilerSyncState::CLOSE_DEVICE and profiler_state_manager->do_sync_on_close) {
+        profiler_state_manager->do_sync_on_close = false;
+        for (const auto& synced_with_host_device : profiler_state_manager->device_host_time_pair) {
             auto deviceToSync = tt::DevicePool::instance().get_active_device(synced_with_host_device.first);
-            syncDeviceHost(deviceToSync, SYNC_CORE, false);
+            syncDeviceHost(deviceToSync, ProfilerStateManager::SYNC_CORE, false);
         }
         //  If at least one sender receiver pair has been found
         if (first_connected_device_id != -1) {
@@ -637,11 +653,14 @@ void InitDeviceProfiler(IDevice* device) {
 
         const chip_id_t device_id = device->id();
 
-        if (tt_metal_device_profiler_map.find(device_id) == tt_metal_device_profiler_map.end()) {
+        const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+            tt::tt_metal::MetalContext::instance().profiler_state_manager();
+        if (profiler_state_manager->device_profiler_map.find(device_id) ==
+            profiler_state_manager->device_profiler_map.end()) {
             if (firstInit.exchange(false)) {
-                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(device, true));
+                profiler_state_manager->device_profiler_map.emplace(device_id, DeviceProfiler(device, true));
             } else {
-                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(device, false));
+                profiler_state_manager->device_profiler_map.emplace(device_id, DeviceProfiler(device, false));
             }
         }
 
@@ -654,7 +673,7 @@ void InitDeviceProfiler(IDevice* device) {
 
         const uint32_t num_dram_banks = soc_desc.get_num_dram_views();
 
-        auto& profiler = tt_metal_device_profiler_map.at(device_id);
+        auto& profiler = profiler_state_manager->device_profiler_map.at(device_id);
         profiler.setLastFDReadAsNotDone();
         profiler.profile_buffer_bank_size_bytes = bank_size_bytes;
         profiler.profile_buffer.resize(profiler.profile_buffer_bank_size_bytes * num_dram_banks / sizeof(uint32_t));
@@ -710,8 +729,10 @@ void ReadDeviceProfilerResults(
     ZoneScoped;
 
     if (getDeviceProfilerState()) {
-        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
-        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+            tt::tt_metal::MetalContext::instance().profiler_state_manager();
+        auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
 
         if (skipReadingDeviceProfilerResults(state)) {
@@ -797,8 +818,10 @@ void ProcessDeviceProfilerResults(
     ZoneScoped;
 
     if (getDeviceProfilerState()) {
-        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
-        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+            tt::tt_metal::MetalContext::instance().profiler_state_manager();
+        auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
 
         if (skipReadingDeviceProfilerResults(state)) {
@@ -861,8 +884,10 @@ void ReadDeviceProfilerResults(
     if (getDeviceProfilerState()) {
         TT_ASSERT(device->is_initialized());
 
-        auto profiler_it = tt_metal_device_profiler_map.find(device->id());
-        TT_ASSERT(profiler_it != tt_metal_device_profiler_map.end());
+        const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+            tt::tt_metal::MetalContext::instance().profiler_state_manager();
+        auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
+        TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
         DeviceProfiler& profiler = profiler_it->second;
 
         if (useFastDispatch(device)) {
@@ -886,16 +911,20 @@ void ReadDeviceProfilerResults(
 
 void SetDeviceProfilerDir(const std::string& output_dir) {
 #if defined(TRACY_ENABLE)
-    for (auto& device_id : tt_metal_device_profiler_map) {
-        tt_metal_device_profiler_map.at(device_id.first).setOutputDir(output_dir);
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+    for (auto& device_id : profiler_state_manager->device_profiler_map) {
+        profiler_state_manager->device_profiler_map.at(device_id.first).setOutputDir(output_dir);
     }
 #endif
 }
 
 void FreshProfilerDeviceLog() {
 #if defined(TRACY_ENABLE)
-    for (auto& device_id : tt_metal_device_profiler_map) {
-        tt_metal_device_profiler_map.at(device_id.first).freshDeviceLog();
+    const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+        tt::tt_metal::MetalContext::instance().profiler_state_manager();
+    for (auto& device_id : profiler_state_manager->device_profiler_map) {
+        profiler_state_manager->device_profiler_map.at(device_id.first).freshDeviceLog();
     }
 #endif
 }
@@ -934,9 +963,11 @@ void ReadMeshDeviceProfilerResults(
         TT_ASSERT(mesh_device.is_initialized());
 
         if (useFastDispatch(&mesh_device)) {
+            const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
+                tt::tt_metal::MetalContext::instance().profiler_state_manager();
             for (IDevice* device : mesh_device.get_devices()) {
-                auto profiler_it = detail::tt_metal_device_profiler_map.find(device->id());
-                TT_ASSERT(profiler_it != detail::tt_metal_device_profiler_map.end());
+                auto profiler_it = profiler_state_manager->device_profiler_map.find(device->id());
+                TT_ASSERT(profiler_it != profiler_state_manager->device_profiler_map.end());
                 DeviceProfiler& profiler = profiler_it->second;
 
                 if (profiler.isLastFDReadDone() && state == ProfilerReadState::LAST_FD_READ) {


### PR DESCRIPTION
### Ticket
#27669 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17416017023)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/17416022736)
- [x] New/Existing tests provide coverage for changes