### PR TITLE
[skip ci] Renaming TG Model perf to Galaxy Model perf Pipeline

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -1,4 +1,4 @@
-name: "[internal] TG model perf tests impl"
+name: "[internal] Galaxy model perf tests impl"
 
 on:
   workflow_call:
@@ -19,10 +19,10 @@ on:
       topology:
         required: false
         type: string
-        default: "config-tg"
+        default: "topology-6u"
 
 jobs:
-  tg-model-perf-tests:
+  galaxy-model-perf-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -32,14 +32,15 @@ jobs:
             model-type: "CNN",
             arch: wormhole_b0,
             save-perf-data: false,
+            timeout: 60,
             cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="7,7" ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },  # Pavle Josipovic
           {
             name: "Galaxy Llama 70B model perf tests", #see GH issue #26295
             model-type: "Llama-70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}"],
             save-perf-data: true,
+            timeout: 60,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U053W15B6JF # Djordje Ivanovic
           },
@@ -57,6 +58,7 @@ jobs:
             model-type: "Llama-70B",
             arch: wormhole_b0,
             save-perf-data: true,
+            timeout: 60,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_prefill_model_perf_tg_device --dispatch-mode ""',
             owner_id: U03PUAKE719 # Miguel Tairum
           },
@@ -65,6 +67,7 @@ jobs:
             model-type: "SD3.5",
             arch: wormhole_b0,
             save-perf-data: true,
+            timeout: 60,
             cmd: 'TT_MM_THROTTLE_PERF=5 pytest models/experimental/stable_diffusion_35_large/tests/test_performance.py -k "tg_cfg2_sp4_tp4"',
             owner_id: U03FJB5TM5Y # Colman Glagovich
           },
@@ -111,7 +114,7 @@ jobs:
         with:
           name: ${{ inputs.wheel-artifact-name || 'wheel artifact not specified' }}
       - name: Run model perf regression tests
-        timeout-minutes: 60
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         uses: ./.github/actions/docker-run
         env:
           LOGURU_LEVEL: INFO
@@ -194,6 +197,11 @@ jobs:
           name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.model }}-bare-metal
           path:
             ${{ steps.check-perf-report.outputs.perf_report_filename_all_gather }}
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -16,10 +16,10 @@ jobs:
       build-wheel: true
       version: 22.04
       toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake" # stopgap until issue 20140 is resolved
-  tg-model-perf-tests:
+  galaxy-model-perf-tests:
     needs: build-artifact-profiler
     secrets: inherit
-    uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
+    uses: ./.github/workflows/galaxy-model-perf-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -197,7 +197,7 @@ jobs:
     if: ${{ needs.determine-tests.outputs.run-model-perf == 'true' }}
     needs: [build-artifact, determine-tests]
     secrets: inherit
-    uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
+    uses: ./.github/workflows/galaxy-model-perf-tests-impl.yaml
     with:
       extra-tag: ${{ needs.determine-tests.outputs.clean-extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -19,7 +19,7 @@ jobs:
   tg-model-perf-tests:
     needs: build-artifact-profiler
     secrets: inherit
-    uses: ./.github/workflows/tg-model-perf-tests-impl.yaml
+    uses: ./.github/workflows/galaxy-model-perf-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27953

### Problem description
Sunsetting TGs so pipelines needed to be updated -> TG model perf tests pipeline

### What's changed
Changed the file name tg-model-perf-tests-impl.yaml -> galaxy-model-perf-tests-impl.yaml

also changed the default to go from default: "config-tg" -> to default: "topology-6u" within the impl file
Changed the dependent files as well
Updated the impl file to include slack notifications

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/17502926654