### PR TITLE
Remove unused variants of SetRuntimeArgs

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -7,10 +7,6 @@ Runtime Arguments
 
 .. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args)
 
-.. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(IDevice* device, const std::shared_ptr<Kernel>& kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::shared_ptr<RuntimeArgs>& runtime_args)
-
-.. doxygenfunction:: tt::tt_metal::SetRuntimeArgs(IDevice* device, const std::shared_ptr<Kernel>& kernel, const std::vector< CoreCoord > & core_spec, const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args)
-
 .. doxygenfunction:: tt::tt_metal::GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core)
 
 .. doxygenfunction:: tt::tt_metal::GetRuntimeArgs(const Program &program, KernelHandle kernel_id)

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -73,23 +73,11 @@ Program create_simple_unary_program(Buffer& input, Buffer& output) {
 
     CoreRange core_range({0, 0});
     CreateCircularBuffer(program, core_range, input_cb_config);
-    std::shared_ptr<RuntimeArgs> writer_runtime_args = std::make_shared<RuntimeArgs>();
-    std::shared_ptr<RuntimeArgs> reader_runtime_args = std::make_shared<RuntimeArgs>();
+    auto writer_runtime_args = {output.address(), uint32_t(0), output.num_pages()};
+    auto reader_runtime_args = {input.address(), uint32_t(0), input.num_pages()};
 
-    *writer_runtime_args = {
-        &output,
-        (uint32_t)0,
-        output.num_pages()
-    };
-
-    *reader_runtime_args = {
-        &input,
-        (uint32_t)0,
-        input.num_pages()
-    };
-
-    SetRuntimeArgs(device, detail::GetKernel(program, writer_kernel), worker, writer_runtime_args);
-    SetRuntimeArgs(device, detail::GetKernel(program, reader_kernel), worker, reader_runtime_args);
+    SetRuntimeArgs(program, writer_kernel, worker, writer_runtime_args);
+    SetRuntimeArgs(program, reader_kernel, worker, reader_runtime_args);
 
     CircularBufferConfig output_cb_config = CircularBufferConfig(2048, {{tt::CBIndex::c_16, tt::DataFormat::Float16_b}})
                                                 .set_page_size(tt::CBIndex::c_16, 2048);

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -280,15 +280,13 @@ bool flatten_stress(std::shared_ptr<distributed::MeshDevice> mesh_device, uint32
 
         std::vector<uint32_t> golden = gold_standard_flatten(*src_vec, {num_tiles_r * 32, num_tiles_c * 32});
         // Set the runtime args asynchronously
-        std::shared_ptr<tt_metal::RuntimeArgs> writer_runtime_args = std::make_shared<tt_metal::RuntimeArgs>();
-        std::shared_ptr<tt_metal::RuntimeArgs> compute_runtime_args = std::make_shared<tt_metal::RuntimeArgs>();
-        *compute_runtime_args = {
-            src_dram_buffer.get(), (uint32_t)0, num_tiles_r, num_tiles_c, num_bytes_per_tensor_row};
-        *writer_runtime_args = {dst_dram_buffer.get(), (uint32_t)0, num_tiles * 32};
+        auto compute_runtime_args = {
+            src_dram_buffer->address(), uint32_t(0), num_tiles_r, num_tiles_c, num_bytes_per_tensor_row};
+        auto writer_runtime_args = {dst_dram_buffer->address(), uint32_t(0), num_tiles * 32};
 
-        SetRuntimeArgs(device, tt_metal::detail::GetKernel(program_, flatten_kernel), core, compute_runtime_args);
+        SetRuntimeArgs(program_, flatten_kernel, core, compute_runtime_args);
+        SetRuntimeArgs(program_, unary_writer_kernel, core, writer_runtime_args);
 
-        SetRuntimeArgs(device, tt_metal::detail::GetKernel(program_, unary_writer_kernel), core, writer_runtime_args);
         // Async write input
         EnqueueWriteBuffer(device->command_queue(), src_dram_buffer, src_vec, false);
         // Share ownership of buffer with program

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -195,15 +195,12 @@ Program create_simple_unary_program(Buffer& input, Buffer& output, Buffer* cb_in
 
     CoreRange core_range({0, 0});
     CreateCircularBuffer(program, core_range, input_cb_config);
-    std::shared_ptr<RuntimeArgs> writer_runtime_args = std::make_shared<RuntimeArgs>();
-    std::shared_ptr<RuntimeArgs> reader_runtime_args = std::make_shared<RuntimeArgs>();
 
-    *writer_runtime_args = {&output, (uint32_t)0, output.num_pages()};
+    auto writer_runtime_args = {output.address(), uint32_t(0), output.num_pages()};
+    auto reader_runtime_args = {input.address(), uint32_t(0), input.num_pages()};
 
-    *reader_runtime_args = {&input, (uint32_t)0, input.num_pages()};
-
-    SetRuntimeArgs(device, detail::GetKernel(program, writer_kernel), worker, writer_runtime_args);
-    SetRuntimeArgs(device, detail::GetKernel(program, reader_kernel), worker, reader_runtime_args);
+    SetRuntimeArgs(program, writer_kernel, worker, writer_runtime_args);
+    SetRuntimeArgs(program, reader_kernel, worker, reader_runtime_args);
 
     CircularBufferConfig output_cb_config = CircularBufferConfig(2048, {{tt::CBIndex::c_16, tt::DataFormat::Float16_b}})
                                                 .set_page_size(tt::CBIndex::c_16, 2048);

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -449,9 +449,6 @@ void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program&
 // ==================================================
 //           COMPILE & EXECUTE KENRNELS
 // ==================================================
-// clang-format on
-using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
-// clang-format off
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
  * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
@@ -513,47 +510,6 @@ void SetRuntimeArgs(
     KernelHandle kernel,
     const std::vector<CoreCoord>& core_spec,
     const std::vector<std::vector<uint32_t>>& runtime_args);
-
-// clang-format off
-/**
- * Set runtime args for a kernel that are sent to the specified cores using the command queue. This API must be used when Asynchronous Command Queue Mode is enabled.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
- *
- * Return value: void
- *
- * | Argument     | Description                                                            | Type                                                   | Valid Range                                                                | Required |
- * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------|----------|
- * | device       | The device that runtime args are being written to.                     | IDevice*                                               |                                                                            | Yes      |
- * | kernel       | The kernel that will receive these runtime args.                       | std::shared_ptr<Kernel>                                |                                                                            | Yes      |
- * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
- * | runtime_args | The runtime args to be written                                         | std::shared_ptr<RuntimeArgs>                           |                                                                            | Yes      |
-*/
-// clang-format on
-// void SetRuntimeArgs(
-//     IDevice* device,
-//     const std::shared_ptr<Kernel>& kernel,
-//     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-//     const std::shared_ptr<RuntimeArgs>& runtime_args);
-
-// clang-format off
-/**
- * Set multiple runtime arguments of a kernel using the command queue. Each core can have distinct arguments. This API must be used when Asynchronous Command Queue Mode is enabled.
- * Maximum of 341 allowed runtime args per core (unique and common runtime args count toward same limit).
- *
- * Return value: void
- * | Argument     | Description                                                            | Type                                                   | Valid Range                                                                | Required |
- * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------|----------|
- * | device       | The device that runtime args are being written to.                     | IDevice*                                               |                                                                            | Yes      |
- * | kernel       | The kernel that will receive these runtime args.                       | std::shared_ptr<Kernel>                                |                                                                            | Yes      |
- * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::vector< CoreCoord > &                       | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
- * | runtime_args | The runtime args to be written                                         | const std::vector<std::shared_ptr<RuntimeArgs>>        | Outer vector size must be equal to size of core_spec vector                | Yes      |
- */
-// clang-format on
-// void SetRuntimeArgs(
-//     IDevice* device,
-//     const std::shared_ptr<Kernel>& kernel,
-//     const std::vector<CoreCoord>& core_spec,
-//     const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args);
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -529,11 +529,11 @@ void SetRuntimeArgs(
  * | runtime_args | The runtime args to be written                                         | std::shared_ptr<RuntimeArgs>                           |                                                                            | Yes      |
 */
 // clang-format on
-void SetRuntimeArgs(
-    IDevice* device,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::shared_ptr<RuntimeArgs>& runtime_args);
+// void SetRuntimeArgs(
+//     IDevice* device,
+//     const std::shared_ptr<Kernel>& kernel,
+//     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+//     const std::shared_ptr<RuntimeArgs>& runtime_args);
 
 // clang-format off
 /**
@@ -549,11 +549,11 @@ void SetRuntimeArgs(
  * | runtime_args | The runtime args to be written                                         | const std::vector<std::shared_ptr<RuntimeArgs>>        | Outer vector size must be equal to size of core_spec vector                | Yes      |
  */
 // clang-format on
-void SetRuntimeArgs(
-    IDevice* device,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::vector<CoreCoord>& core_spec,
-    const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args);
+// void SetRuntimeArgs(
+//     IDevice* device,
+//     const std::shared_ptr<Kernel>& kernel,
+//     const std::vector<CoreCoord>& core_spec,
+//     const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args);
 
 // clang-format off
 /**

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -393,27 +393,6 @@ void CaptureSetRuntimeArgsUint32VecPerCore(
 
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::SetRuntimeArgsUint32VecPerCoreCommand, cmd.Union());
 }
-void CaptureSetRuntimeArgs(
-    IDevice* /*device*/,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::shared_ptr<RuntimeArgs>& runtime_args) {
-    auto& ctx = LightMetalCaptureContext::get();
-    auto& fbb = ctx.get_builder();
-    uint32_t kernel_global_id = ctx.get_global_id(kernel.get());
-    auto [core_spec_type, core_spec_offset] = to_flatbuffer(fbb, core_spec);
-    auto rt_args_offset = to_flatbuffer(fbb, runtime_args);
-    log_debug(
-        tt::LogMetalTrace,
-        "{}: kernel_global_id: {} rt_args_size: {}",
-        __FUNCTION__,
-        kernel_global_id,
-        runtime_args->size());
-
-    auto cmd = tt::tt_metal::flatbuffer::CreateSetRuntimeArgsCommand(
-        fbb, kernel_global_id, core_spec_type, core_spec_offset, rt_args_offset);
-    CaptureCommand(tt::tt_metal::flatbuffer::CommandType::SetRuntimeArgsCommand, cmd.Union());
-}
 
 void CaptureCreateCircularBuffer(
     CBHandle& cb_handle,

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -126,12 +126,6 @@ void CaptureSetRuntimeArgsUint32VecPerCore(
     const std::vector<CoreCoord>& core_spec,
     const std::vector<std::vector<uint32_t>>& runtime_args);
 
-void CaptureSetRuntimeArgs(
-    IDevice* device,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::shared_ptr<RuntimeArgs>& runtime_args);
-
 void CaptureCreateCircularBuffer(
     CBHandle& cb_handle,
     Program& program,

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -626,7 +626,8 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::SetRuntimeArg
         kernel,
         "Attempted to SetRuntimeArgs() using a Kernel w/ global_id: {} that was not previously created.",
         cmd->kernel_global_id());
-    SetRuntimeArgs(this->device_, kernel, core_spec, runtime_args);
+    // TODO: Cleanup Reference to this command
+    // SetRuntimeArgs(this->device_, kernel, core_spec, runtime_args);
 }
 
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* cmd) {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -358,6 +358,9 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
         case ::tt::tt_metal::flatbuffer::CommandType::NONE:
             TT_THROW("LightMetalReplay execute encountered unsupported cmd type NONE");
             break;
+        default:
+            TT_THROW("LightMetalReplay execute encountered unsupported cmd type {}", command->cmd_type());
+            break;
     }
 }
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -347,10 +347,6 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
             execute(command->cmd_as_SetRuntimeArgsUint32VecPerCoreCommand());
             break;
         }
