### PR TITLE
Stable_diffusion remove throttling for BH

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -4,3 +4,5 @@
 
 # L1 Small Size Constants
 SD_L1_SMALL_SIZE = 19616
+# Trace Region Size Constants
+SD_TRACE_REGION_SIZE = 789835776

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -27,7 +27,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition
     UNet2DConditionModel as UNet2D,
 )
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
-from models.utility_functions import enable_persistent_kernel_cache, profiler
+from models.utility_functions import enable_persistent_kernel_cache, is_wormhole_b0, profiler
 
 
 def load_inputs(input_path):
@@ -68,7 +68,8 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
     profiler.clear()
 
     # Until di/dt issues are resolved
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    if is_wormhole_b0():
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -226,7 +227,8 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
     enable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    if is_wormhole_b0():
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
@@ -366,7 +368,8 @@ def run_demo_inference_diffusiondb(
     enable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    if is_wormhole_b0():
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
 
     assert (
         num_inference_steps >= 4

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -19,7 +19,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import compile_trace_sd
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -525,7 +525,7 @@ def run_demo_inference_diffusiondb(
 
 @pytest.mark.parametrize(
     "device_params",
-    [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}],
+    [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -14,7 +14,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import compile_trace_sd
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -180,7 +180,7 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
 def warmup_model():
     # create device, these constants are specific to n150 & n300
     device_id = 0
-    device_params = {"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}
+    device_params = {"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}
     device = ttnn.CreateDevice(device_id=device_id, **device_params)
     num_inference_steps = 50
     image_size = (512, 512)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -22,7 +22,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition
     UNet2DConditionModel as UNet2D,
 )
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
-from models.utility_functions import disable_persistent_kernel_cache
+from models.utility_functions import disable_persistent_kernel_cache, is_wormhole_b0
 
 
 def constant_prop_time_embeddings(timesteps, sample, time_proj):
@@ -40,7 +40,8 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
     disable_persistent_kernel_cache()
 
     # Until di/dt issues are resolved
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    if is_wormhole_b0():
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
     assert (
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -6,7 +6,7 @@ import pytest
 import torchvision.transforms as transforms
 from diffusers import StableDiffusionPipeline
 
-from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.demo.demo import load_inputs
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference as demo
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_diffusiondb as demo_db
@@ -15,7 +15,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789321728}], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
 )
 @pytest.mark.parametrize(
     "num_prompts",
@@ -37,7 +37,7 @@ def test_demo_sd_db(device, reset_seeds, input_path, num_prompts, num_inference_
 
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789835776}], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
 )
 @pytest.mark.parametrize(
     "input_path",

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -11,7 +11,7 @@ from loguru import logger
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import run
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -47,7 +47,7 @@ def unsqueeze_all_params_to_4d(params):
 
 
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 15659008}], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
 )
 def test_stable_diffusion_unet_trace(device):
     assert is_wormhole_b0() or is_blackhole(), "SD 1.4 runs on Wormhole B0 or Blackhole"
@@ -175,7 +175,7 @@ def test_stable_diffusion_unet_trace(device):
 
 
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 6458368}], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
 )
 def test_stable_diffusion_vae_trace(device):
     if is_wormhole_b0():
@@ -246,7 +246,7 @@ def test_stable_diffusion_vae_trace(device):
 
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": 789321728}], indirect=True
+    "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -259,7 +259,8 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
         num_inference_steps >= 4
     ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
     # Until di/dt issues are resolved
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    if is_wormhole_b0():
+        os.environ["TT_MM_THROTTLE_PERF"] = "5"
     # Clear global profiler state before starting measurements
     profiler.clear()
 


### PR DESCRIPTION
### Problem description
Matmul throttle should be used on wormhole, not blackhole.

### What's changed
- added check if is wormhole for matmul throttle
- unified `trace_region_size` for stable_diffusion into a variable

### Checklist
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/17426741585)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [stable_diffusion passed](https://github.com/tenstorrent/tt-metal/actions/runs/17426710398)