### PR TITLE
[tt-train] Switch from ttnn::gelu_bw -> ttnn::experimental::gelu_bw (fused one)

### DIFF
--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -57,6 +57,7 @@
 #include <ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp>                  // NOLINT
 #include <ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp>          // NOLINT
 #include <ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp>      // NOLINT
+#include <ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp>                     // NOLINT
 #include <ttnn/operations/full_like/full_like.hpp>                                                         // NOLINT
 #include <ttnn/operations/matmul/matmul.hpp>                                                               // NOLINT
 #include <ttnn/operations/moreh/moreh_adamw/moreh_adamw.hpp>                                               // NOLINT

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -38,16 +38,13 @@ autograd::TensorPtr gelu(const autograd::TensorPtr& tensor) {
     auto out = autograd::create_tensor();
     out->set_value(ttnn::gelu(tensor->get_value()));
     autograd::GradFunction grad = [tensor, out]() {
-        tt::tt_metal::MemoryConfig mem_config;
         static const std::string approx_mode = "none";
-        auto res = ttnn::gelu_bw(out->get_grad(), tensor->get_value(), approx_mode, mem_config);
-        assert(res.size() == 1U && "Gelu backward should return only one gradient");
-        tensor->add_grad(res.front().value());
+        auto dL_dt = ttnn::experimental::gelu_bw(out->get_grad(), tensor->get_value(), approx_mode);
+        tensor->add_grad(dL_dt);
     };
 
     std::vector<autograd::NodeId> links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
-
     return out;
 }
 


### PR DESCRIPTION
### Problem description
@philei-tt implemented `ttnn::experimental::gelu_bw` which is helpful for gpt2 models. 

NanoGPT benchmark:
* Baseline - 277ms
* Experimental gelu - 253ms
* GeLU -> ReLU - 229ms

### What's changed
Substitute `ttnn::gelu_bw` with `ttnn::experimental::gelu_bw`

### Checklist
- [x] New/Existing tests provide coverage for changes