### PR TITLE
[vLLM nightly] Ensure artifact names are properly set for failing jobs

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -295,6 +295,7 @@ jobs:
           owner: ${{ matrix.test-group.co-owner-2-id }}
 
       - name: Set artifact prefix
+        if: ${{ !cancelled() }}
         id: set-artifact-prefix
         run: |
           # Replace spaces with underscores


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Set artifact prefix step was being skipped for failing jobs (minor issue with https://github.com/tenstorrent/tt-metal/commit/f02732bb11d0f2b67ce4b750e89ad5837b48dc55)

### What's changed
- Always set artifact prefix for correct artifact name, except when job is cancelled (and artifact is not uploaded)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

vLLM nightly tests (only 2 jobs for quick test) - https://github.com/tenstorrent/tt-metal/actions/runs/17499179993 (unrelated failure for Llama70B-GLX)