### PR TITLE
Yolov6l optimization

### DIFF
--- a/models/demos/yolov6l/README.md
+++ b/models/demos/yolov6l/README.md
@@ -23,13 +23,11 @@ pytest --disable-warnings models/demos/yolov6l/tests/pcc/test_ttnn_yolov6l.py
 
 #### Single Device (BS=1) :
 
-- For `640x640`, end-2-end perf is `103` FPS.
+- For `640x640`, end-2-end perf is `103` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l
   ```
-
-  Note: Reported e2e perf for single device is from N150 execution (that uses tensix dispatch). If you are running for single device on N300, the e2e perf will be slow as N300 uses eth dispatch.
 
 #### Multi Device (DP=2, N300) :
 

--- a/models/demos/yolov6l/README.md
+++ b/models/demos/yolov6l/README.md
@@ -23,15 +23,17 @@ pytest --disable-warnings models/demos/yolov6l/tests/pcc/test_ttnn_yolov6l.py
 
 #### Single Device (BS=1) :
 
-- For `640x640`, end-2-end perf is `65` FPS.
+- For `640x640`, end-2-end perf is `103` FPS.
 
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l
   ```
 
+  Note: The FPS for single device reported above is for N150 card and FPS numbers would differ for N300 card since N150 uses tensix dispatch whereas N300 uses eth dispatch.
+
 #### Multi Device (DP=2, N300) :
 
-- For `640x640`, end-2-end perf is `130` FPS.
+- For `640x640`, end-2-end perf is `184` FPS.
 
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l_dp

