### PR TITLE
fix bug that disabled two txq mode in Fabric on Blackhole

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -703,9 +703,6 @@ void FabricEriscDatamoverConfig::configure_buffer_slots_helper(
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     std::size_t channel_buffer_size_bytes, Topology topology, FabricEriscDatamoverOptions options) :
     FabricEriscDatamoverConfig(topology) {
-    this->sender_txq_id = 0;
-    this->receiver_txq_id = 0;
-
     // Update sender channel servicing based on fabric tensix configuration
     if (options.fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED) {
         // Use default direction (EAST) for the constructor case since direction isn't available here

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -275,19 +275,21 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
     if (this->sender_txq_id != this->receiver_txq_id) {
         // counters are packed contiguously in memory, This can lead to resends of values but
         // this is safe for free running counters, which are enabled in this mode.
-        size_t num_eth_words_consumed = tt::align(sizeof(uint32_t) * num_sender_channels, field_size);
+        size_t num_words_consumed_per_counter = tt::align(sizeof(uint32_t) * num_sender_channels, field_size);
+
+        next_l1_addr = tt::align(next_l1_addr, field_size);
 
         this->to_sender_channel_remote_ack_counters_base_addr = next_l1_addr;
-        next_l1_addr += num_eth_words_consumed;
+        next_l1_addr += num_words_consumed_per_counter;
 
         this->to_sender_channel_remote_completion_counters_base_addr = next_l1_addr;
-        next_l1_addr += num_eth_words_consumed;
+        next_l1_addr += num_words_consumed_per_counter;
 
         this->receiver_channel_remote_ack_counters_base_addr = next_l1_addr;
-        next_l1_addr += num_eth_words_consumed;
+        next_l1_addr += num_words_consumed_per_counter;
 
         this->receiver_channel_remote_completion_counters_base_addr = next_l1_addr;
-        next_l1_addr += num_eth_words_consumed;
+        next_l1_addr += num_words_consumed_per_counter;
     }
 
     this->edm_channel_ack_addr = next_l1_addr;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -343,10 +343,10 @@ struct FabricEriscDatamoverConfig {
     // Conditionally used fields. BlackHole with 2-erisc uses these fields for sending credits back to sender.
     // We use/have these fields because we can't send reg-writes over Ethernet on both TXQs. Therefore,
     // use use a different crediting scheme.
-    std::array<std::size_t, num_sender_channels> to_sender_channel_remote_ack_counter_addrs = {};
-    std::array<std::size_t, num_sender_channels> to_sender_channel_remote_completion_counter_addrs = {};
-    std::array<std::size_t, num_receiver_channels> receiver_channel_remote_ack_counter_addrs = {};
-    std::array<std::size_t, num_receiver_channels> receiver_channel_remote_completion_counter_addrs = {};
+    size_t to_sender_channel_remote_ack_counters_base_addr = 0;
+    size_t to_sender_channel_remote_completion_counters_base_addr = 0;
+    size_t receiver_channel_remote_ack_counters_base_addr = 0;
+    size_t receiver_channel_remote_completion_counters_base_addr = 0;
 
     // Channel Allocations
     std::size_t max_l1_loading_size = 0;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -326,53 +326,32 @@ static_assert(
 
 constexpr size_t TO_SENDER_CREDIT_COUNTERS_START_IDX = SPECIAL_MARKER_2_IDX + SPECIAL_MARKER_CHECK_ENABLED;
 
-constexpr std::array<size_t, NUM_SENDER_CHANNELS> to_sender_remote_ack_counter_addrs =
-    conditional_get_next_n_args<multi_txq_enabled, size_t, TO_SENDER_CREDIT_COUNTERS_START_IDX, NUM_SENDER_CHANNELS>();
+constexpr size_t to_sender_remote_ack_counters_base_address =
+    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX>();
 
-constexpr std::array<size_t, NUM_SENDER_CHANNELS> to_sender_remote_completion_counter_addrs =
-    conditional_get_next_n_args<
-        multi_txq_enabled,
-        size_t,
-        TO_SENDER_CREDIT_COUNTERS_START_IDX + NUM_SENDER_CHANNELS,
-        NUM_SENDER_CHANNELS>();
+constexpr size_t to_sender_remote_completion_counters_base_address =
+    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 1>();
 
-constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> local_receiver_ack_counter_ptrs = conditional_get_next_n_args<
-    multi_txq_enabled,
-    size_t,
-    TO_SENDER_CREDIT_COUNTERS_START_IDX + 2 * NUM_SENDER_CHANNELS,
-    NUM_RECEIVER_CHANNELS>();
+constexpr size_t local_receiver_ack_counters_base_address =
+    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 2>();
 
-constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> local_receiver_completion_counter_ptrs =
-    conditional_get_next_n_args<
-        multi_txq_enabled,
-        size_t,
-        TO_SENDER_CREDIT_COUNTERS_START_IDX + 2 * NUM_SENDER_CHANNELS + NUM_RECEIVER_CHANNELS,
-        NUM_RECEIVER_CHANNELS>();
+constexpr size_t local_receiver_completion_counters_base_address =
+    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 3>();
 
-template <typename T>
-constexpr bool counter_credit_addresses_are_valid(const T& counter_addresses) {
-    for (size_t i = 0; i < counter_addresses.size(); i++) {
-        if (counter_addresses[i] == 0) {
-            return false;
-        }
-    }
-    return true;
-}
 static_assert(
-    !multi_txq_enabled || counter_credit_addresses_are_valid(to_sender_remote_ack_counter_addrs),
-    "to_sender_remote_ack_counter_addrs must be valid");
+    !multi_txq_enabled || to_sender_remote_ack_counters_base_address != 0,
+    "to_sender_remote_ack_counters_base_address must be valid");
 static_assert(
-    !multi_txq_enabled || counter_credit_addresses_are_valid(to_sender_remote_completion_counter_addrs),
-    "to_sender_remote_completion_counter_addrs must be valid");
+    !multi_txq_enabled || to_sender_remote_completion_counters_base_address != 0,
+    "to_sender_remote_completion_counters_base_address must be valid");
 static_assert(
-    !multi_txq_enabled || counter_credit_addresses_are_valid(local_receiver_ack_counter_ptrs),
-    "local_receiver_ack_counter_ptrs must be valid");
+    !multi_txq_enabled || local_receiver_ack_counters_base_address != 0,
+    "local_receiver_ack_counters_base_address must be valid");
 static_assert(
-    !multi_txq_enabled || counter_credit_addresses_are_valid(local_receiver_completion_counter_ptrs),
-    "local_receiver_completion_counter_ptrs must be valid");
+    !multi_txq_enabled || local_receiver_completion_counters_base_address != 0,
+    "local_receiver_completion_counters_base_address must be valid");
 
