### PR TITLE
[skip ci] bugprone-multi-level-implicit-pointer-conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >
   -bugprone-forwarding-reference-overload,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-integer-division,
-  -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
   -bugprone-optional-value-conversion,
   -bugprone-sizeof-expression,

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -71,8 +71,8 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     for (size_t i = skip; i < s; ++i) {
         bt.push_back(demangle(strings[i]));
     }
-    free(strings);
-    free(array);
+    free(strings);  // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
+    free(array);    // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
 
     return bt;
 }

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -68,7 +68,7 @@ static void print_stack_trace() {
         }
     }
 
-    free(strings);
+    free(strings);  // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
 }
 // NOLINTEND(cppcoreguidelines-no-malloc)
 

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -28,6 +28,8 @@
 #include <tt_stl/type_name.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+// NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
+
 namespace ttsl {
 
 template <typename T>
@@ -1578,3 +1580,5 @@ namespace [[deprecated("Use ttsl namespace instead")]] stl {
 using namespace ::ttsl;
 }  // namespace stl
 }  // namespace tt
+
+// NOLINTEND(bugprone-multi-level-implicit-pointer-conversion)


### PR DESCRIPTION
### Ticket
#22758
Closes #28054 

### Problem description
We have this check disabled
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.html

### What's changed
- Enable it globally
- Disable it in `reflection.hpp` because who knows what black magic that is doing
- Disable it in terminal code paths where we fetch the backtrace.