### PR TITLE
Add FLOAT32 grid support to ttnn.grid_sample

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -85,6 +85,7 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
 
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize("batch_output_channels", [True, False])
+@pytest.mark.parametrize("grid_dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize(
     "input_shape, grid_shape, grid_batching_factor",
     [
@@ -95,9 +96,14 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
     ],
 )
 def test_grid_sample_batch_output_channels_flag(
-    device, input_shape, grid_shape, grid_batching_factor, batch_output_channels, use_precomputed_grid
+    device, input_shape, grid_shape, grid_batching_factor, batch_output_channels, use_precomputed_grid, grid_dtype
 ):
     """Test grid sample with batch_output_channels flag - both true and false behaviors"""
+
+    # Skip float32 grid with precomputed grid - not currently supported
+    if grid_dtype == "float32" and use_precomputed_grid:
+        pytest.skip("Precomputed grid with FLOAT32 grid dtype is not currently supported")
+
     torch.manual_seed(42)
 
     batch_size, channels, height, width = input_shape
@@ -143,7 +149,10 @@ def test_grid_sample_batch_output_channels_flag(
         # Reshape for grid batching: (N, H, W*K, 2) -> (N, H, W, 2*K)
         new_grid_w = grid_w // grid_batching_factor
         new_last_dim = 2 * grid_batching_factor
-        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+        if grid_dtype == "float32":
+            ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
+        else:  # bfloat16
+            ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
         ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
         ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
 
@@ -176,5 +185,5 @@ def test_grid_sample_batch_output_channels_flag(
     # Verify numerical correctness
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(
-        f"batch_output_channels={batch_output_channels} test (batching_factor={grid_batching_factor}, precomputed={use_precomputed_grid}): {pcc_message}"
+        f"batch_output_channels={batch_output_channels} test (batching_factor={grid_batching_factor}, precomputed={use_precomputed_grid}, grid_dtype={grid_dtype}): {pcc_message}"
     )

--- a/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
@@ -25,7 +25,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ((2, 160, 32, 8), (2, 28, 6, 2)),
     ],
 )
-def test_grid_sample_random_grid(device, input_shape, grid_shape):
+@pytest.mark.parametrize("grid_dtype", ["bfloat16", "float32"])
+def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
     """Test grid_sample with completely random grid coordinates"""
 
     torch.manual_seed(0)
@@ -33,25 +34,39 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape):
     torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
     torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
-    # Makes a random grid with coordinates in range [-1, 1]
-    torch_grid = torch.rand(grid_shape, dtype=torch.bfloat16) * 2.0 - 1.0
-
-    torch_grid_float = torch_grid.to(torch.float32)
+    # Create a random grid with coordinates in range [-1, 1]
+    torch_grid_f32 = torch.rand(grid_shape, dtype=torch.float32) * 2.0 - 1.0
 
     torch_output_nchw = F.grid_sample(
-        torch_input_nchw, torch_grid_float, mode="bilinear", padding_mode="zeros", align_corners=False
+        torch_input_nchw, torch_grid_f32, mode="bilinear", padding_mode="zeros", align_corners=False
     )
 
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
     ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_grid = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    if grid_dtype == "float32":
+        ttnn_grid = ttnn.from_torch(torch_grid_f32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.float32)
+    else:  # bfloat16
+        torch_grid_bf16 = torch_grid_f32.to(torch.bfloat16)
+        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
-    logger.info(pcc_message)
+    logger.info(f"{grid_dtype.upper()} grid PCC: {pcc_message}")
+
+    # Test allclose with grid type specific tolerances
+    if grid_dtype == "float32":
+        atol, rtol = 0.2, 1e-2
+    else:  # bfloat16
+        atol, rtol = 1.0, 1e-1
+
+    allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+
+    assert pcc_passed, f"{grid_dtype.upper()} grid test failed with PCC below threshold"
+    assert allclose_passed, f"{grid_dtype.upper()} grid test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
@@ -67,7 +82,8 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape):
         ((3, 224, 40, 40), (3, 32, 32, 2)),
     ],
 )
-def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape):
+@pytest.mark.parametrize("grid_dtype", ["bfloat16", "float32"])
+def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, grid_dtype):
     torch.manual_seed(0)
 
     batch_size, grid_h, grid_w, _ = grid_shape
@@ -88,18 +104,33 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape):
         torch_input_nchw, torch_grid, mode="bilinear", padding_mode="zeros", align_corners=False
     )
 
-    torch_grid_bf16 = torch_grid.to(torch.bfloat16)
-
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
     ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    if grid_dtype == "float32":
+        ttnn_grid = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.float32)
+    else:  # bfloat16
+        torch_grid_bf16 = torch_grid.to(torch.bfloat16)
+        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
-    logger.info(pcc_message)
+    logger.info(f"{grid_dtype.upper()} grid PCC: {pcc_message}")
+
+    # Test allclose with grid type specific tolerances
+    if grid_dtype == "float32":
+        atol, rtol = 0.2, 1e-2
+    else:  # bfloat16
+        atol, rtol = 1.0, 1e-1
+
+    allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+    logger.info(f"{grid_dtype.upper()} grid allclose (atol={atol}, rtol={rtol}): {allclose_passed}")
+
+    assert pcc_passed, f"{grid_dtype.upper()} grid test failed with PCC below threshold"
+    assert allclose_passed, f"{grid_dtype.upper()} grid test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)

--- a/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
@@ -59,7 +59,7 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
 
     # Test allclose with grid type specific tolerances
     if grid_dtype == "float32":
-        atol, rtol = 0.2, 1e-2
+        atol, rtol = 0.02, 1e-2
     else:  # bfloat16
         atol, rtol = 1.0, 1e-1
 
@@ -122,7 +122,7 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, grid_dty
 
     # Test allclose with grid type specific tolerances
     if grid_dtype == "float32":
-        atol, rtol = 0.2, 1e-2
+        atol, rtol = 0.02, 1e-2
     else:  # bfloat16
         atol, rtol = 1.0, 1e-1
 

--- a/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
@@ -25,7 +25,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ((2, 160, 32, 8), (2, 28, 6, 2)),
     ],
 )
-@pytest.mark.parametrize("grid_dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
 def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
     """Test grid_sample with completely random grid coordinates"""
 
@@ -45,28 +45,23 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
 
     ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-    if grid_dtype == "float32":
-        ttnn_grid = ttnn.from_torch(torch_grid_f32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.float32)
-    else:  # bfloat16
-        torch_grid_bf16 = torch_grid_f32.to(torch.bfloat16)
-        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_grid = ttnn.from_torch(torch_grid_f32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=grid_dtype)
 
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
-    logger.info(f"{grid_dtype.upper()} grid PCC: {pcc_message}")
 
     # Test allclose with grid type specific tolerances
-    if grid_dtype == "float32":
+    if grid_dtype == ttnn.float32:
         atol, rtol = 0.02, 1e-2
     else:  # bfloat16
         atol, rtol = 1.0, 1e-1
 
     allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
 
-    assert pcc_passed, f"{grid_dtype.upper()} grid test failed with PCC below threshold"
-    assert allclose_passed, f"{grid_dtype.upper()} grid test failed allclose comparison (atol={atol}, rtol={rtol})"
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
@@ -82,7 +77,7 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
         ((3, 224, 40, 40), (3, 32, 32, 2)),
     ],
 )
-@pytest.mark.parametrize("grid_dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
 def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, grid_dtype):
     torch.manual_seed(0)
 
@@ -108,29 +103,23 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, grid_dty
 
     ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-    if grid_dtype == "float32":
-        ttnn_grid = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.float32)
-    else:  # bfloat16
-        torch_grid_bf16 = torch_grid.to(torch.bfloat16)
-        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_grid = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=grid_dtype)
 
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
-    logger.info(f"{grid_dtype.upper()} grid PCC: {pcc_message}")
 
     # Test allclose with grid type specific tolerances