-        case ::tt::tt_metal::flatbuffer::CommandType::SetRuntimeArgsCommand: {
-            execute(command->cmd_as_SetRuntimeArgsCommand());
-            break;
-        }
         case ::tt::tt_metal::flatbuffer::CommandType::CreateCircularBufferCommand: {
             execute(command->cmd_as_CreateCircularBufferCommand());
             break;
@@ -611,23 +607,6 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::SetRuntimeArg
     auto core_spec = from_flatbuffer(cmd->core_spec());
     auto runtime_args = from_flatbuffer(cmd->args());
     SetRuntimeArgs(*program, kernel_id, core_spec, runtime_args);
-}
-
-void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsCommand* cmd) {
-    log_debug(
-        tt::LogMetalTrace,
-        "LightMetalReplay(SetRuntimeArgs). kernel_global_id: {} rt_args_size: {}",
-        cmd->kernel_global_id(),
-        cmd->args()->size());
-    auto core_spec = core_spec_from_flatbuffer(cmd);
-    auto runtime_args = rt_args_from_flatbuffer(cmd->args());
-    auto kernel = get_kernel_from_map(cmd->kernel_global_id());
-    TT_FATAL(
-        kernel,
-        "Attempted to SetRuntimeArgs() using a Kernel w/ global_id: {} that was not previously created.",
-        cmd->kernel_global_id());
-    // TODO: Cleanup Reference to this command
-    // SetRuntimeArgs(this->device_, kernel, core_spec, runtime_args);
 }
 
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* cmd) {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -77,7 +77,6 @@ public:
     void execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* command);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32Command* command);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32VecPerCoreCommand* cmd);
