### PR TITLE
Get device arch without opening device

### DIFF
--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -370,5 +370,12 @@ bool ReadFromDeviceL1(
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
+/**
+ * Return the name of the architecture present.
+ *
+ * Return value: std::string
+ */
+std::string get_physical_architecture_name();
+
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -14,6 +14,26 @@
 
 namespace tt::tt_metal {
 
+inline tt::ARCH get_physical_architecture() {
+    auto arch = tt::ARCH::Invalid;
+    // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.
+    // This map holds PCI info for each mmio chip.
+    auto devices_info = PCIDevice::enumerate_devices_info();
+    if (devices_info.size() > 0) {
+        arch = devices_info.begin()->second.get_arch();
+        for (auto& [device_id, device_info] : devices_info) {
+            tt::ARCH detected_arch = device_info.get_arch();
+            TT_FATAL(
+                arch == detected_arch,
+                "Expected all devices to be {} but device {} is {}",
+                tt::arch_to_str(arch),
+                device_id,
+                tt::arch_to_str(detected_arch));
+        }
+    }
+    return arch;
+}
+
 /**
  * @brief Detects the platform architecture based on the environment or hardware.
  *
@@ -47,6 +67,7 @@ namespace tt::tt_metal {
  * @see tt::get_arch_from_string
  * @see PCIDevice::enumerate_devices_info
  */
+
 inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtoptions) {
     auto arch = tt::ARCH::Invalid;
     // If running in mock mode, derive architecture from provided cluster descriptor
@@ -61,21 +82,7 @@ inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtopti
         tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
         arch = init.get_arch_name();
     } else {
-        // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.
-        // This map holds PCI info for each mmio chip.
-        auto devices_info = PCIDevice::enumerate_devices_info();
-        if (devices_info.size() > 0) {
-            arch = devices_info.begin()->second.get_arch();
-            for (auto& [device_id, device_info] : devices_info) {
-                tt::ARCH detected_arch = device_info.get_arch();
-                TT_FATAL(
-                    arch == detected_arch,
-                    "Expected all devices to be {} but device {} is {}",
-                    tt::arch_to_str(arch),
-                    device_id,
-                    tt::arch_to_str(detected_arch));
-            }
-        }
+        arch = get_physical_architecture();
     }
 
     return arch;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -58,6 +58,7 @@
 #include "fabric/hw/inc/fabric_routing_mode.h"
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
+#include "get_platform_architecture.hpp"
 
 namespace tt {
 
@@ -411,6 +412,10 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(
         &regval, tt_cxy_pair(device->id(), worker_core), address);
     return true;
+}
+
+std::string get_physical_architecture_name() {
+    return tt::get_string_lowercase(tt::tt_metal::get_physical_architecture());
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -518,7 +518,10 @@ void device_module(py::module& m_device) {
         +------------------+----------------------------------+-----------------------+-------------+----------+
     )doc");
 
-    m_device.def("get_arch_name", &tt::tt_metal::hal::get_arch_name, "Return the name of the architecture present.");
+    m_device.def(
+        "get_arch_name",
+        &tt::tt_metal::detail::get_physical_architecture_name,
+        "Return the name of the architecture present.");
 
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);
     m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);


### PR DESCRIPTION
### Ticket
#25388 

### Problem description
We are double opening device just to get the arch

### What's changed
Get the arch type directly from pice devices on umd

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17437160004l)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17416659060)
- [x] (Failed similar to main) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17416665375)