### PR TITLE
[skip ci] bugprone-unused-raii

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,6 @@ Checks: >
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-self-assignment,
   -bugprone-unused-local-non-trivial-variable,
-  -bugprone-unused-raii,
   -bugprone-use-after-move,
   -cert-arr39-c,
   -cert-dcl16-c,

--- a/ttnn/core/distributed/distributed_pybind.cpp
+++ b/ttnn/core/distributed/distributed_pybind.cpp
@@ -67,6 +67,7 @@ public:
 
 namespace py = pybind11;
 
+// NOLINTBEGIN(bugprone-unused-raii)
 void py_module_types(py::module& module) {
     py::class_<MeshToTensor, std::unique_ptr<MeshToTensor>>(module, "CppMeshToTensor");
     py::class_<TensorToMesh, std::unique_ptr<TensorToMesh>>(module, "CppTensorToMesh");
@@ -87,6 +88,7 @@ void py_module_types(py::module& module) {
     py::class_<DistributedHostBuffer>(module, "DistributedHostBuffer");
     py::class_<TensorTopology>(module, "TensorTopology");
 }
+// NOLINTEND(bugprone-unused-raii)
 
 void py_module(py::module& module) {
     static_cast<py::class_<MeshShape>>(module.attr("MeshShape"))

--- a/ttnn/cpp/ttnn-pybind/.clang-tidy
+++ b/ttnn/cpp/ttnn-pybind/.clang-tidy
@@ -1,0 +1,2 @@
+InheritParentConfig: true
+Checks: -bugprone-unused-raii


### PR DESCRIPTION
### Ticket
#22758 

### Problem description
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-raii.html

This check was disabled, because it was falsely triggered by pybind11 code.

### What's changed
- Enable check
- Disable it for pybind11 code.