### PR TITLE
Increase PCIe range allowed by NOC sanitization

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -964,17 +964,12 @@ void MetalContext::initialize_firmware(
 dev_msgs::core_info_msg_t MetalContext::populate_core_info_msg(
     chip_id_t device_id, HalProgrammableCoreType programmable_core_type) const {
     const metal_SocDescriptor& soc_d = cluster_->get_soc_desc(device_id);
-    uint64_t pcie_chan_base_addr = cluster_->get_pcie_base_addr_from_device(device_id);
-    uint32_t num_host_channels = cluster_->get_num_host_channels(device_id);
-    uint64_t pcie_chan_end_addr = pcie_chan_base_addr;
-    for (int pcie_chan = 0; pcie_chan < num_host_channels; pcie_chan++) {
-        pcie_chan_end_addr += cluster_->get_host_channel_size(device_id, pcie_chan);
-    }
+    // Use architecture-defined supported PCIe address bounds
     auto factory = hal_->get_dev_msgs_factory(programmable_core_type);
     dev_msgs::core_info_msg_t buffer = factory.create<dev_msgs::core_info_msg_t>();
     auto core_info = buffer.view();
-    core_info.noc_pcie_addr_base() = pcie_chan_base_addr;
-    core_info.noc_pcie_addr_end() = pcie_chan_end_addr;
+    core_info.noc_pcie_addr_base() = hal_->get_pcie_addr_lower_bound();
+    core_info.noc_pcie_addr_end() = hal_->get_pcie_addr_upper_bound();
     core_info.noc_dram_addr_base() = 0;
     core_info.noc_dram_addr_end() = soc_d.dram_core_size;
     core_info.l1_unreserved_start() = align(worker_l1_unreserved_start_, hal_->get_alignment(HalMemType::DRAM));

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -45,6 +45,10 @@ Hal::Hal(tt::ARCH arch, bool is_base_routing_fw_enabled) : arch_(arch) {
     }
 }
 
+uint64_t Hal::get_pcie_addr_lower_bound() const { return pcie_addr_lower_bound_; }
+
+uint64_t Hal::get_pcie_addr_upper_bound() const { return pcie_addr_upper_bound_; }
+
 uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programmable_core_type_index) const {
     uint32_t index = static_cast<uint32_t>(programmable_core_type_index);
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -257,6 +257,9 @@ private:
     std::vector<uint32_t> mem_write_alignments_;
     std::vector<uint32_t> mem_alignments_with_pcie_;
     uint32_t max_processors_per_core_{};
+    // Architecture-defined PCIe address range
+    uint64_t pcie_addr_lower_bound_{};
+    uint64_t pcie_addr_upper_bound_{};
     uint32_t num_nocs_{};
     uint32_t noc_addr_node_id_bits_{};
     uint32_t noc_node_id_ = 0;
@@ -464,6 +467,11 @@ public:
                 launch_msg, programmable_core_type, processor_class, processor_type_idx, iram_text_size);
         }
     }
+
+    // Returns the supported PCIe address range for the current architecture
+    uint64_t get_pcie_addr_lower_bound() const;
+    // Inclusive upper bound
+    uint64_t get_pcie_addr_upper_bound() const;
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -329,6 +329,12 @@ void Hal::initialize_bh() {
     this->nan_ = NAN_BH;
     this->inf_ = INF_BH;
 
+    // PCIe address range for Blackhole. Includes both the direct mapping to the IOMMU address range, as well as the
+    // mapping through the outbound iATU. See
+    // https://github.com/tenstorrent/tt-isa-documentation/tree/main/BlackholeA0/PCIExpressTile for more details.
+    this->pcie_addr_lower_bound_ = 0x0000000000000000ULL;
+    this->pcie_addr_upper_bound_ = 0x13FF'FFFF'FFFF'FFFFULL;
+
     this->noc_x_id_translate_table_ = {
         NOC_CFG(NOC_X_ID_TRANSLATE_TABLE_0),
         NOC_CFG(NOC_X_ID_TRANSLATE_TABLE_1),

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -341,6 +341,11 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
     this->nan_ = NAN_WHB0;
     this->inf_ = INF_WHB0;
 
+    // PCIe address range for Wormhole. Includes the mapping through the outbound iATU. See
+    // https://github.com/tenstorrent/tt-isa-documentation/tree/main/WormholeB0/PCIExpressTile for more details.
+    this->pcie_addr_lower_bound_ = 0x8'0000'0000ULL;
+    this->pcie_addr_upper_bound_ = 0x8'FFFE'0000ULL - 1ULL;
+
     this->noc_x_id_translate_table_ = {
         NOC_CFG(NOC_X_ID_TRANSLATE_TABLE_0),
         NOC_CFG(NOC_X_ID_TRANSLATE_TABLE_1),


### PR DESCRIPTION
### Ticket
#25675

### Problem description
Currently NOC sanitization assumes that all access to the PCIe cores is intended for the hugepage, so it restricts accesses to that region. This is problematic if we want to be able to access other pinned memory.

### What's changed
Add functions to the HAL to retrieve the range of PCIe addresses that are allowed to be accessed, instead of reading information from the UMD. On Wormhole we allow access to the entire ATU, while on Blackhole we allow reading two different ranges, one with the ATU and one without.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes