### PR TITLE
[skip ci] bugprone-nondeterministic-pointer-iteration-order

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,6 @@ Checks: >
   -bugprone-integer-division,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
-  -bugprone-nondeterministic-pointer-iteration-order,
   -bugprone-optional-value-conversion,
   -bugprone-sizeof-expression,
   -bugprone-suspicious-stringview-data-usage,

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -463,11 +463,13 @@ void run_mcast_recv_step(
         recv_programs[dev] = create_receiver_program(compile_time_args, receiver_runtime_args, receiver_logical_core);
     }
     // Run the mcast receiver programs
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         log_debug(tt::LogTest, "Run receiver on: {}", dev->id());
         fixture->RunProgramNonblocking(dev, *recv_program);
     }
 
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         fixture->WaitForSingleProgramDone(dev, *recv_program);
     }
@@ -480,6 +482,7 @@ void run_mcast_recv_step(
         tt::tt_metal::distributed::multihost::Tag{0}              // exchange tests results over tag 0
     );
 
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, _] : recv_programs) {
         std::vector<uint32_t> receiver_status;
         tt_metal::detail::ReadFromDeviceL1(

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -311,6 +311,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     }
 
     // Launch sender and receiver programs and wait for them to finish
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         log_info(tt::LogTest, "Run receiver on: {}", dev->id());
         fixture->RunProgramNonblocking(dev, *recv_program);
@@ -318,6 +319,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     log_info(tt::LogTest, "Run Sender on: {}", sender_device->id());
     fixture->RunProgramNonblocking(sender_device, sender_program);
 
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         fixture->WaitForSingleProgramDone(dev, *recv_program);
     }
@@ -336,6 +338,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     uint64_t sender_bytes =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, _] : recv_programs) {
         std::vector<uint32_t> receiver_status;
         tt_metal::detail::ReadFromDeviceL1(

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -123,6 +123,7 @@ DistributedHostBuffer DistributedHostBuffer::transform(
 
     // Transform one HostBuffer per shard group
     if (policy == ProcessShardExecutionPolicy::SEQUENTIAL || indices_to_process.size() < 2) {
+        // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& [key, group] : shard_group_indices) {
             HostBuffer out = fn(shards[group.front()]->buffer);
             for (size_t i : group) {

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -50,6 +50,7 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
     std::vector<BufferInfo> buffer_infos;
     for (auto device : devices) {
         const auto allocated_buffers = device->allocator()->get_allocated_buffers();
+        // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
             auto address = buffer->address();
@@ -105,6 +106,7 @@ std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::dis
     std::vector<BufferPageInfo> buffer_page_infos;
     for (auto device : devices) {
         const auto allocated_buffers = device->allocator()->get_allocated_buffers();
+        // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& buffer : allocated_buffers) {
             if (not buffer->is_l1()) {
                 continue;


### PR DESCRIPTION
### Ticket
#22758 
Closes #27887 

### Problem description
We had this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/nondeterministic-pointer-iteration-order.html
Iterating over an unordered map of pointers occurs in nondeterministic order.

If iteration order is irrelevant this can be ignored, but it should be considered during development.

```
When violations are basically fine

You truly don’t care about order 
(e.g., you’re just visiting all items, and the order never leaks into user-visible output, hashing, or scheduling decisions). 
In such cases, the warning is informational. The docs say the check is advisory for exactly this reason.
```

### What's changed
- Enable check
- Disable existing violations (PLEASE CHECK THEM)