### PR TITLE
[Deepseek] Lm_head intergrated. PCC=0.84 needs debug

### DIFF
--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -71,7 +71,7 @@ def test_forward_pass(
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
     # Setup: Convert weights and get weight_config
-    weight_config = LMHead.convert_weights(hf_config, [state_dict], tmp_path, mesh_device)
+    weight_config = LMHead.convert_weights(hf_config, [state_dict], tmp_path, mesh_device, state_dict_prefix="lm_head.")
     model_config = get_model_config(LMHead, mode, hf_config, mesh_device, 3)
     model_state = LMHead.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -9,7 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Model
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3ForCausalLM
 from models.demos.deepseek_v3.tt.mla_1d import MLA1D
 from models.demos.deepseek_v3.tt.model_1d import Model1D
 from models.demos.deepseek_v3.tt.rope import RotarySetup
@@ -32,15 +32,18 @@ def merge_dicts(parent, child, prefix):
             parent[prefix + f"{k}"] = v
 
 
-def create_whole_model_state_dict(model_path, hf_config):
+def create_whole_model_state_dict(model_path, hf_config, prefix="model."):
     state_dict = {}
+
     state_dict_temp = load_state_dict(model_path, "model.embed_tokens")
-    merge_dicts(state_dict, state_dict_temp, "embed_tokens.")
+    merge_dicts(state_dict, state_dict_temp, prefix + "embed_tokens.")
     for li in range(hf_config.num_hidden_layers):
         state_dict_temp = load_state_dict(model_path, f"model.layers.{li}")
-        merge_dicts(state_dict, state_dict_temp, f"layers.{li}.")
+        merge_dicts(state_dict, state_dict_temp, prefix + f"layers.{li}.")
     state_dict_temp = load_state_dict(model_path, "model.norm")
-    merge_dicts(state_dict, state_dict_temp, "norm.")
+    merge_dicts(state_dict, state_dict_temp, prefix + "norm.")
+    state_dict_temp = load_state_dict(model_path, "lm_head")
+    merge_dicts(state_dict, state_dict_temp, "lm_head.")
 
     return state_dict
 
@@ -56,9 +59,7 @@ def hf_config(hf_config):
 def load_reference_model(hf_config):
     """Load the reference model for testing."""
 
-    model = DeepseekV3Model(hf_config).eval()
-
-    return model
+    return DeepseekV3ForCausalLM(hf_config).eval()
 
 
 @pytest.mark.parametrize(
@@ -84,7 +85,7 @@ def load_reference_model(hf_config):
 )
 @pytest.mark.parametrize(
     "weights_type",
-    ["random", "real"],
+    ["real", "random"],
 )
 def test_forward_pass(
     module_path, mode, seq_len, batch_size, hf_config, tmp_path, mesh_device, model_path, ccl, reset_seeds, weights_type
@@ -144,14 +145,13 @@ def test_forward_pass(
             position_ids=position_idxs,
             mode=mode,
         )
-
     ############################
     ### Set up TTNN configs
     ############################
     logger.info("Setting up TTNN configs")
 
     # For now, since we're only loading one layer, we can replicate
-    weight_config = Model1D.convert_weights(hf_config, state_dict, tmp_path, mesh_device)
+    weight_config = Model1D.convert_weights(hf_config, state_dict, tmp_path, mesh_device, state_dict_prefix="model.")
 
     if mode == "prefill":
         model_config = Model1D.prefill_model_config(hf_config, mesh_device)
@@ -236,13 +236,13 @@ def test_forward_pass(
         tt_output = Model1D.forward_prefill(tt_input, run_config, user_id, rope_tensors, tt_page_table)
     else:
         tt_output = Model1D.forward_decode(tt_input, position_idxs_tensor, rope_tensors, tt_page_table, run_config)
-    tt_output_torch = ttnn.to_torch(
-        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_shape)
-    )[output_row_idx, ...]
 
-    if mode == "decode":
-        # Torch Shape: [batch_size, seq_len, hidden_size]
-        tt_output_torch = tt_output_torch.permute(1, 0, 2)
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))
+
+    assert (
+        tt_output_torch.shape[-1] == hf_config.vocab_size
+    ), f"Output shape mismatch: {tt_output_torch.shape} vs {hf_config.vocab_size}"
+    reference_output = reference_output.permute(1, 0, 2).unsqueeze(0)  # [1,1,B,V]
 
     ############################
     ### Validation

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -12,6 +12,7 @@ import ttnn
 from models.demos.deepseek_v3.tt.ccl_1d import CCL1D
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block import DecoderBlock
 from models.demos.deepseek_v3.tt.embedding_1d import Embedding1D
