### PR TITLE
Ashah/27518/job name change

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -46,30 +46,30 @@ permissions:
   packages: write
   checks: write
 
-# run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
-# jobs:
-#   build-artifact:
-#     uses: ./.github/workflows/build-artifact.yaml
-#     permissions:
-#       packages: write
-#     secrets: inherit
-#     with:
-#       build-type: ${{ inputs.build-type || 'Release' }}
-#       build-wheel: true
-#       version: ${{ inputs.version || '22.04' }}
-#       skip-tt-train: false
-#   build-artifact-profiler:
-#     uses: ./.github/workflows/build-artifact.yaml
-#     permissions:
-#       packages: write
-#     secrets: inherit
-#     with:
-#       build-type: ${{ inputs.build-type || 'Release' }}
-#       build-wheel: true
-#       tracy: true
-#       version: ${{ inputs.version || '22.04' }}
+run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
+      version: ${{ inputs.version || '22.04' }}
+      skip-tt-train: false
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
+      tracy: true
+      version: ${{ inputs.version || '22.04' }}
 
-  # Slow Dispatch Unit Tests
+  # # Slow Dispatch Unit Tests
   # sd-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -87,7 +87,7 @@ permissions:
   #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # Fast Dispatch Unit Tests
+  # # Fast Dispatch Unit Tests
   # fast-dispatch-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -104,7 +104,7 @@ permissions:
   #     runner-label: ${{ matrix.test-group.runner-label }}
   #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # Fabric Unit Tests
+  # # Fabric Unit Tests
   # fabric-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -121,7 +121,7 @@ permissions:
   #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # TTNN FD Unit tests
+  # # TTNN FD Unit tests
   # ttnn-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -140,7 +140,7 @@ permissions:
   #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # FD Model Tests
+  # # FD Model Tests
   # models-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -157,7 +157,7 @@ permissions:
   #     runner-label: ${{ matrix.test-group.runner-label }}
   #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # FD C++ Unit Tests
+  # # FD C++ Unit Tests
   # cpp-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -191,7 +191,7 @@ permissions:
   #     runner-label: ${{ matrix.test-group.runner-label }}
   #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # TT-CNN Unit tests
+  # # TT-CNN Unit tests
   # tt-cnn-unit-tests:
   #   needs: build-artifact
   #   secrets: inherit
@@ -227,6 +227,7 @@ permissions:
   #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
   #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
   #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+
   t3000-apc-fast-tests:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
@@ -261,19 +262,19 @@ permissions:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # test-ttnn-tutorials:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #       ]
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  test-ttnn-tutorials:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+        ]
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -46,188 +46,188 @@ permissions:
   packages: write
   checks: write
 
-run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
-jobs:
-  build-artifact:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
-      version: ${{ inputs.version || '22.04' }}
-      skip-tt-train: false
-  build-artifact-profiler:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
-      tracy: true
-      version: ${{ inputs.version || '22.04' }}
+# run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
+# jobs:
+#   build-artifact:
+#     uses: ./.github/workflows/build-artifact.yaml
+#     permissions:
+#       packages: write
+#     secrets: inherit
+#     with:
+#       build-type: ${{ inputs.build-type || 'Release' }}
+#       build-wheel: true
+#       version: ${{ inputs.version || '22.04' }}
+#       skip-tt-train: false
+#   build-artifact-profiler:
+#     uses: ./.github/workflows/build-artifact.yaml
+#     permissions:
+#       packages: write
+#     secrets: inherit
+#     with:
+#       build-type: ${{ inputs.build-type || 'Release' }}
+#       build-wheel: true
+#       tracy: true
+#       version: ${{ inputs.version || '22.04' }}
 
   # Slow Dispatch Unit Tests
-  sd-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # sd-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Fast Dispatch Unit Tests
-  fast-dispatch-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # fast-dispatch-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Fabric Unit Tests
-  fabric-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # fabric-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN FD Unit tests
-  ttnn-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/ttnn-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # ttnn-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/ttnn-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   # FD Model Tests
-  models-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/models-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # models-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/models-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
-  cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  tt-train-cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/tt-train-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/cpp-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # tt-train-cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/tt-train-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   # TT-CNN Unit tests
-  tt-cnn-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/tt-cnn-post-commit.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # tt-cnn-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/tt-cnn-post-commit.yaml
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  run-profiler-regression:
-    needs: [build-artifact-profiler]
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/run-profiler-regression.yaml
-    secrets: inherit
-    with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-  t3000-fast-tests:
+  # run-profiler-regression:
+  #   needs: [build-artifact-profiler]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #         { arch: wormhole_b0, runner-label: N300 },
+  #       ]
+  #   uses: ./.github/workflows/run-profiler-regression.yaml
+  #   secrets: inherit
+  #   with:
+  #     arch: ${{ matrix.test-group.arch}}
+  #     runner-label: ${{ matrix.test-group.runner-label}}
+  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  t3000-apc-fast-tests:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit
@@ -236,7 +236,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # tg-demo-apc-tests:
+  # 6U-apc-fast-tests:
   #   if: ${{ github.event.pull_request.head.repo.fork == false }}
   #   needs: build-artifact
   #   secrets: inherit
