### PR TITLE
#23538 Remove int32 data type from sharding-related tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1984,7 +1984,7 @@ profile_a_b_shape_pairs = [
 @pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
     (
-        (torch.bfloat16, ttnn.bfloat16)
+        (torch.bfloat16, ttnn.bfloat16),
         # (torch.float32, ttnn.float32)
     ),
 )

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -434,7 +434,6 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     "dtype_pt, dtype_tt",
     (
         [torch.bfloat16, ttnn.bfloat16],
-        [torch.int32, ttnn.int32],
         [torch.float32, ttnn.float32],
     ),
 )
@@ -1106,7 +1105,6 @@ def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, d
     "dtype_pt, dtype_tt",
     (
         [torch.bfloat16, ttnn.bfloat16],
-        [torch.int32, ttnn.int32],
         [torch.float32, ttnn.float32],
     ),
 )
@@ -1842,13 +1840,9 @@ def test_binary_sharded_invalid_row_major_layout(
         _ = ttnn.add(a_tt, b_tt, memory_config=a_sharded_config, use_legacy=None)
 
 
-@pytest.mark.skip(reason="Skipping test for dchen/23538-sharded_ND")
 @pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
-    (
-        [torch.bfloat16, ttnn.bfloat16],
-        [torch.int32, ttnn.int32],
-    ),
+    ([torch.bfloat16, ttnn.bfloat16],),
 )
 @pytest.mark.parametrize(
     "a_shape, b_shape, shard_type, shard_size, core_range",
@@ -1990,8 +1984,7 @@ profile_a_b_shape_pairs = [
 @pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
     (
-        (torch.bfloat16, ttnn.bfloat16),
-        # (torch.int32, ttnn.int32),
+        (torch.bfloat16, ttnn.bfloat16)
         # (torch.float32, ttnn.float32)
     ),
 )


### PR DESCRIPTION

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/23538)

### Problem description
Very rare ND test issue. Pattern points to sharding + int32. But no root cause identified.

### What's changed
Remove int32 data type test, because it is not focus of broadcasting test.
- Remove [torch.int32, ttnn.int32] from test_binary_sharded_bcast_w
- Remove [torch.int32, ttnn.int32] from test_binary_sharded_row_major_layout
- Remove skip decorator from test_binary_sharded_row_major_layout
- Apply black formatting fixes

This focuses sharding tests on bfloat16 and float32 data types only, excluding int32 which may have specific ND sharding issues.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [TG demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes