### PR TITLE
Adding batched grid support for ttnn.grid_sample

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -84,94 +84,20 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
 
 
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
+@pytest.mark.parametrize("batch_output_channels", [True, False])
 @pytest.mark.parametrize(
     "input_shape, grid_shape, grid_batching_factor",
     [
         ((1, 256, 48, 160), (1, 25281, 7, 2), 7),
-        ((1, 128, 32, 32), (1, 16, 16, 2), 4),
-    ],
-)
-def test_grid_sample_channel_extending(device, input_shape, grid_shape, grid_batching_factor, use_precomputed_grid):
-    """Test grid sample with channel extending functionality (multiple coordinate sets)"""
-    torch.manual_seed(523)
-
-    batch_size, channels, height, width = input_shape
-    grid_n, grid_h, grid_w, grid_coords = grid_shape
-
-    # Validate that grid_batching_factor is a divisor of width
-    assert (
-        grid_w % grid_batching_factor == 0
-    ), f"grid_batching_factor {grid_batching_factor} must divide grid width {grid_w}"
-
-    # Create input tensor (NCHW -> NHWC)
-    torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
-    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
-
-    # Generate random grid tensor
-    grid_tensor = torch.rand(batch_size, grid_h, grid_w, 2, dtype=torch.float32) * 2.0 - 1.0
-
-    # Create host ttnn tensor
-    ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
-
-    if use_precomputed_grid:
-        input_shape_nhwc = [batch_size, height, width, channels]
-        ttnn_grid_precomputed = ttnn.prepare_grid_sample_grid(
-            ttnn_grid_host, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
-        )
-        new_grid_w = grid_w // grid_batching_factor
-        final_last_dim = 6 * grid_batching_factor
-        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_precomputed, (batch_size, grid_h, new_grid_w, final_last_dim))
-        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
-    else:
-        new_grid_w = grid_w // grid_batching_factor
-        new_last_dim = 2 * grid_batching_factor
-        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
-        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
-        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
-
-    ttnn_input = ttnn.from_torch(
-        torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
-    )
-
-    ttnn_output = ttnn.grid_sample(
-        ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid, extend_channels=True
-    )
-    ttnn_output_torch = ttnn.to_torch(ttnn_output)
-
-    torch_output_nchw = F.grid_sample(
-        torch_input_nchw, grid_tensor, mode="bilinear", padding_mode="zeros", align_corners=False
-    )
-    torch_output_nhwc_ = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
-
-    torch_expected_nhwc = (
-        torch_output_nhwc_.view(batch_size, grid_h, new_grid_w, grid_batching_factor, channels)
-        .contiguous()
-        .view(batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
-    )
-
-    # Check output shape
-    expected_shape = (batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
-    assert ttnn_output_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_output_torch.shape}"
-    pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
-    logger.info(
-        f"Channel extending test (extent_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
-    )
-
-
-@pytest.mark.parametrize("use_precomputed_grid", [True, False])
-@pytest.mark.parametrize("extend_channels", [True, False])
-@pytest.mark.parametrize(
-    "input_shape, grid_shape, grid_batching_factor",
-    [
         ((1, 64, 16, 32), (1, 8, 12, 2), 3),
         ((2, 32, 8, 16), (2, 6, 8, 2), 2),
         ((1, 128, 32, 32), (1, 16, 16, 2), 4),
     ],
 )
-def test_grid_sample_extend_channels_flag(
-    device, input_shape, grid_shape, grid_batching_factor, extend_channels, use_precomputed_grid
+def test_grid_sample_batch_output_channels_flag(
+    device, input_shape, grid_shape, grid_batching_factor, batch_output_channels, use_precomputed_grid
 ):
-    """Test grid sample with extend_channels flag - both true and false behaviors"""
+    """Test grid sample with batch_output_channels flag - both true and false behaviors"""
     torch.manual_seed(42)
 
     batch_size, channels, height, width = input_shape
@@ -221,15 +147,18 @@ def test_grid_sample_extend_channels_flag(
         ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
         ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
 
-    # Call TTNN grid_sample with extend_channels flag
+    # Call TTNN grid_sample with batch_output_channels flag
     ttnn_output = ttnn.grid_sample(
-        ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid, extend_channels=extend_channels
+        ttnn_input,
+        ttnn_grid_device,
+        use_precomputed_grid=use_precomputed_grid,
+        batch_output_channels=batch_output_channels,
     )
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
-    # Prepare expected output based on extend_channels flag
-    if extend_channels:
-        # extend_channels=True: output shape (N, H, W, C*K) - channels extended
+    # Prepare expected output based on batch_output_channels flag
+    if batch_output_channels:
+        # batch_output_channels=True: output shape (N, H, W, C*K) - channels batched
         expected_shape = (batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
         torch_expected_nhwc = (
             torch_output_nhwc.view(batch_size, grid_h, new_grid_w, grid_batching_factor, channels)
@@ -237,7 +166,7 @@ def test_grid_sample_extend_channels_flag(
             .view(batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
         )
     else:
-        # extend_channels=False: output shape (N, H, W*K, C) - W dimension extended
+        # batch_output_channels=False: output shape (N, H, W*K, C) - W dimension extended
         expected_shape = (batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
         torch_expected_nhwc = torch_output_nhwc.view(batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
 
@@ -247,5 +176,5 @@ def test_grid_sample_extend_channels_flag(
     # Verify numerical correctness
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(
-        f"extend_channels={extend_channels} test (batching_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
+        f"batch_output_channels={batch_output_channels} test (batching_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
     )

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -16,19 +16,19 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "input_shape, grid_shape",
     [
-        ((1, 256, 12, 40), (1, 7, 25281, 2)),
-        ((1, 256, 24, 80), (1, 7, 25281, 2)),
+        # ((1, 256, 12, 40), (1, 7, 25281, 2)),
+        # ((1, 256, 24, 80), (1, 7, 25281, 2)),
         ((1, 256, 48, 160), (1, 7, 25281, 2)),
-        ((16, 32, 100, 100), (16, 10000, 4, 2)),
-        ((48, 32, 12, 20), (48, 3567, 8, 2)),
-        ((8, 32, 100, 100), (8, 300, 4, 2)),
-        ((8, 32, 100, 100), (8, 2000, 4, 2)),
-        ((16, 32, 50, 50), (16, 10000, 1, 2)),
-        ((48, 32, 80, 45), (48, 4832, 1, 2)),
-        ((48, 32, 40, 23), (48, 4832, 1, 2)),
-        ((48, 32, 20, 12), (48, 4832, 1, 2)),
-        ((48, 32, 10, 6), (48, 4832, 1, 2)),
-        ((8, 32, 50, 50), (8, 3604, 1, 2)),
+        # ((16, 32, 100, 100), (16, 10000, 4, 2)),
+        # ((48, 32, 12, 20), (48, 3567, 8, 2)),
+        # ((8, 32, 100, 100), (8, 300, 4, 2)),
+        # ((8, 32, 100, 100), (8, 2000, 4, 2)),
+        # ((16, 32, 50, 50), (16, 10000, 1, 2)),
+        # ((48, 32, 80, 45), (48, 4832, 1, 2)),
+        # ((48, 32, 40, 23), (48, 4832, 1, 2)),
+        # ((48, 32, 20, 12), (48, 4832, 1, 2)),
+        # ((48, 32, 10, 6), (48, 4832, 1, 2)),
+        # ((8, 32, 50, 50), (8, 3604, 1, 2)),
     ],
 )
 def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_precomputed_grid):
@@ -79,3 +79,94 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(pcc_message)
+
+
+@pytest.mark.parametrize("use_precomputed_grid", [False, True])
+@pytest.mark.parametrize(
+    "input_shape, grid_shape, channel_extent_factor",
+    [
+        # ((1, 32, 16, 16), (1, 25281, 7, 2), 1),
+        ((1, 32, 16, 16), (1, 8, 8, 2), 1),
+        # ((2, 64, 24, 24), (2, 12, 12, 2), 2),
+        # ((2, 64, 24, 24), (2, 12, 12, 2), 3),
+        # ((1, 128, 32, 32), (1, 16, 16, 2), 2),
+        # ((1, 128, 32, 32), (1, 16, 16, 2), 4),
+        # ((4, 64, 20, 20), (4, 10, 10, 2), 2),
+        # ((4, 64, 20, 20), (4, 10, 10, 2), 5),
+        # ((1, 96, 24, 24), (1, 12, 12, 2), 3),
+        # ((1, 96, 24, 24), (1, 12, 12, 2), 6),
+    ],
+)
+def test_grid_sample_channel_extending(device, input_shape, grid_shape, channel_extent_factor, use_precomputed_grid):
+    """Test grid sample with channel extending functionality (multiple coordinate sets)"""
+    torch.manual_seed(0)
+
+    batch_size, channels, height, width = input_shape
+    grid_n, grid_h, grid_w, grid_coords = grid_shape
+
+    # Validate that channel_extent_factor is a divisor of width
+    assert (
+        width % channel_extent_factor == 0
+    ), f"channel_extent_factor {channel_extent_factor} must divide width {width}"
+
+    # Create input tensor (NCHW -> NHWC)
+    torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    # Generate random grid tensor
+    grid_tensor = torch.rand(batch_size, grid_h, grid_w, 2, dtype=torch.float32) * 2.0 - 1.0
+
+    # Create host ttnn tensor
+    ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
+
+    if use_precomputed_grid:
+        input_shape_nhwc = [batch_size, height, width, channels]
+        ttnn_grid_precomputed = ttnn.prepare_grid_sample_grid(
+            ttnn_grid_host, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
+        )
+        new_grid_w = grid_w // channel_extent_factor
+        final_last_dim = 6 * channel_extent_factor
+        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_precomputed, (batch_size, grid_h, new_grid_w, final_last_dim))
+        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
+    else:
+        new_grid_w = grid_w // channel_extent_factor
+        new_last_dim = 2 * channel_extent_factor
+        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
+        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
+
+    # Convert input to device
+    ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    # Run grid sample
+    ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid)
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    # For torch comparison, just do regular grid sample and reshape the output
+    torch_output_nchw = F.grid_sample(
+        torch_input_nchw, grid_tensor, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    torch_output_nhwc_ = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    # Reshape the torch output to match ttnn output: divide width by channel_extent_factor, multiply channels by channel_extent_factor
+    torch_expected_nhwc = (
+        torch_output_nhwc_.view(batch_size, grid_h, new_grid_w, channel_extent_factor, channels)
+        .permute(0, 1, 2, 4, 3)
+        .contiguous()
+        .view(batch_size, grid_h, new_grid_w, channels * channel_extent_factor)
+    )
+
+    # Check output shape
+    expected_shape = (batch_size, grid_h, new_grid_w, channels * channel_extent_factor)
+    assert ttnn_output_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_output_torch.shape}"
+
+    pcc, pcc_message = assert_with_pcc(torch_output_nhwc_.contiguous(), torch_expected_nhwc.contiguous())
+    logger.info(pcc_message)
+    # print(f"TTNN output shape: {ttnn_output_torch.shape}")
+    # print(f"Expected shape: {torch_expected_nhwc.shape}")
+
+    # # Check numerical accuracy
+    pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
+    logger.info(
+        f"Channel extending test (extent_factor={channel_extent_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -16,19 +16,19 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "input_shape, grid_shape",
     [
-        # ((1, 256, 12, 40), (1, 7, 25281, 2)),
-        # ((1, 256, 24, 80), (1, 7, 25281, 2)),
+        ((1, 256, 12, 40), (1, 7, 25281, 2)),
+        ((1, 256, 24, 80), (1, 7, 25281, 2)),
         ((1, 256, 48, 160), (1, 7, 25281, 2)),
-        # ((16, 32, 100, 100), (16, 10000, 4, 2)),
-        # ((48, 32, 12, 20), (48, 3567, 8, 2)),
-        # ((8, 32, 100, 100), (8, 300, 4, 2)),
-        # ((8, 32, 100, 100), (8, 2000, 4, 2)),
-        # ((16, 32, 50, 50), (16, 10000, 1, 2)),
-        # ((48, 32, 80, 45), (48, 4832, 1, 2)),
-        # ((48, 32, 40, 23), (48, 4832, 1, 2)),
-        # ((48, 32, 20, 12), (48, 4832, 1, 2)),
-        # ((48, 32, 10, 6), (48, 4832, 1, 2)),
-        # ((8, 32, 50, 50), (8, 3604, 1, 2)),
+        ((16, 32, 100, 100), (16, 10000, 4, 2)),
+        ((48, 32, 12, 20), (48, 3567, 8, 2)),
+        ((8, 32, 100, 100), (8, 300, 4, 2)),
+        ((8, 32, 100, 100), (8, 2000, 4, 2)),
+        ((16, 32, 50, 50), (16, 10000, 1, 2)),
+        ((48, 32, 80, 45), (48, 4832, 1, 2)),
+        ((48, 32, 40, 23), (48, 4832, 1, 2)),
+        ((48, 32, 20, 12), (48, 4832, 1, 2)),
+        ((48, 32, 10, 6), (48, 4832, 1, 2)),
+        ((8, 32, 50, 50), (8, 3604, 1, 2)),
     ],
 )
 def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_precomputed_grid):
@@ -83,25 +83,17 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
     logger.info(pcc_message)
 
 
-@pytest.mark.parametrize("use_precomputed_grid", [False, True])
+@pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize(
     "input_shape, grid_shape, channel_extent_factor",
     [
         ((1, 256, 48, 160), (1, 25281, 7, 2), 7),
-        # ((1, 32, 16, 16), (1, 8, 8, 2), 1),
-        # ((2, 64, 24, 24), (2, 12, 12, 2), 2),
-        # ((2, 64, 24, 24), (2, 12, 12, 2), 3),
-        # ((1, 128, 32, 32), (1, 16, 16, 2), 2),
-        # ((1, 128, 32, 32), (1, 16, 16, 2), 4),
-        # ((4, 64, 20, 20), (4, 10, 10, 2), 2),
-        # ((4, 64, 20, 20), (4, 10, 10, 2), 5),
-        # ((1, 96, 24, 24), (1, 12, 12, 2), 3),
-        # ((1, 96, 24, 24), (1, 12, 12, 2), 6),
+        ((1, 128, 32, 32), (1, 16, 16, 2), 4),
     ],
 )
 def test_grid_sample_channel_extending(device, input_shape, grid_shape, channel_extent_factor, use_precomputed_grid):
     """Test grid sample with channel extending functionality (multiple coordinate sets)"""
-    torch.manual_seed(0)
+    torch.manual_seed(523)
 
     batch_size, channels, height, width = input_shape
     grid_n, grid_h, grid_w, grid_coords = grid_shape
@@ -137,23 +129,20 @@ def test_grid_sample_channel_extending(device, input_shape, grid_shape, channel_
         ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
         ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
 
-    # Convert input to device
-    ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_input = ttnn.from_torch(
+        torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
 
-    # Run grid sample
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
-    # For torch comparison, just do regular grid sample and reshape the output
     torch_output_nchw = F.grid_sample(
         torch_input_nchw, grid_tensor, mode="bilinear", padding_mode="zeros", align_corners=False
     )
     torch_output_nhwc_ = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
-    # Reshape the torch output to match ttnn output: divide width by channel_extent_factor, multiply channels by channel_extent_factor
     torch_expected_nhwc = (
         torch_output_nhwc_.view(batch_size, grid_h, new_grid_w, channel_extent_factor, channels)
-        .permute(0, 1, 2, 4, 3)
         .contiguous()
         .view(batch_size, grid_h, new_grid_w, channels * channel_extent_factor)
     )
@@ -161,13 +150,6 @@ def test_grid_sample_channel_extending(device, input_shape, grid_shape, channel_
     # Check output shape
     expected_shape = (batch_size, grid_h, new_grid_w, channels * channel_extent_factor)
     assert ttnn_output_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_output_torch.shape}"
-
-    # pcc, pcc_message = assert_with_pcc(torch_output_nhwc_.contiguous(), torch_expected_nhwc.contiguous())
-    # logger.info(pcc_message)
-    # print(f"TTNN output shape: {ttnn_output_torch.shape}")
-    # print(f"Expected shape: {torch_expected_nhwc.shape}")
-
-    # # Check numerical accuracy
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(
         f"Channel extending test (extent_factor={channel_extent_factor}, precomputed={use_precomputed_grid}): {pcc_message}"

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -133,7 +133,9 @@ def test_grid_sample_channel_extending(device, input_shape, grid_shape, grid_bat
         torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
 
-    ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid)
+    ttnn_output = ttnn.grid_sample(
+        ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid, extend_channels=True
+    )
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     torch_output_nchw = F.grid_sample(
@@ -153,4 +155,97 @@ def test_grid_sample_channel_extending(device, input_shape, grid_shape, grid_bat
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(
         f"Channel extending test (extent_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
+    )
+
+
+@pytest.mark.parametrize("use_precomputed_grid", [True, False])
+@pytest.mark.parametrize("extend_channels", [True, False])
+@pytest.mark.parametrize(
+    "input_shape, grid_shape, grid_batching_factor",
+    [
+        ((1, 64, 16, 32), (1, 8, 12, 2), 3),
+        ((2, 32, 8, 16), (2, 6, 8, 2), 2),
+        ((1, 128, 32, 32), (1, 16, 16, 2), 4),
+    ],
+)
+def test_grid_sample_extend_channels_flag(
+    device, input_shape, grid_shape, grid_batching_factor, extend_channels, use_precomputed_grid
+):
+    """Test grid sample with extend_channels flag - both true and false behaviors"""
+    torch.manual_seed(42)
+
+    batch_size, channels, height, width = input_shape
+    grid_n, grid_h, grid_w, grid_coords = grid_shape
+
+    # Validate that grid_batching_factor is a divisor of width
+    assert (
+        grid_w % grid_batching_factor == 0
+    ), f"grid_batching_factor {grid_batching_factor} must divide grid width {grid_w}"
+
+    # Create input tensor (NCHW -> NHWC)
+    torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    # Generate random grid tensor for PyTorch reference
+    grid_tensor = torch.rand(batch_size, grid_h, grid_w, 2, dtype=torch.float32) * 2.0 - 1.0
+
+    # Create PyTorch reference output
+    torch_output_nchw = F.grid_sample(
+        torch_input_nchw, grid_tensor, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    # Prepare TTNN grid with batching
+    ttnn_input = ttnn.from_torch(
+        torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    if use_precomputed_grid:
+        # Create precomputed grid
+        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
+        input_shape_nhwc = [batch_size, height, width, channels]
+        ttnn_grid_precomputed = ttnn.prepare_grid_sample_grid(
+            ttnn_grid_host, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
+        )
+
+        # Reshape for grid batching: (N, H, W*K, 6) -> (N, H, W, 6*K)
+        new_grid_w = grid_w // grid_batching_factor
+        final_last_dim = 6 * grid_batching_factor
+        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_precomputed, (batch_size, grid_h, new_grid_w, final_last_dim))
+        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
+    else:
+        # Reshape for grid batching: (N, H, W*K, 2) -> (N, H, W, 2*K)
+        new_grid_w = grid_w // grid_batching_factor
+        new_last_dim = 2 * grid_batching_factor
+        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
+        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
+
+    # Call TTNN grid_sample with extend_channels flag
+    ttnn_output = ttnn.grid_sample(
+        ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid, extend_channels=extend_channels
+    )
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    # Prepare expected output based on extend_channels flag
+    if extend_channels:
+        # extend_channels=True: output shape (N, H, W, C*K) - channels extended
+        expected_shape = (batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
+        torch_expected_nhwc = (
+            torch_output_nhwc.view(batch_size, grid_h, new_grid_w, grid_batching_factor, channels)
+            .contiguous()
+            .view(batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
+        )
+    else:
+        # extend_channels=False: output shape (N, H, W*K, C) - W dimension extended
+        expected_shape = (batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
+        torch_expected_nhwc = torch_output_nhwc.view(batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
+
+    # Verify output shape
+    assert ttnn_output_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_output_torch.shape}"
+
+    # Verify numerical correctness
+    pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
+    logger.info(
+        f"extend_channels={extend_channels} test (batching_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
     )

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -11,9 +11,6 @@ namespace ttnn::operations::grid_sample {
 using namespace tt;
 using namespace tt::tt_metal;
 
-constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
-constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
-
 void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto& grid_tensor = input_tensors.at(1);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -22,15 +22,18 @@ void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
 
     // Shape validation
     TT_FATAL(input_tensor.logical_shape().rank() == 4, "Input tensor must be 4D (N, C, H, W)");
-    TT_FATAL(grid_tensor.logical_shape().rank() == 4, "Grid tensor must be 4D (N, H_out, W_out, 2)");
+    TT_FATAL(grid_tensor.logical_shape().rank() == 4, "Grid tensor must be 4D (N, H_out, W_out, multiple_of_2_or_6)");
 
+    uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
     if (use_precomputed_grid_) {
         TT_FATAL(
-            grid_tensor.logical_shape()[-1] == 6,
-            "Grid tensor last dimension must be 6 (h_nw, w_nw, weight_nw, weight_ne, weight_sw, weight_se)");
+            grid_last_dim % 6 == 0 && grid_last_dim >= 6,
+            "Grid tensor last dimension must be a multiple of 6 (multiple sets of h_nw, w_nw, weight_nw, weight_ne, "
+            "weight_sw, weight_se)");
     } else {
         TT_FATAL(
-            grid_tensor.logical_shape()[-1] == 2, "Grid tensor last dimension must be 2 (x, y relative coordinates)");
+            grid_last_dim % 2 == 0 && grid_last_dim >= 2,
+            "Grid tensor last dimension must be a multiple of 2 (multiple sets of x, y relative coordinates)");
     }
 
     TT_FATAL(
@@ -80,9 +83,14 @@ std::vector<TensorSpec> GridSample::compute_output_specs(const std::vector<Tenso
     uint32_t C = input_shape[-1];
     uint32_t H_out = grid_shape[1];
     uint32_t W_out = grid_shape[2];
+    uint32_t grid_last_dim = grid_shape[-1];
 
-    // Define output shape: (N, C, H_out, W_out)
-    const ttnn::Shape output_shape({N, H_out, W_out, C});
+    // Calculate number of grids and output channels
+    uint32_t num_grids = use_precomputed_grid_ ? (grid_last_dim / 6) : (grid_last_dim / 2);
+    uint32_t C_out = C * num_grids;
+
+    // Define output shape: (N, H_out, W_out, C_out) where C_out = C * num_grids
+    const ttnn::Shape output_shape({N, H_out, W_out, C_out});
 
     // Output has same data type as input
     const DataType output_data_type = input_tensor.dtype();

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -49,9 +49,8 @@ void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
         const uint32_t grid_batching_factor = grid_last_dim / num_elements_per_grid_point;
         TT_FATAL(
             grid_batching_factor > 1,
-            "batch_output_channels=True requires grid batching factor K > 1, but got K=" +
-                std::to_string(grid_batching_factor) +
-                ". Use a batched grid with multiple coordinate sets per spatial location.");
+            "batch_output_channels=True requires grid batching factor K > 1. Use a batched grid with multiple "
+            "coordinate sets per row of grid.");
     }
 
     // Data type validation

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -86,8 +86,15 @@ std::vector<TensorSpec> GridSample::compute_output_specs(const std::vector<Tenso
     uint32_t grid_last_dim = grid_shape[-1];
 
     // Calculate number of grids and output channels
-    uint32_t num_grids = use_precomputed_grid_ ? (grid_last_dim / 6) : (grid_last_dim / 2);
-    uint32_t C_out = C * num_grids;
+
+    // Calculate the number of batched grid points per grid row
+
+    const uint32_t num_of_elements_per_grid_point = use_precomputed_grid_ ? 6 : 2;
+    uint32_t grid_batching_factor = grid_last_dim / num_of_elements_per_grid_point;
+
+    // The channels get extended by grid_batching_factor
+    uint32_t channel_extend_factor = grid_batching_factor;
+    uint32_t C_out = C * channel_extend_factor;
 
     // Define output shape: (N, H_out, W_out, C_out) where C_out = C * num_grids
     const ttnn::Shape output_shape({N, H_out, W_out, C_out});

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
@@ -19,6 +19,7 @@ struct GridSample {
     const std::string mode_;
     const std::string padding_mode_;
     const bool use_precomputed_grid_;
+    const bool extend_channels_;
     const tt::tt_metal::MemoryConfig output_mem_config_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
@@ -27,10 +28,14 @@ struct GridSample {
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 
     static constexpr auto attribute_names =
-        std::forward_as_tuple("mode", "padding_mode", "use_precomputed_grid", "output_mem_config");
+        std::forward_as_tuple("mode", "padding_mode", "use_precomputed_grid", "extend_channels", "output_mem_config");
     auto attribute_values() const {
         return std::forward_as_tuple(
-            this->mode_, this->padding_mode_, this->use_precomputed_grid_, this->output_mem_config_);
+            this->mode_,
+            this->padding_mode_,
+            this->use_precomputed_grid_,
+            this->extend_channels_,
+            this->output_mem_config_);
     }
 };
 
@@ -45,6 +50,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const Tensor& output_tensor,
     const std::string& mode,
     const std::string& padding_mode,
-    bool use_precomputed_grid);
+    bool use_precomputed_grid,
+    bool extend_channels);
 
 }  // namespace ttnn::operations::grid_sample

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
@@ -12,6 +12,9 @@
 
 namespace ttnn::operations::grid_sample {
 
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
+constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
+
 struct GridSample {
     const std::string mode_;
     const std::string padding_mode_;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
@@ -19,7 +19,7 @@ struct GridSample {
     const std::string mode_;
     const std::string padding_mode_;
     const bool use_precomputed_grid_;
-    const bool extend_channels_;
+    const bool batch_output_channels_;
     const tt::tt_metal::MemoryConfig output_mem_config_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
@@ -27,14 +27,14 @@ struct GridSample {
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 
-    static constexpr auto attribute_names =
-        std::forward_as_tuple("mode", "padding_mode", "use_precomputed_grid", "extend_channels", "output_mem_config");
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "mode", "padding_mode", "use_precomputed_grid", "batch_output_channels", "output_mem_config");
     auto attribute_values() const {
         return std::forward_as_tuple(
             this->mode_,
             this->padding_mode_,
             this->use_precomputed_grid_,
-            this->extend_channels_,
+            this->batch_output_channels_,
             this->output_mem_config_);
     }
 };
@@ -51,6 +51,6 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const std::string& mode,
     const std::string& padding_mode,
     bool use_precomputed_grid,
-    bool extend_channels);
+    bool batch_output_channels);
 
 }  // namespace ttnn::operations::grid_sample

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -106,8 +106,8 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const uint32_t output_cb_page_size = tt::constants::FACE_WIDTH * output_tensor.element_size();
     const uint32_t output_cb_num_pages = out_ntiles_c * buffering_factor;
     // Calculate number of grids for multi-grid support (needed for reader compile args)
-    uint32_t grid_last_dim = grid_shape[-1];
-    uint32_t num_grids = use_precomputed_grid ? (grid_last_dim / 6) : (grid_last_dim / 2);
+    uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
+    const uint32_t num_grids = use_precomputed_grid ? (grid_last_dim / 6) : (grid_last_dim / 2);
 
     const auto [output_cb_index, output_cb_handle] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, output_cb_page_size, output_cb_num_pages, output_cb_data_format);
@@ -160,7 +160,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                              // 10: Scalar CB 1 (unused)
             output_cb_index,                          // 11: Output CB
             one_scalar_per_core,                      // 12: Scalar mode
-            in_ntiles_c                               // 13: Tiles per channel (for CB space reservation)
+            out_ntiles_c                              // 13: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_1 = tt::tt_metal::CreateKernel(
@@ -191,7 +191,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             dummy_cb_id,                              // 10: Scalar CB 1 (unused)
             output_cb_index,                          // 11: Output CB
             one_scalar_per_core,                      // 12: Scalar mode
-            in_ntiles_c                               // 13: Tiles per channel (for CB space reservation)
+            out_ntiles_c                              // 13: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_2 = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -82,7 +82,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const uint32_t buffering_factor = 2;
 
     // CB0: Grid data buffer (holds grid coordinates for current output position)
-    const uint32_t grid_cb_num_pages = buffering_factor;
+    const uint32_t grid_cb_num_pages = 1;
     const auto [grid_cb_index, grid_cb_handle] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, aligned_grid_stick_nbytes, grid_cb_num_pages, grid_cb_data_format);
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -20,6 +20,9 @@
 
 namespace ttnn::operations::grid_sample {
 
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
+constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
+
 tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const Tensor& input_tensor,
     const Tensor& grid_tensor,
@@ -109,7 +112,8 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const uint32_t output_cb_num_pages = out_ntiles_c * buffering_factor;
     // Calculate the number of data points batched into a single grid row
     uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
-    const uint32_t num_of_elements_per_grid_point = use_precomputed_grid ? 6 : 2;
+    const uint32_t num_of_elements_per_grid_point =
+        use_precomputed_grid ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT : STANDARD_GRID_ELEMENTS_PER_POINT;
     const uint32_t grid_batching_factor = grid_last_dim / num_of_elements_per_grid_point;
 
     const auto [output_cb_index, output_cb_handle] = tt::tt_metal::create_cb(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -50,9 +50,11 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const uint32_t grid_buffer_alignment = grid_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                                ? tt::tt_metal::hal::get_dram_alignment()
                                                : tt::tt_metal::hal::get_l1_alignment();
+
     const uint32_t src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                               ? tt::tt_metal::hal::get_dram_alignment()
                                               : tt::tt_metal::hal::get_l1_alignment();
+
     const uint32_t dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                               ? tt::tt_metal::hal::get_dram_alignment()
                                               : tt::tt_metal::hal::get_l1_alignment();
@@ -73,7 +75,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t total_cores = num_cores_x * num_cores_y;
 
-    // Work distribution - distribute output sticks across cores
+    // Work distribution - distribute output and grid sticks across cores
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, output_nsticks);
 
@@ -105,9 +107,10 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
 
     const uint32_t output_cb_page_size = tt::constants::FACE_WIDTH * output_tensor.element_size();
     const uint32_t output_cb_num_pages = out_ntiles_c * buffering_factor;
-    // Calculate number of grids for multi-grid support (needed for reader compile args)
+    // Calculate the number of data points batched into a single grid row
     uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
-    const uint32_t num_grids = use_precomputed_grid ? (grid_last_dim / 6) : (grid_last_dim / 2);
+    const uint32_t num_of_elements_per_grid_point = use_precomputed_grid ? 6 : 2;
+    const uint32_t grid_batching_factor = grid_last_dim / num_of_elements_per_grid_point;
 
     const auto [output_cb_index, output_cb_handle] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, output_cb_page_size, output_cb_num_pages, output_cb_data_format);
@@ -121,7 +124,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
         (std::uint32_t)input_height,
         (std::uint32_t)input_width,
         (std::uint32_t)(output_height * output_width),  // output_hw_size at index 13
-        (std::uint32_t)num_grids,                       // number of grids per spatial position
+        (std::uint32_t)grid_batching_factor,            // number of grids per spatial position
     };
 
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
@@ -147,20 +150,20 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     // Kernel for core group 1
     if (core_group_1.num_cores() > 0) {
         std::vector<uint32_t> compute_compile_time_args_1 = {
-            in_ntiles_c,                              // 0: Input tiles per channel
-            reduction_size,                           // 1: Reduction size (4 for bilinear)
-            split_reader,                             // 2: Split reader flag
-            num_grids * num_sticks_per_core_group_1,  // 3: Total grid interpolations per core for group 1
-            channels_per_shard,                       // 4: Channels per shard
-            in_nblocks_c,                             // 5: Channel blocks
-            max_rows_for_reduction,                   // 6: Max rows
-            input_cb_index,                           // 7: Input CB
-            dummy_cb_id,                              // 8: Input CB 1 (unused)
-            scalar_cb_index,                          // 9: Scalar CB
-            dummy_cb_id,                              // 10: Scalar CB 1 (unused)
-            output_cb_index,                          // 11: Output CB
-            one_scalar_per_core,                      // 12: Scalar mode
-            out_ntiles_c                              // 13: Tiles per channel (for CB space reservation)
+            in_ntiles_c,                                         // 0: Input tiles per channel
+            reduction_size,                                      // 1: Reduction size (4 for bilinear)
+            split_reader,                                        // 2: Split reader flag
+            grid_batching_factor * num_sticks_per_core_group_1,  // 3: Total grid interpolations per core for group 1
+            channels_per_shard,                                  // 4: Channels per shard
+            in_nblocks_c,                                        // 5: Channel blocks
+            max_rows_for_reduction,                              // 6: Max rows
+            input_cb_index,                                      // 7: Input CB
+            dummy_cb_id,                                         // 8: Input CB 1 (unused)
+            scalar_cb_index,                                     // 9: Scalar CB
+            dummy_cb_id,                                         // 10: Scalar CB 1 (unused)
+            output_cb_index,                                     // 11: Output CB
+            one_scalar_per_core,                                 // 12: Scalar mode
+            out_ntiles_c                                         // 13: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_1 = tt::tt_metal::CreateKernel(
@@ -178,20 +181,20 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     // Kernel for core group 2 (if it exists)
     if (core_group_2.num_cores() > 0) {
         std::vector<uint32_t> compute_compile_time_args_2 = {
-            in_ntiles_c,                              // 0: Input tiles per channel
-            reduction_size,                           // 1: Reduction size (4 for bilinear)
-            split_reader,                             // 2: Split reader flag
-            num_grids * num_sticks_per_core_group_2,  // 3: Total grid interpolations per core for group 2
-            channels_per_shard,                       // 4: Channels per shard
-            in_nblocks_c,                             // 5: Channel blocks
-            max_rows_for_reduction,                   // 6: Max rows
-            input_cb_index,                           // 7: Input CB
-            dummy_cb_id,                              // 8: Input CB 1 (unused)
-            scalar_cb_index,                          // 9: Scalar CB
-            dummy_cb_id,                              // 10: Scalar CB 1 (unused)
-            output_cb_index,                          // 11: Output CB
-            one_scalar_per_core,                      // 12: Scalar mode
-            out_ntiles_c                              // 13: Tiles per channel (for CB space reservation)
+            in_ntiles_c,                                         // 0: Input tiles per channel
+            reduction_size,                                      // 1: Reduction size (4 for bilinear)
+            split_reader,                                        // 2: Split reader flag
+            grid_batching_factor * num_sticks_per_core_group_2,  // 3: Total grid interpolations per core for group 2
+            channels_per_shard,                                  // 4: Channels per shard
+            in_nblocks_c,                                        // 5: Channel blocks
+            max_rows_for_reduction,                              // 6: Max rows
+            input_cb_index,                                      // 7: Input CB
+            dummy_cb_id,                                         // 8: Input CB 1 (unused)
+            scalar_cb_index,                                     // 9: Scalar CB
+            dummy_cb_id,                                         // 10: Scalar CB 1 (unused)
+            output_cb_index,                                     // 11: Output CB
+            one_scalar_per_core,                                 // 12: Scalar mode
+            out_ntiles_c                                         // 13: Tiles per channel (for CB space reservation)
         };
 
         compute_kernel_group_2 = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -20,9 +20,6 @@
 
 namespace ttnn::operations::grid_sample {
 
-constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
-constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
-
 tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const Tensor& input_tensor,
     const Tensor& grid_tensor,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -79,13 +79,11 @@ void kernel_main() {
     // Outer loop: iterate over spatial positions (output sticks)
     for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
         // Read the grid stick for this spatial position (contains num_grids sets of coordinates)
-        cb_reserve_back(grid_cb_index, 1);
         uint32_t l1_write_grid_addr = get_write_ptr(grid_cb_index);
         uint64_t grid_noc_addr = s0.get_noc_addr(spatial_pos);
 
         noc_async_read(grid_noc_addr, l1_write_grid_addr, grid_stick_nbytes);
         noc_async_read_barrier();
-        cb_push_back(grid_cb_index, 1);
 
         volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_grid_addr);
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
     constexpr uint32_t input_height = get_compile_time_arg_val(5);
     constexpr uint32_t input_width = get_compile_time_arg_val(6);
     constexpr uint32_t output_hw_size = get_compile_time_arg_val(7);
-    constexpr uint32_t num_grids = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_batches = get_compile_time_arg_val(8);
 
     constexpr auto src_args = TensorAccessorArgs<9>();
     constexpr auto grid_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
@@ -85,7 +85,7 @@ void kernel_main() {
 
     // Outer loop: iterate over spatial positions (output sticks)
     for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
-        // Read the grid stick for this spatial position (contains num_grids sets of coordinates)
+        // Read the grid stick for this spatial position (contains grid_batches sets of coordinates)
         uint32_t l1_write_grid_addr = get_write_ptr(grid_cb_index);
         uint64_t grid_noc_addr = s0.get_noc_addr(spatial_pos);
 
@@ -97,8 +97,8 @@ void kernel_main() {
         uint32_t curr_batch = spatial_pos / output_hw_size;
         uint32_t batch_offset = curr_batch * input_height * input_width;
 
-        // Inner loop: process num_grids coordinate sets within this spatial position
-        for (uint32_t grid_idx = 0; grid_idx < num_grids; ++grid_idx) {
+        // Inner loop: process grid_batches coordinate sets within this spatial position
+        for (uint32_t grid_idx = 0; grid_idx < grid_batches; ++grid_idx) {
             uint16_t weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf;
             int32_t h0, h1, w0, w1;
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.cpp
@@ -19,6 +19,7 @@ ttnn::Tensor ExecuteGridSample::invoke(
     const std::string& mode,
     const std::string& padding_mode,
     bool use_precomputed_grid,
+    bool extend_channels,
     const std::optional<MemoryConfig>& memory_config) {
     // Use input memory config if not specified
     auto output_memory_config = memory_config.value_or(grid.memory_config());
@@ -29,6 +30,7 @@ ttnn::Tensor ExecuteGridSample::invoke(
             .mode_ = mode,
             .padding_mode_ = padding_mode,
             .use_precomputed_grid_ = use_precomputed_grid,
+            .extend_channels_ = extend_channels,
             .output_mem_config_ = output_memory_config},
         {input_tensor, grid});
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.cpp
@@ -19,7 +19,7 @@ ttnn::Tensor ExecuteGridSample::invoke(
     const std::string& mode,
     const std::string& padding_mode,
     bool use_precomputed_grid,
-    bool extend_channels,
+    bool batch_output_channels,
     const std::optional<MemoryConfig>& memory_config) {
     // Use input memory config if not specified
     auto output_memory_config = memory_config.value_or(grid.memory_config());
@@ -30,7 +30,7 @@ ttnn::Tensor ExecuteGridSample::invoke(
             .mode_ = mode,
             .padding_mode_ = padding_mode,
             .use_precomputed_grid_ = use_precomputed_grid,
-            .extend_channels_ = extend_channels,
+            .batch_output_channels_ = batch_output_channels,
             .output_mem_config_ = output_memory_config},
         {input_tensor, grid});
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
@@ -35,6 +35,7 @@ struct ExecuteGridSample {
         const std::string& mode = "bilinear",
         const std::string& padding_mode = "zeros",
         bool use_precomputed_grid = false,
+        bool extend_channels = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample.hpp
@@ -35,7 +35,7 @@ struct ExecuteGridSample {
         const std::string& mode = "bilinear",
         const std::string& padding_mode = "zeros",
         bool use_precomputed_grid = false,
-        bool extend_channels = false,
+        bool batch_output_channels = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_pybind.cpp
@@ -18,7 +18,7 @@ namespace py = pybind11;
 
 void bind_grid_sample(py::module& module) {
     const auto doc = R"doc(
-        grid_sample(input_tensor: ttnn.Tensor, grid: ttnn.Tensor, *, mode: str = "bilinear", padding_mode: str = "zeros", use_precomputed_grid: bool = False, extend_channels: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+        grid_sample(input_tensor: ttnn.Tensor, grid: ttnn.Tensor, *, mode: str = "bilinear", padding_mode: str = "zeros", use_precomputed_grid: bool = False, batch_output_channels: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
         Performs grid sampling on the input tensor using the provided sampling grid.
 
@@ -30,15 +30,19 @@ void bind_grid_sample(py::module& module) {
             input_tensor (ttnn.Tensor): Input tensor of shape (N, H_in, W_in, C) - channel last format
             grid (ttnn.Tensor): Sampling grid with flexible batching support:
                                * Standard mode (use_precomputed_grid=False):
-                                 - Shape (N, H_out, W_out, 2*K) where K is the grid batching factor
-                                 - Contains K sets of normalized coordinates in range [-1, 1]
+                                 - Shape (N, H_grid, W_grid, 2*K) where K is the grid batching factor
+                                 - Contains K sets of normalized coordinates in range [-1, 1] packed into the last dimension
                                  - Each coordinate pair (x, y): x=-1 (leftmost), x=+1 (rightmost), y=-1 (topmost), y=+1 (bottommost)
                                  - When K=1: standard single coordinate per location (maps 1:1 to PyTorch F.grid_sample behavior)
-                                 - When K>1: multiple coordinate sets batched per grid location
+                                 - When K>1: K coordinate sets are packed per spatial location, typically created by reshaping
+                                   a larger grid from (N, H_grid, W_grid*K, 2) to (N, H_grid, W_grid, 2*K), where the desired grid shape would be W_grid*K
                                * Precomputed mode (use_precomputed_grid=True):
-                                 - Shape (N, H_out, W_out, 6*K) containing K sets of precomputed data
+                                 - Shape (N, H_grid, W_grid, 6*K) containing K sets of precomputed data packed into the last dimension
                                  - Each set has 6 elements: pixel coordinates and bilinear interpolation weights
-                                 - Generated using ttnn.prepare_grid_sample_grid() for K=1, then ttnn.reshape() for K>1
+                                 - When K=1: standard precomputed grid
+                                 - When K>1: K precomputed sets are packed per spatial location, typically created by reshaping
+                                   a larger precomputed grid from (N, H_grid, W_grid*K, 6) to (N, H_grid, W_grid, 6*K), where the desired grid shape would be W_grid*K
+                                 - Generated using ttnn.prepare_grid_sample_grid() for K=1, then ttnn.reshape() for K>1, both being done on host side
 
         Keyword Args:
             mode (str): Interpolation mode. Currently only "bilinear" is supported.
@@ -46,43 +50,49 @@ void bind_grid_sample(py::module& module) {
             use_precomputed_grid (bool): Whether to use precomputed grid coordinates.
                                    When False (default): grid should be normalized coordinates in [-1, 1]
                                    When True: grid should be preprocessed using ttnn.prepare_grid_sample_grid()
-            extend_channels (bool): Controls how grid batching factor K affects output dimensions:
-                                   When True: extend channels (legacy behavior) - output shape (N, H_out, W_out, C*K)
-                                   When False (default): extend W dimension - output shape (N, H_out, W_out*K, C)
-                                   This flag decouples channel extension from grid batching behavior.
-            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation.
+            batch_output_channels (bool): Controls how grid batching factor K affects output dimensions:
+                                    When False (default): extend W dimension - output shape (N, H_grid, W_grid*K, C)
+                                     The K coordinate sets produce K spatial outputs, expanding the width dimension
+                                   When True: batch output channels - output shape (N, H_grid, W_grid, C*K)
+                                     The K coordinate sets produce K channel groups, expanding the channel dimension
+                                   Setting this argument to True requires for K (grid batching factor) to be larger than one
+                                   Note: K doesn't disappear when batch_output_channels=False, it just gets distributed to the width dimension
+            memory_config (ttnn.MemoryConfig, optional): Output memory configuration for the operation.
 
         Returns:
-            ttnn.Tensor: Output tensor shape depends on extend_channels flag:
-                        - When extend_channels=False (default): (N, H_out, W_out*K, C) - W dimension extended
-                        - When extend_channels=True: (N, H_out, W_out, C*K) - channels extended (legacy behavior)
-                        Where K is the grid batching factor. When K=1, both behaviors produce the same output shape.
+            ttnn.Tensor: Output tensor shape depends on batch_output_channels flag:
+                        - When batch_output_channels=False (default): (N, H_grid, W_grid*K, C) - W dimension extended
+                        - When batch_output_channels=True: (N, H_grid, W_grid, C*K) - channels batched
+                        Where K is the grid batching factor.
 
         Example:
             >>> # Create input tensor (N=1, H=4, W=4, C=32) - channel last format
             >>> input_tensor = ttnn.from_torch(torch.randn(1, 4, 4, 32), device=device)
 
-            >>> # Example 1: Standard single grid (K=1) - both extend_channels values produce same result
+            >>> # Example 1: Standard single grid (K=1) - both batch_output_channels values produce same result
             >>> theta = torch.tensor([[[1., 0., 0.], [0., 1., 0.]]], dtype=torch.float)
             >>> grid = torch.nn.functional.affine_grid(theta, (1, 32, 4, 4), align_corners=False)
             >>> grid_tensor = ttnn.from_torch(grid.to(torch.bfloat16), device=device)
-            >>> output_default = ttnn.grid_sample(input_tensor, grid_tensor)  # extend_channels=False (default)
-            >>> output_channels = ttnn.grid_sample(input_tensor, grid_tensor, extend_channels=True)
+            >>> output_default = ttnn.grid_sample(input_tensor, grid_tensor)  # batch_output_channels=False (default)
             >>> print(output_default.shape)  # [1, 4, 4, 32] - same for both when K=1
-            >>> print(output_channels.shape) # [1, 4, 4, 32] - same for both when K=1
 
-            >>> # Example 2: Batched grid (K=4) - demonstrates different behaviors
-            >>> # Create grid with 4 coordinate sets per location: shape (1, 4, 4, 8) where K=4
-            >>> batched_grid = torch.randn(1, 4, 4, 8) * 0.5  # K=4 coordinate sets
+            >>> # Example 2: Grid batching (K=4) - demonstrates proper reshaping workflow
+            >>> # Step 1: Create natural grid as you normally would (like in PyTorch)
+            >>> K = 4  # Grid batching factor
+            >>> natural_grid = torch.randn(1, 4, 16, 2) * 0.5  # Natural shape: (N, H_grid, W_grid*K, 2)
+            >>>
+            >>> # Step 2: Reshape for optimization - pack K coordinate sets into last dimension
+            >>> W_grid = 16 // K  # W_grid = 4
+            >>> batched_grid = natural_grid.view(1, 4, W_grid, 2*K)  # Reshaped: (1, 4, 4, 8)
             >>> batched_grid_tensor = ttnn.from_torch(batched_grid.to(torch.bfloat16), device=device)
             >>>
-            >>> # extend_channels=False (default): W dimension extended
+            >>> # batch_output_channels=False (default): W dimension extended
             >>> output_w_extend = ttnn.grid_sample(input_tensor, batched_grid_tensor)
-            >>> print(output_w_extend.shape)  # [1, 4, 16, 32] - W extended from 4 to 16 (4*K)
+            >>> print(output_w_extend.shape)  # [1, 4, 16, 32] - W extended from 4 to 16 (W_grid*K)
             >>>
-            >>> # extend_channels=True: channels extended (legacy behavior)
-            >>> output_c_extend = ttnn.grid_sample(input_tensor, batched_grid_tensor, extend_channels=True)
-            >>> print(output_c_extend.shape)  # [1, 4, 4, 128] - channels extended from 32 to 128 (32*K)
+            >>> # batch_output_channels=True: channels batched
+            >>> output_c_extend = ttnn.grid_sample(input_tensor, batched_grid_tensor, batch_output_channels=True)
+            >>> print(output_c_extend.shape)  # [1, 4, 4, 128] - channels batched from 32 to 128 (K*C)
 
             >>> # Example 3: Using precomputed grid for better performance
             >>> grid_float32 = ttnn.from_torch(grid, dtype=ttnn.float32)
@@ -106,7 +116,7 @@ void bind_grid_sample(py::module& module) {
             py::arg("mode") = "bilinear",
             py::arg("padding_mode") = "zeros",
             py::arg("use_precomputed_grid") = false,
-            py::arg("extend_channels") = false,
+            py::arg("batch_output_channels") = false,
             py::arg("memory_config") = std::nullopt});
 }
 


### PR DESCRIPTION
### Problem description

Downloading of the grid was slow in grid sample op, since the final dimension was small (2 or 6 datums representing one point in space)

### What's changed

Added support for batching the input grid into the final dimension. This increases the performance for loading the input grid, as information about more grid points is downloaded at the same time.

Also added an "extend_channels" flag, which could be used to concatenate the interpolated sticks from the same input stick into the channel dimension, increasing the inner dimension instead of the second inner dimension. Read the pybind docs for more information

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17408119088/job/49473413467) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17408124406)
- [x] [L2 nightly pool] (https://github.com/tenstorrent/tt-metal/actions/runs/17408138783)