### PR TITLE
[skip ci] We should checkout our pr branch in pr-gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -79,6 +79,7 @@ jobs:
       build-type: ${{ inputs.build-type || 'ASan' }}
       publish-artifact: false
       skip-tt-train: true
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
   find-changed-files:
     if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
@@ -152,6 +153,7 @@ jobs:
       publish-artifact: false
       skip-tt-train: true
       distributed: false
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
   metalium-examples:
     needs: [ build, find-changed-files ]
@@ -217,7 +219,7 @@ jobs:
       run: sudo chown -R $(whoami) /github/home # Thanks GH...
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
         fetch-depth: 0
         submodules: "recursive"
     - name: Set safe directory for Git


### PR DESCRIPTION
### Ticket
NA

### Problem description
When PR-Gate runs on PR, it is pulling submodules from main, and not from the pr-branch.

### What's changed
pr-gate can pass the pr SHA to build-artifact when its a pull request.