@@ -261,19 +261,19 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  test-ttnn-tutorials:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-        ]
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # test-ttnn-tutorials:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       test-group: [
+  #         { arch: wormhole_b0, runner-label: N150 },
+  #       ]
+  #   with:
+  #     arch: ${{ matrix.test-group.arch }}
+  #     runner-label: ${{ matrix.test-group.runner-label }}
+  #     docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -69,164 +69,164 @@ jobs:
       tracy: true
       version: ${{ inputs.version || '22.04' }}
 
-  # # Slow Dispatch Unit Tests
-  # sd-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # Fast Dispatch Unit Tests
-  # fast-dispatch-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # Fabric Unit Tests
-  # fabric-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # TTNN FD Unit tests
-  # ttnn-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/ttnn-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Slow Dispatch Unit Tests
+  sd-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Fast Dispatch Unit Tests
+  fast-dispatch-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Fabric Unit Tests
+  fabric-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # TTNN FD Unit tests
+  ttnn-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # # FD Model Tests
-  # models-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/models-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # # FD C++ Unit Tests
-  # cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/cpp-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # tt-train-cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/tt-train-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # # TT-CNN Unit tests
-  # tt-cnn-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/tt-cnn-post-commit.yaml
-  #   with:
-  #     arch: ${{ matrix.test-group.arch }}
-  #     runner-label: ${{ matrix.test-group.runner-label }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # FD Model Tests
+  models-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/models-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # FD C++ Unit Tests
+  cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  tt-train-cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/tt-train-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # TT-CNN Unit tests
+  tt-cnn-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/tt-cnn-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # run-profiler-regression:
-  #   needs: [build-artifact-profiler]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       test-group: [
-  #         { arch: wormhole_b0, runner-label: N150 },
-  #         { arch: wormhole_b0, runner-label: N300 },
-  #       ]
-  #   uses: ./.github/workflows/run-profiler-regression.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: ${{ matrix.test-group.arch}}
-  #     runner-label: ${{ matrix.test-group.runner-label}}
-  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  run-profiler-regression:
+    needs: [build-artifact-profiler]
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
 
   t3000-apc-fast-tests:
     if: ${{ github.event.pull_request.head.repo.fork == false }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -237,7 +237,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  # 6U-apc-fast-tests:
+  # galaxy-apc-fast-tests:
   #   if: ${{ github.event.pull_request.head.repo.fork == false }}
   #   needs: build-artifact
   #   secrets: inherit

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -25,10 +25,10 @@ on:
       tests-json:
         description: |
           JSON object specifying which tests to run.
-          Example: {"sd-unit-tests":true,"fast-dispatch-unit-tests":true,"fabric-unit-tests":true,"cpp-unit-tests":true,"ttnn-unit-tests":true,"models-unit-tests":true,"tt-train-cpp-unit-tests":true,"run-profiler-regression":true,"t3000-fast-tests":true,"test-ttnn-tutorials":true}
+          Example: {"sd-unit-tests":true,"fast-dispatch-unit-tests":true,"fabric-unit-tests":true,"cpp-unit-tests":true,"ttnn-unit-tests":true,"models-unit-tests":true,"tt-train-cpp-unit-tests":true,"run-profiler-regression":true,"t3000-apc-fast-tests":true,"test-ttnn-tutorials":true}
         required: false
         type: string
-        default: '{"sd-unit-tests":true,"fast-dispatch-unit-tests":true,"fabric-unit-tests":true,"cpp-unit-tests":true,"ttnn-unit-tests":true,"models-unit-tests":true,"tt-train-cpp-unit-tests":true,"run-profiler-regression":true,"t3000-fast-tests":true,"test-ttnn-tutorials":true}'
+        default: '{"sd-unit-tests":true,"fast-dispatch-unit-tests":true,"fabric-unit-tests":true,"cpp-unit-tests":true,"ttnn-unit-tests":true,"models-unit-tests":true,"tt-train-cpp-unit-tests":true,"run-profiler-regression":true,"t3000-apc-fast-tests":true,"test-ttnn-tutorials":true}'
       commit:
         required: false
         type: string
@@ -224,19 +224,19 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
 
-  t3000-fast-tests:
+  t3000-apc-fast-tests:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 't3000-fast-tests') }}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 't3000-apc-fast-tests') }}
     secrets: inherit
-    uses: ./.github/workflows/t3000-fast-tests-impl.yaml
+    uses: ./.github/workflows/t3000-apc-fast-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  tg-demo-apc-tests:
+  galaxy-apc-fast-tests:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'tg-demo-apc-tests') }}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'galaxy-apc-fast-tests') }}
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Ticket
#27518

### Problem description
We are updating job names so that developers clearly know that both T3K and TG are present in APC. This is part of standardizing our pipeline naming convention for clarity and consistency.

### What’s changed 

Job names updated:
t3000-fast-tests → t3000-apc-fast-tests
tg-demo-apc-tests → 6U-apc-fast-tests

### Quick checks:

<img width="3456" height="1840" alt="image" src="https://github.com/user-attachments/assets/babfc302-7bd4-498f-89b8-48ce1b93dcf4" />