### PR TITLE
Point-to-point Fabric Benchmark

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -68,7 +68,7 @@ jobs:
           {
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
-            name: "T3K ubench - Unicast (sockets)",
+            name: "Fabric Collectives ubench - Point to Point",
             cmd: "bash tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh"
           } # Tomer Levin
         ]

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -64,7 +64,13 @@ jobs:
             runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
             name: "BH P150 PCIe Performance",
             cmd: build/tools/mem_bench --benchmark_filter="Device (Reading|Writing) Host"
-          } # Nigel Huang
+          }, # Nigel Huang
+          {
+            arch: wormhole_b0,
+            runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
+            name: "T3K ubench - Unicast (sockets)",
+            cmd: "bash tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh"
+          } # Tomer Levin
         ]
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -69,7 +69,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "Fabric Collectives ubench - Point to Point",
-            cmd: "bash tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh"
+            cmd: "tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh"
           } # Tomer Levin
         ]
     container:

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -190,3 +190,41 @@ target_sources(
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_1d_fabric_loopback_latency.cpp
 )
+
+# ---- Bench: unicast ----
+add_executable(
+    bench_unicast
+    ${CMAKE_CURRENT_SOURCE_DIR}/benchmark/collectives/unicast/bench_unicast_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/benchmark/collectives/unicast/run_unicast_once.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/benchmark/collectives/common/perf_helpers.cpp
+)
+
+target_link_libraries(
+    bench_unicast
+    PRIVATE
+        tt_metal
+        fabric
+        gtest
+        test_common_libs
+)
+
+add_dependencies(bench_unicast tt_metal)
+
+target_include_directories(
+    bench_unicast
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${UMD_HOME}
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+        ${PROJECT_BINARY_DIR}/tt_metal/third_party/umd/device/api
+        ${PROJECT_BINARY_DIR}/tt_metal/third_party/umd/device/generated
+)
+
+set_target_properties(
+    bench_unicast
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal/tt_fabric
+)

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "perf_helpers.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+#include <tt-metalium/device_pool.hpp>
+using tt::DevicePool;
+
+namespace tt::tt_fabric::bench {
+
+double mean_of(const std::vector<double>& v) {
+    if (v.empty()) {
+        return 0.0;
+    }
+    double s = std::accumulate(v.begin(), v.end(), 0.0);
+    return s / static_cast<double>(v.size());
+}
+
+double stddev_of(const std::vector<double>& v, double m) {
+    if (v.size() < 2) {
+        return 0.0;
+    }
+    double acc = 0.0;
+    for (double x : v) {
+        double d = x - m;
+        acc += d * d;
+    }
+    return std::sqrt(acc / static_cast<double>(v.size() - 1));
+}
+
+double percentile(std::vector<double> v, double p_in_0_100) {
+    if (v.empty()) {
+        return 0.0;
+    }
+    p_in_0_100 = std::clamp(p_in_0_100, 0.0, 100.0);
+    const size_t n = v.size();
+    const size_t k = static_cast<size_t>(std::round((p_in_0_100 / 100.0) * (n - 1)));
+    std::nth_element(v.begin(), v.begin() + k, v.end());
+    return v[k];
+}
+
+PerfStats aggregate_stats(const std::vector<PerfPoint>& pts) {
+    PerfStats s{};
+    if (pts.empty()) {
+        return s;
+    }
+    s.bytes = pts.front().bytes;
+    s.iters = static_cast<int>(pts.size());
+
+    std::vector<double> v_ms;
+    v_ms.reserve(pts.size());
+    std::vector<double> v_gbps;
+    v_gbps.reserve(pts.size());
+    for (const auto& p : pts) {
+        v_ms.push_back(p.ms);
+        v_gbps.push_back(p.gbps);
+    }
+
+    s.mean_ms = mean_of(v_ms);
+    s.std_ms = stddev_of(v_ms, s.mean_ms);
+    s.p50_ms = percentile(v_ms, 50.0);
+    s.p95_ms = percentile(v_ms, 95.0);
+    s.min_ms = *std::min_element(v_ms.begin(), v_ms.end());
+    s.max_ms = *std::max_element(v_ms.begin(), v_ms.end());
+    s.mean_gbps = mean_of(v_gbps);
+    return s;
+}
+
+void warmup_once(HelpersFixture* fixture, PerfParams base, int iters) {
+    for (int i = 0; i < iters; ++i) {
+        (void)run_unicast_once(fixture, base);
+    }
+}
+
+PerfStats run_repeated(HelpersFixture* fixture, const PerfParams& p, int warmup_iters, int iters) {
+    for (int w = 0; w < warmup_iters; ++w) {
+        (void)run_unicast_once(fixture, p);
+    }
+    std::vector<PerfPoint> pts;
+    pts.reserve(iters > 0 ? iters : 0);
+    for (int i = 0; i < iters; ++i) {
+        pts.push_back(run_unicast_once(fixture, p));
+    }
+    return aggregate_stats(pts);
+}
+
+tt::tt_metal::IDevice* find_device_by_id(chip_id_t phys_id) {
+    auto devices = DevicePool::instance().get_all_active_devices();
+    for (auto* d : devices) {
+        if (d->id() == phys_id) {
+            return d;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace tt::tt_fabric::bench

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
@@ -54,11 +54,11 @@ PerfStats aggregate_stats(const std::vector<PerfPoint>& pts) {
 
     std::vector<double> v_ms;
     v_ms.reserve(pts.size());
-    std::vector<double> v_gbps;
-    v_gbps.reserve(pts.size());
+    std::vector<double> v_GB_s;
+    v_GB_s.reserve(pts.size());
     for (const auto& p : pts) {
         v_ms.push_back(p.ms);
-        v_gbps.push_back(p.gbps);
+        v_GB_s.push_back(p.GB_s);
     }
 
     s.mean_ms = mean_of(v_ms);
@@ -68,13 +68,13 @@ PerfStats aggregate_stats(const std::vector<PerfPoint>& pts) {
     s.min_ms = *std::min_element(v_ms.begin(), v_ms.end());
     s.max_ms = *std::max_element(v_ms.begin(), v_ms.end());
     // throughput stats
-    s.mean_gbps = mean_of(v_gbps);
-    s.std_gbps = stddev_of(v_gbps, s.mean_gbps);
-    s.p50_gbps = percentile(v_gbps, 50.0);
-    s.p10_gbps = percentile(v_gbps, 10.0);
-    s.min_gbps = *std::min_element(v_gbps.begin(), v_gbps.end());
-    s.max_gbps = *std::max_element(v_gbps.begin(), v_gbps.end());
-    s.cv_gbps_pct = (s.mean_gbps > 0.0) ? (s.std_gbps / s.mean_gbps) * 100.0 : 0.0;
+    s.mean_GB_s = mean_of(v_GB_s);
+    s.std_GB_s = stddev_of(v_GB_s, s.mean_GB_s);
+    s.p50_GB_s = percentile(v_GB_s, 50.0);
+    s.p10_GB_s = percentile(v_GB_s, 10.0);
+    s.min_GB_s = *std::min_element(v_GB_s.begin(), v_GB_s.end());
+    s.max_GB_s = *std::max_element(v_GB_s.begin(), v_GB_s.end());
+    s.cv_GB_s_pct = (s.mean_GB_s > 0.0) ? (s.std_GB_s / s.mean_GB_s) * 100.0 : 0.0;
     return s;
 }
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
@@ -67,7 +67,14 @@ PerfStats aggregate_stats(const std::vector<PerfPoint>& pts) {
     s.p95_ms = percentile(v_ms, 95.0);
     s.min_ms = *std::min_element(v_ms.begin(), v_ms.end());
     s.max_ms = *std::max_element(v_ms.begin(), v_ms.end());
+    // throughput stats
     s.mean_gbps = mean_of(v_gbps);
+    s.std_gbps = stddev_of(v_gbps, s.mean_gbps);
+    s.p50_gbps = percentile(v_gbps, 50.0);
+    s.p10_gbps = percentile(v_gbps, 10.0);
+    s.min_gbps = *std::min_element(v_gbps.begin(), v_gbps.end());
+    s.max_gbps = *std::max_element(v_gbps.begin(), v_gbps.end());
+    s.cv_gbps_pct = (s.mean_gbps > 0.0) ? (s.std_gbps / s.mean_gbps) * 100.0 : 0.0;
     return s;
 }
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
@@ -6,14 +6,14 @@
 #include <cstdint>
 #include <vector>
 
-#include "fabric_fixture.hpp"
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt::tt_fabric::bench {
 
-using HelpersFixture = ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture;
+using HelpersFixture = ::tt::tt_metal::MeshDeviceFixtureBase;
 
 // ---- Reusable defaults -------
 inline constexpr uint32_t kDefaultMeshId = 0;
@@ -23,6 +23,7 @@ inline constexpr bool kDefaultUseDramDst = false;
 inline constexpr uint32_t kDefaultTensorBytes = 1u << 20;  // 1 MiB
 inline constexpr uint32_t kDefaultPageSize = 4096;         // 4 KiB
 inline constexpr tt::tt_metal::CoreCoord kDefaultCore = {0, 0};
+inline constexpr uint32_t kDefaultTraceIters = 100;
 
 // ---- Shared data types ----
 struct PerfPoint {
@@ -41,6 +42,7 @@ struct PerfParams {
     uint32_t page_size = kDefaultPageSize;
     tt::tt_metal::CoreCoord sender_core = kDefaultCore;
     tt::tt_metal::CoreCoord receiver_core = kDefaultCore;
+    uint32_t trace_iters = kDefaultTraceIters;  // number of enqueues captured per trace
 };
 
 struct PerfStats {

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
@@ -14,6 +14,16 @@
 namespace tt::tt_fabric::bench {
 
 using HelpersFixture = ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture;
+
+// ---- Reusable defaults -------
+inline constexpr uint32_t kDefaultMeshId = 0;
+inline constexpr chip_id_t kDefaultSrcChip = 0;
+inline constexpr chip_id_t kDefaultDstChip = 1;
+inline constexpr bool kDefaultUseDramDst = false;
+inline constexpr uint32_t kDefaultTensorBytes = 1u << 20;  // 1 MiB
+inline constexpr uint32_t kDefaultPageSize = 4096;         // 4 KiB
+inline constexpr tt::tt_metal::CoreCoord kDefaultCore = {0, 0};
+
 // ---- Shared data types ----
 struct PerfPoint {
     uint64_t bytes{};
@@ -23,14 +33,14 @@ struct PerfPoint {
 };
 
 struct PerfParams {
-    uint32_t mesh_id = 0;
-    chip_id_t src_chip = 0;
-    chip_id_t dst_chip = 1;
-    bool use_dram_dst = false;
-    uint32_t tensor_bytes = 1024 * 1024;
-    uint32_t page_size = 4096;
-    tt::tt_metal::CoreCoord sender_core{0, 0};
-    tt::tt_metal::CoreCoord receiver_core{0, 0};
+    uint32_t mesh_id = kDefaultMeshId;
+    chip_id_t src_chip = kDefaultSrcChip;
+    chip_id_t dst_chip = kDefaultDstChip;
+    bool use_dram_dst = kDefaultUseDramDst;
+    uint32_t tensor_bytes = kDefaultTensorBytes;
+    uint32_t page_size = kDefaultPageSize;
+    tt::tt_metal::CoreCoord sender_core = kDefaultCore;
+    tt::tt_metal::CoreCoord receiver_core = kDefaultCore;
 };
 
 struct PerfStats {

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
@@ -19,7 +19,7 @@ struct PerfPoint {
     uint64_t bytes{};
     double sec{};
     double ms{};
-    double gbps{};
+    double GB_s{};
 };
 
 struct PerfParams {
@@ -39,7 +39,7 @@ struct PerfStats {
     // latency (ms)
     double mean_ms{}, std_ms{}, p50_ms{}, p95_ms{}, min_ms{}, max_ms{};
     // throughput (GB/s)
-    double mean_gbps{}, std_gbps{}, p50_gbps{}, p10_gbps{}, min_gbps{}, max_gbps{}, cv_gbps_pct{};
+    double mean_GB_s{}, std_GB_s{}, p50_GB_s{}, p10_GB_s{}, min_GB_s{}, max_GB_s{}, cv_GB_s_pct{};
 };
 
 PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p);

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
@@ -36,8 +36,10 @@ struct PerfParams {
 struct PerfStats {
     uint64_t bytes{};
     int iters{};
+    // latency (ms)
     double mean_ms{}, std_ms{}, p50_ms{}, p95_ms{}, min_ms{}, max_ms{};
-    double mean_gbps{};
+    // throughput (GB/s)
+    double mean_gbps{}, std_gbps{}, p50_gbps{}, p10_gbps{}, min_gbps{}, max_gbps{}, cv_gbps_pct{};
 };
 
 PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p);

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+#include <vector>
+
+#include "fabric_fixture.hpp"
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace tt::tt_fabric::bench {
+
+using HelpersFixture = ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture;
+// ---- Shared data types ----
+struct PerfPoint {
+    uint64_t bytes{};
+    double sec{};
+    double ms{};
+    double gbps{};
+};
+
+struct PerfParams {
+    uint32_t mesh_id = 0;
+    chip_id_t src_chip = 0;
+    chip_id_t dst_chip = 1;
+    bool use_dram_dst = false;
+    uint32_t tensor_bytes = 1024 * 1024;
+    uint32_t page_size = 4096;
+    tt::tt_metal::CoreCoord sender_core{0, 0};
+    tt::tt_metal::CoreCoord receiver_core{0, 0};
+};
+
+struct PerfStats {
+    uint64_t bytes{};
+    int iters{};
+    double mean_ms{}, std_ms{}, p50_ms{}, p95_ms{}, min_ms{}, max_ms{};
+    double mean_gbps{};
+};
+
+PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p);
+
+// Helpers implemented in perf_helpers.cpp
+double mean_of(const std::vector<double>& v);
+double stddev_of(const std::vector<double>& v, double mean);
+double percentile(std::vector<double> v, double p_in_0_100);
+
+PerfStats aggregate_stats(const std::vector<PerfPoint>& pts);
+
+void warmup_once(HelpersFixture* fixture, PerfParams base, int iters = 1);
+
+PerfStats run_repeated(HelpersFixture* fixture, const PerfParams& p, int warmup_iters, int iters);
+
+// Utility used by multiple tests
+tt::tt_metal::IDevice* find_device_by_id(chip_id_t phys_id);
+
+}  // namespace tt::tt_fabric::bench

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_csv.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_csv.py
@@ -7,24 +7,24 @@ import matplotlib.pyplot as plt
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("csv_path", help="CSV file with columns: bytes,ms,gbps")
+    ap.add_argument("csv_path", help="CSV file with columns: bytes,ms,GB_s")
     ap.add_argument("--title", default="Unicast E2E – N300")
     args = ap.parse_args()
 
-    sizes_B, ms, gbps = [], [], []
+    sizes_B, ms, GB_s = [], [], []
     with open(args.csv_path, newline="") as f:
         r = csv.DictReader(f)
         for row in r:
             sizes_B.append(float(row["bytes"]))
             ms.append(float(row["ms"]))
-            gbps.append(float(row["gbps"]))
+            GB_s.append(float(row["GB_s"]))
 
     sizes_MB = [b / 1e6 for b in sizes_B]
 
     fig, ax1 = plt.subplots(figsize=(7, 4.5))
     ax2 = ax1.twinx()
 
-    ln1 = ax1.plot(sizes_MB, gbps, marker="o", color="tab:blue", label="Throughput (GB/s)")
+    ln1 = ax1.plot(sizes_MB, GB_s, marker="o", color="tab:blue", label="Throughput (GB/s)")
     ln2 = ax2.plot(sizes_MB, ms, marker="s", color="tab:red", label="Latency (ms)")
 
     ax1.set_xlabel("Tensor size (MB)")

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_csv.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_csv.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+import argparse, csv, os
+import matplotlib.pyplot as plt
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv_path", help="CSV file with columns: bytes,ms,gbps")
+    ap.add_argument("--title", default="Unicast E2E – N300")
+    args = ap.parse_args()
+
+    sizes_B, ms, gbps = [], [], []
+    with open(args.csv_path, newline="") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            sizes_B.append(float(row["bytes"]))
+            ms.append(float(row["ms"]))
+            gbps.append(float(row["gbps"]))
+
+    sizes_MB = [b / 1e6 for b in sizes_B]
+
+    fig, ax1 = plt.subplots(figsize=(7, 4.5))
+    ax2 = ax1.twinx()
+
+    ln1 = ax1.plot(sizes_MB, gbps, marker="o", color="tab:blue", label="Throughput (GB/s)")
+    ln2 = ax2.plot(sizes_MB, ms, marker="s", color="tab:red", label="Latency (ms)")
+
+    ax1.set_xlabel("Tensor size (MB)")
+    ax1.set_ylabel("Throughput (GB/s)")
+    ax2.set_ylabel("Latency (ms)")
+
+    ax1.grid(True, linestyle="--", alpha=0.4)
+    ax1.set_title(args.title)
+
+    # One combined legend
+    lns = ln1 + ln2
+    labs = [l.get_label() for l in lns]
+    ax1.legend(lns, labs, loc="best")
+
+    out_png = os.path.splitext(args.csv_path)[0] + ".png"
+    plt.tight_layout()
+    plt.savefig(out_png, dpi=160)
+    print(f"Wrote {out_png}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_heatmap.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_heatmap.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+import argparse, csv, os, math
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def load_csv(path):
+    xs, ys, ms, gbps = [], [], [], []
+    with open(path, newline="") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            xs.append(int(row["x"]))
+            ys.append(int(row["y"]))
+            ms.append(float(row["ms"]))
+            gbps.append(float(row["gbps"]))
+    return xs, ys, ms, gbps
+
+
+def to_grid(xs, ys, vals):
+    maxx = max(xs)
+    maxy = max(ys)
+    grid = np.full((maxy + 1, maxx + 1), np.nan, dtype=float)
+    for x, y, v in zip(xs, ys, vals):
+        grid[y, x] = v
+    return grid
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv_path", help="CSV with columns: x,y,ms,gbps")
+    ap.add_argument("--title", default="Unicast E2E Heatmaps – N300")
+    args = ap.parse_args()
+
+    xs, ys, ms, gbps = load_csv(args.csv_path)
+    ms_grid = to_grid(xs, ys, ms)
+    gbps_grid = to_grid(xs, ys, gbps)
+
+    # Latency heatmap
+    plt.figure(figsize=(7, 5))
+    im1 = plt.imshow(ms_grid, origin="lower", aspect="equal")
+    plt.colorbar(im1, label="Latency (ms)")
+    plt.title(args.title + " — Latency")
+    plt.xlabel("Core X")
+    plt.ylabel("Core Y")
+    out1 = os.path.splitext(args.csv_path)[0] + "_latency.png"
+    plt.tight_layout()
+    plt.savefig(out1, dpi=160)
+    print(f"Wrote {out1}")
+
+    # Throughput heatmap
+    plt.figure(figsize=(7, 5))
+    im2 = plt.imshow(gbps_grid, origin="lower", aspect="equal")
+    plt.colorbar(im2, label="Throughput (GB/s)")
+    plt.title(args.title + " — Throughput")
+    plt.xlabel("Core X")
+    plt.ylabel("Core Y")
+    out2 = os.path.splitext(args.csv_path)[0] + "_throughput.png"
+    plt.tight_layout()
+    plt.savefig(out2, dpi=160)
+    print(f"Wrote {out2}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_heatmap.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/scripts/plot_heatmap.py
@@ -7,15 +7,15 @@ import matplotlib.pyplot as plt
 
 
 def load_csv(path):
-    xs, ys, ms, gbps = [], [], [], []
+    xs, ys, ms, GB_s = [], [], [], []
     with open(path, newline="") as f:
         r = csv.DictReader(f)
         for row in r:
             xs.append(int(row["x"]))
             ys.append(int(row["y"]))
             ms.append(float(row["ms"]))
-            gbps.append(float(row["gbps"]))
-    return xs, ys, ms, gbps
+            GB_s.append(float(row["GB_s"]))
+    return xs, ys, ms, GB_s
 
 
 def to_grid(xs, ys, vals):
@@ -29,13 +29,13 @@ def to_grid(xs, ys, vals):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("csv_path", help="CSV with columns: x,y,ms,gbps")
+    ap.add_argument("csv_path", help="CSV with columns: x,y,ms,GB_s")
     ap.add_argument("--title", default="Unicast E2E Heatmaps – N300")
     args = ap.parse_args()
 
-    xs, ys, ms, gbps = load_csv(args.csv_path)
+    xs, ys, ms, GB_s = load_csv(args.csv_path)
     ms_grid = to_grid(xs, ys, ms)
-    gbps_grid = to_grid(xs, ys, gbps)
+    GB_s_grid = to_grid(xs, ys, GB_s)
 
     # Latency heatmap
     plt.figure(figsize=(7, 5))
@@ -51,7 +51,7 @@ def main():
 
     # Throughput heatmap
     plt.figure(figsize=(7, 5))
-    im2 = plt.imshow(gbps_grid, origin="lower", aspect="equal")
+    im2 = plt.imshow(GB_s_grid, origin="lower", aspect="equal")
     plt.colorbar(im2, label="Throughput (GB/s)")
     plt.title(args.title + " — Throughput")
     plt.xlabel("Core X")

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -217,13 +217,13 @@ int main(int argc, char** argv) {
     // Human-readable result
     log_info(
         tt::LogTest,
-        "Result: p50_ms={} p95_ms={} mean_gbps={} p50_gbps={} p10_gbps={} cv_gbps_pct={}",
+        "Result: p50_ms={} p95_ms={} mean_GB_s={} p50_GB_s={} p10_GB_s={} cv_GB_s_pct={}",
         stats.p50_ms,
         stats.p95_ms,
-        stats.mean_gbps,
-        stats.p50_gbps,
-        stats.p10_gbps,
-        stats.cv_gbps_pct);
+        stats.mean_GB_s,
+        stats.p50_GB_s,
+        stats.p10_GB_s,
+        stats.cv_GB_s_pct);
 
     // Optional CSV artifact
     if (!run.csv_path.empty()) {
@@ -237,12 +237,12 @@ int main(int argc, char** argv) {
         }
         if (newfile) {
             ofs << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,"
-                   "p50_ms,p95_ms,mean_gbps,p50_gbps,p10_gbps,cv_gbps_pct\n";
+                   "p50_ms,p95_ms,mean_GB_s,p50_GB_s,p10_GB_s,cv_GB_s_pct\n";
         }
         ofs << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << "," << p.sender_core.y
             << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes << "," << p.page_size
             << "," << run.iters << "," << run.warmup << "," << stats.p50_ms << "," << stats.p95_ms << ","
-            << stats.mean_gbps << "," << stats.p50_gbps << "," << stats.p10_gbps << "," << stats.cv_gbps_pct << "\n";
+            << stats.mean_GB_s << "," << stats.p50_GB_s << "," << stats.p10_GB_s << "," << stats.cv_GB_s_pct << "\n";
 
         log_info(tt::LogTest, "Appended CSV row to {}", run.csv_path);
     }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp"
+
+// We reuse the existing test fixture infra to bring devices up.
+struct Fixture : public ::tt::tt_fabric::fabric_router_tests::Fabric2DFixture {
+    void TestBody() override {}
+    void setup() { this->SetUp(); }
+    void teardown() { this->TearDown(); }
+
+    // Public wrappers so main() can prepare/cleanup the suite environment
+    static void suite_setup() {
+        ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture::DoSetUpTestSuite(
+            tt::tt_fabric::FabricConfig::FABRIC_2D);
+    }
+    static void suite_teardown() { ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture::DoTearDownTestSuite(); }
+};
+
+// Shorthands
+using tt::tt_fabric::bench::find_device_by_id;
+using tt::tt_fabric::bench::PerfParams;
+using tt::tt_fabric::bench::PerfStats;
+using tt::tt_fabric::bench::run_repeated;
+using tt::tt_fabric::bench::warmup_once;
+
+// Simple parsers (no deps)
+static bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
+    // Accept "m:c" or just "c"
+    size_t colon = s.find(':');
+    if (colon == std::string::npos) {
+        mesh = 0;
+        chip = std::stoi(s);
+        return true;
+    }
+    mesh = static_cast<uint32_t>(std::stoul(s.substr(0, colon)));
+    chip = std::stoi(s.substr(colon + 1));
+    return true;
+}
+static bool parse_xy(const std::string& s, int& x, int& y) {
+    auto comma = s.find(',');
+    if (comma == std::string::npos) {
+        return false;
+    }
+    x = std::stoi(s.substr(0, comma));
+    y = std::stoi(s.substr(comma + 1));
+    return true;
+}
+
+static void usage(const char* argv0) {
+    std::cerr <<
+        R"(Usage:
+  )" << argv0 << R"( --src-dev <mesh:chip|chip> --dst-dev <mesh:chip|chip> --size <bytes>
+         [--page <bytes>] [--src-type <l1|dram|single_bank>] [--dst-type <l1|dram|single_bank>]
+         [--send-core x,y] [--recv-core x,y]
+         [--iters N] [--warmup N]
+         [--no-trace] [--enable-sync]
+         [--csv <path>] [--format <human|csv|json>]
+
+Notes:
+- This binary runs ONE configuration. For sweeps, call it in a loop from a script.
+- --src-type/--dst-type are accepted for future use; current code uses DRAM src and L1/DRAM dst as in your kernels.
+)";
+}
+
+int main(int argc, char** argv) {
+    // Defaults
+    PerfParams p;
+    p.mesh_id = 0;
+    p.src_chip = 0;
+    p.dst_chip = 1;
+    p.page_size = 2048;
+    p.tensor_bytes = 128 * p.page_size;
+    p.use_dram_dst = false;
+    p.sender_core = {0, 0};
+    p.receiver_core = {0, 0};
+
+    int iters = 5, warmup = 1;
+    bool no_trace = false;     // TODO: wire to profiler off
+    bool enable_sync = false;  // TODO: add a start barrier
+    std::string src_dev_str, dst_dev_str;
+    std::string src_type = "dram", dst_type = "l1";  // placeholders for future
+    std::string format = "human";                    // "human" | "csv" | "json"
+    std::string csv_path;                            // if non-empty, append one row
+
+    // Parse argv
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        auto need = [&](int more) {
+            if (i + more >= argc) {
+                usage(argv[0]);
+                return false;
+            }
+            return true;
+        };
+
+        if (a == "--src-dev" && need(1)) {
+            src_dev_str = argv[++i];
+        } else if (a == "--dst-dev" && need(1)) {
+            dst_dev_str = argv[++i];
+        } else if (a == "--size" && need(1)) {
+            p.tensor_bytes = static_cast<uint32_t>(std::stoul(argv[++i]));
+        } else if (a == "--page" && need(1)) {
+            p.page_size = static_cast<uint32_t>(std::stoul(argv[++i]));
+        } else if (a == "--src-type" && need(1)) {
+            src_type = argv[++i];
+        } else if (a == "--dst-type" && need(1)) {
+            dst_type = argv[++i];
+            p.use_dram_dst = (dst_type == "dram");
+        } else if (a == "--send-core" && need(1)) {
+            int x, y;
+            if (!parse_xy(argv[++i], x, y)) {
+                usage(argv[0]);
+                return 2;
+            }
+            p.sender_core = {x, y};
+        } else if (a == "--recv-core" && need(1)) {
+            int x, y;
+            if (!parse_xy(argv[++i], x, y)) {
+                usage(argv[0]);
+                return 2;
+            }
+            p.receiver_core = {x, y};
+        } else if (a == "--iters" && need(1)) {
+            iters = std::stoi(argv[++i]);
+        } else if (a == "--warmup" && need(1)) {
+            warmup = std::stoi(argv[++i]);
+        } else if (a == "--no-trace") {
+            no_trace = true;
+        } else if (a == "--enable-sync") {
+            enable_sync = true;
+        } else if (a == "--csv" && need(1)) {
+            csv_path = argv[++i];
+        } else if (a == "--format" && need(1)) {
+            format = argv[++i];
+        } else {
+            usage(argv[0]);
+            return 2;
+        }
+    }
+
+    if (src_dev_str.empty() || dst_dev_str.empty() || p.tensor_bytes == 0) {
+        usage(argv[0]);
+        return 2;
+    }
+    uint32_t src_mesh = 0, dst_mesh = 0;
+    int src_chip = 0, dst_chip = 0;
+    if (!parse_mesh_chip(src_dev_str, src_mesh, src_chip)) {
+        usage(argv[0]);
+        return 2;
+    }
+    if (!parse_mesh_chip(dst_dev_str, dst_mesh, dst_chip)) {
+        usage(argv[0]);
+        return 2;
+    }
+    p.mesh_id = src_mesh;  // assume same mesh
+    p.src_chip = static_cast<chip_id_t>(src_chip);
+    p.dst_chip = static_cast<chip_id_t>(dst_chip);
+
+    // Bring up the fixture env and run
+    Fixture::suite_setup();
+    Fixture fixture;
+    fixture.setup();
+    warmup_once(&fixture, p, warmup);
+    auto stats = run_repeated(&fixture, p, /*warmup_iters=*/0, /*iters=*/iters);
+    fixture.teardown();
+    Fixture::suite_teardown();
+
+    // Output
+    if (format == "human") {
+        std::cout << "[bench] src=" << src_dev_str << " dst=" << dst_dev_str << " size=" << p.tensor_bytes
+                  << " page=" << p.page_size << " iters=" << iters << " warmup=" << warmup << " p50_ms=" << stats.p50_ms
+                  << " p95_ms=" << stats.p95_ms << " mean_gbps=" << stats.mean_gbps << "\n";
+    } else if (format == "csv") {
+        // print a single CSV row to stdout
+        std::cout
+            << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,p50_ms,p95_ms,mean_gbps\n";
+        std::cout << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << ","
+                  << p.sender_core.y << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes
+                  << "," << p.page_size << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms
+                  << "," << stats.mean_gbps << "\n";
+    } else if (format == "json") {
+        std::cout << "{"
+                  << "\"mesh\":" << p.mesh_id << ",\"src_chip\":" << p.src_chip << ",\"dst_chip\":" << p.dst_chip
+                  << ",\"send_core\":[" << p.sender_core.x << "," << p.sender_core.y << "]"
+                  << ",\"recv_core\":[" << p.receiver_core.x << "," << p.receiver_core.y << "]"
+                  << ",\"sizeB\":" << p.tensor_bytes << ",\"pageB\":" << p.page_size << ",\"iters\":" << iters
+                  << ",\"warmup\":" << warmup << ",\"p50_ms\":" << stats.p50_ms << ",\"p95_ms\":" << stats.p95_ms
+                  << ",\"mean_gbps\":" << stats.mean_gbps << "}\n";
+    }
+
+    if (!csv_path.empty()) {
+        // append one row; create header if new
+        bool newfile = false;
+        {
+            std::ifstream chk(csv_path);
+            newfile = !chk.good();
+        }
+        std::ofstream ofs(csv_path, std::ios::app);
+        if (newfile) {
+            ofs << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,p50_ms,p95_ms,mean_"
+                   "gbps\n";
+        }
+        ofs << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << "," << p.sender_core.y
+            << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes << "," << p.page_size
+            << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms << "," << stats.mean_gbps
+            << "\n";
+    }
+
+    return 0;
+}

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -88,16 +88,6 @@ static bool parse_xy(const std::string& s, int& x, int& y) {
 // Fills RunOptions + PerfParams + raw src/dst strings. Returns false on bad args.
 static bool parse_cli_or_usage(
     int argc, char** argv, RunOptions& run, PerfParams& p, std::string& src_dev_str, std::string& dst_dev_str) {
-    // Workload defaults
-    p.mesh_id = 0;
-    p.src_chip = 0;
-    p.dst_chip = 1;
-    p.page_size = 2048;
-    p.tensor_bytes = 128 * p.page_size;
-    p.use_dram_dst = false;
-    p.sender_core = {0, 0};
-    p.trace_iters = 1;
-
     std::string src_type = "dram";  // reserved
     std::string dst_type = "l1";    // reserved
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -179,15 +179,17 @@ int main(int argc, char** argv) {
     if (format == "human") {
         std::cout << "[bench] src=" << src_dev_str << " dst=" << dst_dev_str << " size=" << p.tensor_bytes
                   << " page=" << p.page_size << " iters=" << iters << " warmup=" << warmup << " p50_ms=" << stats.p50_ms
-                  << " p95_ms=" << stats.p95_ms << " mean_gbps=" << stats.mean_gbps << "\n";
+                  << " p95_ms=" << stats.p95_ms << " mean_gbps=" << stats.mean_gbps << " p50_gbps=" << stats.p50_gbps
+                  << " p10_gbps=" << stats.p10_gbps << " cv_gbps_pct=" << stats.cv_gbps_pct << "\n";
     } else if (format == "csv") {
         // print a single CSV row to stdout
-        std::cout
-            << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,p50_ms,p95_ms,mean_gbps\n";
+        std::cout << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,"
+                  << "p50_ms,p95_ms,mean_gbps,p50_gbps,p10_gbps,cv_gbps_pct\n";
         std::cout << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << ","
                   << p.sender_core.y << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes
                   << "," << p.page_size << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms
-                  << "," << stats.mean_gbps << "\n";
+                  << "," << stats.mean_gbps << "," << stats.p50_gbps << "," << stats.p10_gbps << ","
+                  << stats.cv_gbps_pct << "\n";
     } else if (format == "json") {
         std::cout << "{"
                   << "\"mesh\":" << p.mesh_id << ",\"src_chip\":" << p.src_chip << ",\"dst_chip\":" << p.dst_chip
@@ -207,13 +209,13 @@ int main(int argc, char** argv) {
         }
         std::ofstream ofs(csv_path, std::ios::app);
         if (newfile) {
-            ofs << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,p50_ms,p95_ms,mean_"
-                   "gbps\n";
+            ofs << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,"
+                   "p50_ms,p95_ms,mean_gbps,p50_gbps,p10_gbps,cv_gbps_pct\n";
         }
         ofs << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << "," << p.sender_core.y
             << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes << "," << p.page_size
             << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms << "," << stats.mean_gbps
-            << "\n";
+            << "," << stats.p50_gbps << "," << stats.p10_gbps << "," << stats.cv_gbps_pct << "\n";
     }
 
     return 0;

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <string>
-#include <fstream>
 #include <vector>
-#include <gtest/gtest.h>
+#include <filesystem>
 
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp"
@@ -18,7 +19,6 @@ struct Fixture : public ::tt::tt_fabric::fabric_router_tests::Fabric2DFixture {
     void setup() { this->SetUp(); }
     void teardown() { this->TearDown(); }
 
-    // Public wrappers so main() can prepare/cleanup the suite environment
     static void suite_setup() {
         ::tt::tt_fabric::fabric_router_tests::BaseFabricFixture::DoSetUpTestSuite(
             tt::tt_fabric::FabricConfig::FABRIC_2D);
@@ -27,15 +27,42 @@ struct Fixture : public ::tt::tt_fabric::fabric_router_tests::Fabric2DFixture {
 };
 
 // Shorthands
-using tt::tt_fabric::bench::find_device_by_id;
 using tt::tt_fabric::bench::PerfParams;
 using tt::tt_fabric::bench::PerfStats;
 using tt::tt_fabric::bench::run_repeated;
 using tt::tt_fabric::bench::warmup_once;
 
-// Simple parsers (no deps)
+namespace {
+
+struct RunOptions {
+    int iters = 100;
+    int warmup = 1;
+    bool no_trace = false;     // reserved
+    bool enable_sync = false;  // reserved
+    std::string csv_path;      // if non-empty, append one row
+};
+
+static void usage(const char* argv0) {
+    log_error(
+        tt::LogTest,
+        "{}",
+        fmt::format(
+            R"(Usage:
+  {} --src-dev <mesh:chip|chip> --dst-dev <mesh:chip|chip> --size <bytes>
+         [--page <bytes>] [--src-type <l1|dram|single_bank>] [--dst-type <l1|dram|single_bank>]
+         [--send-core x,y] [--recv-core x,y]
+         [--iters N] [--warmup N]
+         [--no-trace] [--enable-sync]
+         [--csv <path>]
+
+Notes:
+- This binary runs ONE configuration. For sweeps, call it in a loop from a script.
+- --src-type/--dst-type are accepted for future use; current code uses DRAM src and L1/DRAM dst as in your kernels.
+)",
+            argv0));
+}
+
 static bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
-    // Accept "m:c" or just "c"
     size_t colon = s.find(':');
     if (colon == std::string::npos) {
         mesh = 0;
@@ -46,6 +73,7 @@ static bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
     chip = std::stoi(s.substr(colon + 1));
     return true;
 }
+
 static bool parse_xy(const std::string& s, int& x, int& y) {
     auto comma = s.find(',');
     if (comma == std::string::npos) {
@@ -56,25 +84,10 @@ static bool parse_xy(const std::string& s, int& x, int& y) {
     return true;
 }
 
-static void usage(const char* argv0) {
-    std::cerr <<
-        R"(Usage:
-  )" << argv0 << R"( --src-dev <mesh:chip|chip> --dst-dev <mesh:chip|chip> --size <bytes>
-         [--page <bytes>] [--src-type <l1|dram|single_bank>] [--dst-type <l1|dram|single_bank>]
-         [--send-core x,y] [--recv-core x,y]
-         [--iters N] [--warmup N]
-         [--no-trace] [--enable-sync]
-         [--csv <path>] [--format <human|csv|json>]
-
-Notes:
-- This binary runs ONE configuration. For sweeps, call it in a loop from a script.
-- --src-type/--dst-type are accepted for future use; current code uses DRAM src and L1/DRAM dst as in your kernels.
-)";
-}
-
-int main(int argc, char** argv) {
-    // Defaults
-    PerfParams p;
+// Fills RunOptions + PerfParams + raw src/dst strings. Returns false on bad args.
+static bool parse_cli_or_usage(
+    int argc, char** argv, RunOptions& run, PerfParams& p, std::string& src_dev_str, std::string& dst_dev_str) {
+    // Workload defaults
     p.mesh_id = 0;
     p.src_chip = 0;
     p.dst_chip = 1;
@@ -84,139 +97,156 @@ int main(int argc, char** argv) {
     p.sender_core = {0, 0};
     p.receiver_core = {0, 0};
 
-    int iters = 5, warmup = 1;
-    bool no_trace = false;     // TODO: wire to profiler off
-    bool enable_sync = false;  // TODO: add a start barrier
-    std::string src_dev_str, dst_dev_str;
-    std::string src_type = "dram", dst_type = "l1";  // placeholders for future
-    std::string format = "human";                    // "human" | "csv" | "json"
-    std::string csv_path;                            // if non-empty, append one row
+    std::string src_type = "dram";  // reserved
+    std::string dst_type = "l1";    // reserved
 
-    // Parse argv
+    auto need = [&](int i, int more) {
+        if (i + more >= argc) {
+            usage(argv[0]);
+            return false;
+        }
+        return true;
+    };
+
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
-        auto need = [&](int more) {
-            if (i + more >= argc) {
+
+        if (a == "--src-dev" && need(i, 1)) {
+            src_dev_str = argv[++i];
+        } else if (a == "--dst-dev" && need(i, 1)) {
+            dst_dev_str = argv[++i];
+        } else if (a == "--size" && need(i, 1)) {
+            p.tensor_bytes = static_cast<uint32_t>(std::stoul(argv[++i]));
+        } else if (a == "--page" && need(i, 1)) {
+            p.page_size = static_cast<uint32_t>(std::stoul(argv[++i]));
+        } else if (a == "--src-type" && need(i, 1)) {
+            src_type = argv[++i];
+        } else if (a == "--dst-type" && need(i, 1)) {
+            dst_type = argv[++i];
+            p.use_dram_dst = (dst_type == "dram");
+        } else if (a == "--send-core" && need(i, 1)) {
+            int x, y;
+            if (!parse_xy(argv[++i], x, y)) {
                 usage(argv[0]);
                 return false;
             }
-            return true;
-        };
-
-        if (a == "--src-dev" && need(1)) {
-            src_dev_str = argv[++i];
-        } else if (a == "--dst-dev" && need(1)) {
-            dst_dev_str = argv[++i];
-        } else if (a == "--size" && need(1)) {
-            p.tensor_bytes = static_cast<uint32_t>(std::stoul(argv[++i]));
-        } else if (a == "--page" && need(1)) {
-            p.page_size = static_cast<uint32_t>(std::stoul(argv[++i]));
-        } else if (a == "--src-type" && need(1)) {
-            src_type = argv[++i];
-        } else if (a == "--dst-type" && need(1)) {
-            dst_type = argv[++i];
-            p.use_dram_dst = (dst_type == "dram");
-        } else if (a == "--send-core" && need(1)) {
-            int x, y;
-            if (!parse_xy(argv[++i], x, y)) {
-                usage(argv[0]);
-                return 2;
-            }
             p.sender_core = {x, y};
-        } else if (a == "--recv-core" && need(1)) {
+        } else if (a == "--recv-core" && need(i, 1)) {
             int x, y;
             if (!parse_xy(argv[++i], x, y)) {
                 usage(argv[0]);
-                return 2;
+                return false;
             }
             p.receiver_core = {x, y};
-        } else if (a == "--iters" && need(1)) {
-            iters = std::stoi(argv[++i]);
-        } else if (a == "--warmup" && need(1)) {
-            warmup = std::stoi(argv[++i]);
+        } else if (a == "--iters" && need(i, 1)) {
+            run.iters = std::stoi(argv[++i]);
+        } else if (a == "--warmup" && need(i, 1)) {
+            run.warmup = std::stoi(argv[++i]);
         } else if (a == "--no-trace") {
-            no_trace = true;
+            run.no_trace = true;
         } else if (a == "--enable-sync") {
-            enable_sync = true;
-        } else if (a == "--csv" && need(1)) {
-            csv_path = argv[++i];
-        } else if (a == "--format" && need(1)) {
-            format = argv[++i];
+            run.enable_sync = true;
+        } else if (a == "--csv" && need(i, 1)) {
+            run.csv_path = argv[++i];
         } else {
             usage(argv[0]);
-            return 2;
+            return false;
         }
     }
 
     if (src_dev_str.empty() || dst_dev_str.empty() || p.tensor_bytes == 0) {
         usage(argv[0]);
-        return 2;
+        return false;
     }
+
     uint32_t src_mesh = 0, dst_mesh = 0;
     int src_chip = 0, dst_chip = 0;
     if (!parse_mesh_chip(src_dev_str, src_mesh, src_chip)) {
         usage(argv[0]);
-        return 2;
+        return false;
     }
     if (!parse_mesh_chip(dst_dev_str, dst_mesh, dst_chip)) {
         usage(argv[0]);
-        return 2;
+        return false;
     }
+
     p.mesh_id = src_mesh;  // assume same mesh
     p.src_chip = static_cast<chip_id_t>(src_chip);
     p.dst_chip = static_cast<chip_id_t>(dst_chip);
+
+    return true;
+}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) {
+    RunOptions run;
+    PerfParams p;
+    std::string src_dev_str, dst_dev_str;
+
+    if (!parse_cli_or_usage(argc, argv, run, p, src_dev_str, dst_dev_str)) {
+        return 2;
+    }
+
+    log_info(
+        tt::LogTest,
+        "Starting unicast bench: src={} dst={} sizeB={} pageB={} send_core=[{},{}] recv_core=[{},{}] iters={} "
+        "warmup={}",
+        src_dev_str,
+        dst_dev_str,
+        p.tensor_bytes,
+        p.page_size,
+        p.sender_core.x,
+        p.sender_core.y,
+        p.receiver_core.x,
+        p.receiver_core.y,
+        run.iters,
+        run.warmup);
 
     // Bring up the fixture env and run
     Fixture::suite_setup();
     Fixture fixture;
     fixture.setup();
-    warmup_once(&fixture, p, warmup);
-    auto stats = run_repeated(&fixture, p, /*warmup_iters=*/0, /*iters=*/iters);
+
+    warmup_once(&fixture, p, run.warmup);
+    auto stats = run_repeated(&fixture, p, /*warmup_iters=*/0, /*iters=*/run.iters);
+
     fixture.teardown();
     Fixture::suite_teardown();
 
-    // Output
-    if (format == "human") {
-        std::cout << "[bench] src=" << src_dev_str << " dst=" << dst_dev_str << " size=" << p.tensor_bytes
-                  << " page=" << p.page_size << " iters=" << iters << " warmup=" << warmup << " p50_ms=" << stats.p50_ms
-                  << " p95_ms=" << stats.p95_ms << " mean_gbps=" << stats.mean_gbps << " p50_gbps=" << stats.p50_gbps
-                  << " p10_gbps=" << stats.p10_gbps << " cv_gbps_pct=" << stats.cv_gbps_pct << "\n";
-    } else if (format == "csv") {
-        // print a single CSV row to stdout
-        std::cout << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,"
-                  << "p50_ms,p95_ms,mean_gbps,p50_gbps,p10_gbps,cv_gbps_pct\n";
-        std::cout << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << ","
-                  << p.sender_core.y << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes
-                  << "," << p.page_size << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms
-                  << "," << stats.mean_gbps << "," << stats.p50_gbps << "," << stats.p10_gbps << ","
-                  << stats.cv_gbps_pct << "\n";
-    } else if (format == "json") {
-        std::cout << "{"
-                  << "\"mesh\":" << p.mesh_id << ",\"src_chip\":" << p.src_chip << ",\"dst_chip\":" << p.dst_chip
-                  << ",\"send_core\":[" << p.sender_core.x << "," << p.sender_core.y << "]"
-                  << ",\"recv_core\":[" << p.receiver_core.x << "," << p.receiver_core.y << "]"
-                  << ",\"sizeB\":" << p.tensor_bytes << ",\"pageB\":" << p.page_size << ",\"iters\":" << iters
-                  << ",\"warmup\":" << warmup << ",\"p50_ms\":" << stats.p50_ms << ",\"p95_ms\":" << stats.p95_ms
-                  << ",\"mean_gbps\":" << stats.mean_gbps << "}\n";
-    }
+    // Human-readable result
+    log_info(
+        tt::LogTest,
+        "Result: p50_ms={} p95_ms={} mean_gbps={} p50_gbps={} p10_gbps={} cv_gbps_pct={}",
+        stats.p50_ms,
+        stats.p95_ms,
+        stats.mean_gbps,
+        stats.p50_gbps,
+        stats.p10_gbps,
+        stats.cv_gbps_pct);
 
-    if (!csv_path.empty()) {
-        // append one row; create header if new
-        bool newfile = false;
-        {
-            std::ifstream chk(csv_path);
-            newfile = !chk.good();
+    // Optional CSV artifact
+    if (!run.csv_path.empty()) {
+        std::filesystem::create_directories(std::filesystem::path(run.csv_path).parent_path());
+        bool newfile = !std::ifstream(run.csv_path).good();
+
+        std::ofstream ofs(run.csv_path, std::ios::app);
+        if (!ofs) {
+            log_error(tt::LogTest, "Failed to open CSV path for append: {}", run.csv_path);
+            return 1;
         }
-        std::ofstream ofs(csv_path, std::ios::app);
         if (newfile) {
             ofs << "mesh,src_chip,dst_chip,send_x,send_y,recv_x,recv_y,sizeB,pageB,iters,warmup,"
                    "p50_ms,p95_ms,mean_gbps,p50_gbps,p10_gbps,cv_gbps_pct\n";
         }
         ofs << p.mesh_id << "," << p.src_chip << "," << p.dst_chip << "," << p.sender_core.x << "," << p.sender_core.y
             << "," << p.receiver_core.x << "," << p.receiver_core.y << "," << p.tensor_bytes << "," << p.page_size
-            << "," << iters << "," << warmup << "," << stats.p50_ms << "," << stats.p95_ms << "," << stats.mean_gbps
-            << "," << stats.p50_gbps << "," << stats.p10_gbps << "," << stats.cv_gbps_pct << "\n";
+            << "," << run.iters << "," << run.warmup << "," << stats.p50_ms << "," << stats.p95_ms << ","
+            << stats.mean_gbps << "," << stats.p50_gbps << "," << stats.p10_gbps << "," << stats.cv_gbps_pct << "\n";
+
+        log_info(tt::LogTest, "Appended CSV row to {}", run.csv_path);
     }
 
+    log_info(tt::LogTest, "Unicast bench completed successfully.");
     return 0;
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -43,7 +43,7 @@ struct RunOptions {
     std::string csv_path;      // if non-empty, append one row
 };
 
-static void usage(const char* argv0) {
+void usage(const char* argv0) {
     std::string bin = std::filesystem::path(argv0).filename().string();
     if (bin.empty()) {
         bin = "build/test/tt_metal/tt_fabric/bench_unicast";
@@ -92,7 +92,7 @@ Legend:
     log_error(tt::LogTest, "{}", text);
 }
 
-static bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
+bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
     size_t colon = s.find(':');
     if (colon == std::string::npos) {
         mesh = 0;
@@ -104,7 +104,7 @@ static bool parse_mesh_chip(const std::string& s, uint32_t& mesh, int& chip) {
     return true;
 }
 
-static bool parse_xy(const std::string& s, int& x, int& y) {
+bool parse_xy(const std::string& s, int& x, int& y) {
     auto comma = s.find(',');
     if (comma == std::string::npos) {
         return false;
@@ -115,7 +115,7 @@ static bool parse_xy(const std::string& s, int& x, int& y) {
 }
 
 // Fills RunOptions + PerfParams + raw src/dst strings. Returns false on bad args.
-static bool parse_cli_or_usage(
+bool parse_cli_or_usage(
     int argc, char** argv, RunOptions& run, PerfParams& p, std::string& src_dev_str, std::string& dst_dev_str) {
     std::string src_type = "dram";  // reserved
     std::string dst_type = "l1";    // reserved

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="generated/profiler/.logs/unicast"
+mkdir -p "$OUT"
+
+COMMON="--sizes 4096,32768,1048576 --iters 150 --page 4096 \
+        --tolerance-pct 10 --out-dir $OUT"
+
+# Run 1: 0:0 -> 0:1, recv core 0,0
+python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py \
+  --src 0:0 --dst 0:1 \
+  --recv-core 0,0 \
+  $COMMON \
+  --p50-targets 4096:0.0377505,32768:0.309901,1048576:3.87211 \
+  --csv "$OUT/unicast_0to1.csv"
+
+# Run 2: 0:0 -> 0:3, recv core 6,6  (corner-ish)
+python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py \
+  --src 0:0 --dst 0:3 \
+  --recv-core 6,6 \
+  $COMMON \
+  --p50-targets 4096:0.0368183,32768:0.283387,1048576:3.52898 \
+  --csv "$OUT/unicast_0to3.csv"

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUT="generated/profiler/.logs/unicast"
+OUT="${TT_METAL_HOME}/generated/test_reports/unicast"
 mkdir -p "$OUT"
 
 COMMON="--sizes 4096,32768,1048576 --iters 150 --page 4096 \

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 OUT="${TT_METAL_HOME}/generated/test_reports/unicast"
 mkdir -p "$OUT"
 
-COMMON="--sizes 4096,32768,1048576 --iters 150 --page 4096 \
+COMMON="--sizes 4096,32768,1048576 --warmup 1 --iters 10 --trace-iters 100  --page 4096 \
         --tolerance-pct 10 --out-dir $OUT"
 
 # Run 1: 0:0 -> 0:1, recv core 0,0
@@ -12,7 +12,7 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:1 \
   --recv-core 0,0 \
   $COMMON \
-  --p50-targets 4096:0.0377505,32768:0.309901,1048576:3.87211 \
+  --p50-targets 4096:1.147,32768:4.07484,1048576:6.04014 \
   --csv "$OUT/unicast_0to1.csv"
 
 # Run 2: 0:0 -> 0:3, recv core 6,6  (corner-ish)

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -20,5 +20,5 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:3 \
   --recv-core 6,6 \
   $COMMON \
-  --p50-targets 4096:0.0368183,32768:0.283387,1048576:3.52898 \
+  --p50-targets 4096:0.985881,32768:3.54215,1048576:5.60438 \
   --csv "$OUT/unicast_0to3.csv"

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 OUT="${TT_METAL_HOME}/generated/test_reports/unicast"
 mkdir -p "$OUT"
@@ -12,7 +12,7 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:1 \
   --recv-core 0,0 \
   $COMMON \
-  --p50-targets 4096:1.147,32768:4.07484,1048576:6.04014 \
+  --p50-targets 4096:1.002,32768:3.682,1048576:6.006 \
   --csv "$OUT/unicast_0to1.csv"
 
 # Run 2: 0:0 -> 0:3, recv core 6,6  (corner-ish)
@@ -20,5 +20,5 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:3 \
   --recv-core 6,6 \
   $COMMON \
-  --p50-targets 4096:0.985881,32768:3.54215,1048576:5.60438 \
+  --p50-targets 4096:0.993,32768:3.544,1048576:5.605 \
   --csv "$OUT/unicast_0to3.csv"

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh
@@ -4,7 +4,7 @@ set -uo pipefail
 OUT="${TT_METAL_HOME}/generated/test_reports/unicast"
 mkdir -p "$OUT"
 
-COMMON="--sizes 4096,32768,1048576 --warmup 1 --iters 10 --trace-iters 100  --page 4096 \
+COMMON="--sizes 1048576 --warmup 1 --iters 10 --trace-iters 100  --page 4096 \
         --tolerance-pct 10 --out-dir $OUT"
 
 # Run 1: 0:0 -> 0:1, recv core 0,0
@@ -12,7 +12,7 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:1 \
   --recv-core 0,0 \
   $COMMON \
-  --p50-targets 4096:1.002,32768:3.682,1048576:6.006 \
+  --p50-targets 1048576:6.006 \
   --csv "$OUT/unicast_0to1.csv"
 
 # Run 2: 0:0 -> 0:3, recv core 6,6  (corner-ish)
@@ -20,5 +20,5 @@ python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.
   --src 0:0 --dst 0:3 \
   --recv-core 6,6 \
   $COMMON \
-  --p50-targets 4096:0.993,32768:3.544,1048576:5.605 \
+  --p50-targets 1048576:5.605 \
   --csv "$OUT/unicast_0to3.csv"

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 
 // CT (compile-time) args:
@@ -25,9 +24,5 @@ void kernel_main() {
     uint32_t exp_lo = (uint32_t)(expected_noc & 0xffffffffull);
     uint32_t exp_hi = (uint32_t)(expected_noc >> 32);
 
-    DPRINT << "[RX] wait sem=0x" << HEX() << sem_addr << " noc=0x" << exp_hi << "_" << exp_lo << DEC()
-           << " expect=" << expected_value << " core=(" << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << ")\n";
-
     noc_semaphore_wait(sem_ptr, expected_value);
-    DPRINT << "[RX] done; sem >= " << expected_value << "\n";
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+
+// CT (compile-time) args:
+//   none
+// RT (runtime) args:
+//   0: completion_sem_addr   (u32)  // L1 address of the global semaphore on receiver
+//   1: expected_value        (u32)  // e.g. number of pages, or just 1
+
+void kernel_main() {
+    size_t idx = 0;
+    const uint32_t sem_addr = get_arg_val<uint32_t>(idx++);
+    const uint32_t expected_value = get_arg_val<uint32_t>(idx++);
+
+    volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+
+    const uint64_t expected_noc = safe_get_noc_addr(my_x[0], my_y[0], sem_addr);
+
+    uint32_t exp_lo = (uint32_t)(expected_noc & 0xffffffffull);
+    uint32_t exp_hi = (uint32_t)(expected_noc >> 32);
+
+    DPRINT << "[RX] wait sem=0x" << HEX() << sem_addr << " noc=0x" << exp_hi << "_" << exp_lo << DEC()
+           << " expect=" << expected_value << " core=(" << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << ")\n";
+
+    noc_semaphore_wait(sem_ptr, expected_value);
+    DPRINT << "[RX] done; sem >= " << expected_value << "\n";
+}

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
@@ -26,4 +26,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
 
     noc_semaphore_wait(sem_ptr, expected_value);
+
+    // Reset for next iteration so we always observe a fresh 0→1 transition.
+    // (Prevents the next run from passing the wait immediately on a stale '1'.)
+    noc_semaphore_set(sem_ptr, 0);
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
@@ -19,10 +19,5 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
 
-    const uint64_t expected_noc = safe_get_noc_addr(my_x[0], my_y[0], sem_addr);
-
-    uint32_t exp_lo = (uint32_t)(expected_noc & 0xffffffffull);
-    uint32_t exp_hi = (uint32_t)(expected_noc >> 32);
-
     noc_semaphore_wait(sem_ptr, expected_value);
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_rx.cpp
@@ -6,8 +6,14 @@
 #include "dataflow_api.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 
-// CT (compile-time) args:
-//   none
+// Receiver-side completion wait.
+// Runs on the destination device and blocks until the receiver's global
+// semaphore reaches `expected_value`. In this bench, the sender atomically
+// increments the semaphore after sending all pages, so reaching the target
+// value implies "all data has arrived". Fabric guarantees the semaphore
+// signal is delivered after payload data.
+//
+// CT (compile-time) args: none
 // RT (runtime) args:
 //   0: completion_sem_addr   (u32)  // L1 address of the global semaphore on receiver
 //   1: expected_value        (u32)  // e.g. number of pages, or just 1

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    constexpr bool SRC_IS_DRAM = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t NUM_PAGES = get_compile_time_arg_val(1);
+    constexpr uint32_t PAGE_SIZE = get_compile_time_arg_val(2);
+    constexpr uint32_t CB_ID = tt::CBIndex::c_0;
+
+    const uint32_t src_base = get_arg_val<uint32_t>(0);
+
+    const InterleavedAddrGen<SRC_IS_DRAM> src_ag = {.bank_base_address = src_base, .page_size = PAGE_SIZE};
+
+    DPRINT << "[RD] start, src_base=0x" << HEX() << src_base << " num_pages=" << DEC() << NUM_PAGES
+           << " page_size=" << PAGE_SIZE << "\n";
+
+    for (uint32_t i = 0; i < NUM_PAGES; ++i) {
+        cb_reserve_back(CB_ID, 1);
+        uint32_t l1_dst = get_write_ptr(CB_ID);
+
+        uint64_t src_noc = get_noc_addr(i, src_ag);
+        DPRINT << "[RD] page " << i << " noc=0x" << HEX() << (uint32_t)(src_noc & 0xffffffffu) << "\n";
+        noc_async_read(src_noc, l1_dst, PAGE_SIZE);
+        noc_async_read_barrier();
+
+        cb_push_back(CB_ID, 1);
+        DPRINT << "[RD] pushed page " << i << " into CB\n";
+    }
+}

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
-//
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
@@ -15,18 +14,36 @@ void kernel_main() {
     constexpr uint32_t PAGE_SIZE = get_compile_time_arg_val(CTA_BASE + 2);
     constexpr uint32_t CB_ID = tt::CBIndex::c_0;
 
-    const uint32_t src_base = get_arg_val<uint32_t>(0);
+    // Process pages in groups of 4; CB capacity will be sized larger on the host.
+    constexpr uint32_t GROUP_PAGES = 4;
 
+    const uint32_t src_base = get_arg_val<uint32_t>(0);
     const auto src_acc = TensorAccessor(ta_args, /*bank_base=*/src_base, /*page_size=*/PAGE_SIZE);
 
-    for (uint32_t i = 0; i < NUM_PAGES; ++i) {
-        cb_reserve_back(CB_ID, 1);
-        uint32_t l1_dst = get_write_ptr(CB_ID);
+    uint32_t sent = 0;
+    while (sent < NUM_PAGES) {
+        // how many pages in this group (last group may be smaller than 4)
+        uint32_t this_group = GROUP_PAGES;
+        uint32_t remaining = NUM_PAGES - sent;
+        if (remaining < this_group) {
+            this_group = remaining;
+        }
 
-        uint64_t src_noc = src_acc.get_noc_addr(i);
-        noc_async_read(src_noc, l1_dst, PAGE_SIZE);
+        // reserve space for whole group and get base write pointer
+        cb_reserve_back(CB_ID, this_group);
+        uint32_t l1_base = get_write_ptr(CB_ID);
+
+        // queue all reads for the group
+        for (uint32_t i = 0; i < this_group; ++i) {
+            uint64_t src_noc = src_acc.get_noc_addr(sent + i);
+            uint32_t l1_dst = l1_base + i * PAGE_SIZE;
+            noc_async_read(src_noc, l1_dst, PAGE_SIZE);
+        }
+
+        // wait for the group to complete, then publish the group to the consumer
         noc_async_read_barrier();
+        cb_push_back(CB_ID, this_group);
 
-        cb_push_back(CB_ID, 1);
+        sent += this_group;
     }
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_reader_to_cb.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 #include "accessor/tensor_accessor.h"
 #include "accessor/tensor_accessor_args.h"
 
@@ -20,19 +19,14 @@ void kernel_main() {
 
     const auto src_acc = TensorAccessor(ta_args, /*bank_base=*/src_base, /*page_size=*/PAGE_SIZE);
 
-    DPRINT << "[RD] start, src_base=0x" << HEX() << src_base << " num_pages=" << DEC() << NUM_PAGES
-           << " page_size=" << PAGE_SIZE << "\n";
-
     for (uint32_t i = 0; i < NUM_PAGES; ++i) {
         cb_reserve_back(CB_ID, 1);
         uint32_t l1_dst = get_write_ptr(CB_ID);
 
         uint64_t src_noc = src_acc.get_noc_addr(i);
-        DPRINT << "[RD] page " << i << " noc=0x" << HEX() << (uint32_t)(src_noc & 0xffffffffu) << "\n";
         noc_async_read(src_noc, l1_dst, PAGE_SIZE);
         noc_async_read_barrier();
 
         cb_push_back(CB_ID, 1);
-        DPRINT << "[RD] pushed page " << i << " into CB\n";
     }
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 #include "dataflow_api.h"
-#include "tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp"
+#include "fabric/fabric_edm_packet_header.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -62,13 +62,7 @@ void kernel_main() {
 #if defined(DYNAMIC_ROUTING_ENABLED)
     static_assert(false, "Dynamic routing is not supported");
 #endif
-    fabric_set_unicast_route(
-        mh,
-        eth_chan_directions::EAST,  // ignored for dynamic routing
-        /*my_dev_id*/ 0,            // ignored by dynamic route
-        /*dst_dev_id*/ dst_dev_id,
-        /*dst_mesh_id*/ dst_mesh_id,
-        /*ew_dim*/ 0);
+    (void)fabric_set_unicast_route(mh, /*dst_dev_id=*/dst_dev_id, /*dst_mesh_id=*/dst_mesh_id);
 
     sender.open<true>();
 
@@ -85,7 +79,7 @@ void kernel_main() {
         uint64_t dest_noc_addr = dst_acc.get_noc_addr(/*page_id=*/i, /*offset=*/0, /*noc=*/0);
 
         // Build the NOC header for this page
-        fabric_set_unicast_route(mh, eth_chan_directions::EAST, /*my_dev_id*/ 0, dst_dev_id, dst_mesh_id, /*ew_dim*/ 0);
+        (void)fabric_set_unicast_route(mh, /*dst_dev_id=*/dst_dev_id, /*dst_mesh_id=*/dst_mesh_id);
         header->to_noc_unicast_write(NocUnicastCommandHeader{dest_noc_addr}, PAGE_SIZE);
 
         // TEMP (2D API): payload then header. Will be a single call after uplift
@@ -105,7 +99,7 @@ void kernel_main() {
 
     const uint64_t sem_noc = safe_get_noc_addr(rx_noc_x, rx_noc_y, sem_l1_addr, /*NOC_INDEX=*/0);
 
-    fabric_set_unicast_route(mh, eth_chan_directions::EAST, /*my_dev_id*/ 0, dst_dev_id, dst_mesh_id, /*ew_dim*/ 0);
+    (void)fabric_set_unicast_route(mh, /*dst_dev_id=*/dst_dev_id, /*dst_mesh_id=*/dst_mesh_id);
     header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader(sem_noc, /*inc=*/1, /*width_bits=*/32));
 
     sender.wait_for_empty_write_slot();

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
@@ -55,8 +55,6 @@ void kernel_main() {
     auto mh = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(header);
 #if defined(DYNAMIC_ROUTING_ENABLED)
     static_assert(false, "Dynamic routing is not supported");
-#else
-
 #endif
     fabric_set_unicast_route(
         mh,

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
@@ -53,7 +53,6 @@ void kernel_main() {
 
     // TEMP (2D API): manual packet header. Post-uplift this becomes implicit.
     volatile tt_l1_ptr PACKET_HEADER_TYPE* header = PacketHeaderPool::allocate_header();
-    zero_l1_buf((uint32_t*)header, sizeof(PACKET_HEADER_TYPE));
 
     // Fabric route setup (temporary 2D API):
     // Program a fixed unicast route to (dst_mesh_id, dst_dev_id). Dynamic routing is not

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/unicast_tx_writer_cb_to_dst.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "debug/dprint.h"
+
+using namespace tt;
+using namespace tt::tt_fabric;
+
+// CT args:
+//   0: TOTAL_PAGES
+//   1: PAGE_SIZE
+//
+// RT args (must match host):
+//   0: dst_base       (u32)  // receiver buffer base (L1 offset or DRAM base)
+//   1: dst_is_dram    (u32)  // 0=L1, 1=DRAM
+//   2: dst_mesh_id    (u32)  // logical (truncated to u16)
+//   3: dst_dev_id     (u32)  // logical (truncated to u16)
+//   4: rx_noc_x       (u32)  // receiver worker XY
+//   5: rx_noc_y       (u32)
+//   6: sem_l1_addr    (u32)  // receiver L1 semaphore address
+
+void kernel_main() {
+    constexpr uint32_t TOTAL_PAGES = get_compile_time_arg_val(0);
+    constexpr uint32_t PAGE_SIZE = get_compile_time_arg_val(1);
+    constexpr uint32_t CB_ID = tt::CBIndex::c_0;
+
+    size_t idx = 0;
+    const uint32_t dst_base = get_arg_val<uint32_t>(idx++);
+    const bool dst_is_dram = (get_arg_val<uint32_t>(idx++) != 0);
+    const uint16_t dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(idx++));
+    const uint16_t dst_dev_id = static_cast<uint16_t>(get_arg_val<uint32_t>(idx++));
+    const uint32_t rx_noc_x = get_arg_val<uint32_t>(idx++);
+    const uint32_t rx_noc_y = get_arg_val<uint32_t>(idx++);
+    const uint32_t sem_l1_addr = get_arg_val<uint32_t>(idx++);
+
+    // Build fabric connection from remaining RT args
+    auto sender = WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(idx);
+
+    // Reusable packet header in L1
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* header = PacketHeaderPool::allocate_header();
+    zero_l1_buf((uint32_t*)header, sizeof(PACKET_HEADER_TYPE));
+
+    DPRINT << "[WR] route-intent dst_mesh=" << (uint32_t)dst_mesh_id << " dst_dev=" << (uint32_t)dst_dev_id
+           << " rx_xy=(" << rx_noc_x << "," << rx_noc_y << ")\n";
+
+    // Fabric header (2D dynamic routing): route to (dst_mesh_id, dst_dev_id)
+    auto mh = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(header);
+#if defined(DYNAMIC_ROUTING_ENABLED)
+    static_assert(false, "Dynamic routing is not supported");
+#else
+
+#endif
+    fabric_set_unicast_route(
+        mh,
+        eth_chan_directions::EAST,  // ignored for dynamic routing
+        /*my_dev_id*/ 0,            // ignored by dynamic route
+        /*dst_dev_id*/ dst_dev_id,
+        /*dst_mesh_id*/ dst_mesh_id,
+        /*ew_dim*/ 0);
+
+    DPRINT << "[WR] send_type(write)=" << (uint32_t)header->noc_send_type << "\n";
+
+    sender.open<true>();
+
+    DPRINT << "[WR] open conn dst_dev=" << dst_dev_id << " dst_mesh=" << dst_mesh_id << " total_pages=" << TOTAL_PAGES
+           << "\n";
+
+    for (uint32_t i = 0; i < TOTAL_PAGES; ++i) {
+        cb_wait_front(CB_ID, 1);
+        const uint32_t src_l1_addr = get_read_ptr(CB_ID);
+
+        sender.wait_for_empty_write_slot();
+
+        // Compute destination NOC address (DRAM interleaved vs L1 + XY)
+        uint64_t dest_noc_addr;
+        if (dst_is_dram) {
+            const InterleavedAddrGen<true> gen{.bank_base_address = dst_base, .page_size = PAGE_SIZE};
+            dest_noc_addr = get_noc_addr(/*page_idx=*/i, gen, /*remote_noc=*/0, /*NOC_INDEX=*/0);
+        } else {
+            const uint32_t l1_off = dst_base + i * PAGE_SIZE;
+            dest_noc_addr = safe_get_noc_addr(rx_noc_x, rx_noc_y, l1_off, /*NOC_INDEX=*/0);
+        }
+
+        // Build the NOC header for this page
+        fabric_set_unicast_route(mh, eth_chan_directions::EAST, /*my_dev_id*/ 0, dst_dev_id, dst_mesh_id, /*ew_dim*/ 0);
+        header->to_noc_unicast_write(NocUnicastCommandHeader{dest_noc_addr}, PAGE_SIZE);
+
+        DPRINT << "[WR] page " << i << " noc_lo=0x" << HEX() << (uint32_t)(dest_noc_addr & 0xffffffffu) << " noc_hi=0x"
+               << (uint32_t)(dest_noc_addr >> 32) << DEC() << " rx_xy=(" << rx_noc_x << "," << rx_noc_y << ")\n";
+
+        DPRINT << "[WR] send_type(write)=" << (uint32_t)header->noc_send_type << "\n";
+
+        // 1) send payload (no header)
+        sender.send_payload_without_header_non_blocking_from_address(src_l1_addr, PAGE_SIZE);
+        // 2) send header (completes the packet)
+        sender.send_payload_blocking_from_address((uint32_t)header, sizeof(PACKET_HEADER_TYPE));
+
+        cb_pop_front(CB_ID, 1);
+        DPRINT << "[WR] page " << i << " sent\n";
+    }
+
+    noc_async_writes_flushed();
+
+    // Final signal: bump receiver semaphore so the receiver kernel exits
+    if (sem_l1_addr != 0) {
+        const uint64_t sem_noc = safe_get_noc_addr(rx_noc_x, rx_noc_y, sem_l1_addr, /*NOC_INDEX=*/0);
+        uint32_t sem_lo = (uint32_t)(sem_noc & 0xffffffffull);
+        uint32_t sem_hi = (uint32_t)(sem_noc >> 32);
+
+        fabric_set_unicast_route(mh, eth_chan_directions::EAST, /*my_dev_id*/ 0, dst_dev_id, dst_mesh_id, /*ew_dim*/ 0);
+        header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader(sem_noc, /*inc=*/1, /*width_bits=*/32));
+
+        DPRINT << "[WR] sem-inc dst noc_hi=0x" << HEX() << sem_hi << " noc_lo=0x" << sem_lo << DEC() << " rx_xy=("
+               << rx_noc_x << "," << rx_noc_y << ")\n";
+        DPRINT << "[WR] send_type(seminc)=" << (uint32_t)header->noc_send_type << "\n";
+
+        sender.wait_for_empty_write_slot();
+        sender.send_payload_flush_non_blocking_from_address((uint32_t)header, sizeof(PACKET_HEADER_TYPE));
+        DPRINT << "[WR] sem bump sent\n";
+    }
+    DPRINT << "[WR] close conn\n";
+    sender.close();
+}

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -57,14 +57,14 @@ PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
     std::cout << "[alloc] src_phys=" << src_phys << " dst_phys=" << dst_phys << " bytes=" << p.tensor_bytes
               << std::endl;
 
-    // ---------- Build a receiver progrma ----------
+    // ---------- Build a receiver program ----------
     tt::tt_metal::Program receiver_prog = tt::tt_metal::CreateProgram();
 
     // create a global semaphore on the dst device
     auto gsem = tt::tt_metal::CreateGlobalSemaphore(
         dst_dev,
         dst_dev->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::SubDeviceId{0}),
-        /*initial=*/0,
+        /*initial_value=*/0,
         tt::tt_metal::BufferType::L1);
 
     const tt::tt_metal::CoreCoord receiver_core = p.receiver_core;
@@ -168,7 +168,7 @@ PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
     std::cout << " (using " << link_idx << ")\n";
 
     tt::tt_fabric::append_fabric_connection_rt_args(
-        src, dst, /*link_index=*/link_idx, sender_prog, p.sender_core, writer_rt);
+        src, dst, /*link_idx=*/link_idx, sender_prog, p.sender_core, writer_rt);
 
     tt::tt_metal::SetRuntimeArgs(sender_prog, writer_k, p.sender_core, writer_rt);
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -269,15 +269,15 @@ Notes:
     // Perf point
     const double e2e_sec = std::chrono::duration<double>(t1 - t0).count();
     const uint64_t bytes = static_cast<uint64_t>(p.tensor_bytes);
-    const double gb = static_cast<double>(bytes) / 1e9;
-    const double gbps = (e2e_sec > 0.0) ? (gb / e2e_sec) : 0.0;
+    const double GB = static_cast<double>(bytes) / 1e9;          // gigabytes
+    const double GB_s = (e2e_sec > 0.0) ? (GB / e2e_sec) : 0.0;  // GB per second
     const double ms = e2e_sec * 1000.0;
 
     return PerfPoint{
         .bytes = bytes,
         .sec = e2e_sec,
         .ms = ms,
-        .gbps = gbps,
+        .GB_s = GB_s,
     };
 }
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -165,7 +165,8 @@ PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
 
     const uint32_t NUM_PAGES = (p.tensor_bytes + p.page_size - 1) / p.page_size;
     const uint32_t CB_ID = tt::CBIndex::c_0;
-    auto cb_cfg = tt::tt_metal::CircularBufferConfig(2 * p.page_size, {{CB_ID, tt::DataFormat::Float16}})
+    // CB holds 8 pages total so the reader can fill 4 while the writer drains 4.
+    auto cb_cfg = tt::tt_metal::CircularBufferConfig(8 * p.page_size, {{CB_ID, tt::DataFormat::Float16}})
                       .set_page_size(CB_ID, p.page_size);
     (void)tt::tt_metal::CreateCircularBuffer(sender_prog, p.sender_core, cb_cfg);
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <vector>
+
+#include <tt-metalium/tt_metal.hpp>
+#include "fabric_fixture.hpp"
+#include "tests/tt_metal/tt_fabric/common/utils.hpp"
+#include "tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+
+namespace tt::tt_fabric::bench {
+PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
+    const auto& cp = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    tt::tt_fabric::FabricNodeId src{tt::tt_fabric::MeshId{p.mesh_id}, p.src_chip};
+    tt::tt_fabric::FabricNodeId dst{tt::tt_fabric::MeshId{p.mesh_id}, p.dst_chip};
+
+    chip_id_t src_phys = cp.get_physical_chip_id_from_fabric_node_id(src);
+    chip_id_t dst_phys = cp.get_physical_chip_id_from_fabric_node_id(dst);
+
+    // Get IDevice*
+    auto* src_dev = find_device_by_id(src_phys);
+    auto* dst_dev = find_device_by_id(dst_phys);
+    if (!src_dev || !dst_dev) {
+        ADD_FAILURE() << "Failed to find devices: src=" << src_phys << " dst=" << dst_phys;
+        return PerfPoint{};
+    }
+
+    tt::tt_metal::CoreCoord tx_xy = src_dev->worker_core_from_logical_core(p.sender_core);
+    tt::tt_metal::CoreCoord rx_xy = dst_dev->worker_core_from_logical_core(p.receiver_core);
+
+    // Allocate simple flat buffers
+    tt::tt_metal::BufferConfig src_cfg{
+        .device = src_dev,
+        .size = p.tensor_bytes,
+        .page_size = p.page_size,
+        .buffer_type = tt::tt_metal::BufferType::DRAM  // or L1 if it fits
+    };
+    tt::tt_metal::BufferConfig dst_cfg{
+        .device = dst_dev,
+        .size = p.tensor_bytes,
+        .page_size = p.page_size,
+        .buffer_type = p.use_dram_dst ? tt::tt_metal::BufferType::DRAM : tt::tt_metal::BufferType::L1};
+
+    auto src_buf = tt::tt_metal::CreateBuffer(src_cfg);
+    auto dst_buf = tt::tt_metal::CreateBuffer(dst_cfg);
+
+    std::cout << "[alloc] src_phys=" << src_phys << " dst_phys=" << dst_phys << " bytes=" << p.tensor_bytes
+              << std::endl;
+
+    // ---------- Build a receiver progrma ----------
+    tt::tt_metal::Program receiver_prog = tt::tt_metal::CreateProgram();
+
+    // create a global semaphore on the dst device
+    auto gsem = tt::tt_metal::CreateGlobalSemaphore(
+        dst_dev,
+        dst_dev->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::SubDeviceId{0}),
+        /*initial=*/0,
+        tt::tt_metal::BufferType::L1);
+
+    const tt::tt_metal::CoreCoord receiver_core = p.receiver_core;
+
+    constexpr const char* KDIR = "tests/tt_metal/tt_fabric/benchmark/collectives/unicast/kernels/";
+    auto rx_wait_k = tt::tt_metal::CreateKernel(
+        receiver_prog,
+        std::string(KDIR) + "unicast_rx.cpp",
+        receiver_core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_0_default});
+
+    // expected_value = 1  -> return after sender bumps the sem once
+    tt::tt_metal::SetRuntimeArgs(receiver_prog, rx_wait_k, receiver_core, {gsem.address(), 1u});
+
+    // ---------------- Sender program: READER (RISCV_0) + WRITER (RISCV_1) ----------------
+    tt::tt_metal::Program sender_prog = tt::tt_metal::CreateProgram();
+
+    // Compute how many pages we need to send for the requested tensor size.
+    const uint32_t NUM_PAGES = (p.tensor_bytes + p.page_size - 1) / p.page_size;
+    const uint32_t CB_ID = tt::CBIndex::c_0;
+    auto cb_cfg = tt::tt_metal::CircularBufferConfig(2 * p.page_size, {{CB_ID, tt::DataFormat::Float16}})
+                      .set_page_size(CB_ID, p.page_size);
+    (void)tt::tt_metal::CreateCircularBuffer(sender_prog, p.sender_core, cb_cfg);
+
+    std::cout << "[host] src_buf=0x" << std::hex << src_buf->address() << " dst_buf=0x" << dst_buf->address()
+              << " sem_addr=0x" << gsem.address() << std::dec << "\n";
+
+    std::cout << "[host] launching RX: core=(" << receiver_core.x << "," << receiver_core.y << ") expect=1\n";
+    std::cout << "[host] launching TX: pages=" << NUM_PAGES << " page_size=" << p.page_size
+              << " dst_is_dram=" << (p.use_dram_dst ? 1 : 0) << "\n";
+
+    // READER kernel (DRAM->CB or L1->CB). We read from src_buf (DRAM).
+    auto reader_k = tt::tt_metal::CreateKernel(
+        sender_prog,
+        std::string(KDIR) + "unicast_tx_reader_to_cb.cpp",
+        p.sender_core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .compile_args = {1u /*SRC_IS_DRAM*/, NUM_PAGES, p.page_size}});
+    tt::tt_metal::SetRuntimeArgs(sender_prog, reader_k, p.sender_core, {(uint32_t)src_buf->address()});
+
+    // WRITER kernel (CB->Fabric->dst + final sem INC)
+    auto writer_k = tt::tt_metal::CreateKernel(
+        sender_prog,
+        std::string(KDIR) + "unicast_tx_writer_cb_to_dst.cpp",
+        p.sender_core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::RISCV_1_default,
+            .compile_args = {NUM_PAGES, p.page_size}});
+
+    // Writer runtime args
+    std::vector<uint32_t> writer_rt = {
+        (uint32_t)dst_buf->address(),        // 0: dst_base (receiver L1 offset)
+        (uint32_t)(p.use_dram_dst ? 1 : 0),  // 1: dst_is_dram (we set false above)
+        (uint32_t)p.mesh_id,                 // 2: dst_mesh_id (logical)
+        (uint32_t)p.dst_chip,                // 3: dst_dev_id  (logical)
+        (uint32_t)rx_xy.x,                   // 4: receiver_noc_x
+        (uint32_t)rx_xy.y,                   // 5: receiver_noc_y
+        (uint32_t)gsem.address()             // 6: receiver L1 semaphore addr
+    };
+
+    auto dir_opt = get_eth_forwarding_direction(src, dst);
+
+    auto dir_to_str = [](eth_chan_directions d) {
+        switch (d) {
+            case eth_chan_directions::NORTH: return "NORTH";
+            case eth_chan_directions::SOUTH: return "SOUTH";
+            case eth_chan_directions::EAST: return "EAST";
+            case eth_chan_directions::WEST: return "WEST";
+            default: return "UNKNOWN";
+        }
+    };
+
+    if (dir_opt.has_value()) {
+        std::cout << "[host] CP forwarding dir = " << dir_to_str(*dir_opt) << "\n";
+    } else {
+        std::cout << "[host] CP forwarding dir = <none>\n";
+    }
+
+    std::cout << "[host] logical src(mesh=" << p.mesh_id << ", dev=" << p.src_chip << ") -> dst(mesh=" << p.mesh_id
+              << ", dev=" << p.dst_chip << ")\n";
+
+    std::cout << "[host] physical src=" << src_phys << " -> dst=" << dst_phys << "\n";
+
+    // Append fabric connection RT args so WorkerToFabricEdmSender can open the link
+    auto links = tt::tt_fabric::get_forwarding_link_indices(src, dst);
+    if (links.empty()) {
+        ADD_FAILURE() << "No forwarding links from src(mesh=" << p.mesh_id << ",dev=" << p.src_chip
+                      << ") to dst(mesh=" << p.mesh_id << ",dev=" << p.dst_chip << ")";
+        return PerfPoint{};
+    }
+
+    uint32_t link_idx = links[0];
+    std::cout << "[host] forwarding links:";
+    for (auto li : links) {
+        std::cout << " " << li;
+    }
+    std::cout << " (using " << link_idx << ")\n";
+
+    tt::tt_fabric::append_fabric_connection_rt_args(
+        src, dst, /*link_index=*/link_idx, sender_prog, p.sender_core, writer_rt);
+
+    tt::tt_metal::SetRuntimeArgs(sender_prog, writer_k, p.sender_core, writer_rt);
+
+    // ---------------- Run order: receiver first (waits), then sender ----------------
+    fixture->RunProgramNonblocking(dst_dev, receiver_prog);
+
+    auto t0 = std::chrono::steady_clock::now();
+    fixture->RunProgramNonblocking(src_dev, sender_prog);
+    fixture->WaitForSingleProgramDone(dst_dev, receiver_prog);
+    auto t1 = std::chrono::steady_clock::now();
+
+    fixture->WaitForSingleProgramDone(src_dev, sender_prog);
+
+    // Compute E2E metrics
+    const double e2e_sec = std::chrono::duration<double>(t1 - t0).count();
+    const uint64_t bytes = static_cast<uint64_t>(p.tensor_bytes);
+    const double gb = static_cast<double>(bytes) / 1e9;
+    const double gbps = (e2e_sec > 0.0) ? (gb / e2e_sec) : 0.0;
+    const double ms = e2e_sec * 1000.0;
+
+    std::cout << "[perf] E2E: bytes=" << static_cast<uint64_t>(bytes) << " time=" << e2e_sec << " s"
+              << " (" << ms << " ms)"
+              << " throughput=" << gbps << " GB/s\n";
+
+    return PerfPoint{
+        .bytes = bytes,
+        .sec = e2e_sec,
+        .ms = ms,
+        .gbps = gbps,
+    };
+}
+}  // namespace tt::tt_fabric::bench

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -278,10 +278,10 @@ Notes:
     // -------------------------- end PROGRAM FACTORY --------------------------
 
     // --- Mesh trace capture & replay ---
-    auto sender_workload = Dist::MeshWorkload();
-    auto receiver_workload = Dist::MeshWorkload();
-    Dist::AddProgramToMeshWorkload(sender_workload, std::move(sender_prog), Dist::MeshCoordinateRange(src_coord));
-    Dist::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_prog), Dist::MeshCoordinateRange(dst_coord));
+    Dist::MeshWorkload sender_workload;
+    Dist::MeshWorkload receiver_workload;
+    sender_workload.add_program(Dist::MeshCoordinateRange(src_coord), std::move(sender_prog));
+    receiver_workload.add_program(Dist::MeshCoordinateRange(dst_coord), std::move(receiver_prog));
 
     // 1) Warm-up each workload (receiver first so it's ready, then sender)
     Dist::EnqueueMeshWorkload(mcq, receiver_workload, /*blocking=*/false);

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -39,7 +39,7 @@ def main():
     ap.add_argument("--sizes", default="4096,32768,1048576")
     ap.add_argument("--out-dir", default="generated/profiler/.logs/unicast")
     ap.add_argument("--csv", default="")
-    ap.add_argument("--min-p50-gbps", type=float, default=None)  # simple single floor
+    ap.add_argument("--min-p50-GB-s", type=float, default=None)  # simple single floor
     ap.add_argument("--p50-targets", type=str, default="")  # per-size: "4096:0.04,32768:0.28,1048576:2.45"
     ap.add_argument("--tolerance-pct", type=float, default=5.0)
     args = ap.parse_args()
@@ -91,30 +91,30 @@ def main():
                 print(f"FAIL: no row for size {size}", file=sys.stderr)
                 failed = True
                 continue
-            measured = float(row["p50_gbps"])
+            measured = float(row["p50_GB_s"])
             if size in targets:
                 lo = targets[size] * (1.0 - args.tolerance_pct / 100.0)
                 if measured < lo:
                     print(
-                        f"FAIL size {size}: p50_gbps={measured:.3f} < {lo:.3f} "
+                        f"FAIL size {size}: p50_GB_s={measured:.3f} < {lo:.3f} "
                         f"(target {targets[size]:.3f} -{args.tolerance_pct:.1f}%)",
                         file=sys.stderr,
                     )
                     failed = True
                 else:
                     print(
-                        f"PASS size {size}: p50_gbps={measured:.3f} ≥ {lo:.3f} "
+                        f"PASS size {size}: p50_GB_s={measured:.3f} ≥ {lo:.3f} "
                         f"(target {targets[size]:.3f} -{args.tolerance_pct:.1f}%)"
                     )
             else:
                 print(f"NOTE: no target for size {size}, measured p50={measured:.3f} GB/s")
         if failed:
             sys.exit(1)
-    elif args.min_p50_gbps is not None:
-        last_p50 = float(rows[-1]["p50_gbps"])
-        if last_p50 < args.min_p50_gbps:
-            sys.exit(f"FAIL: p50_gbps={last_p50} < min={args.min_p50_gbps}")
-        print(f"PASS: p50_gbps={last_p50} ≥ min={args.min_p50_gbps}")
+    elif args.min_p50_GB_s is not None:
+        last_p50 = float(rows[-1]["p50_GB_s"])
+        if last_p50 < args.min_p50_GB_ss:
+            sys.exit(f"FAIL: p50_GB_s={last_p50} < min={args.min_p50_GB_s}")
+        print(f"PASS: p50_GB_s={last_p50} ≥ min={args.min_p50_GB_s}")
     else:
         print("NOTE: no CI guard thresholds provided.")
 

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -1,46 +1,125 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
-import subprocess
+import argparse, csv, re, subprocess, sys
 from pathlib import Path
 
-BIN = "build/test/tt_metal/tt_fabric/bench_unicast"
-SRC = "0:0"
-DST = "0:1"
-PAGE = "2048"
-ITERS = "5"
-WARMUP = "1"
-CSV = Path("artifacts/unicast_sweep.csv")
-CSV.parent.mkdir(parents=True, exist_ok=True)
 
-sizes = [65536, 131072, 262144, 524288]  # bytes
-recv_cores = [(0, 0), (1, 0), (2, 0)]  # x,y list
+def parse_sizes(s: str):
+    return [int(x) for x in re.split(r"[,\s]+", s.strip()) if x]
 
-for size in sizes:
-    for rx, ry in recv_cores:
+
+def parse_core(s: str):
+    x, y = s.split(",")
+    return int(x), int(y)
+
+
+def parse_targets(s: str):
+    out = {}
+    if not s:
+        return out
+    for pair in re.split(r"[,\s]+", s.strip()):
+        if not pair:
+            continue
+        sz, val = pair.split(":")
+        out[int(sz)] = float(val)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", default="build/test/tt_metal/tt_fabric/bench_unicast")
+    ap.add_argument("--src", default="0:0")
+    ap.add_argument("--dst", default="0:1")
+    ap.add_argument("--page", type=int, default=4096)
+    ap.add_argument("--iters", type=int, default=100)
+    ap.add_argument("--warmup", type=int, default=1)
+    ap.add_argument("--send-core", default="0,0")
+    ap.add_argument("--recv-core", default="0,0")
+    ap.add_argument("--sizes", default="4096,32768,1048576")
+    ap.add_argument("--out-dir", default="generated/profiler/.logs/unicast")
+    ap.add_argument("--csv", default="")
+    ap.add_argument("--min-p50-gbps", type=float, default=None)  # simple single floor
+    ap.add_argument("--p50-targets", type=str, default="")  # per-size: "4096:0.04,32768:0.28,1048576:2.45"
+    ap.add_argument("--tolerance-pct", type=float, default=5.0)
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = Path(args.csv) if args.csv else (out_dir / "unicast_sweep.csv")
+
+    sizes = parse_sizes(args.sizes)
+    rx, ry = parse_core(args.recv_core)
+    targets = parse_targets(args.p50_targets)
+
+    for size in sizes:
         cmd = [
-            BIN,
+            args.bin,
             "--src-dev",
-            SRC,
+            args.src,
             "--dst-dev",
-            DST,
+            args.dst,
             "--size",
             str(size),
             "--page",
-            PAGE,
+            str(args.page),
             "--send-core",
-            "0,0",
+            args.send_core,
             "--recv-core",
             f"{rx},{ry}",
             "--iters",
-            ITERS,
+            str(args.iters),
             "--warmup",
-            WARMUP,
+            str(args.warmup),
             "--format",
             "csv",
             "--csv",
-            str(CSV),
+            str(csv_path),
         ]
         print(">>", " ".join(cmd))
         subprocess.run(cmd, check=True)
+
+    with csv_path.open(newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        sys.exit("FAIL: CSV has no rows")
+
+    if targets:
+        failed = False
+        for size in sizes:
+            # last row for this size (in case CSV already had prior runs)
+            row = next((r for r in reversed(rows) if int(r["sizeB"]) == size), None)
+            if row is None:
+                print(f"FAIL: no row for size {size}", file=sys.stderr)
+                failed = True
+                continue
+            measured = float(row["p50_gbps"])
+            if size in targets:
+                lo = targets[size] * (1.0 - args.tolerance_pct / 100.0)
+                if measured < lo:
+                    print(
+                        f"FAIL size {size}: p50_gbps={measured:.3f} < {lo:.3f} "
+                        f"(target {targets[size]:.3f} -{args.tolerance_pct:.1f}%)",
+                        file=sys.stderr,
+                    )
+                    failed = True
+                else:
+                    print(
+                        f"PASS size {size}: p50_gbps={measured:.3f} ≥ {lo:.3f} "
+                        f"(target {targets[size]:.3f} -{args.tolerance_pct:.1f}%)"
+                    )
+            else:
+                print(f"NOTE: no target for size {size}, measured p50={measured:.3f} GB/s")
+        if failed:
+            sys.exit(1)
+    elif args.min_p50_gbps is not None:
+        last_p50 = float(rows[-1]["p50_gbps"])
+        if last_p50 < args.min_p50_gbps:
+            sys.exit(f"FAIL: p50_gbps={last_p50} < min={args.min_p50_gbps}")
+        print(f"PASS: p50_gbps={last_p50} ≥ min={args.min_p50_gbps}")
+    else:
+        print("NOTE: no CI guard thresholds provided.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#!/usr/bin/env python3
+import subprocess
+
+BIN = "build/test/tt_metal/tt_fabric/bench_unicast"
+SRC = "0:0"
+DST = "0:1"
+PAGE = "2048"
+ITERS = "5"
+WARMUP = "1"
+CSV = "artifacts/unicast_sweep.csv"
+
+sizes = [65536, 131072, 262144, 524288]  # bytes
+recv_cores = [(0, 0), (1, 0), (2, 0)]  # x,y list
+
+for size in sizes:
+    for rx, ry in recv_cores:
+        cmd = [
+            BIN,
+            "--src-dev",
+            SRC,
+            "--dst-dev",
+            DST,
+            "--size",
+            str(size),
+            "--page",
+            PAGE,
+            "--send-core",
+            "0,0",
+            "--recv-core",
+            f"{rx},{ry}",
+            "--iters",
+            ITERS,
+            "--warmup",
+            WARMUP,
+            "--format",
+            "csv",
+            "--csv",
+            CSV,
+        ]
+        print(">>", " ".join(cmd))
+        subprocess.run(cmd, check=True)

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/env python3
 import subprocess
 
 BIN = "build/test/tt_metal/tt_fabric/bench_unicast"

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -71,8 +71,6 @@ def main():
             str(args.iters),
             "--warmup",
             str(args.warmup),
-            "--format",
-            "csv",
             "--csv",
             str(csv_path),
         ]

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -120,7 +120,7 @@ def main():
             sys.exit(1)
     elif args.min_p50_GB_s is not None:
         last_p50 = float(rows[-1]["p50_GB_s"])
-        if last_p50 < args.min_p50_GB_ss:
+        if last_p50 < args.min_p50_GB_s:
             sys.exit(f"FAIL: p50_GB_s={last_p50} < min={args.min_p50_GB_s}")
         print(f"PASS: p50_GB_s={last_p50} ≥ min={args.min_p50_GB_s}")
     else:

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess
+from pathlib import Path
 
 BIN = "build/test/tt_metal/tt_fabric/bench_unicast"
 SRC = "0:0"
@@ -10,7 +11,8 @@ DST = "0:1"
 PAGE = "2048"
 ITERS = "5"
 WARMUP = "1"
-CSV = "artifacts/unicast_sweep.csv"
+CSV = Path("artifacts/unicast_sweep.csv")
+CSV.parent.mkdir(parents=True, exist_ok=True)
 
 sizes = [65536, 131072, 262144, 524288]  # bytes
 recv_cores = [(0, 0), (1, 0), (2, 0)]  # x,y list
@@ -38,7 +40,7 @@ for size in sizes:
             "--format",
             "csv",
             "--csv",
-            CSV,
+            str(CSV),
         ]
         print(">>", " ".join(cmd))
         subprocess.run(cmd, check=True)

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py
@@ -42,6 +42,12 @@ def main():
     ap.add_argument("--min-p50-GB-s", type=float, default=None)  # simple single floor
     ap.add_argument("--p50-targets", type=str, default="")  # per-size: "4096:0.04,32768:0.28,1048576:2.45"
     ap.add_argument("--tolerance-pct", type=float, default=5.0)
+    ap.add_argument(
+        "--trace-iters",
+        type=int,
+        default=1,
+        help="number of enqueues captured per trace (batch size for replay timing)",
+    )
     args = ap.parse_args()
 
     out_dir = Path(args.out_dir)
@@ -73,6 +79,8 @@ def main():
             str(args.warmup),
             "--csv",
             str(csv_path),
+            "--trace-iters",
+            str(args.trace_iters),
         ]
         print(">>", " ".join(cmd))
         subprocess.run(cmd, check=True)

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
@@ -209,8 +209,6 @@ def main():
                 ITERS,
                 "--warmup",
                 WARMUP,
-                "--format",
-                "csv",
                 "--csv",
                 str(HOST_CSV),
             ]

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
@@ -128,7 +128,7 @@ def run_one_under_tracy(run_name: str, cmd_argv: list[str]) -> None:
     """
     ARTIFACTS.mkdir(parents=True, exist_ok=True)
 
-    runner = ARTIFACTS / f"_bench_runner_{int(time.time()*1000)}.py"
+    runner = ARTIFACTS / f"_bench_runner_{os.getpid()}_{time.time_ns()}.py"
     runner.write_text("import subprocess, sys\n" f"subprocess.run({repr(cmd_argv)}, check=True)\n")
 
     env = os.environ.copy()
@@ -146,7 +146,13 @@ def run_one_under_tracy(run_name: str, cmd_argv: list[str]) -> None:
         run_name,
         str(runner),
     ]
-    subprocess.run(tracy_cmd, check=True, env=env)
+    try:
+        subprocess.run(tracy_cmd, check=True, env=env)
+    finally:
+        try:
+            runner.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def read_last_host_row(csv_path: Path) -> dict:

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os, sys, csv, time, re, subprocess, tempfile
+from pathlib import Path
+
+BIN = "build/test/tt_metal/tt_fabric/bench_unicast"
+SRC = "0:0"
+DST = "0:1"
+PAGE = "2048"
+ITERS = "5"
+WARMUP = "1"
+
+ARTIFACTS = Path("artifacts/prof_runs")
+HOST_CSV = Path("artifacts/unicast_sweep.csv")
+COMBINED_CSV = Path("artifacts/unicast_sweep_with_kernel.csv")
+
+sizes = [65536, 131072, 262144, 524288]  # bytes
+recv_cores = [(0, 0), (1, 0), (2, 0)]  # (x,y)
+
+
+def latest_report_dir(artifacts: Path, run_name: str) -> Path:
+    base = artifacts / "reports" / run_name
+    ts_dirs = [p for p in base.iterdir() if p.is_dir()] if base.exists() else []
+    if not ts_dirs:
+        raise FileNotFoundError(f"No Tracy reports at {base}")
+    return sorted(ts_dirs)[-1]
+
+
+def read_chip_freq_mhz_from_device_log(devlog: Path) -> float:
+    # first line looks like: "ARCH: wormhole_b0, CHIP_FREQ[MHz]: 1000"
+    with devlog.open() as f:
+        line = f.readline()
+    m = re.search(r"CHIP_FREQ\[MHz\]:\s*(\d+\.?\d*)", line or "")
+    return float(m.group(1)) if m else 1000.0
+
+
+def extract_kernel_times(report_dir: Path):
+    """
+    Compute:
+      - kernel_longest_ms: longest single kernel interval across all devices/cores
+    """
+    devlog = report_dir / "profile_log_device.csv"
+    if not devlog.exists():
+        return {"kernel_longest_ms": None}
+
+    mhz_default = read_chip_freq_mhz_from_device_log(devlog)
+
+    # profile_log_device.csv: skip the first header line, then parse rows
+    with devlog.open(newline="") as f:
+        f.readline()  # ARCH line
+        r = csv.DictReader(f)
+        # normalize keys (strip spaces)
+        field = lambda name: next((k for k in r.fieldnames if k and k.strip() == name), None)
+
+        k_slot = field("PCIe slot")
+        k_cx = field("core_x")
+        k_cy = field("core_y")
+        k_proc = field("RISC processor type")
+        k_timer = field("timer_id")
+        k_cycles = field("time[cycles since reset]")
+        k_type = field("type")
+        k_zone = field("zone name")
+
+        if not all([k_slot, k_cx, k_cy, k_proc, k_timer, k_cycles, k_type, k_zone]):
+            return {"kernel_longest_ms": None}
+
+        # Collect START/END pairs per (device, core, proc, timer)
+        starts = {}
+        intervals = []  # list of (start_ns, end_ns)
+        for row in r:
+            if "KERNEL" not in (row[k_zone] or ""):
+                continue
+
+            dev = int(row[k_slot])
+            freq_mhz = mhz_default
+
+            # cycles -> ns using header chip frequency
+            try:
+                cyc = float(row[k_cycles])
+            except (TypeError, ValueError):
+                continue
+            t_ns = (cyc * 1000.0) / float(freq_mhz)
+
+            key = (dev, row[k_cx], row[k_cy], row[k_proc], row[k_timer])
+            etype = (row[k_type] or "").strip()
+            if etype == "ZONE_START":
+                starts[key] = t_ns
+            elif etype == "ZONE_END" and key in starts:
+                intervals.append((starts.pop(key), t_ns))
+
+        if not intervals:
+            return {"kernel_longest_ms": None}
+
+        # --- focus on the last run cluster to avoid long bring-up intervals ---
+        last_end = max(e for _, e in intervals)
+        window_ns = 100_000_000  # 100 ms window near the end of the trace
+        recent = [(s, e) for (s, e) in intervals if s >= (last_end - window_ns)]
+
+        if not recent:  # fallback if windowing removed everything
+            recent = intervals
+
+        dur_ns = [e - s for (s, e) in recent if e >= s]
+
+        if not dur_ns:
+            return {"kernel_longest_ms": None}
+
+        longest_ms = max(dur_ns) / 1e6
+        return {"kernel_longest_ms": round(float(longest_ms), 6)}
+
+
+def append_combined_row(host_csv_row: dict, kernel: dict):
+    COMBINED_CSV.parent.mkdir(parents=True, exist_ok=True)
+    row = dict(host_csv_row)
+    row.update(kernel)
+    write_header = not COMBINED_CSV.exists()
+    with COMBINED_CSV.open("a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if write_header:
+            w.writeheader()
+        w.writerow(row)
+
+
+def run_one_under_tracy(run_name: str, cmd_argv: list[str]) -> None:
+    """
+    Creating a tiny temp runner script that just runs the bench command.
+    """
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+    runner = ARTIFACTS / f"_bench_runner_{int(time.time()*1000)}.py"
+    runner.write_text("import subprocess, sys\n" f"subprocess.run({repr(cmd_argv)}, check=True)\n")
+
+    env = os.environ.copy()
+    env["TT_METAL_DEVICE_PROFILER"] = "1"  # enable device profiler
+
+    tracy_cmd = [
+        sys.executable,
+        "-m",
+        "tracy",
+        "-p",
+        "-r",
+        "-o",
+        str(ARTIFACTS),
+        "-n",
+        run_name,
+        str(runner),
+    ]
+    subprocess.run(tracy_cmd, check=True, env=env)
+
+
+def read_last_host_row(csv_path: Path) -> dict:
+    with csv_path.open(newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        raise RuntimeError(f"No rows in {csv_path}")
+    return rows[-1]
+
+
+def main():
+    # Make sure host CSV exists & has header if empty (so bench can append cleanly)
+    if not HOST_CSV.exists():
+        HOST_CSV.parent.mkdir(parents=True, exist_ok=True)
+        with HOST_CSV.open("w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(
+                [
+                    "mesh",
+                    "src_chip",
+                    "dst_chip",
+                    "send_x",
+                    "send_y",
+                    "recv_x",
+                    "recv_y",
+                    "sizeB",
+                    "pageB",
+                    "iters",
+                    "warmup",
+                    "p50_ms",
+                    "p95_ms",
+                    "mean_gbps",
+                ]
+            )
+
+    for size in sizes:
+        for rx, ry in recv_cores:
+            run_name = f"unicast_size{size}_rx{rx}_{ry}"
+            bench_cmd = [
+                BIN,
+                "--src-dev",
+                SRC,
+                "--dst-dev",
+                DST,
+                "--size",
+                str(size),
+                "--page",
+                PAGE,
+                "--send-core",
+                "0,0",
+                "--recv-core",
+                f"{rx},{ry}",
+                "--iters",
+                ITERS,
+                "--warmup",
+                WARMUP,
+                "--format",
+                "csv",
+                "--csv",
+                str(HOST_CSV),
+            ]
+            print(">>", " ".join(bench_cmd))
+            run_one_under_tracy(run_name, bench_cmd)
+
+            # 1) Read the row bench appended
+            host_row = read_last_host_row(HOST_CSV)
+
+            # 2) Parse Tracy’s report for this run
+            rep_dir = latest_report_dir(ARTIFACTS, run_name)
+            kernel = extract_kernel_times(rep_dir)
+
+            # 3) Append combined row
+            append_combined_row(host_row, kernel)
+
+            # 4) One-line summary
+            print(
+                f"[ok] size={size} recv=({rx},{ry}) "
+                f"host_p50_ms={host_row['p50_ms']} "
+                f"kernel_longest_ms={kernel['kernel_longest_ms']}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep_with_tracy.py
@@ -184,7 +184,7 @@ def main():
                     "warmup",
                     "p50_ms",
                     "p95_ms",
-                    "mean_gbps",
+                    "mean_GB_s",
                 ]
             )
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27916)

### Problem description
Adding P2P Fabric Unicast Benchmark (host + kernels + sweep run)

### What's changed

**Summary**
1. Host writes a deterministic payload to SRC DRAM and zeros to DST buffer (L1 by default, DRAM optional).

2. Sender program: DRAM→CB (RISCV_0) then CB→Fabric (RISCV_1). After last page it atomic_inc's a receiver global semaphore.

3. Receiver program: waits on the semaphore then resets it to 0 for the next run.

4. We capture N enqueues (--trace-iters) in a single MeshCQ trace and replay once, dividing wall-time by N to amortize host/driver overhead.

5. Host verifies payload and records timings.

**Command-line usage (T3K example)**
Single run
build/test/tt_metal/tt_fabric/bench_unicast \
  --src-dev 0:0 --dst-dev 0:1 \
  --size 1048576 --page 4096 \
  --send-core 0,0 --recv-core 0,0 \
  --iters 10 --warmup 1 --trace-iters 64 \
  --csv artifacts/unicast.csv

Sweep multiple sizes (helper script)
python tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_sweep.py \
  --src 0:0 --dst 0:1 \
  --sizes 4096,32768,1048576 \
  --recv-core 0,0 \
  --iters 10 --warmup 1 --trace-iters 64 \
  --out-dir artifacts

**Flag semantics**
--trace-iters: how many enqueues are captured inside one trace (the batch size a single replay executes).
--iters: how many capture+replay cycles to run for statistics (p50/mean/etc.).
--page: page size for CB paging. --size is total tensor bytes. Pages = ceil(size / page).

**CI integration**
CI wrapper writes CSVs to ${TT_METAL_HOME}/generated/test_reports/unicast so they are auto-collected:
`bash tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh`

Defaults in the sweep script point to generated/profiler/.logs/unicast.

**Current limitations / status**
Architectures: Implemented and tested on Wormhole B0 (T3K/N300). Blackhole: not validated yet.
Fabric: Uses Fabric 2D
Inter-mesh: Not tested (i.e., across two separate MeshDevices).
Tensor layout: Tested with standard (interleaved) layout. Blackhole DRAM–interleaved tensors are not supported yet here.
Link selection: First available forwarding link is used. No link sweep yet.
Validation: Payload check requires tensor_bytes % 4 == 0.

Sample performance for T3K, p50 throughput

0:0 → 0:1, recv(0,0)
4 KiB: ~ 1.15 GB/s
32 KiB: ~ 4.07 GB/s
1 MiB: ~ 6.04 GB/s

0:0 → 0:3, recv(6,6)
4 KiB: ~ 0.99 GB/s
32 KiB: ~ 3.54 GB/s
1 MiB: ~ 5.60 GB/s


[Microbenchmark run](https://github.com/tenstorrent/tt-metal/actions/runs/18138055240)
[All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18137456697)