### PR TITLE
[skip ci] Split single-card-demo-tests.yaml by frequency

### DIFF
--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "(Single-card) Demo tests"
+name: "(Single-card) Demo tests${{ github.event.schedule == '0 */4 * * 0,6' && ' (with perf runs)' || ' (no perf)' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -12,8 +12,8 @@ on:
         type: boolean
         default: true
   schedule:
-    - cron: "0 5 * * 1,2,3,4,5"
-    - cron: "0 */4 * * 0,6"
+    - cron: "0 5 * * 1,2,3,4,5" # frequency of functional models
+    - cron: "0 */4 * * 0,6" # frequency of perf models
 
 jobs:
   build-artifact:
@@ -37,4 +37,4 @@ jobs:
       # Using || true after is dangerous since that will always be passed in if first value is falsy
       # which it can be if inputs.run-perf-tests isn't clicked. So, scope the default true to only
       # when we're not using workflow_dispatch and can't possibly have an input anyway
-      run-perf-tests: ${{ inputs.run-perf-tests || (github.event_name != 'workflow_dispatch' && true) }}
+      run-perf-tests: ${{ inputs.run-perf-tests || (github.event_name != 'workflow_dispatch' && github.event.schedule == '0 */4 * * 0,6') }}


### PR DESCRIPTION
### What's changed
Split tests in Single-card Demo pipeline by frequent tests (evaluates functionality) and non-frequent tests (evaluates performance)
