### PR TITLE
#0:Softmax-fix.

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -648,7 +648,7 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
         /*inplace=*/true,
         /*output_mem_config=*/input_tensor.memory_config(),
         /*program_config=*/program_config,
-        /*is_causal_mask=*/false,
+        /*is_causal_mask=*/true,
         /*compute_kernel_config=*/compute_kernel_config_val,
         /*is_scale_causal_mask_hw_dims_softmax=*/true,
         /*numeric_stable=*/numeric_stable);


### PR DESCRIPTION
### Ticket
NO TICKET

### Problem description
Commit [5dafb36a631b2df15d53d1c4946a909c4c384bb9](https://github.com/tenstorrent/tt-metal/commit/5dafb36a631b2df15d53d1c4946a909c4c384bb9)
causes falcon 7b to fail with `Causal mask is required for scale causal mask HW dims softmax`
in [device perf CI](https://github.com/tenstorrent/tt-metal/actions/runs/17490118725/job/49678354055#step:5:274)

### What's changed
- Wrong flag was used - changed.

### Checklist
- APC https://github.com/tenstorrent/tt-metal/actions/runs/17495759054
- (Single-card) Device perf regressions (`previous fail`): https://github.com/tenstorrent/tt-metal/actions/runs/17495747592