-constexpr size_t SPECIAL_MARKER_3_IDX =
-    TO_SENDER_CREDIT_COUNTERS_START_IDX + (multi_txq_enabled ? 2 * (NUM_SENDER_CHANNELS + NUM_RECEIVER_CHANNELS) : 0);
+constexpr size_t SPECIAL_MARKER_3_IDX = TO_SENDER_CREDIT_COUNTERS_START_IDX + (multi_txq_enabled ? 4 : 0);
 constexpr size_t SPECIAL_MARKER_3 = 0x30c0ffee;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_3_IDX) == SPECIAL_MARKER_3,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -25,15 +25,16 @@ struct ReceiverChannelCounterBasedResponseCreditSender {
         }
     }
 
-    static FORCE_INLINE uint32_t eth_word_align(uint32_t addr) { return addr & ~0xF; }
+    static FORCE_INLINE uint32_t round_down_to_eth_word_alignment(uint32_t addr) { return addr & ~0xF; }
 
     FORCE_INLINE void send_completion_credit(uint8_t src_id) {
         completion_counters[src_id]++;
         completion_counters_base_ptr[src_id] = completion_counters[src_id];
         internal_::eth_send_packet_bytes_unsafe(
             receiver_txq_id,
-            eth_word_align(reinterpret_cast<uint32_t>(this->ack_counters_base_ptr + src_id)),
-            eth_word_align(to_sender_remote_completion_counters_base_address + src_id * sizeof(uint32_t)),
+            round_down_to_eth_word_alignment(reinterpret_cast<uint32_t>(this->completion_counters_base_ptr + src_id)),
+            round_down_to_eth_word_alignment(
+                to_sender_remote_completion_counters_base_address + src_id * sizeof(uint32_t)),
             ETH_WORD_SIZE_BYTES);
     }
 
