### PR TITLE
Fix ASan errors in Mem Bench and Watcher Dump

### DIFF
--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/core_descriptor.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include "dev_msgs.h"
+#include "tt_metal/hw/inc/dev_msgs.h"
 #include <tt-metalium/allocator_types.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <llrt/hal.hpp>

--- a/tt_metal/tools/mem_bench/CMakeLists.txt
+++ b/tt_metal/tools/mem_bench/CMakeLists.txt
@@ -19,9 +19,6 @@ target_link_libraries(
     mem_bench
     PRIVATE
         Metalium::Metal
-        TT::Metalium::Common
-        Metalium::Metal::Impl
-        Metalium::Metal::LLRT
         numa
         benchmark::benchmark
 )

--- a/tt_metal/tools/mem_bench/host_utils.hpp
+++ b/tt_metal/tools/mem_bench/host_utils.hpp
@@ -10,7 +10,7 @@
 #include <span>
 #include <vector>
 
-#include "dispatch/memcpy.hpp"
+#include "tt_metal/impl/dispatch/memcpy.hpp"
 #include "vector_aligned.hpp"
 
 namespace tt::tt_metal::tools::mem_bench {

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -3,7 +3,6 @@ target_link_libraries(
     watcher_dump
     PRIVATE
         Metalium::Metal
-        Metalium::Metal::LLRT
         TT::STL
 )
 target_include_directories(

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -45,7 +45,7 @@ void dump_data(
     std::filesystem::create_directories(cq_dir);
 
     // Only look at user-specified devices
-    vector<IDevice*> devices;
+    vector<std::unique_ptr<IDevice>> devices;
     for (chip_id_t id : device_ids) {
         string cq_fname = cq_dir.string() + fmt::format("device_{}_completion_q.txt", id);
         std::ofstream cq_file = std::ofstream(cq_fname);
@@ -54,7 +54,7 @@ void dump_data(
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
         IDevice* device = tt::tt_metal::CreateDeviceMinimal(
             id, num_hw_cqs, DispatchCoreConfig{eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER});
-        devices.push_back(device);
+        devices.push_back(std::unique_ptr<IDevice>(device));
         if (dump_cqs) {
             cout << "Dumping Command Queues into: " << cq_dir.string() << endl;
             std::unique_ptr<SystemMemoryManager> sysmem_manager = std::make_unique<SystemMemoryManager>(id, num_hw_cqs);


### PR DESCRIPTION
Some issues found with ASan:
- ODR violation in both tools
- Memory leak in watcher dump because the IDevice pointer was not deleted

BH
https://github.com/tenstorrent/tt-metal/actions/runs/17500523683
Build across all configs
https://github.com/tenstorrent/tt-metal/actions/runs/17500521671
APC
https://github.com/tenstorrent/tt-metal/actions/runs/17500512673