### PR TITLE
Fix `llk_unpack_A_block` to respect `start_tile_index` offset and add failing test case

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -30,7 +30,10 @@ void MAIN {
         cb_reserve_back(out_cb_id, num_single_transfer);
 
         // Copy num_single_transfer tiles from in_cb to DEST
-        copy_block_matmul_partials(in_cb_id, 0, 0, num_single_transfer);
+        for (uint32_t i = 0; i < num_single_transfer; ++i) {
+            copy_block_matmul_partials(in_cb_id, i, i, 1);
+        }
+        
         // Pack num_single_transfer tiles to out_cb
         pack_tile_block(0, out_cb_id, num_single_transfer);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -33,7 +33,6 @@ void MAIN {
         for (uint32_t i = 0; i < num_single_transfer; ++i) {
             copy_block_matmul_partials(in_cb_id, i, i, 1);
         }
-        
         // Pack num_single_transfer tiles to out_cb
         pack_tile_block(0, out_cb_id, num_single_transfer);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -116,7 +116,7 @@ inline void llk_unpack_A_block(
     std::uint32_t operand_id = get_operand_id(operand);
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
-    std::uint32_t address = base_address;
+    std::uint32_t address = base_address + start_tile_index * offset_address;
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -116,7 +116,7 @@ inline void llk_unpack_A_block(
     std::uint32_t operand_id = get_operand_id(operand);
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
-    std::uint32_t address = base_address;
+    std::uint32_t address = base_address + start_tile_index * offset_address;
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");


### PR DESCRIPTION
### Ticket

Fixes #11837 

### Problem description
`tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h::llk_unpack_A_block` does not respect the start_tile_index parameter as an offset into the CB. This leads to incorrect block reads when start_tile_index != 0.

### What's changed

- Modified test kernel call to [copy_block_matmul_partials](https://github.com/tenstorrent/tt-metal/blob/63ec6a01ab79db1d89bb8ce2dced518c2842b371/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp#L33) to do tile by tile copy in a for loop by modifying start_tile_index. This for loop would be executed num_single_transfer times.

- That test should fail with current llk_unpack_A_block implementation for both BH and WH. So later we can modify the `llk_unpack_A_block` implementation to correctly account for start_tile_index when calculating address.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-quick-trigger.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes