### PR TITLE
change LM-Head prefill buffer size on Llama-3.3-70B on Galaxy

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -522,7 +522,7 @@ class TT_CCL:
                 "FF3": [(1, 1, seqlen, 3584)],
                 "FF2": [(1, 1, seqlen, 2048)],
                 "LAYERNORM": [(1, 1, seqlen, 128)],
-                "LM_HEAD": [(1, 1, 32, 16384)],
+                "LM_HEAD": [(4, 1, 32, 16384)],
                 "SAMPLING": [(1, 1, 32, 128 * 1024)],
             }
             for key, shape in buffers_dict.items():


### PR DESCRIPTION
The persistent buffer for LM-Head prefill in Llama-3.3-70B on Galaxy was wrong.