-    void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::LightMetalCompareCommand* command);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -247,66 +247,6 @@ inline void SetRuntimeArgsImpl(
     }
 }
 
-void SetRuntimeArgsImpl(
-    const std::shared_ptr<Kernel>& kernel,
-    const CoreCoord& core_coord,
-    const std::shared_ptr<RuntimeArgs>& runtime_args_ptr,
-    bool /*blocking*/) {
-    std::vector<uint32_t> resolved_runtime_args = {};
-    resolved_runtime_args.reserve(runtime_args_ptr->size());
-
-    for (const auto& arg : *(runtime_args_ptr)) {
-        const auto resolved = std::visit(
-            ttsl::overloaded{
-                [](Buffer* buffer) { return buffer->address(); },
-                [](uint32_t address) { return address; },
-            },
-            arg);
-        resolved_runtime_args.push_back(resolved);
-    }
-    kernel->set_runtime_args(core_coord, resolved_runtime_args);
-}
-
-inline void SetRuntimeArgsImpl(
-    const std::shared_ptr<Kernel> kernel,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::shared_ptr<RuntimeArgs>& runtime_args,
-    bool blocking) {
-    // SetRuntimeArgs API for Async CQ Mode
-    std::visit(
-        ttsl::overloaded{
-            [&](const CoreCoord& core_spec) { SetRuntimeArgsImpl(kernel, core_spec, runtime_args, blocking); },
-            [&](const CoreRange& core_spec) {
-                for (auto x = core_spec.start_coord.x; x <= core_spec.end_coord.x; x++) {
-                    for (auto y = core_spec.start_coord.y; y <= core_spec.end_coord.y; y++) {
-                        SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args, blocking);
-                    }
-                }
-            },
-            [&](const CoreRangeSet& core_spec) {
-                for (const auto& core_range : core_spec.ranges()) {
-                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                            SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args, blocking);
-                        }
-                    }
-                }
-            },
-        },
-        core_spec);
-}
-
-inline void SetRuntimeArgsImpl(
-    const std::shared_ptr<Kernel>& kernel,
-    const std::vector<CoreCoord>& core_spec,
-    const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args,
-    bool blocking) {
-    // SetRuntimeArgs API for Async CQ Mode (support vector of runtime args)
-    for (size_t i = 0; i < core_spec.size(); i++) {
-        SetRuntimeArgsImpl(kernel, core_spec[i], runtime_args[i], blocking);
-    }
-}
-
 }  // namespace
 
 namespace detail {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1350,31 +1350,6 @@ void SetRuntimeArgs(
     }
 }
 