--- a/models/demos/yolov6l/README.md
+++ b/models/demos/yolov6l/README.md
@@ -29,11 +29,11 @@ pytest --disable-warnings models/demos/yolov6l/tests/pcc/test_ttnn_yolov6l.py
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l
   ```
 
-  Note: The FPS for single device reported above is for N150 card and FPS numbers would differ for N300 card since N150 uses tensix dispatch whereas N300 uses eth dispatch.
+  Note: Reported e2e perf for single device is from N150 execution (that uses tensix dispatch). If you are running for single device on N300, the e2e perf will be slow as N300 uses eth dispatch.
 
 #### Multi Device (DP=2, N300) :
 
-- For `640x640`, end-2-end perf is `184` FPS.
+- For `640x640`, end-2-end perf is `181` FPS.
 
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l_dp

--- a/models/demos/yolov6l/runner/performant_runner_infra.py
+++ b/models/demos/yolov6l/runner/performant_runner_infra.py
@@ -113,7 +113,7 @@ class YOLOv6lPerformanceRunnerInfra:
         torch_output_tensor = self.torch_output_tensor if torch_output_tensor is None else torch_output_tensor
         output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=self.mesh_composer)
 
-        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor[0], output_tensor, pcc=0.99)
+        self.pcc_passed, self.pcc_message = assert_with_pcc(torch_output_tensor[0], output_tensor, pcc=0.99)
 
         logger.info(
             f"yolov6l - batch_size={self.batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, PCC={self.pcc_message}"

--- a/models/demos/yolov6l/tests/pcc/test_bep_c3.py
+++ b/models/demos/yolov6l/tests/pcc/test_bep_c3.py
@@ -41,4 +41,5 @@ def test_yolov6l_bepc3(device, reset_seeds, model_location_generator):
 
     output = ttnn.to_torch(output)
     output = output.permute(0, 3, 1, 2)
+    output = output.reshape(torch_output.shape)
     assert_with_pcc(torch_output, output, pcc=0.99)

--- a/models/demos/yolov6l/tests/pcc/test_cspbep_backbone.py
+++ b/models/demos/yolov6l/tests/pcc/test_cspbep_backbone.py
@@ -50,4 +50,5 @@ def test_yolov6l_cspbep_backbone(device, reset_seeds, model_location_generator):
 
     output_3 = ttnn.to_torch(output[3])
     output_3 = output_3.permute(0, 3, 1, 2)
+    output_3 = output_3.reshape(torch_output[3].shape)
     assert_with_pcc(torch_output[3], output_3, pcc=0.99)

--- a/models/demos/yolov6l/tests/pcc/test_cspbep_backbone.py
+++ b/models/demos/yolov6l/tests/pcc/test_cspbep_backbone.py
@@ -38,14 +38,17 @@ def test_yolov6l_cspbep_backbone(device, reset_seeds, model_location_generator):
 
     output_0 = ttnn.to_torch(output[0])
     output_0 = output_0.permute(0, 3, 1, 2)
+    output_0 = output_0.reshape(torch_output[0].shape)
     assert_with_pcc(torch_output[0], output_0, pcc=0.99)
 
     output_1 = ttnn.to_torch(output[1])
     output_1 = output_1.permute(0, 3, 1, 2)
+    output_1 = output_1.reshape(torch_output[1].shape)
     assert_with_pcc(torch_output[1], output_1, pcc=0.99)
 
     output_2 = ttnn.to_torch(output[2])
     output_2 = output_2.permute(0, 3, 1, 2)
+    output_2 = output_2.reshape(torch_output[2].shape)
     assert_with_pcc(torch_output[2], output_2, pcc=0.99)
 
     output_3 = ttnn.to_torch(output[3])

--- a/models/demos/yolov6l/tests/pcc/test_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tests/pcc/test_csprep_bifpanneck.py
@@ -68,12 +68,15 @@ def test_yolov6l_csprep_bifpanneck(device, reset_seeds, model_location_generator
 
     output_0 = ttnn.to_torch(output[0])
     output_0 = output_0.permute(0, 3, 1, 2)
+    output_0 = output_0.reshape(torch_output[0].shape)
     assert_with_pcc(torch_output[0], output_0, pcc=0.99)
 
     output_1 = ttnn.to_torch(output[1])
     output_1 = output_1.permute(0, 3, 1, 2)
+    output_1 = output_1.reshape(torch_output[1].shape)
     assert_with_pcc(torch_output[1], output_1, pcc=0.99)
 
     output_2 = ttnn.to_torch(output[2])
     output_2 = output_2.permute(0, 3, 1, 2)
+    output_2 = output_2.reshape(torch_output[2].shape)
     assert_with_pcc(torch_output[2], output_2, pcc=0.99)

--- a/models/demos/yolov6l/tests/pcc/test_sppf.py
+++ b/models/demos/yolov6l/tests/pcc/test_sppf.py
@@ -38,4 +38,5 @@ def test_yolov6l_sppf(device, reset_seeds, model_location_generator):
 
     output = ttnn.to_torch(output)
     output = output.permute(0, 3, 1, 2)
+    output = output.reshape(torch_output.shape)
     assert_with_pcc(torch_output, output, pcc=0.99)

--- a/models/demos/yolov6l/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov6l/tests/perf/test_e2e_performant.py
@@ -17,7 +17,7 @@ from models.utility_functions import disable_persistent_kernel_cache, run_for_wo
 
 
 def get_expected_times(name):
-    base = {"yolov6l": (183.7, 0.017)}
+    base = {"yolov6l": (183.7, 0.0096)}
     return base[name]
 
 

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 87.5],
+        [1, 88.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 110],
+        [1, 110.3],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 100],
+        [1, 102],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 97],
+        [1, 97.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 88.5],
+        [1, 96.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 86.5],
+        [1, 87.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 102],
+        [1, 102.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 97.5],
+        [1, 100],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 83],
+        [1, 86.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 102.5],
+        [1, 104],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 81],
+        [1, 82],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 104],
+        [1, 110],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 96.5],
+        [1, 97],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 77],
+        [1, 81],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.utility_functions import is_wormhole_b0, run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 82],
+        [1, 83],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tt/common.py
+++ b/models/demos/yolov6l/tt/common.py
@@ -183,12 +183,14 @@ class Yolov6x_Conv_T_2D:
             enable_act_double_buffer=False,
             enable_split_reader=False,
             output_layout=ttnn.TILE_LAYOUT,
+            reshard_if_not_optimal=True,
         )
         self.compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_fidelity=ttnn.MathFidelity.LoFi,
             fp32_dest_acc_en=False,
-            packer_l1_acc=False,
+            packer_l1_acc=True,
+            math_approx_mode=True,
         )
         if config_override and "act_block_h" in config_override:
             self.conv_config.act_block_h_override = config_override["act_block_h"]

--- a/models/demos/yolov6l/tt/model_preprocessing.py
+++ b/models/demos/yolov6l/tt/model_preprocessing.py
@@ -31,6 +31,8 @@ def generate_anchors(device, feats, fpn_strides, grid_cell_offset=0.5, weights_m
         stride_tensor.append(torch.full((h * w, 1), stride, dtype=torch.float))
     anchor_points = torch.cat(anchor_points)
     stride_tensor = torch.cat(stride_tensor)
+    anchor_points = anchor_points.permute(1, 0)
+    stride_tensor = stride_tensor.permute(1, 0)
     return (
         ttnn.from_torch(
             anchor_points,
@@ -89,7 +91,7 @@ def create_yolov6l_model_parameters(model: Model, torch_input: torch.Tensor, dev
     strides = torch.tensor([8.0, 16.0, 32.0])
     anchor_points, stride_tensor = generate_anchors(device, feats, strides, weights_mesh_mapper=weights_mesh_mapper)
 
-    ones_tensor = torch.ones((1, 8400, 1), dtype=torch.float32)
+    ones_tensor = torch.ones((1, 1, 8400), dtype=torch.float32)
     ones_tensor = ttnn.from_torch(
         ones_tensor,
         dtype=ttnn.bfloat16,
@@ -125,7 +127,7 @@ def create_yolov6l_model_parameters_detect(model: Model, torch_input: torch.Tens
     parameters["anchors"] = anchor_points
     parameters["strides"] = stride_tensor
 
-    ones_tensor = torch.ones((1, 8400, 1), dtype=torch.float32)
+    ones_tensor = torch.ones((1, 1, 8400), dtype=torch.float32)
     ones_tensor = ttnn.from_torch(ones_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     parameters["ones_tensor"] = ones_tensor
     return parameters

--- a/models/demos/yolov6l/tt/model_preprocessing.py
+++ b/models/demos/yolov6l/tt/model_preprocessing.py
@@ -33,10 +33,20 @@ def generate_anchors(device, feats, fpn_strides, grid_cell_offset=0.5, weights_m
     stride_tensor = torch.cat(stride_tensor)
     return (
         ttnn.from_torch(
-            anchor_points, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=weights_mesh_mapper
+            anchor_points,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            mesh_mapper=weights_mesh_mapper,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         ),
         ttnn.from_torch(
-            stride_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=weights_mesh_mapper
+            stride_tensor,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            mesh_mapper=weights_mesh_mapper,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         ),
     )
 
@@ -81,7 +91,12 @@ def create_yolov6l_model_parameters(model: Model, torch_input: torch.Tensor, dev
 
     ones_tensor = torch.ones((1, 8400, 1), dtype=torch.float32)
     ones_tensor = ttnn.from_torch(
-        ones_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, mesh_mapper=weights_mesh_mapper
+        ones_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        mesh_mapper=weights_mesh_mapper,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     if "detect" in parameters:
         parameters.detect["anchors"] = anchor_points

--- a/models/demos/yolov6l/tt/ttnn_bepc3.py
+++ b/models/demos/yolov6l/tt/ttnn_bepc3.py
@@ -6,6 +6,14 @@ import ttnn
 from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 from models.demos.yolov6l.tt.ttnn_repblock import TtRepBlock
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtBepC3:
     def __init__(
@@ -52,6 +60,8 @@ class TtBepC3:
         )
 
     def __call__(self, x):
+        if use_signpost:
+            signpost(header="TtBepC3 Start")
         conv1 = self.cv1(x)
         rep, _, _ = self.repblock(conv1)
         conv2 = self.cv2(x)
@@ -61,4 +71,6 @@ class TtBepC3:
 
         concat_output = ttnn.concat([rep, conv2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
         conv3 = self.cv3(concat_output)
+        if use_signpost:
+            signpost(header="TtBepC3 End")
         return conv3

--- a/models/demos/yolov6l/tt/ttnn_bepc3.py
+++ b/models/demos/yolov6l/tt/ttnn_bepc3.py
@@ -65,11 +65,27 @@ class TtBepC3:
         conv1 = self.cv1(x)
         rep, _, _ = self.repblock(conv1)
         conv2 = self.cv2(x)
-        conv2 = ttnn.to_memory_config(conv2, memory_config=ttnn.L1_MEMORY_CONFIG)
-        conv2 = ttnn.to_layout(conv2, layout=ttnn.TILE_LAYOUT)
-        rep = ttnn.to_memory_config(rep, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        concat_output = ttnn.concat([rep, conv2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        if conv2.memory_config().memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+            strategy_layout = ttnn.ShardStrategy.HEIGHT
+            output_sharded_memory_config = ttnn.create_sharded_memory_config(
+                [
+                    rep.memory_config().shard_spec.shape[0],
+                    2 * rep.memory_config().shard_spec.shape[1],
+                ],
+                core_grid=rep.memory_config().shard_spec.grid,
+                strategy=strategy_layout,
+                use_height_and_width_as_shard_shape=True,
+            )
+        else:
+            conv2 = ttnn.to_memory_config(conv2, memory_config=ttnn.L1_MEMORY_CONFIG)
+            conv2 = ttnn.to_layout(conv2, layout=ttnn.TILE_LAYOUT)
+            rep = ttnn.to_memory_config(rep, memory_config=ttnn.L1_MEMORY_CONFIG)
+            output_sharded_memory_config = ttnn.L1_MEMORY_CONFIG
+
+        concat_output = ttnn.concat([rep, conv2], dim=-1, memory_config=output_sharded_memory_config)
+        ttnn.deallocate(rep)
+        ttnn.deallocate(conv2)
         conv3 = self.cv3(concat_output)
         if use_signpost:
             signpost(header="TtBepC3 End")

--- a/models/demos/yolov6l/tt/ttnn_bepc3.py
+++ b/models/demos/yolov6l/tt/ttnn_bepc3.py
@@ -25,6 +25,7 @@ class TtBepC3:
         shard_layout=None,
         shard_layout_cv2=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         shard_layout_rep_block_first_two=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        reshape=True,
     ):
         self.parameters = parameters
         self.model_params = model_params
@@ -48,7 +49,7 @@ class TtBepC3:
             conv_pth=parameters.cv3.block.conv,
             activation="silu",
             shard_layout=shard_layout_cv2 if shard_layout == None else shard_layout,
-            reshape=True,
+            reshape=reshape,
         )
         self.repblock = TtRepBlock(
             device,

--- a/models/demos/yolov6l/tt/ttnn_bepc3.py
+++ b/models/demos/yolov6l/tt/ttnn_bepc3.py
@@ -41,6 +41,7 @@ class TtBepC3:
             conv_pth=parameters.cv2.block.conv,
             shard_layout=shard_layout_cv2 if shard_layout == None else shard_layout,
             activation="silu",
+            deallocate_activation=True,
         )
         self.cv3 = Yolov6l_Conv2D(
             device=device,

--- a/models/demos/yolov6l/tt/ttnn_bepc3.py
+++ b/models/demos/yolov6l/tt/ttnn_bepc3.py
@@ -25,7 +25,6 @@ class TtBepC3:
         shard_layout=None,
         shard_layout_cv2=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         shard_layout_rep_block_first_two=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        reshape=True,
     ):
         self.parameters = parameters
         self.model_params = model_params
@@ -49,7 +48,6 @@ class TtBepC3:
             conv_pth=parameters.cv3.block.conv,
             activation="silu",
             shard_layout=shard_layout_cv2 if shard_layout == None else shard_layout,
-            reshape=reshape,
         )
         self.repblock = TtRepBlock(
             device,

--- a/models/demos/yolov6l/tt/ttnn_bifusion.py
+++ b/models/demos/yolov6l/tt/ttnn_bifusion.py
@@ -5,6 +5,14 @@
 import ttnn
 from models.demos.yolov6l.tt.common import Yolov6l_Conv2D, Yolov6x_Conv_T_2D
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtBiFusion:
     def __init__(self, device, parameters, model_params):
@@ -45,6 +53,8 @@ class TtBiFusion:
         )
 
     def __call__(self, x):
+        if use_signpost:
+            signpost(header="TtBiFusion Start")
         conv_t = self.upsample(x[0])
         conv1 = self.cv1(x[1])
         conv2 = self.cv2(x[2])
@@ -64,4 +74,6 @@ class TtBiFusion:
         )
         output = ttnn.concat([conv_t, conv1, downsample], dim=-1, memory_config=output_sharded_memory_config)
         output, out_h, out_w = self.cv3(output)
+        if use_signpost:
+            signpost(header="TtBiFusion End")
         return output, out_h, out_w

--- a/models/demos/yolov6l/tt/ttnn_bifusion.py
+++ b/models/demos/yolov6l/tt/ttnn_bifusion.py
@@ -41,7 +41,7 @@ class TtBiFusion:
         self.upsample = Yolov6x_Conv_T_2D(
             model_params.upsample.upsample_transpose,
             parameters.upsample.upsample_transpose,
-            shard_layout=shard_layout,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             device=device,
         )
         self.downsample = Yolov6l_Conv2D(
@@ -50,6 +50,7 @@ class TtBiFusion:
             conv_pth=parameters.downsample.block.conv,
             activation="relu",
             deallocate_activation=True,
+            shard_layout=shard_layout,
         )
 
     def __call__(self, x):

--- a/models/demos/yolov6l/tt/ttnn_bifusion.py
+++ b/models/demos/yolov6l/tt/ttnn_bifusion.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
 
 
 class TtBiFusion:
-    def __init__(self, device, parameters, model_params):
+    def __init__(self, device, parameters, model_params, shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED):
         self.parameters = parameters
         self.model_params = model_params
         self.cv1 = Yolov6l_Conv2D(
@@ -41,7 +41,7 @@ class TtBiFusion:
         self.upsample = Yolov6x_Conv_T_2D(
             model_params.upsample.upsample_transpose,
             parameters.upsample.upsample_transpose,
-            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            shard_layout=shard_layout,
             device=device,
         )
         self.downsample = Yolov6l_Conv2D(

--- a/models/demos/yolov6l/tt/ttnn_bifusion.py
+++ b/models/demos/yolov6l/tt/ttnn_bifusion.py
@@ -74,6 +74,9 @@ class TtBiFusion:
             use_height_and_width_as_shard_shape=True,
         )
         output = ttnn.concat([conv_t, conv1, downsample], dim=-1, memory_config=output_sharded_memory_config)
+        ttnn.deallocate(conv_t)
+        ttnn.deallocate(conv1)
+        ttnn.deallocate(downsample)
         output, out_h, out_w = self.cv3(output)
         if use_signpost:
             signpost(header="TtBiFusion End")

--- a/models/demos/yolov6l/tt/ttnn_bottlerep.py
+++ b/models/demos/yolov6l/tt/ttnn_bottlerep.py
@@ -5,6 +5,14 @@
 import ttnn
 from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtBottleRep:
     def __init__(self, device, parameters, model_params, shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED):
@@ -31,6 +39,8 @@ class TtBottleRep:
         )
 
     def __call__(self, x):
+        if use_signpost:
+            signpost(header="TtBottleRep Start")
         x_conv1 = self.cv1(x)
         x_conv2, out_h, out_w = self.cv2(x_conv1)
 
@@ -49,4 +59,6 @@ class TtBottleRep:
 
         ttnn.deallocate(x_conv2)
         ttnn.deallocate(x)
+        if use_signpost:
+            signpost(header="TtBottleRep End")
         return output, out_h, out_w

--- a/models/demos/yolov6l/tt/ttnn_bottlerep.py
+++ b/models/demos/yolov6l/tt/ttnn_bottlerep.py
@@ -24,7 +24,6 @@ class TtBottleRep:
             conv_pth=parameters.conv1.block.conv,
             shard_layout=shard_layout,
             activation="silu",
-            activation_dtype=ttnn.bfloat16,
         )
         self.cv2 = Yolov6l_Conv2D(
             device=device,

--- a/models/demos/yolov6l/tt/ttnn_bottlerep.py
+++ b/models/demos/yolov6l/tt/ttnn_bottlerep.py
@@ -31,8 +31,6 @@ class TtBottleRep:
             conv=model_params.conv2.block.conv,
             conv_pth=parameters.conv2.block.conv,
             shard_layout=shard_layout,
-            act_block_h=True,
-            act_blocks=32,
             activation="silu",
             return_height_width=True,
             deallocate_activation=True,

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -7,6 +7,14 @@ from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 from models.demos.yolov6l.tt.ttnn_bepc3 import TtBepC3
 from models.demos.yolov6l.tt.ttnn_sppf import TtSppf
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtCSPBepBackbone:
     def __init__(self, device, parameters, model_params):
@@ -68,6 +76,8 @@ class TtCSPBepBackbone:
         self.erblock5_2 = TtSppf(device, parameters.ERBlock_5[2].sppf, model_params.ERBlock_5[2].sppf)
 
     def __call__(self, x):
+        if use_signpost:
+            signpost(header="TtCSPBepBackbone Start")
         outputs = []
         stem = self.stem(x)
         erblock2_0 = self.erblock2_0(stem)
@@ -87,4 +97,6 @@ class TtCSPBepBackbone:
         erblock5_1 = self.erblock5_1(erblock5_0)
         erblock5_2 = self.erblock5_2(erblock5_1)
         outputs.append(erblock5_2)
+        if use_signpost:
+            signpost(header="TtCSPBepBackbone End")
         return tuple(outputs)

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -25,6 +25,7 @@ class TtCSPBepBackbone:
             conv=model_params.stem.block.conv,
             conv_pth=parameters.stem.block.conv,
             activation="silu",
+            activation_dtype=ttnn.bfloat16,
             deallocate_activation=True,
         )
         self.erblock2_0 = Yolov6l_Conv2D(

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -34,7 +34,13 @@ class TtCSPBepBackbone:
             conv_pth=parameters.ERBlock_2[0].block.conv,
             activation="silu",
         )
-        self.erblock2_1 = TtBepC3(device, parameters.ERBlock_2[1], model_params.ERBlock_2[1], n=6)
+        self.erblock2_1 = TtBepC3(
+            device,
+            parameters.ERBlock_2[1],
+            model_params.ERBlock_2[1],
+            n=6,
+            reshape=False,
+        )
 
         self.erblock3_0 = Yolov6l_Conv2D(
             device=device,
@@ -42,7 +48,13 @@ class TtCSPBepBackbone:
             conv_pth=parameters.ERBlock_3[0].block.conv,
             activation="silu",
         )
-        self.erblock3_1 = TtBepC3(device, parameters.ERBlock_3[1], model_params.ERBlock_3[1], n=12)
+        self.erblock3_1 = TtBepC3(
+            device,
+            parameters.ERBlock_3[1],
+            model_params.ERBlock_3[1],
+            n=12,
+            reshape=False,
+        )
 
         self.erblock4_0 = Yolov6l_Conv2D(
             device=device,
@@ -51,7 +63,13 @@ class TtCSPBepBackbone:
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             activation="silu",
         )
-        self.erblock4_1 = TtBepC3(device, parameters.ERBlock_4[1], model_params.ERBlock_4[1], n=18)
+        self.erblock4_1 = TtBepC3(
+            device,
+            parameters.ERBlock_4[1],
+            model_params.ERBlock_4[1],
+            n=18,
+            reshape=False,
+        )
 
         self.erblock5_0 = Yolov6l_Conv2D(
             device=device,
@@ -86,8 +104,7 @@ class TtCSPBepBackbone:
 
         erblock4_0 = self.erblock4_0(erblock3_1)
         erblock4_1 = self.erblock4_1(erblock4_0)
-        erblock4 = ttnn.clone(erblock4_1)
-        outputs.append(erblock4)
+        outputs.append(erblock4_1)
 
         erblock5_0 = self.erblock5_0(erblock4_1)
         erblock5_1 = self.erblock5_1(erblock5_0)

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -39,7 +39,6 @@ class TtCSPBepBackbone:
             parameters.ERBlock_2[1],
             model_params.ERBlock_2[1],
             n=6,
-            reshape=False,
         )
 
         self.erblock3_0 = Yolov6l_Conv2D(
@@ -53,7 +52,6 @@ class TtCSPBepBackbone:
             parameters.ERBlock_3[1],
             model_params.ERBlock_3[1],
             n=12,
-            reshape=False,
         )
 
         self.erblock4_0 = Yolov6l_Conv2D(
@@ -68,7 +66,6 @@ class TtCSPBepBackbone:
             parameters.ERBlock_4[1],
             model_params.ERBlock_4[1],
             n=18,
-            reshape=False,
         )
 
         self.erblock5_0 = Yolov6l_Conv2D(
@@ -85,7 +82,6 @@ class TtCSPBepBackbone:
             n=6,
             shard_layout_cv2=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             shard_layout_rep_block_first_two=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            reshape=False,
         )
         self.erblock5_2 = TtSppf(device, parameters.ERBlock_5[2].sppf, model_params.ERBlock_5[2].sppf)
 

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -25,8 +25,6 @@ class TtCSPBepBackbone:
             conv=model_params.stem.block.conv,
             conv_pth=parameters.stem.block.conv,
             activation="silu",
-            activation_dtype=ttnn.bfloat16,
-            reshape=True,
             deallocate_activation=True,
         )
         self.erblock2_0 = Yolov6l_Conv2D(
@@ -34,7 +32,6 @@ class TtCSPBepBackbone:
             conv=model_params.ERBlock_2[0].block.conv,
             conv_pth=parameters.ERBlock_2[0].block.conv,
             activation="silu",
-            reshape=True,
         )
         self.erblock2_1 = TtBepC3(device, parameters.ERBlock_2[1], model_params.ERBlock_2[1], n=6)
 
@@ -43,7 +40,6 @@ class TtCSPBepBackbone:
             conv=model_params.ERBlock_3[0].block.conv,
             conv_pth=parameters.ERBlock_3[0].block.conv,
             activation="silu",
-            reshape=True,
         )
         self.erblock3_1 = TtBepC3(device, parameters.ERBlock_3[1], model_params.ERBlock_3[1], n=12)
 
@@ -53,7 +49,6 @@ class TtCSPBepBackbone:
             conv_pth=parameters.ERBlock_4[0].block.conv,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             activation="silu",
-            reshape=True,
         )
         self.erblock4_1 = TtBepC3(device, parameters.ERBlock_4[1], model_params.ERBlock_4[1], n=18)
 
@@ -63,7 +58,6 @@ class TtCSPBepBackbone:
             conv_pth=parameters.ERBlock_5[0].block.conv,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             activation="silu",
-            reshape=True,
         )
         self.erblock5_1 = TtBepC3(
             device,

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -33,6 +33,7 @@ class TtCSPBepBackbone:
             conv=model_params.ERBlock_2[0].block.conv,
             conv_pth=parameters.ERBlock_2[0].block.conv,
             activation="silu",
+            deallocate_activation=True,
         )
         self.erblock2_1 = TtBepC3(
             device,

--- a/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
+++ b/models/demos/yolov6l/tt/ttnn_cspbep_backbone.py
@@ -67,6 +67,7 @@ class TtCSPBepBackbone:
             n=6,
             shard_layout_cv2=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             shard_layout_rep_block_first_two=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            reshape=False,
         )
         self.erblock5_2 = TtSppf(device, parameters.ERBlock_5[2].sppf, model_params.ERBlock_5[2].sppf)
 

--- a/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
@@ -7,6 +7,13 @@ from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 from models.demos.yolov6l.tt.ttnn_bepc3 import TtBepC3
 from models.demos.yolov6l.tt.ttnn_bifusion import TtBiFusion
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtCSPRepBiFPANNeck:
     def __init__(self, device, parameters, model_params):
@@ -49,6 +56,8 @@ class TtCSPRepBiFPANNeck:
         )
 
     def __call__(self, input_list):
+        if use_signpost:
+            signpost(header="TtCSPRepBiFPANNeck Start")
         (input_tensor_3, input_tensor_2, input_tensor_1, input_tensor_0) = input_list
 
         fpn_out0 = self.reduce_layer0(input_tensor_0)
@@ -89,5 +98,8 @@ class TtCSPRepBiFPANNeck:
         pan_out0 = self.Rep_n4(p_concat_layer2)
 
         outputs = [pan_out2, pan_out_1, pan_out0]
+
+        if use_signpost:
+            signpost(header="TtCSPRepBiFPANNeck End")
 
         return outputs

--- a/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
@@ -26,7 +26,7 @@ class TtCSPRepBiFPANNeck:
             activation="relu",
         )
         self.Bifusion0 = TtBiFusion(device, parameters.Bifusion0, model_params.Bifusion0)
-        self.Rep_p4 = TtBepC3(device, parameters.Rep_p4, model_params.Rep_p4, n=12, reshape=False)
+        self.Rep_p4 = TtBepC3(device, parameters.Rep_p4, model_params.Rep_p4, n=12)
 
         self.reduce_layer1 = Yolov6l_Conv2D(
             device=device,
@@ -35,7 +35,7 @@ class TtCSPRepBiFPANNeck:
             activation="relu",
         )
         self.Bifusion1 = TtBiFusion(device, parameters.Bifusion1, model_params.Bifusion1)
-        self.Rep_p3 = TtBepC3(device, parameters.Rep_p3, model_params.Rep_p3, n=12, reshape=False)
+        self.Rep_p3 = TtBepC3(device, parameters.Rep_p3, model_params.Rep_p3, n=12)
 
         self.downsample2 = Yolov6l_Conv2D(
             device=device,
@@ -43,7 +43,7 @@ class TtCSPRepBiFPANNeck:
             conv_pth=parameters.downsample2.block.conv,
             activation="relu",
         )
-        self.Rep_n3 = TtBepC3(device, parameters.Rep_n3, model_params.Rep_n3, n=12, reshape=False)
+        self.Rep_n3 = TtBepC3(device, parameters.Rep_n3, model_params.Rep_n3, n=12)
 
         self.downsample1 = Yolov6l_Conv2D(
             device=device,
@@ -57,7 +57,6 @@ class TtCSPRepBiFPANNeck:
             model_params.Rep_n4,
             n=12,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            reshape=False,
         )
 
     def __call__(self, input_list):

--- a/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
@@ -35,7 +35,7 @@ class TtCSPRepBiFPANNeck:
             activation="relu",
         )
         self.Bifusion1 = TtBiFusion(device, parameters.Bifusion1, model_params.Bifusion1)
-        self.Rep_p3 = TtBepC3(device, parameters.Rep_p3, model_params.Rep_p3, n=12)
+        self.Rep_p3 = TtBepC3(device, parameters.Rep_p3, model_params.Rep_p3, n=12, reshape=False)
 
         self.downsample2 = Yolov6l_Conv2D(
             device=device,
@@ -43,7 +43,7 @@ class TtCSPRepBiFPANNeck:
             conv_pth=parameters.downsample2.block.conv,
             activation="relu",
         )
-        self.Rep_n3 = TtBepC3(device, parameters.Rep_n3, model_params.Rep_n3, n=12)
+        self.Rep_n3 = TtBepC3(device, parameters.Rep_n3, model_params.Rep_n3, n=12, reshape=False)
 
         self.downsample1 = Yolov6l_Conv2D(
             device=device,
@@ -52,7 +52,12 @@ class TtCSPRepBiFPANNeck:
             activation="relu",
         )
         self.Rep_n4 = TtBepC3(
-            device, parameters.Rep_n4, model_params.Rep_n4, n=12, shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED
+            device,
+            parameters.Rep_n4,
+            model_params.Rep_n4,
+            n=12,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            reshape=False,
         )
 
     def __call__(self, input_list):
@@ -80,10 +85,10 @@ class TtCSPRepBiFPANNeck:
             use_height_and_width_as_shard_shape=True,
         )
         p_concat_layer1 = ttnn.concat([down_feat1, fpn_out1], dim=-1, memory_config=output_sharded_memory_config)
-        pan_out1 = self.Rep_n3(p_concat_layer1)
-        pan_out_1 = ttnn.clone(pan_out1)
+        pan_out_1 = self.Rep_n3(p_concat_layer1)
+        # pan_out_1 = ttnn.clone(pan_out1)
 
-        down_feat0 = self.downsample1(pan_out1)
+        down_feat0 = self.downsample1(pan_out_1)
 
         output_sharded_memory_config = ttnn.create_sharded_memory_config(
             [

--- a/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
@@ -25,7 +25,9 @@ class TtCSPRepBiFPANNeck:
             conv_pth=parameters.reduce_layer0.block.conv,
             activation="relu",
         )
-        self.Bifusion0 = TtBiFusion(device, parameters.Bifusion0, model_params.Bifusion0)
+        self.Bifusion0 = TtBiFusion(
+            device, parameters.Bifusion0, model_params.Bifusion0, shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        )
         self.Rep_p4 = TtBepC3(device, parameters.Rep_p4, model_params.Rep_p4, n=12)
 
         self.reduce_layer1 = Yolov6l_Conv2D(

--- a/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
+++ b/models/demos/yolov6l/tt/ttnn_csprep_bifpanneck.py
@@ -26,7 +26,7 @@ class TtCSPRepBiFPANNeck:
             activation="relu",
         )
         self.Bifusion0 = TtBiFusion(device, parameters.Bifusion0, model_params.Bifusion0)
-        self.Rep_p4 = TtBepC3(device, parameters.Rep_p4, model_params.Rep_p4, n=12)
+        self.Rep_p4 = TtBepC3(device, parameters.Rep_p4, model_params.Rep_p4, n=12, reshape=False)
 
         self.reduce_layer1 = Yolov6l_Conv2D(
             device=device,
@@ -86,7 +86,6 @@ class TtCSPRepBiFPANNeck:
         )
         p_concat_layer1 = ttnn.concat([down_feat1, fpn_out1], dim=-1, memory_config=output_sharded_memory_config)
         pan_out_1 = self.Rep_n3(p_concat_layer1)
-        # pan_out_1 = ttnn.clone(pan_out1)
 
         down_feat0 = self.downsample1(pan_out_1)
 

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -5,6 +5,13 @@
 import ttnn
 from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtDetect:
     def __init__(self, device, parameters, model_params):
@@ -124,6 +131,8 @@ class TtDetect:
         self.ones_tensor = parameters.ones_tensor
 
     def __call__(self, input_list):
+        if use_signpost:
+            signpost(header="TtDetect Start")
         stems_0 = self.stem_0(input_list[0])
         stems_1 = self.stem_1(input_list[1])
         stems_2 = self.stem_2(input_list[2])
@@ -215,5 +224,8 @@ class TtDetect:
 
         bbox = ttnn.multiply(bbox, self.strides)
         output = ttnn.concat([bbox, self.ones_tensor, cls_score_list], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        if use_signpost:
+            signpost(header="TtDetect End")
 
         return output

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -194,9 +194,9 @@ class TtDetect:
         cls_output_1 = ttnn.squeeze(cls_output_1, dim=0)
         cls_output_2 = ttnn.squeeze(cls_output_2, dim=0)
 
-        cls_output_0 = ttnn.sharded_to_interleaved(cls_output_0)
-        cls_output_1 = ttnn.sharded_to_interleaved(cls_output_1)
-        cls_output_2 = ttnn.sharded_to_interleaved(cls_output_2)
+        cls_output_0 = ttnn.sharded_to_interleaved(cls_output_0, memory_config=ttnn.L1_MEMORY_CONFIG)
+        cls_output_1 = ttnn.sharded_to_interleaved(cls_output_1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        cls_output_2 = ttnn.sharded_to_interleaved(cls_output_2, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         reg_output_0 = ttnn.permute(reg_output_0, (0, 3, 1, 2))
         reg_output_0 = ttnn.reshape(reg_output_0, (1, 4, reg_output_0.shape[3]))
@@ -219,8 +219,8 @@ class TtDetect:
         c1, c2 = reg_dist_list[:, :, :2], reg_dist_list[:, :, 2:4]
         c1 = ttnn.to_layout(c1, layout=ttnn.TILE_LAYOUT)
         c2 = ttnn.to_layout(c2, layout=ttnn.TILE_LAYOUT)
-        x1y1 = self.anchors - c1
-        x2y2 = self.anchors + c2
+        x1y1 = ttnn.sub(self.anchors, c1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        x2y2 = ttnn.add(self.anchors, c2, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         c_xy = x1y1 + x2y2
         c_xy = ttnn.div(c_xy, 2)

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -34,6 +34,7 @@ class TtDetect:
             conv=model_params.stems[2].block.conv,
             conv_pth=parameters.stems[2].block.conv,
             activation="silu",
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         )
 
         self.cls_convs_0 = Yolov6l_Conv2D(

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -83,19 +83,16 @@ class TtDetect:
             device=device,
             conv=model_params.cls_preds[0],
             conv_pth=parameters.cls_preds[0],
-            reshape=True,
         )
         self.cls_preds_1 = Yolov6l_Conv2D(
             device=device,
             conv=model_params.cls_preds[1],
             conv_pth=parameters.cls_preds[1],
-            reshape=True,
         )
         self.cls_preds_2 = Yolov6l_Conv2D(
             device=device,
             conv=model_params.cls_preds[2],
             conv_pth=parameters.cls_preds[2],
-            reshape=True,
         )
 
         self.reg_preds_0 = Yolov6l_Conv2D(
@@ -192,10 +189,13 @@ class TtDetect:
         cls_output_1 = ttnn.sigmoid_accurate(cls_output_1)
         cls_output_2 = ttnn.sigmoid_accurate(cls_output_2)
 
-        # Since self.nc=80 we have eliminated permute before reshape
-        cls_output_0 = ttnn.reshape(cls_output_0, (1, cls_output_0.shape[1] * cls_output_0.shape[2], 80))
-        cls_output_1 = ttnn.reshape(cls_output_1, (1, cls_output_1.shape[1] * cls_output_1.shape[2], 80))
-        cls_output_2 = ttnn.reshape(cls_output_2, (1, cls_output_2.shape[1] * cls_output_2.shape[2], 80))
+        cls_output_0 = ttnn.squeeze(cls_output_0, dim=0)
+        cls_output_1 = ttnn.squeeze(cls_output_1, dim=0)
+        cls_output_2 = ttnn.squeeze(cls_output_2, dim=0)
+
+        cls_output_0 = ttnn.sharded_to_interleaved(cls_output_0)
+        cls_output_1 = ttnn.sharded_to_interleaved(cls_output_1)
+        cls_output_2 = ttnn.sharded_to_interleaved(cls_output_2)
 
         reg_output_0 = ttnn.permute(reg_output_0, (0, 3, 1, 2))
         reg_output_0 = ttnn.reshape(reg_output_0, (1, 4, reg_output_0.shape[3]))

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -206,6 +206,9 @@ class TtDetect:
         cls_output_0 = ttnn.sharded_to_interleaved(cls_output_0, memory_config=ttnn.L1_MEMORY_CONFIG)
         cls_output_1 = ttnn.sharded_to_interleaved(cls_output_1, memory_config=ttnn.L1_MEMORY_CONFIG)
         cls_output_2 = ttnn.sharded_to_interleaved(cls_output_2, memory_config=ttnn.L1_MEMORY_CONFIG)
+        cls_output_0 = ttnn.permute(cls_output_0, (0, 2, 1))
+        cls_output_1 = ttnn.permute(cls_output_1, (0, 2, 1))
+        cls_output_2 = ttnn.permute(cls_output_2, (0, 2, 1))
 
         reg_output_0 = ttnn.permute(reg_output_0, (0, 3, 1, 2))
         reg_output_0 = ttnn.reshape(reg_output_0, (1, 4, reg_output_0.shape[3]))
@@ -217,7 +220,7 @@ class TtDetect:
         reg_output_2 = ttnn.reshape(reg_output_2, (1, 4, reg_output_2.shape[3]))
 
         cls_score_list = ttnn.concat(
-            [cls_output_0, cls_output_1, cls_output_2], dim=1, memory_config=ttnn.L1_MEMORY_CONFIG
+            [cls_output_0, cls_output_1, cls_output_2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG
         )
 
         ttnn.deallocate(cls_output_0)
@@ -231,23 +234,22 @@ class TtDetect:
         ttnn.deallocate(reg_output_1)
         ttnn.deallocate(reg_output_2)
 
-        reg_dist_list = ttnn.permute(reg_dist_list, (0, 2, 1))
+        c1, c2 = reg_dist_list[:, :2, :], reg_dist_list[:, 2:4, :]
 
-        c1, c2 = reg_dist_list[:, :, :2], reg_dist_list[:, :, 2:4]
-        c1 = ttnn.to_layout(c1, layout=ttnn.TILE_LAYOUT)
-        c2 = ttnn.to_layout(c2, layout=ttnn.TILE_LAYOUT)
         x1y1 = ttnn.sub(self.anchors, c1, memory_config=ttnn.L1_MEMORY_CONFIG)
         x2y2 = ttnn.add(self.anchors, c2, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         c_xy = x1y1 + x2y2
         c_xy = ttnn.div(c_xy, 2)
         wh = x2y2 - x1y1
-        bbox = ttnn.concat([c_xy, wh], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        bbox = ttnn.concat([c_xy, wh], dim=1, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(c_xy)
         ttnn.deallocate(wh)
 
         bbox = ttnn.multiply(bbox, self.strides)
-        output = ttnn.concat([bbox, self.ones_tensor, cls_score_list], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        output = ttnn.concat([bbox, self.ones_tensor, cls_score_list], dim=1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        output = ttnn.permute(output, (0, 2, 1))
 
         if use_signpost:
             signpost(header="TtDetect End")

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -163,13 +163,14 @@ class TtDetect:
         reg_output_2 = ttnn.reshape(
             reg_output_2, (reg_output_0.shape[0], 4, 17, reg_output_2.shape[2] * reg_output_2.shape[3])
         )
+        reg_output_0 = ttnn.to_layout(reg_output_0, ttnn.TILE_LAYOUT)
+        reg_output_1 = ttnn.to_layout(reg_output_1, ttnn.TILE_LAYOUT)
+        reg_output_2 = ttnn.to_layout(reg_output_2, ttnn.TILE_LAYOUT)
+
         reg_output_0 = ttnn.permute(reg_output_0, (0, 2, 1, 3))
         reg_output_1 = ttnn.permute(reg_output_1, (0, 2, 1, 3))
         reg_output_2 = ttnn.permute(reg_output_2, (0, 2, 1, 3))
 
-        reg_output_0 = ttnn.to_layout(reg_output_0, ttnn.TILE_LAYOUT)
-        reg_output_1 = ttnn.to_layout(reg_output_1, ttnn.TILE_LAYOUT)
-        reg_output_2 = ttnn.to_layout(reg_output_2, ttnn.TILE_LAYOUT)
         reg_output_0 = ttnn.softmax(reg_output_0, 1)
         reg_output_1 = ttnn.softmax(reg_output_1, 1)
         reg_output_2 = ttnn.softmax(reg_output_2, 1)

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -207,9 +207,17 @@ class TtDetect:
             [cls_output_0, cls_output_1, cls_output_2], dim=1, memory_config=ttnn.L1_MEMORY_CONFIG
         )
 
+        ttnn.deallocate(cls_output_0)
+        ttnn.deallocate(cls_output_1)
+        ttnn.deallocate(cls_output_2)
+
         reg_dist_list = ttnn.concat(
             [reg_output_0, reg_output_1, reg_output_2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG
         )
+        ttnn.deallocate(reg_output_0)
+        ttnn.deallocate(reg_output_1)
+        ttnn.deallocate(reg_output_2)
+
         reg_dist_list = ttnn.permute(reg_dist_list, (0, 2, 1))
 
         c1, c2 = reg_dist_list[:, :, :2], reg_dist_list[:, :, 2:4]
@@ -222,9 +230,14 @@ class TtDetect:
         c_xy = ttnn.div(c_xy, 2)
         wh = x2y2 - x1y1
         bbox = ttnn.concat([c_xy, wh], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        ttnn.deallocate(c_xy)
+        ttnn.deallocate(wh)
 
         bbox = ttnn.multiply(bbox, self.strides)
         output = ttnn.concat([bbox, self.ones_tensor, cls_score_list], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        ttnn.deallocate(bbox)
+        ttnn.deallocate(self.ones_tensor)
+        ttnn.deallocate(cls_score_list)
 
         if use_signpost:
             signpost(header="TtDetect End")

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -207,9 +207,13 @@ class TtDetect:
         reg_output_2 = ttnn.permute(reg_output_2, (0, 3, 1, 2))
         reg_output_2 = ttnn.reshape(reg_output_2, (1, 4, reg_output_2.shape[3]))
 
-        cls_score_list = ttnn.concat([cls_output_0, cls_output_1, cls_output_2], dim=1)
+        cls_score_list = ttnn.concat(
+            [cls_output_0, cls_output_1, cls_output_2], dim=1, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
 
-        reg_dist_list = ttnn.concat([reg_output_0, reg_output_1, reg_output_2], dim=-1)
+        reg_dist_list = ttnn.concat(
+            [reg_output_0, reg_output_1, reg_output_2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
         reg_dist_list = ttnn.permute(reg_dist_list, (0, 2, 1))
 
         c1, c2 = reg_dist_list[:, :, :2], reg_dist_list[:, :, 2:4]

--- a/models/demos/yolov6l/tt/ttnn_detect.py
+++ b/models/demos/yolov6l/tt/ttnn_detect.py
@@ -167,17 +167,13 @@ class TtDetect:
         reg_output_1 = ttnn.to_layout(reg_output_1, ttnn.TILE_LAYOUT)
         reg_output_2 = ttnn.to_layout(reg_output_2, ttnn.TILE_LAYOUT)
 
-        reg_output_0 = ttnn.permute(reg_output_0, (0, 2, 1, 3))
-        reg_output_1 = ttnn.permute(reg_output_1, (0, 2, 1, 3))
-        reg_output_2 = ttnn.permute(reg_output_2, (0, 2, 1, 3))
+        reg_output_0 = ttnn.permute(reg_output_0, (0, 1, 3, 2))
+        reg_output_1 = ttnn.permute(reg_output_1, (0, 1, 3, 2))
+        reg_output_2 = ttnn.permute(reg_output_2, (0, 1, 3, 2))
 
-        reg_output_0 = ttnn.softmax(reg_output_0, 1)
-        reg_output_1 = ttnn.softmax(reg_output_1, 1)
-        reg_output_2 = ttnn.softmax(reg_output_2, 1)
-
-        reg_output_0 = ttnn.permute(reg_output_0, (0, 2, 3, 1))
-        reg_output_1 = ttnn.permute(reg_output_1, (0, 2, 3, 1))
-        reg_output_2 = ttnn.permute(reg_output_2, (0, 2, 3, 1))
+        reg_output_0 = ttnn.softmax(reg_output_0, -1)
+        reg_output_1 = ttnn.softmax(reg_output_1, -1)
+        reg_output_2 = ttnn.softmax(reg_output_2, -1)
 
         reg_output_0 = self.proj_conv(reg_output_0)
         reg_output_1 = self.proj_conv(reg_output_1)

--- a/models/demos/yolov6l/tt/ttnn_repblock.py
+++ b/models/demos/yolov6l/tt/ttnn_repblock.py
@@ -5,6 +5,14 @@
 import ttnn
 from models.demos.yolov6l.tt.ttnn_bottlerep import TtBottleRep
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtRepBlock:
     def __init__(
@@ -35,8 +43,12 @@ class TtRepBlock:
             )
 
     def __call__(self, inpur_tensor):
+        if use_signpost:
+            signpost(header="TtRepBlock Start")
         output, out_h, out_w = self.conv1(inpur_tensor)
         for i in range(self.n_blocks):
             block = getattr(self, f"bottle_rep{i}")
             output, out_h, out_w = block(output)
+        if use_signpost:
+            signpost(header="TtRepBlock End")
         return output, out_h, out_w

--- a/models/demos/yolov6l/tt/ttnn_sppf.py
+++ b/models/demos/yolov6l/tt/ttnn_sppf.py
@@ -5,6 +5,14 @@
 import ttnn
 from models.demos.yolov6l.tt.common import Yolov6l_Conv2D
 
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
 
 class TtSppf:
     def __init__(self, device, parameters, model_params):
@@ -28,6 +36,8 @@ class TtSppf:
         )
 
     def __call__(self, x):
+        if use_signpost:
+            signpost(header="TtSppf Start")
         conv1 = self.cv1(x)
         y = [conv1]
         for i in range(3):
@@ -55,4 +65,6 @@ class TtSppf:
             ttnn.deallocate(y[i])
 
         conv2 = self.cv2(concat_output)
+        if use_signpost:
+            signpost(header="TtSppf End")
         return conv2

--- a/models/demos/yolov6l/tt/ttnn_sppf.py
+++ b/models/demos/yolov6l/tt/ttnn_sppf.py
@@ -58,7 +58,7 @@ class TtSppf:
         for i in range(len(y)):
             y[i] = ttnn.sharded_to_interleaved(y[i])
             y[i] = ttnn.to_layout(y[i], ttnn.ROW_MAJOR_LAYOUT)
-        concat_output = ttnn.concat(y, dim=-1)
+        concat_output = ttnn.concat(y, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         for i in range(len(y)):
             ttnn.deallocate(y[i])

--- a/models/demos/yolov6l/tt/ttnn_sppf.py
+++ b/models/demos/yolov6l/tt/ttnn_sppf.py
@@ -56,7 +56,7 @@ class TtSppf:
             y.append(output)
 
         for i in range(len(y)):
-            y[i] = ttnn.sharded_to_interleaved(y[i])
+            y[i] = ttnn.sharded_to_interleaved(y[i], memory_config=ttnn.L1_MEMORY_CONFIG)
             y[i] = ttnn.to_layout(y[i], ttnn.ROW_MAJOR_LAYOUT)
         concat_output = ttnn.concat(y, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
 

--- a/models/demos/yolov6l/tt/ttnn_sppf.py
+++ b/models/demos/yolov6l/tt/ttnn_sppf.py
@@ -32,6 +32,7 @@ class TtSppf:
             conv_pth=parameters.cv2.block.conv,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             activation="silu",
+            deallocate_activation=True,
         )
 
     def __call__(self, x):

--- a/models/demos/yolov6l/tt/ttnn_sppf.py
+++ b/models/demos/yolov6l/tt/ttnn_sppf.py
@@ -32,7 +32,6 @@ class TtSppf:
             conv_pth=parameters.cv2.block.conv,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             activation="silu",
-            reshape=True,
         )
 
     def __call__(self, x):


### PR DESCRIPTION
### Ticket
#27545

### Problem description
Optimize Yolov6l model

### What's changed
Optimized Yolov6l model. 
Single card - 103(N150)
Single card - 93(N150)
The difference in FPS between n150 and n300 is due to N150 is using tensix dispatch and N300 is using ethernet dispatch.

Data parallel - 184(N300)

Latest perf sheet, [perf_yolov6l.csv](https://github.com/user-attachments/files/22205144/perf_today.csv)

### Checklist
 - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17544365771)
 - [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/17544502026)
 - [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17544476083)
 - [x] [Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17544574018)
  - [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17544531762)