### PR TITLE
Prevent invalid unit MeshDevice objects from being created

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -136,6 +136,23 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
     }
 }
 
+TEST(ThrowOnMultipleMeshDeviceInitialization, UnitMeshes) {
+    auto device_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    std::vector<int> device_ids(device_ids_set.begin(), device_ids_set.end());
+    auto unit_meshes = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(device_ids);
+    for (auto& [_, unit_mesh] : unit_meshes) {
+        EXPECT_EQ(unit_mesh->is_initialized(), true);
+        EXPECT_ANY_THROW(unit_mesh->initialize(
+            /*num_hw_cqs=*/1,
+            /*l1_small_size=*/DEFAULT_L1_SMALL_SIZE,
+            /*trace_region_size=*/DEFAULT_TRACE_REGION_SIZE,
+            /*worker_l1_size=*/DEFAULT_WORKER_L1_SIZE,
+            /*l1_bank_remap=*/{},
+            /*minimal=*/false)
+        );
+    }
+}
+
 TEST_F(MeshDeviceTest, CheckFabricNodeIds) {
     // Check that the fabric node IDs are correctly assigned to the devices in the mesh. Only works for 2D meshes
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -106,6 +106,7 @@ private:
     // protected by api_mutex_. Operations that reconfigure global state (e.g. setting subdevices or enabling tracing)
     // on the device may not be thread safe.
     std::mutex api_mutex_;
+    bool is_internal_state_initialized = false;
     std::shared_ptr<ScopedDevices> scoped_devices_;
     int mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -182,6 +182,8 @@ uint8_t MeshDevice::num_hw_cqs() const {
 }
 
 bool MeshDevice::is_initialized() const {
+    // TODO: Revisit whether we can simplify this when `MeshDevice` initialization isn't so coupled
+    // with individual device initialization.
     if (!is_internal_state_initialized) {
         return false;
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -890,9 +890,8 @@ bool MeshDevice::initialize(
     size_t /*worker_l1_size*/,
     tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
     bool /*minimal*/) {
-    if (this->is_initialized()) {
-        return true;
-    }
+    TT_FATAL(!this->is_initialized(), "MeshDevice is already initialized!");
+
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
     auto sub_devices = {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -182,6 +182,9 @@ uint8_t MeshDevice::num_hw_cqs() const {
 }
 
 bool MeshDevice::is_initialized() const {
+    if (!is_internal_state_initialized) {
+        return false;
+    }
     if (!scoped_devices_) {
         return false;
     }
@@ -324,7 +327,6 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
         device_ids.size());
     std::map<int, std::shared_ptr<MeshDevice>> result;
     for (size_t i = 0; i < device_ids.size(); i++) {
-        submeshes[i]->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
         result[device_ids[i]] = submeshes[i];
     }
     // The Device Profiler must be initialized before Fabric is loaded on the Cluster
@@ -588,6 +590,7 @@ bool MeshDevice::close() {
     sub_device_manager_tracker_.reset();
     scoped_devices_.reset();
     parent_mesh_.reset();
+    is_internal_state_initialized = false;
     return true;
 }
 
@@ -887,6 +890,9 @@ bool MeshDevice::initialize(
     size_t /*worker_l1_size*/,
     tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
     bool /*minimal*/) {
+    if (this->is_initialized()) {
+        return true;
+    }
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
     auto sub_devices = {
@@ -920,6 +926,7 @@ bool MeshDevice::initialize(
         }
     }
     Inspector::mesh_device_initialized(this);
+    is_internal_state_initialized = true;
     return true;
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
When unit MeshDevices are created, `MeshDevice::initialize` was being invoked multiple times. This corrupts `MeshDevice` state by creating duplicate `MeshCommandQueue` entries.


### What's changed
This is fixed by:
1. Removing extraneous call to `MeshDevice::initialize`.
2. Make MeshDevice::initialize() idempotent by tracking whether initialization has been done.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17452162859, https://github.com/tenstorrent/tt-metal/actions/runs/17454472552 (latest)
- [x] [T3K Unit Tests] (https://github.com/tenstorrent/tt-metal/actions/runs/17452162970), https://github.com/tenstorrent/tt-metal/actions/runs/17454500706 (latest)
- [x] Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/17454516929