### PR TITLE
[skip ci] cppcoreguidelines-no-malloc

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,7 +62,6 @@ Checks: >
   -cppcoreguidelines-misleading-capture-default-by-value,
   -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-narrowing-conversions,
-  -cppcoreguidelines-no-malloc,
   -cppcoreguidelines-noexcept-move-operations,
   -cppcoreguidelines-noexcept-swap,
   -cppcoreguidelines-non-private-member-variables-in-classes,

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -21,6 +21,8 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
+
 namespace tt {
 namespace tt_metal {
 class IDevice;
@@ -173,3 +175,5 @@ int main() {
     }
     return 0;
 }
+
+// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -33,6 +33,7 @@ std::ostream& operator<<(std::ostream& os, tt::OStreamJoin<A, B> const& join) {
 
 namespace tt::assert {
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 static std::string demangle(const char* str) {
     size_t size = 0;
     int status = 0;
@@ -47,6 +48,7 @@ static std::string demangle(const char* str) {
     }
     return str;
 }
+// NOLINTEND(cppcoreguidelines-no-malloc)
 
 // https://www.fatalerrors.org/a/backtrace-function-and-assert-assertion-macro-encapsulation.html
 
@@ -56,6 +58,7 @@ static std::string demangle(const char* str) {
  * @param[in] size Maximum number of return layers
  * @param[in] skip Skip the number of layers at the top of the stack
  */
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     std::vector<std::string> bt;
     void** array = (void**)malloc((sizeof(void*) * size));
@@ -73,6 +76,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
 
     return bt;
 }
+// NOLINTEND(cppcoreguidelines-no-malloc)
 
 /**
  * @brief String to get current stack information

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -55,6 +55,7 @@ static std::string noc_address(CoreCoord core, uint64_t a, uint32_t l) {
     return ss.str();
 }
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 static void print_stack_trace() {
     void* array[15];
 
@@ -69,6 +70,7 @@ static void print_stack_trace() {
 
     free(strings);
 }
+// NOLINTEND(cppcoreguidelines-no-malloc)
 
 static void watcher_sanitize_host_noc(
     const char* what,

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.cpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <stdexcept>
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 using namespace ttsl::detail::llvm;
 
 // Check that no bytes are wasted and everything is well-aligned.
@@ -176,3 +177,4 @@ static_assert(
 static_assert(
     sizeof(SmallVectorSizeType<char>) == sizeof(uint32_t), "Expected SmallVectorBase<uint32_t> variant to be in use.");
 #endif
+// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.cpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.cpp
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <stdexcept>
 
-// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 using namespace ttsl::detail::llvm;
 
 // Check that no bytes are wasted and everything is well-aligned.
@@ -120,6 +119,7 @@ static void* replaceAllocation(void* NewElts, size_t TSize, size_t NewCapacity, 
     if (VSize) {
         memcpy(NewEltsReplace, NewElts, VSize * TSize);
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     free(NewElts);
     return NewEltsReplace;
 }
@@ -177,4 +177,3 @@ static_assert(
 static_assert(
     sizeof(SmallVectorSizeType<char>) == sizeof(uint32_t), "Expected SmallVectorBase<uint32_t> variant to be in use.");
 #endif
-// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
@@ -46,6 +46,7 @@
 #include <type_traits>
 #include <utility>
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 namespace ttsl::detail::llvm {
 
 template <typename T>
@@ -1347,3 +1348,5 @@ inline void swap(ttsl::detail::llvm::SmallVector<T, N>& LHS, ttsl::detail::llvm:
 }
 
 }  // end namespace std
+
+// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
@@ -46,7 +46,6 @@
 #include <type_traits>
 #include <utility>
 
-// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 namespace ttsl::detail::llvm {
 
 template <typename T>
@@ -471,6 +470,7 @@ template <typename T, bool TriviallyCopyable>
 void SmallVectorTemplateBase<T, TriviallyCopyable>::takeAllocationForGrow(T* NewElts, size_t NewCapacity) {
     // If this wasn't grown from the inline copy, deallocate the old space.
     if (!this->isSmall()) {
+        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
         free(this->begin());
     }
 
@@ -598,6 +598,7 @@ protected:
     void assignRemote(SmallVectorImpl&& RHS) {
         this->destroy_range(this->begin(), this->end());
         if (!this->isSmall()) {
+            // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
             free(this->begin());
         }
         this->BeginX = RHS.BeginX;
@@ -610,6 +611,7 @@ protected:
         // Subclass has already destructed this vector's elements.
         // If this wasn't grown from the inline copy, deallocate the old space.
         if (!this->isSmall()) {
+            // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
             free(this->begin());
         }
     }
@@ -1348,5 +1350,3 @@ inline void swap(ttsl::detail::llvm::SmallVector<T, N>& LHS, ttsl::detail::llvm:
 }
 
 }  // end namespace std
-
-// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_stl/tt_stl/llvm/memory_alloc.hpp
+++ b/tt_stl/tt_stl/llvm/memory_alloc.hpp
@@ -33,10 +33,10 @@
 #include <cstdlib>
 #include <stdexcept>
 
-// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 namespace ttsl::detail::llvm {
 
 [[nodiscard]] inline void* safe_malloc(size_t Sz) {
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     void* Result = std::malloc(Sz);
     if (Result == nullptr) {
         // It is implementation-defined whether allocation occurs if the space
@@ -51,6 +51,7 @@ namespace ttsl::detail::llvm {
 }
 
 [[nodiscard]] inline void* safe_calloc(size_t Count, size_t Sz) {
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     void* Result = std::calloc(Count, Sz);
     if (Result == nullptr) {
         // It is implementation-defined whether allocation occurs if the space
@@ -65,6 +66,7 @@ namespace ttsl::detail::llvm {
 }
 
 [[nodiscard]] inline void* safe_realloc(void* Ptr, size_t Sz) {
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     void* Result = std::realloc(Ptr, Sz);
     if (Result == nullptr) {
         // It is implementation-defined whether allocation occurs if the space
@@ -79,4 +81,3 @@ namespace ttsl::detail::llvm {
 }
 
 }  // namespace ttsl::detail::llvm
-// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/tt_stl/tt_stl/llvm/memory_alloc.hpp
+++ b/tt_stl/tt_stl/llvm/memory_alloc.hpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <stdexcept>
 
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
 namespace ttsl::detail::llvm {
 
 [[nodiscard]] inline void* safe_malloc(size_t Sz) {
@@ -78,3 +79,4 @@ namespace ttsl::detail::llvm {
 }
 
 }  // namespace ttsl::detail::llvm
+// NOLINTEND(cppcoreguidelines-no-malloc)

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -65,7 +65,7 @@ std::string graph_demangle(const std::string_view name) {
     char* res = abi::__cxa_demangle(name.data(), NULL, NULL, &status);
     const char* const demangled_name = (status == 0) ? res : name.data();
     std::string ret_val(demangled_name);
-    free(res);
+    free(res);  // NOLINT(cppcoreguidelines-no-malloc)
     return ret_val;
 }
 


### PR DESCRIPTION
### Ticket
#22758 
Closes #27893 

### Problem description
We have this check disabled
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/no-malloc.html

Manual memory management is so 1965...

### What's changed
- Enable check
- Disable it for code that currently violates the rule
- From here, the problem shall not grow