@@ -43,8 +44,8 @@ struct ReceiverChannelCounterBasedResponseCreditSender {
         ack_counters_base_ptr[src_id] = ack_counters[src_id];
         internal_::eth_send_packet_bytes_unsafe(
             receiver_txq_id,
-            eth_word_align(reinterpret_cast<uint32_t>(this->ack_counters_base_ptr + src_id)),
-            eth_word_align(to_sender_remote_ack_counters_base_address + src_id * sizeof(uint32_t)),
+            round_down_to_eth_word_alignment(reinterpret_cast<uint32_t>(this->ack_counters_base_ptr + src_id)),
+            round_down_to_eth_word_alignment(to_sender_remote_ack_counters_base_address + src_id * sizeof(uint32_t)),
             ETH_WORD_SIZE_BYTES);
     }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -14,38 +14,45 @@
 struct ReceiverChannelCounterBasedResponseCreditSender {
     ReceiverChannelCounterBasedResponseCreditSender() = default;
     ReceiverChannelCounterBasedResponseCreditSender(size_t receiver_channel_index) :
-        completion_counter_ptr(
-            reinterpret_cast<volatile uint32_t*>(local_receiver_completion_counter_ptrs[receiver_channel_index])),
-        ack_counter_ptr(reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counter_ptrs[receiver_channel_index])),
-        completion_counter(0),
-        ack_counter(0) {}
+        completion_counters_base_ptr(
+            reinterpret_cast<volatile uint32_t*>(local_receiver_completion_counters_base_address)),
+        ack_counters_base_ptr(reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counters_base_address)),
+        completion_counters({}),
+        ack_counters({}) {
+        for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
+            completion_counters[i] = 0;
+            ack_counters[i] = 0;
+        }
+    }
+
+    static FORCE_INLINE uint32_t eth_word_align(uint32_t addr) { return addr & ~0xF; }
 
     FORCE_INLINE void send_completion_credit(uint8_t src_id) {
-        completion_counter++;
-        *completion_counter_ptr = completion_counter;
+        completion_counters[src_id]++;
+        completion_counters_base_ptr[src_id] = completion_counters[src_id];
         internal_::eth_send_packet_bytes_unsafe(
             receiver_txq_id,
-            reinterpret_cast<uint32_t>(this->completion_counter_ptr),
-            to_sender_remote_completion_counter_addrs[src_id],
+            eth_word_align(reinterpret_cast<uint32_t>(this->ack_counters_base_ptr + src_id)),
+            eth_word_align(to_sender_remote_completion_counters_base_address + src_id * sizeof(uint32_t)),
             ETH_WORD_SIZE_BYTES);
     }
 
     // Assumes !eth_txq_is_busy() -- PLEASE CHECK BEFORE CALLING
     FORCE_INLINE void send_ack_credit(uint8_t src_id) {
-        ack_counter++;
-        *ack_counter_ptr = ack_counter;
+        ack_counters[src_id]++;
+        ack_counters_base_ptr[src_id] = ack_counters[src_id];
         internal_::eth_send_packet_bytes_unsafe(
             receiver_txq_id,
-            reinterpret_cast<uint32_t>(this->ack_counter_ptr),
-            to_sender_remote_ack_counter_addrs[src_id],
+            eth_word_align(reinterpret_cast<uint32_t>(this->ack_counters_base_ptr + src_id)),
+            eth_word_align(to_sender_remote_ack_counters_base_address + src_id * sizeof(uint32_t)),
             ETH_WORD_SIZE_BYTES);
     }
 
-    volatile tt_l1_ptr uint32_t* completion_counter_ptr;
-    volatile tt_l1_ptr uint32_t* ack_counter_ptr;
+    volatile tt_l1_ptr uint32_t* completion_counters_base_ptr;
+    volatile tt_l1_ptr uint32_t* ack_counters_base_ptr;
     // Local memory copy to save an L1 load
-    uint32_t completion_counter;
-    uint32_t ack_counter;
+    std::array<uint32_t, NUM_SENDER_CHANNELS> completion_counters;
+    std::array<uint32_t, NUM_SENDER_CHANNELS> ack_counters;
 };
 
 struct ReceiverChannelStreamRegisterFreeSlotsBasedCreditSender {
@@ -112,9 +119,10 @@ struct SenderChannelFromReceiverCounterBasedCreditsReceiver {
     SenderChannelFromReceiverCounterBasedCreditsReceiver() = default;
     SenderChannelFromReceiverCounterBasedCreditsReceiver(size_t sender_channel_index) :
         acks_received_counter_ptr(
-            reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counter_addrs[sender_channel_index])),
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counters_base_address) + sender_channel_index),
         completions_received_counter_ptr(
-            reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counter_addrs[sender_channel_index])),
+            reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counters_base_address) +
+            sender_channel_index),
         acks_received_and_processed(0),
         completions_received_and_processed(0) {}
 


### PR DESCRIPTION
Found by inspection

The Ethernet subsystem txq and rxq assignments were being overridden to both be 0, even though earlier code paths enabled them to be 0 and 1 (for sender channel and receiver channel out traffic, respectively). Additionally, there was a bug with the receiver channel ack (to sender) free running counters which is resolved. The problem was the receiver was not keeping separate counters for each sender channel, but now it is. Note that the free-running counter credits code path was only enabled conditionally when two txqs are enabled, which is why this was not observed previously.

As a part of this fix, an update to the address map for the router was made to pack the counters contiguously in L1, indexed by channel. Each next category of counter (e.g. ack vs completion) is aligned to the next Ethernet word  (aka 16B) aligned address.

Requires https://github.com/tenstorrent/tt-metal/pull/28801 and its dependencies to be merged due to various stability fixes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17898499811
- [x] BH Post Commit: https://github.com/tenstorrent/tt-metal/actions/runs/17897607321
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17897608165
- [x] BH Multi Card Tests: https://github.com/tenstorrent/tt-metal/actions/runs/17897611800