### PR TITLE
Update vLLM nightly test artifacts to include job name and update job names to include WH/BH

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "[T3K] Llama-3.1-8B-Instruct",
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 5,
             benchmark-timeout: 5,
@@ -37,7 +37,7 @@ jobs:
             co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
           {
-            name: "[T3K] Qwen2.5-VL-72B-Instruct",
+            name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
             server-timeout: 30,
             benchmark-timeout: 15,
@@ -48,7 +48,7 @@ jobs:
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
           {
-            name: "[DB] Llama-3.1-8B-Instruct",
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 5,
             benchmark-timeout: 5,
@@ -59,7 +59,7 @@ jobs:
             owner_id: U08GELBB1AP, # Ambrose Ling
           },
           {
-            name: "[QB] Llama-3.1-8B-Instruct",
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 5,
             benchmark-timeout: 5,
@@ -71,7 +71,7 @@ jobs:
           },
           # {
           #   Removing this until #26734 is resolved
-          #   name: "[RB] Llama-3.1-8B-Instruct",
+          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
           #   server-timeout: 35,
           #   benchmark-timeout: 10,
@@ -82,7 +82,7 @@ jobs:
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
           {
-            name: "[TG] Llama-3.3-70B-Instruct",
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
             model: "meta-llama/Llama-3.3-70B-Instruct",
             server-timeout: 35,
             benchmark-timeout: 10,
@@ -94,7 +94,7 @@ jobs:
             co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
           {
-            name: "[TG] Llama-8B DP=16",
+            name: "[WH-GLX] Llama-8B DP=16",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 10,
             benchmark-timeout: 5,
@@ -106,7 +106,7 @@ jobs:
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },
           {
-            name: "[T3K] Gemma3-27B",
+            name: "[WH-T3K] Gemma3-27B",
             model: "google/gemma-3-27b-it",
             server-timeout: 10,
             benchmark-timeout: 5,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -294,12 +294,19 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: ${{ matrix.test-group.co-owner-2-id }}
 
+      - name: Set artifact prefix
+        id: set-artifact-prefix
+        run: |
+          # Replace spaces with underscores
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' ' '_')
+          echo "prefix=vllm_output_${SAFE_NAME}_" >> $GITHUB_OUTPUT
+
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           path: docker-job/output/
-          prefix: "vllm_output_"
+          prefix: ${{ steps.set-artifact-prefix.outputs.prefix }}
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The artifacts produced during the vLLM nightly jobs did not have descriptive names, making it hard to find the artifact corresponding to each job.

### What's changed
- Updated the artifact names to include the test group name (with spaces replaced with underscores)
- Also modified test group names to include WH/BH for clarity

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

vLLM nightly tests - https://github.com/tenstorrent/tt-metal/actions/runs/17472894729