-    if grid_dtype == "float32":
+    if grid_dtype == ttnn.float32:
         atol, rtol = 0.02, 1e-2
     else:  # bfloat16
         atol, rtol = 1.0, 1e-1
 
     allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
-    logger.info(f"{grid_dtype.upper()} grid allclose (atol={atol}, rtol={rtol}): {allclose_passed}")
 
-    assert pcc_passed, f"{grid_dtype.upper()} grid test failed with PCC below threshold"
-    assert allclose_passed, f"{grid_dtype.upper()} grid test failed allclose comparison (atol={atol}, rtol={rtol})"
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
@@ -164,10 +153,8 @@ def test_grid_sample_identity_transform(device, input_shape):
     )
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
-    torch_grid_bf16 = torch_grid.to(torch.bfloat16)
-
     ttnn_input = ttnn.from_torch(torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_grid = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
     ttnn_output_torch = ttnn.to_torch(ttnn_output)

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.cpp
@@ -55,7 +55,13 @@ void GridSample::validate(const std::vector<Tensor>& input_tensors) const {
 
     // Data type validation
     TT_FATAL(input_tensor.dtype() == DataType::BFLOAT16, "Input tensor must be BFLOAT16");
-    TT_FATAL(grid_tensor.dtype() == DataType::BFLOAT16, "Grid tensor must be BFLOAT16");
+    if (use_precomputed_grid_) {
+        TT_FATAL(grid_tensor.dtype() == DataType::BFLOAT16, "Precomputed grid tensor must be BFLOAT16");
+    } else {
+        TT_FATAL(
+            grid_tensor.dtype() == DataType::BFLOAT16 || grid_tensor.dtype() == DataType::FLOAT32,
+            "Grid tensor must be BFLOAT16 or FLOAT32");
+    }
 
     // Layout validation
     TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Input tensor must be ROW_MAJOR layout");

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -113,9 +113,9 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
 
     // CB2: Scalar buffer (holds 4 bilinear interpolation weights)
     const uint32_t scalar_cb_num_pages = buffering_factor;
-    const uint32_t scalar_cb_page_size = tile_size(grid_cb_data_format);  // 4 scalars, aligned
+    const uint32_t scalar_cb_page_size = tile_size(input_cb_data_format);  // 4 scalars, aligned
     const auto [scalar_cb_index, scalar_cb_handle] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, scalar_cb_page_size, scalar_cb_num_pages, grid_cb_data_format);
+        next_cb_index++, program, all_cores, scalar_cb_page_size, scalar_cb_num_pages, input_cb_data_format);
 
     // CB3: Output buffer
     const uint32_t out_ntiles_c = (uint32_t)std::ceil((float)output_shape[-1] / tt::constants::FACE_WIDTH);
@@ -136,6 +136,7 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
         (std::uint32_t)input_width,
         (std::uint32_t)(output_height * output_width),  // output_hw_size at index 13
         (std::uint32_t)grid_batching_factor,            // number of grids per spatial position
+        (std::uint32_t)grid_tensor.dtype(),             // grid data type
     };
 
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);


### PR DESCRIPTION
### Ticket
#27821

### Problem description

ttnn.grid_sample used to give good pcc, but fail the all_close test in some cases.
Upon further inspection, the problems stems from the fact that bfloat16 is not suitable for relative grid coordinates. For example, relative coordinates 0.5 to 1.0 all have the same exponent and only different mantissa, meaning that 2^7 = 128 different values exist in that range. Often times there are grids that require heigher granularities, and bfloat16 is not suitable.

### What's changed

Added support for float32 grid coordinates, in the case when the grid is not precomputed. Even though the grid is float32, the final weights for bilinear interpolation sent to FPU are bfloat16. 
Precomputed grid sends bfloat16 weights and encoded image coordinates regardless, so supporting float32 does not make sense in this.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17493212422)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17493201895)
- [ ] [L2 nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/17493212422)