### PR TITLE
#0: Tilize input before packing to block floats.

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
@@ -65,9 +65,9 @@ tt::tt_metal::HostStorage transform_storage(
                 constexpr bool row_major_input = false;
                 constexpr bool is_exp_a = false;
                 if constexpr (std::is_same_v<DstType, bfloat8_tag>) {
-                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
+                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a);
                 } else if constexpr (std::is_same_v<DstType, bfloat4_tag>) {
-                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
+                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a);
                 } else {
                     static_assert(ttsl::concepts::always_false_v<DstType>, "Unsupported data type");
                 }

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
@@ -53,15 +53,21 @@ tt::tt_metal::HostStorage transform_storage(
         return input_storage;
     } else if constexpr (std::is_same_v<DstType, bfloat4_tag> || std::is_same_v<DstType, bfloat8_tag>) {
         auto transform_fn = [&](const tt::tt_metal::HostBuffer& buffer) {
-            tt::stl::Span<const SrcType> data = buffer.view_as<const SrcType>();
-            const bool row_major_input = input_tensor_spec.layout() == Layout::ROW_MAJOR;
+            ttsl::Span<const SrcType> data = buffer.view_as<const SrcType>();
+            std::vector<SrcType> tilized_data;  // empty if `data` is already in tile layout.
+            if (input_tensor_spec.layout() == Layout::ROW_MAJOR) {
+                tilized_data = tt::tt_metal::tensor_impl::convert_layout_row_major_to_tile(
+                    input_tensor_spec.physical_shape(), input_tensor_spec.tile(), data);
+                data = ttsl::make_const_span(tilized_data);
+            }
 
             auto float_packed_data = [&]() {
+                constexpr bool row_major_input = false;
                 constexpr bool is_exp_a = false;
                 if constexpr (std::is_same_v<DstType, bfloat8_tag>) {
-                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a);
+                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
                 } else if constexpr (std::is_same_v<DstType, bfloat4_tag>) {
-                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a);
+                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
                 } else {
                     static_assert(ttsl::concepts::always_false_v<DstType>, "Unsupported data type");
                 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/27716

### Problem description
https://github.com/tenstorrent/tt-metal/pull/27716 introduced a regression in `models/demos/deepseek_v3/tests/test_moe_experts.py` - PCC in converting the data from RM floats to bfloat4 format.

### What's changed
Revert a part of https://github.com/tenstorrent/tt-metal/pull/27716 that removes an additional conversion to RM float before converting into bfloat4.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17502172027)
- [X] Confirmed offline that deepseek tests are recovered