### PR TITLE
[skip ci] add codeowners to demos/gemma3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -265,6 +265,7 @@ models/demos/vanilla_unet @dvartaniansTT @tenstorrent/cse-developer-ttnn
 models/demos/sentence_bert @arginugaTT @tenstorrent/cse-developer-ttnn
 models/experimental/grok @yieldthought @uaydonat
 models/experimental/gemma3* @ppetrovicTT @handrewsTT @mtairum @rdraskicTT
+models/demos/gemma3* @ppetrovicTT @handrewsTT @mtairum @rdraskicTT
 models/demos/wormhole/vit @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat
 models/demos/vit @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat
 models/experimental/*yolo*/ @tenstorrent/cse-developer-ttnn @uaydonat


### PR DESCRIPTION
Adding codeowners for `models/demos/gemma3`