-// void SetRuntimeArgs(
-//     IDevice* device,
-//     const std::shared_ptr<Kernel>& kernel,
-//     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-//     const std::shared_ptr<RuntimeArgs>& runtime_args) {
-//     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-//     detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
-//     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgs, device, kernel, core_spec, runtime_args);
-//     SetRuntimeArgsImpl(kernel, core_spec, std::move(runtime_args), false);
-// }
-
-// void SetRuntimeArgs(
-//     IDevice* device,
-//     const std::shared_ptr<Kernel>& kernel,
-//     const std::vector<CoreCoord>& core_spec,
-//     const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args) {
-//     TT_FATAL(
-//         core_spec.size() == runtime_args.size(),
-//         "Mismatch between number of cores {} and number of runtime args {} getting updated",
-//         core_spec.size(),
-//         runtime_args.size());
-//     detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
-//     SetRuntimeArgsImpl(kernel, core_spec, runtime_args, false);
-// }
-
 void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args) {
     ZoneScoped;
     if (runtime_args.size() != 0) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1350,30 +1350,30 @@ void SetRuntimeArgs(
     }
 }
 
-void SetRuntimeArgs(
-    IDevice* device,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    const std::shared_ptr<RuntimeArgs>& runtime_args) {
-    LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-    detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
-    LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgs, device, kernel, core_spec, runtime_args);
-    SetRuntimeArgsImpl(kernel, core_spec, std::move(runtime_args), false);
-}
+// void SetRuntimeArgs(
+//     IDevice* device,
+//     const std::shared_ptr<Kernel>& kernel,
+//     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+//     const std::shared_ptr<RuntimeArgs>& runtime_args) {
+//     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
+//     detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+//     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgs, device, kernel, core_spec, runtime_args);
+//     SetRuntimeArgsImpl(kernel, core_spec, std::move(runtime_args), false);
+// }
 
