### PR TITLE
Make Trace Runtime Measurement in query_op_runtime More Stable

### DIFF
--- a/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
@@ -92,15 +92,15 @@ uint64_t execute_time_and_release_trace(TraceID trace_id, MeshDevice* device) {
     try {
         std::array<uint64_t, NUM_TRACE_EXECUTIONS> durations;
 
-        for (size_t i = 0; i < NUM_TRACE_EXECUTIONS + WARMUP_TRACE_EXECUTIONS; ++i) {
+        for (size_t i = 0; i < WARMUP_TRACE_EXECUTIONS; ++i) {
+            ttnn::operations::trace::execute_trace(device, trace_id, ttnn::DefaultQueueId, /* blocking = */ true);
+        }
+
+        for (size_t i = 0; i < NUM_TRACE_EXECUTIONS; ++i) {
             auto start = std::chrono::high_resolution_clock::now();
             ttnn::operations::trace::execute_trace(device, trace_id, ttnn::DefaultQueueId, /* blocking = */ true);
             auto end = std::chrono::high_resolution_clock::now();
-
-            if (i >= WARMUP_TRACE_EXECUTIONS) {
-                durations[i - WARMUP_TRACE_EXECUTIONS] =
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-            }
+            durations[i] = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         }
 
         ttnn::operations::trace::release_trace(device, trace_id);

--- a/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_runtime.hpp
@@ -90,7 +90,6 @@ auto capture_op_trace(Op op, MeshDevice* device, Args&&... args) {
 template <typename TraceID>
 uint64_t execute_time_and_release_trace(TraceID trace_id, MeshDevice* device) {
     try {
-        uint64_t duration = 0;
         std::array<uint64_t, NUM_TRACE_EXECUTIONS> durations;
 
         for (size_t i = 0; i < NUM_TRACE_EXECUTIONS + WARMUP_TRACE_EXECUTIONS; ++i) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4571

### Problem description
The op runtimes returned by this API are not stable enough. The same inputs to can result in a runtime that varies by 2x, making the number useless for the forge optimizer.

### What's changed
- Added warmup iterations prior to collecting trace runtime
  - Empirical analysis showed that the first 3-6 trace executions have higher variance and are generally much higher than the average excluding those
- Collected trace runtime from more iterations and dropped the outliers
- Closes https://github.com/tenstorrent/tt-mlir/issues/4571

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [X] New/Existing tests provide coverage for changes