### PR TITLE
Update references to models/common python files

### DIFF
--- a/models/demos/grayskull/functional_bloom/demo/demo_causal_lm.py
+++ b/models/demos/grayskull/functional_bloom/demo/demo_causal_lm.py
@@ -12,10 +12,10 @@ from loguru import logger
 from transformers import BloomConfig, BloomForCausalLM, BloomTokenizerFast
 from ttnn.model_preprocessing import preprocess_model_parameters
 
-from models import generation_utils
+from models.common import generation_utils
+from models.common.utility_functions import disable_persistent_kernel_cache, profiler
 from models.demos.grayskull.functional_bloom.dataset_utils import get_data
 from models.demos.grayskull.functional_bloom.tt import ttnn_functional_bloom, ttnn_optimized_functional_bloom
-from models.utility_functions import disable_persistent_kernel_cache, profiler
 
 
 def generate_next_token(

--- a/models/demos/grayskull/functional_bloom/demo/demo_qa.py
+++ b/models/demos/grayskull/functional_bloom/demo/demo_qa.py
@@ -12,9 +12,9 @@ from loguru import logger
 from transformers import BloomConfig, BloomForCausalLM, BloomTokenizerFast
 from ttnn.model_preprocessing import preprocess_model_parameters
 
-from models import generation_utils
+from models.common import generation_utils
+from models.common.utility_functions import disable_persistent_kernel_cache, profiler
 from models.demos.grayskull.functional_bloom.tt import ttnn_functional_bloom, ttnn_optimized_functional_bloom
-from models.utility_functions import disable_persistent_kernel_cache, profiler
 
 
 def generate_next_token(

--- a/models/demos/grayskull/t5/demo/conditional_generation_demo.py
+++ b/models/demos/grayskull/t5/demo/conditional_generation_demo.py
@@ -13,9 +13,9 @@ from transformers import AutoTokenizer, T5Config, T5ForConditionalGeneration
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.common.generation_utils import get_logits_processor
+from models.common.utility_functions import disable_persistent_kernel_cache, profiler
 from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
-from models.generation_utils import get_logits_processor
-from models.utility_functions import disable_persistent_kernel_cache, profiler
 
 
 def load_inputs(input_path, batch):

--- a/models/demos/grayskull/t5/demo/question_answering_demo.py
+++ b/models/demos/grayskull/t5/demo/question_answering_demo.py
@@ -13,9 +13,9 @@ from transformers import AutoTokenizer, T5Config, T5ForConditionalGeneration
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.common.generation_utils import get_logits_processor
+from models.common.utility_functions import disable_persistent_kernel_cache, profiler
 from models.demos.grayskull.t5.tt import ttnn_functional_t5, ttnn_optimized_functional_t5
-from models.generation_utils import get_logits_processor
-from models.utility_functions import disable_persistent_kernel_cache, profiler
 
 
 def load_inputs(input_path, batch):

--- a/models/demos/grayskull/t5/test_demo.py
+++ b/models/demos/grayskull/t5/test_demo.py
@@ -12,9 +12,9 @@ from transformers import AutoTokenizer, T5Config, T5ForConditionalGeneration
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.common.generation_utils import get_logits_processor
+from models.common.utility_functions import disable_persistent_kernel_cache, enable_persistent_kernel_cache
 from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
-from models.generation_utils import get_logits_processor
-from models.utility_functions import disable_persistent_kernel_cache, enable_persistent_kernel_cache
 
 
 def load_inputs(input_path, batch):

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -23,11 +23,11 @@ from transformers import (
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.common.generation_utils import get_logits_processor
+from models.common.utility_functions import is_blackhole
 from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.whisper.tt import ttnn_optimized_functional_whisper
 from models.demos.whisper.tt.ttnn_optimized_functional_whisper import WHISPER_L1_SMALL_SIZE, init_kv_cache
-from models.generation_utils import get_logits_processor
-from models.utility_functions import is_blackhole
 
 
 def load_input_paths(folder_path):

--- a/models/experimental/bloom/bloom_utils.py
+++ b/models/experimental/bloom/bloom_utils.py
@@ -6,7 +6,7 @@ import torch
 import json
 import ttnn
 
-from models.generation_utils import get_logits_processor
+from models.common.generation_utils import get_logits_processor
 
 mem_config = ttnn.L1_MEMORY_CONFIG
 

--- a/models/experimental/deit/tt/deit_for_image_classification.py
+++ b/models/experimental/deit/tt/deit_for_image_classification.py
@@ -10,8 +10,8 @@ import ttnn
 
 from models.experimental.deit.tt.deit_config import DeiTConfig
 from models.experimental.deit.tt.deit_model import TtDeiTModel
-from models.helper_funcs import Linear as TtLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import (
     torch_to_tt_tensor_rm,
 )
 

--- a/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
+++ b/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
@@ -11,8 +11,8 @@ import ttnn
 
 from models.experimental.deit.tt.deit_config import DeiTConfig
 from models.experimental.deit.tt.deit_model import TtDeiTModel
-from models.helper_funcs import Linear as TtLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
 )

--- a/models/experimental/deit/tt/deit_intermediate.py
+++ b/models/experimental/deit/tt/deit_intermediate.py
@@ -8,8 +8,8 @@ import ttnn
 
 from models.experimental.deit.tt.activations import ACT2FN
 from models.experimental.deit.tt.deit_config import DeiTConfig
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 
 
 class TtDeiTIntermediate(nn.Module):

--- a/models/experimental/deit/tt/deit_output.py
+++ b/models/experimental/deit/tt/deit_output.py
@@ -6,8 +6,8 @@ from torch import nn
 
 import ttnn
 
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 from models.experimental.deit.tt.deit_config import DeiTConfig
 
 

--- a/models/experimental/deit/tt/deit_pooler.py
+++ b/models/experimental/deit/tt/deit_pooler.py
@@ -6,8 +6,8 @@ from torch import nn
 
 
 import ttnn
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 from models.experimental.deit.tt.deit_config import DeiTConfig
 
 

--- a/models/experimental/deit/tt/deit_self_attention.py
+++ b/models/experimental/deit/tt/deit_self_attention.py
@@ -8,8 +8,8 @@ from typing import Optional
 
 import ttnn
 from tt_lib.fallback_ops import fallback_ops
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 from models.experimental.deit.tt.deit_config import DeiTConfig
 
 

--- a/models/experimental/deit/tt/deit_self_output.py
+++ b/models/experimental/deit/tt/deit_self_output.py
@@ -6,8 +6,8 @@ from torch import nn
 
 
 import ttnn
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 from models.experimental.deit.tt.deit_config import DeiTConfig
 
 

--- a/models/experimental/distilbert/tt/distilbert_ffn.py
+++ b/models/experimental/distilbert/tt/distilbert_ffn.py
@@ -4,11 +4,9 @@
 
 import torch.nn as nn
 
-from models.utility_functions import (
-    torch_to_tt_tensor_rm,
-)
 import ttnn
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 
 
 class TtFFN(nn.Module):

--- a/models/experimental/distilbert/tt/distilbert_for_question_answering.py
+++ b/models/experimental/distilbert/tt/distilbert_for_question_answering.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple, Union
 import torch.nn as nn
 from dataclasses import dataclass
 
-from models.utility_functions import (
+from models.common.utility_functions import (
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
 )
@@ -14,7 +14,7 @@ from models.utility_functions import (
 import ttnn
 from dataclasses import dataclass
 from models.experimental.distilbert.tt.distilbert_model import TtDistilBertModel
-from models.helper_funcs import Linear as TtLinear
+from models.common.helper_funcs import Linear as TtLinear
 
 
 @dataclass

--- a/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
+++ b/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
@@ -6,13 +6,13 @@ from typing import Optional, Tuple, List
 import torch
 import torch.nn as nn
 
-from models.utility_functions import (
+from models.common.utility_functions import (
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
 )
 import ttnn
 import tt_lib.fallback_ops as fallback_ops
-from models.helper_funcs import Linear as TtLinear
+from models.common.helper_funcs import Linear as TtLinear
 
 
 class TtMultiHeadSelfAttention(nn.Module):

--- a/models/experimental/hrnet/tt/hrnet_model.py
+++ b/models/experimental/hrnet/tt/hrnet_model.py
@@ -8,14 +8,12 @@ import timm
 
 import ttnn
 from tt_lib.fallback_ops import fallback_ops
-from models.utility_functions import torch_to_tt_tensor_rm
-
-from models.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear as TtLinear
 
 from models.experimental.hrnet.tt.basicblock import TtBasicBlock
 from models.experimental.hrnet.tt.bottleneck import TtBottleneck
 from models.experimental.hrnet.tt.high_resolution_module import TtHighResolutionModule
-
 
 from models.experimental.hrnet.hrnet_utils import create_batchnorm
 

--- a/models/experimental/llama/tt/llama_attention.py
+++ b/models/experimental/llama/tt/llama_attention.py
@@ -10,8 +10,8 @@ import ttnn
 from typing import Optional, Tuple
 from loguru import logger
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
     pad_by_zero,

--- a/models/experimental/nanogpt/tt/nanogpt_attention.py
+++ b/models/experimental/nanogpt/tt/nanogpt_attention.py
@@ -5,9 +5,9 @@
 import torch.nn as nn
 import ttnn
 import math
-from models.helper_funcs import Linear
+from models.common.helper_funcs import Linear
 
-from models.utility_functions import (
+from models.common.utility_functions import (
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
 )

--- a/models/experimental/nanogpt/tt/nanogpt_mlp.py
+++ b/models/experimental/nanogpt/tt/nanogpt_mlp.py
@@ -4,7 +4,7 @@
 
 import torch
 import ttnn
-from models.helper_funcs import Linear
+from models.common.helper_funcs import Linear
 
 
 class TtMLP(torch.nn.Module):

--- a/models/experimental/nanogpt/tt/nanogpt_model.py
+++ b/models/experimental/nanogpt/tt/nanogpt_model.py
@@ -5,7 +5,7 @@
 import torch
 import torch.nn as nn
 import ttnn
-from models.helper_funcs import Linear
+from models.common.helper_funcs import Linear
 import tt_lib.fallback_ops as fallback_ops
 
 import ttnn
@@ -13,7 +13,7 @@ import ttnn
 import models.experimental.nanogpt.tt.nanogpt_block as nanogpt_block
 from models.experimental.nanogpt.nanogpt_utils import unpad_from_zero
 
-from models.utility_functions import (
+from models.common.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
 )

--- a/models/experimental/roberta/tt/roberta_classification_head.py
+++ b/models/experimental/roberta/tt/roberta_classification_head.py
@@ -6,8 +6,8 @@ import torch.nn as nn
 
 import ttnn
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import tt2torch_tensor, pad_by_zero
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import tt2torch_tensor, pad_by_zero
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 

--- a/models/experimental/roberta/tt/roberta_intermediate.py
+++ b/models/experimental/roberta/tt/roberta_intermediate.py
@@ -7,8 +7,8 @@ import torch.nn as nn
 
 import ttnn
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     tt2torch_tensor,
     pad_by_zero,
 )

--- a/models/experimental/roberta/tt/roberta_output.py
+++ b/models/experimental/roberta/tt/roberta_output.py
@@ -10,8 +10,8 @@ from functools import partial
 
 import ttnn
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     pad_by_zero,
 )
 

--- a/models/experimental/roberta/tt/roberta_pooler.py
+++ b/models/experimental/roberta/tt/roberta_pooler.py
@@ -7,8 +7,8 @@ import torch.nn as nn
 
 import ttnn
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     tt2torch_tensor,
     pad_by_zero,
 )

--- a/models/experimental/roberta/tt/roberta_self_attention.py
+++ b/models/experimental/roberta/tt/roberta_self_attention.py
@@ -11,8 +11,8 @@ from typing import Optional, Tuple
 import ttnn
 
 from tt_lib.fallback_ops import fallback_ops
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     tt2torch_tensor,
     pad_by_zero,
 )

--- a/models/experimental/roberta/tt/roberta_self_output.py
+++ b/models/experimental/roberta/tt/roberta_self_output.py
@@ -8,8 +8,8 @@ from functools import partial
 
 import ttnn
 
-from models.helper_funcs import Linear as TTLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TTLinear
+from models.common.utility_functions import (
     pad_by_zero,
 )
 

--- a/models/experimental/t5/demo/demo_utils.py
+++ b/models/experimental/t5/demo/demo_utils.py
@@ -5,7 +5,7 @@
 import ttnn
 from loguru import logger
 from transformers import AutoTokenizer
-from models.generation_utils import run_generate
+from models.common.generation_utils import run_generate
 
 
 def run_demo_t5(t5_model_constructor):

--- a/models/experimental/t5/t5_utils.py
+++ b/models/experimental/t5/t5_utils.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
-from models.generation_utils import pad_input_32, get_logits_processor
+from models.common.generation_utils import pad_input_32, get_logits_processor
 
 
 def run_generate(

--- a/models/experimental/t5/tests/test_t5_for_conditional_generation.py
+++ b/models/experimental/t5/tests/test_t5_for_conditional_generation.py
@@ -10,8 +10,8 @@ from models.experimental.t5.tt.t5_for_conditional_generation import (
     t5_base_for_conditional_generation,
     flan_t5_small_for_conditional_generation,
 )
-from models.generation_utils import run_generate
-from models.utility_functions import comp_pcc
+from models.common.generation_utils import run_generate
+from models.common.utility_functions import comp_pcc
 
 
 def run_T5ForConditionalGeneration(device, model_constructor, model_name):

--- a/models/experimental/trocr/tt/trocr_attention.py
+++ b/models/experimental/trocr/tt/trocr_attention.py
@@ -10,8 +10,8 @@ from typing import Optional, Tuple
 import ttnn
 from tt_lib import fallback_ops
 
-from models.helper_funcs import Linear
-from models.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear
+from models.common.utility_functions import torch_to_tt_tensor_rm
 
 
 class TtTrOCRAttention(nn.Module):

--- a/models/experimental/trocr/tt/trocr_decoder_layer.py
+++ b/models/experimental/trocr/tt/trocr_decoder_layer.py
@@ -6,8 +6,8 @@ import torch.nn as nn
 from typing import Optional, Tuple
 
 import ttnn
-from models.utility_functions import torch_to_tt_tensor_rm
-from models.helper_funcs import Linear
+from models.common.utility_functions import torch_to_tt_tensor_rm
+from models.common.helper_funcs import Linear
 from models.experimental.trocr.tt.trocr_attention import TtTrOCRAttention
 from models.experimental.trocr.tt.trocr_configuration import TtTrOCRConfig
 

--- a/models/experimental/trocr/tt/trocr_for_causal_llm.py
+++ b/models/experimental/trocr/tt/trocr_for_causal_llm.py
@@ -9,9 +9,9 @@ from typing import Optional, Tuple, Union
 from dataclasses import dataclass
 
 import ttnn
-from models.utility_functions import torch_to_tt_tensor_rm
+from models.common.utility_functions import torch_to_tt_tensor_rm
 from models.experimental.trocr.tt.trocr_decoder_wrapper import TtTrOCRDecoderWrapper
-from models.helper_funcs import Linear
+from models.common.helper_funcs import Linear
 
 
 @dataclass

--- a/models/experimental/vgg/tt/vgg.py
+++ b/models/experimental/vgg/tt/vgg.py
@@ -10,8 +10,8 @@ from typing import List, Union, Dict, cast
 import ttnn
 
 from tt_lib.fallback_ops import fallback_ops
-from models.helper_funcs import Linear as TtLinear
-from models.utility_functions import (
+from models.common.helper_funcs import Linear as TtLinear
+from models.common.utility_functions import (
     is_conv_supported_on_device,
     run_conv_on_device_wrapper,
 )

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -11,8 +11,8 @@ import ttnn._ttnn
 import ttnn.operations
 import ttnn.operations.matmul
 import ttnn.operations.reduction
-from models.helper_funcs import Linear as tt_Linear
-from models.utility_functions import torch2tt_tensor, tt2torch_tensor, ttl_complex_2_torch_complex
+from models.common.helper_funcs import Linear as tt_Linear
+from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, ttl_complex_2_torch_complex
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
 from tests.ttnn.utils_for_testing import assert_with_pcc
 

--- a/tests/ttnn/integration_tests/bloom/test_bloom_for_causal_lm.py
+++ b/tests/ttnn/integration_tests/bloom/test_bloom_for_causal_lm.py
@@ -8,10 +8,10 @@ from loguru import logger
 from transformers import BloomConfig, BloomForCausalLM, BloomTokenizerFast
 
 
-from models import generation_utils
+from models.common import generation_utils
 from models.demos.grayskull.functional_bloom.reference import torch_functional_bloom
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
-from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
+from models.common.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 
 from ttnn.model_preprocessing import preprocess_model_parameters
 

--- a/ttnn/tt_lib/fused_ops/linear.py
+++ b/ttnn/tt_lib/fused_ops/linear.py
@@ -14,7 +14,7 @@ def Linear(in_features: int, out_features: int, weight: List[Union[int, float]],
 
     ``weight`` must be the weight as a tilized list of values.
     """
-    logger.warning("Linear will be deprecated soon, please use linear in models/helper_funcs")
+    logger.warning("Linear will be deprecated soon, please use linear in models/common/helper_funcs")
     assert weight.get_layout() == ttnn.TILE_LAYOUT
     weight = weight.to(device)
 


### PR DESCRIPTION
### Ticket
[Update references to models/common python files #27961](https://github.com/tenstorrent/tt-metal/issues/27961)

### Problem
References are pointing to temporary redirecting files

### What's changed
Updated the following references to reflect files new location
- All references of models/common/generation_utils.py
- All references of models/common/helper_funcs.py
    - Only the references of models/common/utility_functions.py that were on the same files as the references above.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17474659467) CI passes
- [x] [Models Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17565466392) passes (with a few tests failing for reasons unrelated to these changes)
- [x] New/Existing tests provide coverage for changes