-void SetRuntimeArgs(
-    IDevice* device,
-    const std::shared_ptr<Kernel>& kernel,
-    const std::vector<CoreCoord>& core_spec,
-    const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args) {
-    TT_FATAL(
-        core_spec.size() == runtime_args.size(),
-        "Mismatch between number of cores {} and number of runtime args {} getting updated",
-        core_spec.size(),
-        runtime_args.size());
-    detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
-    SetRuntimeArgsImpl(kernel, core_spec, runtime_args, false);
-}
+// void SetRuntimeArgs(
+//     IDevice* device,
+//     const std::shared_ptr<Kernel>& kernel,
+//     const std::vector<CoreCoord>& core_spec,
+//     const std::vector<std::shared_ptr<RuntimeArgs>>& runtime_args) {
+//     TT_FATAL(
+//         core_spec.size() == runtime_args.size(),
+//         "Mismatch between number of cores {} and number of runtime args {} getting updated",
+//         core_spec.size(),
+//         runtime_args.size());
+//     detail::DispatchStateCheck(tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+//     SetRuntimeArgsImpl(kernel, core_spec, runtime_args, false);
+// }
 
 void SetCommonRuntimeArgs(const Program& program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args) {
     ZoneScoped;


### PR DESCRIPTION
### Ticket


### Problem description
Currently, there's four variants of SetRuntimeArgs, as we're trying to remove runtime's general public API surface area, I've identified these variants as functions to be removed as they directly expose the Kernel class and is not used anywhere outside of light-metal and limited unit tests.

### What's changed
Removes two variants of SetRuntimeArgs that uses `std::shared_ptr<Kernel>` instead of `KernelHandle`. Removes the SetRuntimeArgsCmd from light metal.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17450413015) T3K is currently flaky, should not be relevant to this PR.
- [ ] Blackhole Post commit is failing on main