+from models.demos.deepseek_v3.tt.lm_head import LMHead
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import PointToPointConfig, ReshardConfig
@@ -41,6 +42,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
         state_dict: dict[str, torch.Tensor],
         output_path: Path,
         mesh_device: ttnn.MeshDevice,
+        state_dict_prefix: str = "",
     ) -> WeightConfig:
         """Convert weights for the 1D model."""
 
@@ -54,7 +56,9 @@ class Model1D(SharedStateAddOn, AbstractModule):
 
         mlp_decoder_block_state_dicts = [
             [
-                sub_state_dict(state_dict, f"layers.{layer_idx}.") if layer_idx is not None else None
+                sub_state_dict(state_dict, state_dict_prefix + f"layers.{layer_idx}.")
+                if layer_idx is not None
+                else None
                 for layer_idx in mapping
             ]
             for mapping in mlp_meta_layer_mapping
@@ -62,7 +66,10 @@ class Model1D(SharedStateAddOn, AbstractModule):
 
         return {
             "embedding": Embedding1D.convert_weights(
-                hf_config, [sub_state_dict(state_dict, "embed_tokens.")], output_path / "embedding", mesh_device
+                hf_config,
+                [sub_state_dict(state_dict, state_dict_prefix + "embed_tokens.")],
+                output_path / "embedding",
+                mesh_device,
             ),
             "mlp_decoder_block": [
                 DecoderBlock.convert_weights(
@@ -71,7 +78,13 @@ class Model1D(SharedStateAddOn, AbstractModule):
                 for ml in range(cls.NUM_MLP_META_LAYERS)
             ],
             "norm": DistributedRMSNorm.convert_weights(
-                hf_config, [sub_state_dict(state_dict, "norm.")] * mesh_shape[0], output_path / "norm", mesh_device
+                hf_config,
+                [sub_state_dict(state_dict, state_dict_prefix + "norm.")] * mesh_shape[0],
+                output_path / "norm",
+                mesh_device,
+            ),
+            "lm_head": LMHead.convert_weights(
+                hf_config, [sub_state_dict(state_dict, "lm_head.")], output_path / "lm_head", mesh_device
             ),
         }
 
@@ -165,6 +178,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
             ),
             "norm_reshard": ReshardConfig(memory_config=norm_config["input_memory_config"]),
             "norm": norm_config,
+            "lm_head": LMHead.decode_model_config(hf_config, mesh_device, 0),
         }
 
     @classmethod
@@ -197,6 +211,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
                 for _ in range(cls.NUM_MLP_META_LAYERS)
             ],
             "norm": DistributedRMSNorm.create_state(hf_config, mesh_device, ccl),
+            "lm_head": LMHead.create_state(hf_config, mesh_device, ccl),
         }
 
     @classmethod
@@ -263,6 +278,9 @@ class Model1D(SharedStateAddOn, AbstractModule):
 
         x = ttnn.to_memory_config(x, **cfg["norm_reshard"])
         x = DistributedRMSNorm.forward_decode(x, cfg["norm"])
+        x = ttnn.experimental.all_gather_async(x, **cfg["lm_head"]["all_gather"])
+        x = ttnn.to_memory_config(x, cfg["lm_head"]["input_memory_config"])
+        x = LMHead.forward_decode(x, cfg["lm_head"])
 
         return x
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Integrate LM head for Deepseek model.
Real weights: PCC for Model1D in decode mode: 0.9875021496514096
Random weights: PCC for Model1D in decode mode: 0.9942191792398771


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes