### PR TITLE
#23471: SDXL VAE convs optimized

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -22,7 +22,7 @@ import ttnn
 
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 
-SDXL_L1_SMALL_SIZE = 42000
+SDXL_L1_SMALL_SIZE = 29000
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_208_460_670
+    expected_device_perf_cycles_per_iteration = 1_200_568_999
     command = (
         f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_477_531_124
+    expected_device_perf_cycles_per_iteration = 1_208_460_670
     command = (
         f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_200_568_999
+    expected_device_perf_cycles_per_iteration = 1_200_310_545
     command = (
         f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae"
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -36,6 +36,17 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=256,
         )
+        self.conv_configs["ABH_256_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=False,
+            enable_split_reader=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+        )
         self.conv_configs["ABH_128_NO_ADB_HS"] = ttnn.Conv2dConfig(
             weights_dtype=conv_w_dtype,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -47,6 +58,29 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=128,
         )
+        self.conv_configs["ABH_0_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=True,
+            enable_split_reader=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+        )
+
+        self.conv_configs["ABH_32_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=True,
+            enable_split_reader=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=32,
+        )
 
         # BLOCK SHARDED
         self.conv_configs["ABH_0_ADB_WDB_BS"] = ttnn.Conv2dConfig(
@@ -55,19 +89,6 @@ class ModelOptimisations:
             deallocate_activation=True,
             reallocate_halo_output=True,
             enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=0,
-        )
-
-        self.conv_configs["ABH_0_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=False,
             enable_weights_double_buffer=True,
             enable_split_reader=False,
             reshard_if_not_optimal=True,
@@ -87,52 +108,6 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=0,
         )
-        self.conv_configs["ABH_32_NO_ADB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=32,
-        )
-        self.conv_configs["ABH_64_NO_ADB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=64,
-        )
-        self.conv_configs["ABH_64_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=64,
-        )
-        self.conv_configs["ABH_64_NO_ADB_WDB_MOVE_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=False,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=64,
-        )
         self.conv_configs["ABH_64_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -145,82 +120,11 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=64,
         )
-
-        self.conv_configs["ABH_0_ADB_WDB_BS_BF16"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_w_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=True,
-            enable_split_reader=True,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=0,
-        )
-
-        self.conv_configs["ABH_128_ADB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-        )
         self.conv_configs["ABH_128_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             deallocate_activation=True,
             reallocate_halo_output=False,
-            enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-        )
-        self.conv_configs["ABH_128_NO_ADB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-        )
-        self.conv_configs["ABH_128_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-        )
-        self.conv_configs["ABH_128_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=False,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-        )
-        self.conv_configs["ABH_128_NO_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=False,
-            reallocate_halo_output=True,
             enable_act_double_buffer=True,
             enable_weights_double_buffer=True,
             enable_split_reader=False,
@@ -246,30 +150,6 @@ class ModelOptimisations:
             deallocate_activation=True,
             reallocate_halo_output=False,
             enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=256,
-        )
-        self.conv_configs["ABH_256_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=False,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=256,
-        )
-        self.conv_configs["ABH_256_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=False,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
             enable_split_reader=False,
             reshard_if_not_optimal=True,
             act_block_w_div=1,
@@ -302,6 +182,19 @@ class ModelOptimisations:
             act_block_h_override=256,
         )
 
+        self.conv_configs["ABH_512_NO_ADB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            enable_weights_double_buffer=False,
+            enable_split_reader=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=512,
+        )
+
         self.conv_configs["ABH_512_ADB_WDB_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -315,49 +208,10 @@ class ModelOptimisations:
             act_block_h_override=512,
         )
 
-        self.conv_configs["ABH_512_NO_ADB_WDB_BS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=512,
-        )
-
         self.conv_configs["ABH_512_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
             weights_dtype=self.conv_ws_dtype,
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             deallocate_activation=False,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=512,
-        )
-
-        # WIDTH SHARDED
-        self.conv_configs["ABH_256_NO_ADB_WS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=True,
-            enable_act_double_buffer=True,
-            enable_weights_double_buffer=True,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=256,
-        )
-        self.conv_configs["ABH_512_NO_ADB_WS"] = ttnn.Conv2dConfig(
-            weights_dtype=self.conv_ws_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            deallocate_activation=True,
             reallocate_halo_output=True,
             enable_act_double_buffer=True,
             enable_weights_double_buffer=True,
@@ -380,39 +234,6 @@ class ModelOptimisations:
         )
 
         # DRAM CONF
-        self.conv_configs["ABH_64_NO_ADB_DRAM"] = ttnn.Conv2dConfig(
-            weights_dtype=conv_w_dtype,
-            shard_layout=None,
-            deallocate_activation=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=64,
-            output_layout=ttnn.TILE_LAYOUT,
-        )
-        self.conv_configs["ABH_128_NO_ADB_DRAM"] = ttnn.Conv2dConfig(
-            weights_dtype=conv_w_dtype,
-            shard_layout=None,
-            deallocate_activation=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=128,
-            output_layout=ttnn.TILE_LAYOUT,
-        )
-        self.conv_configs["ABH_512_NO_ADB_DRAM"] = ttnn.Conv2dConfig(
-            weights_dtype=conv_w_dtype,
-            shard_layout=None,
-            deallocate_activation=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=False,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=512,
-            output_layout=ttnn.TILE_LAYOUT,
-        )
         self.conv_configs["DEFAULT_DRAM"] = ttnn.Conv2dConfig(
             weights_dtype=conv_w_dtype,
             shard_layout=None,
@@ -423,17 +244,6 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=0,
             output_layout=ttnn.TILE_LAYOUT,
-        )
-        self.conv_configs["ABH_256_NO_ADB_HS"] = ttnn.Conv2dConfig(
-            weights_dtype=conv_w_dtype,
-            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            deallocate_activation=True,
-            reallocate_halo_output=False,
-            enable_act_double_buffer=False,
-            enable_split_reader=True,
-            reshard_if_not_optimal=True,
-            act_block_w_div=1,
-            act_block_h_override=256,
         )
 
         self.matmul_configs["2D_LINEAR_ATTENTION_DO_SEQ_LEN_4096"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -1026,24 +836,30 @@ class ModelOptimisations:
                 return self.conv_configs["DEFAULT"]
         else:
             # VAE
+            # DECODER CONV IN
             if "decoder.conv_in" == conv_path:
-                return self.conv_configs["ABH_256_NO_ADB_HS"]
-            elif ("decoder.up_blocks.2.resnet.0" in conv_path) and ("conv1" in conv_path):
-                return self.conv_configs["ABH_128_NO_ADB_DRAM"]
-            elif ("decoder.up_blocks.2.resnet" in conv_path) and ("conv1" in conv_path):
-                return self.conv_configs["ABH_64_NO_ADB_DRAM"]  # should be 128, OOM in demo
-            # elif ("decoder.up_blocks.2.resnet" in conv_path) and ("conv2" in conv_path):
-            #     return self.conv_configs["ABH_32_NO_ADB_DRAM"] # Note: ABH should be 128 (OOM)
-            elif "decoder.up_blocks.2.upsamplers.0" == conv_path:
-                return self.conv_configs["ABH_64_NO_ADB_DRAM"]  # should be 128, OOM in demo
+                return self.conv_configs["ABH_0_ADB_HS"]
+            # MID BLOCK and UP BLOCK 0
+            elif "decoder.mid_block.resnet" in conv_path or "decoder.up_blocks.0.resnet" in conv_path:
+                return self.conv_configs["ABH_512_NO_ADB_BS"]
+            elif "decoder.up_blocks.0.upsamplers" in conv_path:
+                return self.conv_configs["ABH_256_NO_ADB_BS"]
+            # UP BLOCK 1
+            elif "decoder.up_blocks.1.resnet" in conv_path:
+                return self.conv_configs["ABH_256_NO_ADB_BS"]
+            elif "decoder.up_blocks.1.upsamplers" in conv_path:
+                return self.conv_configs["ABH_256_NO_ADB_BS"]
+            # UP BLOCK 2
+            elif "decoder.up_blocks.2.resnet" in conv_path:
+                return self.conv_configs["ABH_512_NO_ADB_BS"]
+            elif "decoder.up_blocks.1.upsamplers" in conv_path:
+                return self.conv_configs["ABH_512_NO_ADB_BS"]
+            # UP BLOCK 3
+            elif "decoder.up_blocks.3.resnet" in conv_path:
+                return self.conv_configs["ABH_32_ADB_HS"]
+            # DECODER CONV OUT
             elif "decoder.conv_out" == conv_path:
-                return self.conv_configs["ABH_512_NO_ADB_DRAM"]
-            elif (
-                "decoder.mid_block.resnet" in conv_path
-                or "decoder.up_blocks.0.resnet" in conv_path
-                and not "upsampler" in conv_path
-            ):
-                return self.conv_configs["ABH_128_NO_ADB_BS"]
+                return self.conv_configs["ABH_256_NO_ADB_HS"]
             else:
                 return self.conv_configs["DEFAULT_DRAM"]
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -65,6 +65,7 @@ class TtDecoder(LightweightModule):
         )
 
         self.compute_in_config = model_config.get_conv_compute_config(module_path="decoder.conv_in")
+        self.conv_in_config = model_config.get_conv_config(conv_path="decoder.conv_in")
         (
             self.tt_conv_in_weights,
             self.tt_conv_in_bias,
@@ -72,12 +73,12 @@ class TtDecoder(LightweightModule):
         ) = prepare_conv_params(
             conv_in_weights,
             conv_in_bias,
-            model_config.conv_w_dtype,
+            self.conv_in_config.weights_dtype,
         )
         self.conv_in_slice_config = get_DRAM_conv_config(None, 1)
-        self.conv_in_config = model_config.get_conv_config(conv_path="decoder.conv_in")
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="decoder.conv_out")
+        self.conv_out_config = model_config.get_conv_config(conv_path="decoder.conv_out")
         (
             self.tt_conv_out_weights,
             self.tt_conv_out_bias,
@@ -85,10 +86,9 @@ class TtDecoder(LightweightModule):
         ) = prepare_conv_params(
             conv_out_weights,
             conv_out_bias,
-            model_config.conv_w_dtype,
+            self.conv_out_config.weights_dtype,
         )
         self.conv_out_slice_config = get_DRAM_conv_config(None, 2)
-        self.conv_out_config = model_config.get_conv_config(conv_path="decoder.conv_out")
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -37,13 +37,13 @@ class TtUpsample2D(LightweightModule):
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         self.compute_config = model_config.get_conv_compute_config(module_path=module_path)
+        self.conv_config = model_config.get_conv_config(conv_path=module_path)
         self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
             weights,
             bias,
-            model_config.conv_w_dtype,
+            self.conv_config.weights_dtype,
         )
         self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
-        self.conv_config = model_config.get_conv_config(conv_path=module_path)
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def interpolate(self, hidden_states):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -31,17 +31,44 @@ def get_DRAM_GN_config(module_path, idx):
 
 
 def get_DRAM_conv_config(module_path, idx):
+    num_slices = 0
     if module_path is None:
         if idx == 1:
             return None
+        else:
+            num_slices = 8
     elif "mid_block" in module_path:
         return None
     else:
         parts = module_path.split(".")
         block_id = int(parts[parts.index("up_blocks") + 1])
-        if "upsamplers" not in module_path and block_id == 0:
-            return None
+
+        if block_id == 0:
+            if "upsamplers" not in module_path:
+                return None
+            else:
+                num_slices = 2
+        if block_id == 1:
+            if "upsamplers" not in module_path:
+                num_slices = 2
+            else:
+                num_slices = 8
+        if block_id == 2:
+            if "upsamplers" not in module_path:
+                if "resnets.0" in module_path and idx == 1:
+                    num_slices = 8
+                else:
+                    num_slices = 4
+            else:
+                num_slices = 16
+        if block_id == 2 and "upsamplers" not in module_path:
+            if "resnets.0" in module_path and idx == 1:
+                num_slices = 16
+            else:
+                num_slices = 8
+
     slice_type = ttnn.Conv2dSliceWidth
     return ttnn.Conv2dSliceConfig(
         slice_type=slice_type,
+        num_slices=num_slices,
     )

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -61,7 +61,7 @@ def get_DRAM_conv_config(module_path, idx):
                     num_slices = 4
             else:
                 num_slices = 16
-        if block_id == 2 and "upsamplers" not in module_path:
+        if block_id == 3 and "upsamplers" not in module_path:
             if "resnets.0" in module_path and idx == 1:
                 num_slices = 16
             else:

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3444,34 +3444,26 @@ def test_conv2d_sdxl_refiner(
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, auto_shard, deallocate_activation, slice_type, num_slices, act_block_h_override",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, deallocate_activation, slice_type, num_slices, act_block_h_override",
     (
         # 1024x1024 resolution
 
         # VAE
         # kernel 3x3
-        (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 8, 32),
-        (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 16, 32),
-        (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 16, 128),
-        (1, 256, 256, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 4, 64),
-        (1, 512, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, None, 1, 128),
-        (1, 512, 512, 256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 2, 32),
-        (1, 512, 256, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 8, 64),
-        (1, 512, 512, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 8, 32),
+        (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dSliceWidth, 8, 32),
+        (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dSliceWidth, 16, 32),
+        (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dSliceWidth, 16, 512),
+        (1, 256, 256, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dSliceWidth, 4, 512),
+        (1, 512, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, None, 1, 512),
+        (1, 512, 512, 256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dSliceWidth, 2, 256),
+        (1, 512, 256, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dSliceWidth, 8, 512),
+        (1, 512, 512, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dSliceWidth, 8, 256),
 
         # output_channels 3
-        (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, ttnn.Conv2dSliceWidth, 16, 512),
+        (1, 128, 3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dSliceWidth, 8, 256),
 
         # input_channels 4
-        (1, 4, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False, None, 1, 256),
-
-        # kernel 1x1
-        (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0), (1, 1), True, False, None, 1, 0),
-        (1, 512, 256, 512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0), (1, 1), True, False, None, 1, 0),
-
-        # channels 4
-        # Skip specific test case for Blackhole devices
-        (1, 4, 4, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (1, 1), (1, 1), (0, 0), (1, 1), True, False, None, 1, 0),
+        (1, 4, 512, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, None, 1, 0),
     ),
 )
 
@@ -3492,13 +3484,12 @@ def test_conv2d_vae_sdxl(
     stride,
     padding,
     dilation,
-    auto_shard,
+    shard_layout,
     deallocate_activation,
     slice_type,
     num_slices,
     act_block_h_override
 ):
-
     # Skip all on N300
     if device.core_grid.y != 8 and is_wormhole_b0():
         pytest.skip("Needs 8x8 grid for wormhole_b0")
@@ -3513,7 +3504,7 @@ def test_conv2d_vae_sdxl(
     slice_config = ttnn.Conv2dSliceConfig(
         slice_type=slice_type,
         num_slices=num_slices,
-    ) if num_slices > 1 and slice_type is not None else None
+    ) if num_slices > 1 or slice_type is not None else None
 
 
     run_conv(
@@ -3541,15 +3532,15 @@ def test_conv2d_vae_sdxl(
         deallocate_activation=deallocate_activation,
         groups=groups,
         has_bias=True,
-        shard_layout=None,
-        auto_shard=auto_shard,
+        shard_layout=shard_layout,
         memory_config=None,
         input_mesh_mapper=None,
         weight_mesh_mapper=None,
         output_mesh_composer=None,
-        enable_split_reader=False,
         slice_config=slice_config,
         input_layout=ttnn.TILE_LAYOUT,
+        enable_act_double_buffer=False, # TODO: this is set to true in SDXL, need to adapt tests
+        enable_split_reader=True if shard_layout == HS else False,
     )
 
 


### PR DESCRIPTION
### Ticket
#23471 

### What's changed
Optimized VAE convs, this resulted in reduciton of L1 SMALL size.

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17462539812) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17462535580) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17467544978) CI passes