### PR TITLE
DPRINT Support for UINT16

### DIFF
--- a/tt_metal/hw/inc/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/debug/dprint_pages.h
@@ -45,6 +45,17 @@ inline void print_u8_pages(uint32_t l1_addr, uint32_t bytes_per_page, uint32_t n
     }
 }
 
+inline void print_u16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
+    for (uint32_t page = 0; page < npages; ++page) {
+        DPRINT << start + page << ": ";
+        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+            DPRINT << (uint32_t)*ptr << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
 }  // namespace tt::data_movement::common
 
 #endif

--- a/tt_metal/hw/inc/debug/dprint_tensix.h
+++ b/tt_metal/hw/inc/debug/dprint_tensix.h
@@ -188,6 +188,16 @@ inline void dprint_tensix_dest_reg_row_int32(uint16_t row) {
 #endif
 }
 
+// Helper function that prints one row from dest when dest is configured for storing uint16 values.
+// This function should be used only from dprint_tensix_dest_reg.
+inline void dprint_tensix_dest_reg_row_uint16(uint32_t data_format, uint16_t row) {
+    constexpr int ARRAY_LEN = 8;
+    uint32_t rd_data[ARRAY_LEN + 1];  // data + array type
+    row = get_dest_row_id(row, false);
+    dbg_read_dest_acc_row(row, rd_data);
+    dprint_array_with_data_type(data_format, rd_data, 8);
+}
+
 // Print the contents of tile with index tile_id within the destination register
 template <bool print_by_face = false>
 void dprint_tensix_dest_reg(int tile_id = 0) {
@@ -213,6 +223,9 @@ void dprint_tensix_dest_reg(int tile_id = 0) {
                         break;
                     case (uint32_t)DataFormat::Int32:
                         dprint_tensix_dest_reg_row_int32(row);
+                        break;
+                    case (uint32_t)DataFormat::UInt16:
+                        dprint_tensix_dest_reg_row_uint16(data_format_reg_field_value, row);
                         break;
                     case (uint32_t)DataFormat::Float16_b:
                         dprint_tensix_dest_reg_row_float16(data_format_reg_field_value, row);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Dprint did not support Uint16

### What's changed
Both dprint_pages and dprint_tensix_dest_reg functions have been added to support Uint16 debugging needed for max pool with indices.