### PR TITLE
remove persistent buffers from a2a dispatch and a2a combine

### DIFF
--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -20,7 +20,6 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     ReduceScatterAsyncConfig,
     RepeatConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import even_int_div
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -176,43 +175,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         return cls.model_config(hf_config, mesh_device, "prefill")
 
     @classmethod
-    def create_runtime_output_buffers(
-        cls, mesh_device: ttnn.Device, batch_size: int, seq_len: int, cfg: RunDecodeConfig | RunPrefillConfig
-    ) -> dict:
-        batch_size_per_device = even_int_div(batch_size, cfg["num_dispatch_devices"])
-
-        all_to_all_dispatch_output_tensors = ttnn.from_torch(
-            torch.zeros([1, batch_size, seq_len, cfg["hidden_size"]]),
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.bfloat16,
-            memory_config=cfg["all_to_all_dispatch_output_memory_config"],
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        all_to_all_dispatch_metadata_tensors = ttnn.from_torch(
-            torch.zeros([1, batch_size, seq_len, cfg["num_experts_per_tok"]], dtype=torch.int32),
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.uint16,
-            memory_config=cfg["all_to_all_dispatch_metadata_memory_config"],
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        all_to_all_combine_output_tensors = ttnn.from_torch(
-            torch.zeros([cfg["num_experts_per_tok"], batch_size_per_device, seq_len, cfg["hidden_size"]]),
-            device=mesh_device,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            dtype=ttnn.bfloat16,
-            memory_config=cfg["all_to_all_combine_output_memory_config"],
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-
-        return {
-            "all_to_all_dispatch_output_tensors": all_to_all_dispatch_output_tensors,
-            "all_to_all_dispatch_metadata_tensors": all_to_all_dispatch_metadata_tensors,
-            "all_to_all_combine_output_tensors": all_to_all_combine_output_tensors,
-        }
-
-    @classmethod
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         x = ttnn.experimental.all_gather_async(x, **cfg["revert_tp"])
 
@@ -221,8 +183,6 @@ class MoE(SharedStateAddOn, AbstractModule):
             -2
         ]  # Input is expected to be DP. In prefill, this is equivalent to seq_len_per_device
         batch_size = batch_size_per_device * cfg["num_dispatch_devices"]  # Global batch size
-
-        output_buffers = cls.create_runtime_output_buffers(cfg["device"], batch_size, seq_len, cfg)
 
         # 1. MoE gate
         topk_experts_weights, topk_experts_indices = MoEGate.forward(x, cfg["moe_gate"])
@@ -233,18 +193,14 @@ class MoE(SharedStateAddOn, AbstractModule):
         topk_experts_indices_rm = ttnn.reshape(
             topk_experts_indices_rm, shape=(batch_size_per_device, 1, seq_len, cfg["num_experts_per_tok"])
         )
-        ttnn.all_to_all_dispatch(
+        all_to_all_dispatch_output_tensors, all_to_all_dispatch_metadata_tensors = ttnn.all_to_all_dispatch(
             x_rm,
             topk_experts_indices_rm,
             cfg["expert_mapping_tensors"],
-            output_tensors=[
-                output_buffers["all_to_all_dispatch_output_tensors"],
-                output_buffers["all_to_all_dispatch_metadata_tensors"],
-            ],
             **cfg["all_to_all_dispatch"],
         )
         post_all_to_all_dispatch_output = ttnn.reshape(
-            output_buffers["all_to_all_dispatch_output_tensors"], shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
+            all_to_all_dispatch_output_tensors, shape=(1, 1, batch_size * seq_len, cfg["hidden_size"])
         )
         post_all_to_all_dispatch_output = ttnn.repeat(post_all_to_all_dispatch_output, **cfg["activations_repeat"])
         post_all_to_all_dispatch_output = ttnn.to_layout(post_all_to_all_dispatch_output, ttnn.TILE_LAYOUT)
@@ -254,15 +210,14 @@ class MoE(SharedStateAddOn, AbstractModule):
         experts_output = ttnn.reshape(
             experts_output, shape=(cfg["num_experts_per_device"], batch_size, seq_len, cfg["hidden_size"])
         )
-        ttnn.all_to_all_combine(
+        all_to_all_combine_output_tensors = ttnn.all_to_all_combine(
             experts_output,
             cfg["expert_mapping_tensors"],
-            output_buffers["all_to_all_dispatch_metadata_tensors"],
-            optional_output_tensor=output_buffers["all_to_all_combine_output_tensors"],
+            all_to_all_dispatch_metadata_tensors,
             **cfg["all_to_all_combine"],
         )
         post_combine_output_tensor = ttnn.reshape(
-            output_buffers["all_to_all_combine_output_tensors"],
+            all_to_all_combine_output_tensors,
             shape=(cfg["num_experts_per_tok"], 1, batch_size_per_device * seq_len, cfg["hidden_size"]),
         )
         post_combine_output_tensor = ttnn.to_layout(post_combine_output_tensor, ttnn.TILE_LAYOUT)


### PR DESCRIPTION
This pull request refactors the Mixture-of-Experts (MoE) module in `models/demos/deepseek_v3/tt/moe.py` to simplify buffer management and streamline the all-to-all communication logic. The main changes remove the explicit creation and passing of output buffers as these CCLs has internalized the concept.

Refactoring and simplification of buffer management:

* Removed the `create_runtime_output_buffers` method, eliminating manual allocation and management of output buffers for all-to-all operations.

On 6U
No Hangs, correct PCC

On glx-02 (4U)
Seeing a hang on a2a combine. Need to confirm if its an actual hang or just machine issue.



### Checklist
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, 