### PR TITLE
[skip ci] Enable compiler warning: `for-loop-analysis`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,6 @@ add_compile_options(
     -Wno-unused-variable
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-narrowing>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-deprecated-volatile>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-for-loop-analysis>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-logical-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-mismatched-tags>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -122,6 +122,9 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
 )
+if(tokenizers-cpp_ADDED)
+    target_compile_options(tokenizers_cpp PRIVATE -Wno-for-loop-analysis)
+endif()
 # gersemi: on
 
 ####################################################################################################################


### PR DESCRIPTION
### Ticket
#23444 

### Problem description
We have this compiler warning globally disabled, when it only fails for a single dependency.

### What's changed
Enable the compiler warning.