### PR TITLE
UMD file/class rename

### DIFF
--- a/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
+++ b/tests/tt_metal/distributed/test_control_plane_local_mesh_binding.cpp
@@ -15,7 +15,7 @@
 #include "gmock/gmock.h"
 #include <fmt/format.h>
 #include "utils.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_fabric {
 namespace {

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -26,7 +26,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -49,7 +49,7 @@
 #include "tests/tt_metal/distributed/utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <tt-metalium/util.hpp>
 
 namespace tt::tt_metal::distributed::test {

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -29,7 +29,7 @@
 #include "tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -28,7 +28,7 @@
 #include <tt_stl/span.hpp>
 #include "tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.hpp
@@ -8,7 +8,7 @@
 #include <map>
 
 #include <tt-metalium/device.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "tests/tt_metal/tt_fabric/common/fabric_fixture.hpp"
 
 namespace tt::tt_fabric {

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/mesh_graph.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "tests/tt_metal/test_utils/test_common.hpp"
 
 namespace tt::tt_fabric::mesh_socket_tests {

--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -6,8 +6,8 @@
 #include <tt-metalium/utils.hpp>
 
 #include <umd/device/driver_atomics.hpp>
-#include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/tt_simulation_device.h"
+#include <umd/device/cluster_descriptor.hpp>
+#include <umd/device/simulation/simulation_device.hpp>
 #include "impl/context/metal_context.hpp"
 
 #include <string>

--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -5,7 +5,7 @@
 #pragma once
 #include <tt-metalium/utils.hpp>
 
-#include "umd/device/device_api_metal.h"
+#include <umd/device/driver_atomics.hpp>
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_simulation_device.h"
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
+++ b/tests/tt_metal/tt_fabric/common/t3k_mesh_descriptor_chip_mappings.hpp
@@ -8,7 +8,7 @@
 #include <tuple>
 #include <vector>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_fabric {
 

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -35,7 +35,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "gtest/gtest.h"
 
 #include <algorithm>

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -34,7 +34,7 @@
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "gtest/gtest.h"
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -36,7 +36,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -40,7 +40,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/tt_metal_profiler.hpp>
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 
 #include <filesystem>
 #include <functional>

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "fabric.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -33,7 +33,7 @@
 #include "fabric.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/util.hpp>
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -32,7 +32,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/util.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -24,7 +24,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/program.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, ProgramImpl::get_cb_size
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -34,7 +34,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_align.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -27,7 +27,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -22,7 +22,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -21,7 +21,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -29,7 +29,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -31,7 +31,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -33,7 +33,7 @@
 #include <tt_stl/span.hpp>
 
 #include "device_fixture.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -26,7 +26,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/semaphore.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -24,7 +24,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -18,7 +18,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/coordinate_manager.h"
+#include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -19,7 +19,7 @@
 #include "tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "umd/device/coordinate_manager.h"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <cstdint>
 #include "fabric_types.hpp"
 #include "gtest/gtest.h"

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -13,7 +13,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/device.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "context/metal_context.hpp"
 #include "gtest/gtest.h"
 #include <map>

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "gtest/gtest.h"
 #include <map>
 #include <tt-metalium/host_api.hpp>

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -18,7 +18,7 @@
 #include "mesh_dispatch_fixture.hpp"
 #include "system_mesh.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -17,7 +17,7 @@
 #include "dispatch_fixture.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include "system_mesh.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/test_utils/env_vars.hpp"
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -20,7 +20,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -21,7 +21,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
 // A test for printing from ethernet cores.

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
@@ -9,7 +9,7 @@
 #include "debug_tools_fixture.hpp"
 #include "gtest/gtest.h"
 #include "impl/context/metal_context.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
@@ -22,7 +22,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/df/float32.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -33,7 +33,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -20,7 +20,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -21,7 +21,7 @@
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -38,7 +38,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/device.hpp>
 #include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_cluster_api.cpp
@@ -16,7 +16,7 @@
 #include "multi_device_fixture.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -20,7 +20,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -16,7 +16,7 @@
 #include "galaxy_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/host_api.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/device.hpp>
 #include "galaxy_fixture.hpp"
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/host_api.hpp>
 

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -33,7 +33,7 @@
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -47,7 +47,8 @@
 #include "impl/context/metal_context.hpp"
 #include "umd/device/types/arch.h"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace tt {
 namespace tt_metal {
 class CommandQueue;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -45,7 +45,7 @@
 #include "multi_command_queue_fixture.hpp"
 #include <tt-metalium/shape2d.hpp>
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -25,7 +25,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -26,7 +26,7 @@
 #include "multi_command_queue_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -53,7 +53,7 @@
 #include "llrt.hpp"
 #include "multi_command_queue_fixture.hpp"
 #include "random_program_fixture.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -54,7 +54,7 @@
 #include "multi_command_queue_fixture.hpp"
 #include "random_program_fixture.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -55,7 +55,7 @@
 #include "random_program_fixture.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -31,7 +31,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "program_with_kernel_created_from_string_fixture.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -21,7 +21,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 #include <gtest/gtest.h>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel.hpp>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -35,7 +35,7 @@
 #include "random_program_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/common/scoped_timer.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "distributed/mesh_trace.hpp"
 
 // Access to internal API: ProgramImpl::get_id

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/hal_types.hpp>
 #include "impl/context/metal_context.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "impl/dispatch/dispatch_settings.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -10,7 +10,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/fabric.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -33,7 +33,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -38,7 +38,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -39,7 +39,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -41,7 +41,7 @@
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -5,7 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -37,7 +37,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -37,7 +37,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -36,7 +36,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -45,7 +45,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -38,7 +38,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 #include <tt-metalium/distributed.hpp>
 

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -37,7 +37,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 #include <tt-metalium/distributed.hpp>
 

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -36,7 +36,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -33,7 +33,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -39,7 +39,7 @@
 #include "test_golden_impls.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -39,7 +39,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -37,7 +37,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -37,7 +37,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -40,7 +40,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -53,7 +53,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -52,7 +52,7 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -53,7 +53,7 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -54,7 +54,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -57,7 +57,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -42,8 +42,7 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include "umd/device/tt_xy_pair.h"
 #include <tt-metalium/distributed.hpp>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -40,7 +40,7 @@
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/tt_xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -44,7 +44,7 @@
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -43,7 +43,7 @@
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -44,7 +44,7 @@
 #include "test_common.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -45,7 +45,7 @@
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -46,7 +46,7 @@
 #include "test_common.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -42,7 +42,7 @@
 #include "impl/dispatch/command_queue_common.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace tt {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -40,7 +40,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/dispatch/command_queue_common.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -41,7 +41,6 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/dispatch/command_queue_common.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -39,7 +39,7 @@
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <tt-metalium/utils.hpp>
 
 constexpr uint32_t DEFAULT_ITERATIONS = 10000;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -40,7 +40,7 @@
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/math.hpp>
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include <tt-metalium/sub_device.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -44,7 +44,7 @@
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/tt_io.hpp"
 #include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/xy_pair.h"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -46,7 +46,6 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/tt_io.hpp"
-#include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -45,7 +45,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/tt_io.hpp"
+#include <umd/device/tt_io.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -47,7 +47,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/tt_io.hpp"
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 #define CQ_PREFETCH_CMD_BARE_MIN_SIZE \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -11,7 +11,7 @@
 #include <queue>
 #include <optional>
 
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -33,7 +33,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -34,7 +34,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -36,7 +36,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/control_plane.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -34,7 +34,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -35,7 +35,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/constants.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -36,7 +36,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/distributed.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -37,7 +37,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -35,7 +35,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
-#include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/device.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_fabric::fabric_tests {
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/routing_table_generator.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 #include "tt_fabric_test_interfaces.hpp"
 #include "tt_fabric_test_common_types.hpp"

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -36,7 +36,7 @@
 #include "jit_build/build.hpp"
 #include "tt_metal/detail/kernel_cache.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -43,7 +43,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/detail/kernel_cache.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -39,7 +39,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel
 #include "impl/program/program_impl.hpp"

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -38,7 +38,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include "umd/device/types/xy_pair.h"
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -34,7 +34,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -29,7 +29,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -40,7 +40,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace tt {
-enum class ARCH;
 namespace tt_metal {
 class IDevice;
 }  // namespace tt_metal

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -37,7 +37,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -33,7 +33,7 @@
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/tunneling/test_lite_fabric.cpp
+++ b/tests/tt_metal/tt_metal/tunneling/test_lite_fabric.cpp
@@ -4,9 +4,9 @@
 
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
-#include <umd/device/types/arch.h>
-#include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/arch.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
+#include <umd/device/types/xy_pair.hpp>
 
 #include <enchantum/enchantum.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -13,7 +13,7 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include "umd/device/tt_xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/arch.hpp>
 
 TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingMode) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -14,7 +14,7 @@
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingMode) {
     std::size_t num_channels = 4;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -13,7 +13,7 @@
 #include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
 #include "ttnn/operations/ccl/common/types/ccl_types.hpp"
 #include "ttnn/operations/ccl/common/uops/ccl_command.hpp"
-#include "umd/device/tt_xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 using ttnn::ccl::generate_slice_sequence_on_dim;
 using ttnn::ccl::cmd::CclCommandArg;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -47,7 +47,6 @@
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/types.hpp"
-#include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -48,7 +48,7 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/types.hpp"
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/xy_pair.h"
 
 // #include <tt-metalium/kernel_types.hpp>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -49,7 +49,7 @@
 #include "ttnn/types.hpp"
 #include "umd/device/tt_xy_pair.h"
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/xy_pair.h"
+#include <umd/device/types/xy_pair.hpp>
 
 // #include <tt-metalium/kernel_types.hpp>
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -36,7 +36,7 @@
 #include <tt-metalium/tile.hpp>
 
 #include <umd/device/types/arch.hpp>
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "gtest/gtest.h"
 
 #include <algorithm>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -35,7 +35,7 @@
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/tile.hpp>
 
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "gtest/gtest.h"
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -56,8 +56,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
-#include "umd/device/types/arch.h"
-
+#include <umd/device/types/arch.hpp>
 
 ////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -33,7 +33,7 @@
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
     const size_t dim = 3;

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -20,7 +20,7 @@
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/reduction/argmax/argmax.hpp"
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace ttnn::operations::generic::test {
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -44,7 +44,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn_test_fixtures.hpp"
-#include "umd/device/types/cluster_descriptor_types.h"
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -25,7 +25,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -35,7 +35,7 @@
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn_test_fixtures.hpp"
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace ttnn {
 namespace operations {

--- a/tools/scaleout/board/board.cpp
+++ b/tools/scaleout/board/board.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 #include <stdexcept>
 #include <tt_stl/caseless_comparison.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/reflection.hpp>
 
 namespace tt::scaleout_tools {

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/strong_type.hpp>
 
 // Forward declaration and hash specialization for AsicChannel

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -10,7 +10,7 @@
 
 #include <tt_stl/strong_type.hpp>
 #include <board/board.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::scaleout_tools {
 

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -14,7 +14,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <yaml-cpp/yaml.h>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/reflection.hpp>
 #include <board/board.hpp>
 #include <cabling_generator/cabling_generator.hpp>

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <umd/device/cluster.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <umd/device/cluster.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <umd/device/cluster.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <umd/device/cluster.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -5,10 +5,10 @@
 #include "modules/distributed/linear.hpp"
 
 #include <gtest/gtest.h>
-#include <umd/device/cluster.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <umd/device/cluster.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -5,10 +5,10 @@
 #include "ops/distributed/comm_ops.hpp"
 
 #include <gtest/gtest.h>
-#include <umd/device/cluster.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <umd/device/cluster.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <umd/device/cluster.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <memory>
+#include <umd/device/cluster.hpp>
 #include <vector>
 
 #include "autograd/auto_context.hpp"

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/buffer_page_mapping.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/buffer_page_mapping.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/buffer_page_mapping.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace stl {

--- a/tt_metal/api/tt-metalium/command_queue_interface.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_interface.hpp
@@ -10,4 +10,4 @@
 #include <hostdevcommon/fabric_common.h>
 
 #include <tt-metalium/buffer.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace stl {

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <vector>
 
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <umd/device/types/arch.h>                      // tt::ARCH
+#include <umd/device/types/arch.hpp>                    // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <map>
 #include <optional>

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <umd/device/types/arch.hpp>                    // tt::ARCH
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <map>
 #include <optional>
 #include <string>

--- a/tt_metal/api/tt-metalium/data_format.hpp
+++ b/tt_metal/api/tt-metalium/data_format.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <vector>
 #include <tt-metalium/tt_backend_api_types.hpp>  // for DataFormat
-#include <umd/device/types/arch.h>               // for ARCH
+#include <umd/device/types/arch.hpp>             // for ARCH
 #include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
 
 enum class UnpackToDestMode : std::uint8_t;

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -21,7 +21,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/data_types.hpp>
 #include <tt_stl/reflection.hpp>
 
-#include <umd/device/tt_core_coordinates.h>  // CoreType
+#include <umd/device/types/core_coordinates.hpp>  // CoreType
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/fabric_edm_types.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <vector>
 #include <umd/device/types/core_coordinates.hpp>
 #include <optional>

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <vector>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <optional>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include <string>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal::hal {
 

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -28,7 +28,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 
 namespace ll_api {

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -26,7 +26,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/runtime_args_data.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -27,7 +27,7 @@
 #include <tt-metalium/runtime_args_data.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/vector_aligned.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/mesh_trace_id.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -33,8 +33,8 @@
 #include <tt_stl/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <umd/device/types/arch.h>
+#include <umd/device/types/core_coordinates.hpp>
 
-enum class CoreType;
 namespace tt {
 namespace tt_metal {
 class Allocator;

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/fabric_types.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/indestructible.hpp>
-#include <umd/device/types/arch.h>                      // tt::ARCH
+#include <umd/device/types/arch.hpp>                    // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <cstddef>
 #include <cstdint>

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -10,7 +10,7 @@
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <umd/device/types/arch.hpp>                    // tt::ARCH
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 namespace tt {
-enum class ARCH;
 namespace tt_metal {
 enum class ClusterType : std::uint8_t;
 }  // namespace tt_metal

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -16,8 +16,7 @@
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
-
-enum BoardType : uint32_t;
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 //! tt_SocDescriptor contains information regarding the SOC configuration targetted.
 /*!

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -14,7 +14,6 @@
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -11,7 +11,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <umd/device/tt_cluster_descriptor.h>
+#include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -14,7 +14,7 @@
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 //! tt_SocDescriptor contains information regarding the SOC configuration targetted.

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -12,7 +12,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/tt_cluster_descriptor.h>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -13,7 +13,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 

--- a/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
+++ b/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <utility>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 class ProfilerOptionalMetadata {
     using RuntimeID = uint32_t;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt_stl/small_vector.hpp>
 
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 #include <optional>
 

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -12,7 +12,7 @@
 
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/fabric_types.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/api/tt-metalium/semaphore.hpp
+++ b/tt_metal/api/tt-metalium/semaphore.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 
 #include <tt-metalium/core_coord.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/semaphore.hpp
+++ b/tt_metal/api/tt-metalium/semaphore.hpp
@@ -8,8 +8,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <umd/device/tt_soc_descriptor.h>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #include <fmt/base.h>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -22,7 +22,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -24,7 +24,7 @@
 #include <tt-metalium/profiler_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
 class Buffer;

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/util.hpp
+++ b/tt_metal/api/tt-metalium/util.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 
 namespace tt::tt_metal::detail {
 

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -10,7 +10,7 @@
 #include "assert.hpp"
 #include "core_assignment.hpp"
 #include <umd/device/types/arch.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -9,7 +9,7 @@
 
 #include "assert.hpp"
 #include "core_assignment.hpp"
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {

--- a/tt_metal/common/core_assignment.hpp
+++ b/tt_metal/common/core_assignment.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include <umd/device/types/arch.h>  // tt::ARCH
+#include <umd/device/types/arch.hpp>  // tt::ARCH
 #include <vector>
 
 #include "core_coord.hpp"

--- a/tt_metal/common/core_assignment.hpp
+++ b/tt_metal/common/core_assignment.hpp
@@ -9,7 +9,6 @@
 #include "core_coord.hpp"
 
 namespace tt {
-enum class ARCH;
 
 namespace tt_metal {
 // Returns an ordered list of DRAM Bank ID to optimally placed worker cores. Placing DRAM reader or writer

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -8,7 +8,7 @@
 #include <yaml-cpp/yaml.h>
 #include <string>
 
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 
 CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -10,8 +10,6 @@
 
 #include <umd/device/types/arch.h>
 
-enum BoardType : uint32_t;
-
 CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_worker_cores.size(),

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "tracy/Tracy.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -45,7 +45,7 @@
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/impl/device/dispatch.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -55,7 +55,7 @@
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 #include "dispatch/launch_message_ring_buffer_state.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "impl/context/metal_context.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -58,7 +58,8 @@
 #include <umd/device/types/xy_pair.h>
 #include "impl/context/metal_context.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace tt {
 namespace tt_metal {
 class CommandQueue;

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -39,7 +39,8 @@
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 #include "tt_metal/impl/debug/inspector.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace tt {
 namespace tt_metal {
 class IDevice;

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -15,7 +15,7 @@
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/system_mesh_translation_map.cpp
+++ b/tt_metal/distributed/system_mesh_translation_map.cpp
@@ -15,7 +15,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -41,7 +41,6 @@
 #include "metal_soc_descriptor.h"
 #include "routing_table_generator.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -42,7 +42,7 @@
 #include "routing_table_generator.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/serialization/intermesh_link_table.hpp"
 #include "tt_stl/small_vector.hpp"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -41,7 +41,7 @@
 #include "metal_soc_descriptor.h"
 #include "routing_table_generator.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/serialization/intermesh_link_table.hpp"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -40,7 +40,7 @@
 #include "mesh_graph.hpp"
 #include "metal_soc_descriptor.h"
 #include "routing_table_generator.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -30,7 +30,7 @@
 #include "core_coord.hpp"
 #include "fabric_edm_types.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/hal.hpp>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/fabric_edm_types.hpp>
 #include "fabric/fabric_edm_packet_header.hpp"
 #include <tt-metalium/edm_fabric_counters.hpp>

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -22,7 +22,7 @@
 
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 #include "fabric_host_utils.hpp"
 #include "fabric_context.hpp"

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/device.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <optional>
 #include <set>
 #include <vector>

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <enchantum/enchantum.hpp>
 #include "erisc_datamover_builder.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_graph.hpp>                   // FabricType
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include "erisc_datamover_builder.hpp"
 #include <vector>
 #include <limits>

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/assert.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <tt-metalium/metal_soc_descriptor.h>
 #include "impl/context/metal_context.hpp"
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_graph.hpp>                   // FabricType
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <llrt/tt_cluster.hpp>
 #include "erisc_datamover_builder.hpp"
 #include <set>

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <enchantum/enchantum.hpp>
 
 namespace tt::tt_fabric {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -15,7 +15,7 @@
 #include "assert.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <llrt/tt_cluster.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <tt_stl/caseless_comparison.hpp>
 

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -19,10 +19,6 @@
 #include <tt_stl/indestructible.hpp>
 #include <tt_stl/caseless_comparison.hpp>
 
-namespace tt {
-enum class ARCH;
-}  // namespace tt
-
 namespace tt::tt_fabric {
 FabricType operator|(FabricType lhs, FabricType rhs) {
     return static_cast<FabricType>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/strong_type.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -4,7 +4,7 @@
 
 #include <hal.hpp>
 #include <tt_backend_api_types.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <cstdint>
 #include <string>
 

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -14,7 +14,7 @@
 #include "buffer_types.hpp"
 #include "impl/allocator/bank_manager.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -23,7 +23,7 @@
 #include "bank_manager.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/tt_align.hpp>
 
 namespace tt {

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -32,8 +32,7 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <tracy/Tracy.hpp>
 #include <tt_stl/overloaded.hpp>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 namespace buffer_dispatch {

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -18,7 +18,8 @@
 #include <tt_stl/span.hpp>
 #include "dispatch/system_memory_manager.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace tt {
 namespace tt_metal {
 class IDevice;

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -27,7 +27,7 @@
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 namespace experimental {

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -7,7 +7,7 @@
 
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -40,7 +40,7 @@
 #include "tt_backend_api_types.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 using std::cout;
 using std::endl;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -39,7 +39,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_backend_api_types.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 using std::cout;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -38,7 +38,7 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_backend_api_types.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -38,7 +38,6 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_backend_api_types.hpp"
-#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <llrt/rtoptions.hpp>
 #include <memory>
 

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -17,7 +17,7 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -19,7 +19,7 @@
 #include <metal_soc_descriptor.h>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -21,7 +21,7 @@
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 #include "control_plane.hpp"
 #include "core_descriptor.hpp"

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -18,7 +18,7 @@
 #include <fmt/base.h>
 #include <metal_soc_descriptor.h>
 #include <tt-logger/tt-logger.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -20,7 +20,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 #include "control_plane.hpp"

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <umd/device/soc_descriptor.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -31,7 +31,6 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
 #include "rtoptions.hpp"

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -32,7 +32,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "rtoptions.hpp"
 #include "watcher_device_reader.hpp"
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -30,7 +30,7 @@
 #include "metal_soc_descriptor.h"
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>
 #include "rtoptions.hpp"

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -31,7 +31,7 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "rtoptions.hpp"
 #include "watcher_device_reader.hpp"

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -5,7 +5,7 @@
 #pragma once
 #include <core_coord.hpp>
 #include <stdint.h>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <string>
 
 struct metal_SocDescriptor;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -78,7 +78,7 @@
 #include <umd/device/coordinate_manager.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_silicon_driver_common.hpp>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 enum class ARCH;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -76,7 +76,7 @@
 #include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
 #include <tt-metalium/control_plane.hpp>
 #include <umd/device/coordinate_manager.h>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_silicon_driver_common.hpp>
 #include <umd/device/types/xy_pair.hpp>
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,7 +75,7 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
 #include <tt-metalium/control_plane.hpp>
-#include <umd/device/coordinate_manager.h>
+#include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/tensix_soft_reset_options.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -77,7 +77,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include <umd/device/coordinate_manager.h>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_silicon_driver_common.hpp>
+#include <umd/device/types/tensix_soft_reset_options.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -78,7 +78,6 @@
 #include <umd/device/coordinate_manager.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_silicon_driver_common.hpp>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
 
 namespace tt {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -81,7 +81,6 @@
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
-enum class ARCH;
 
 namespace tt_metal {
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -8,7 +8,7 @@
 #include <sched.h>
 #include <tracy/Tracy.hpp>
 #include <tt_metal.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
 #include <algorithm>
 #include <cstdlib>

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -40,7 +40,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include "tt_metal/common/executor.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -7,7 +7,7 @@
 
 #include "impl/context/metal_context.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "device.hpp"
 #include "sub_device_types.hpp"
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -18,7 +18,7 @@
 #include <enchantum/generators.hpp>
 #include <enchantum/iostream.hpp>
 #include <kernel.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 #include "assert.hpp"
 #include "hal_types.hpp"

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -10,7 +10,7 @@
 #include "hal_types.hpp"
 #include "program/program_impl.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -5,8 +5,7 @@
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.h>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -4,7 +4,7 @@
 
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -16,7 +16,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/core_descriptor.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/core_descriptor.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "command_queue_common.hpp"
 #include "dispatch_settings.hpp"
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -13,7 +13,7 @@
 #include "assert.hpp"
 #include "core_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace {

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -14,7 +14,7 @@
 #include "core_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace {
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -12,7 +12,7 @@
 #include "data_types.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_core_manager.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <array>
 #include <cstdint>
 #include <string>

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 class Cluster;

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -10,8 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 class Cluster;

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -38,7 +38,7 @@
 #include "trace/trace_node.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "data_collection.hpp"
 #include "ringbuffer_cache.hpp"
 #include "program/dispatch.hpp"

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -27,7 +27,7 @@
 #include <tt_stl/span.hpp>
 #include "sub_device_types.hpp"
 #include "trace/trace_buffer.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "vector_aligned.hpp"
 #include "worker_config_buffer.hpp"
 #include "trace/trace_node.hpp"

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -28,7 +28,8 @@
 #include "worker_config_buffer.hpp"
 #include "program/dispatch.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace tt {
 namespace tt_metal {
 class IDevice;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -24,7 +24,7 @@
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
 #include "rtoptions.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "dispatch/system_memory_manager.hpp"
 
 #include "tt_metal/api/tt-metalium/device_pool.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -14,7 +14,7 @@
 #include "mesh_graph.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -20,7 +20,7 @@
 #include "hal_types.hpp"
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 #include "tt_metal/api/tt-metalium/device_pool.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -21,7 +21,7 @@
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 #include "tt_metal/api/tt-metalium/device_pool.hpp"
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -7,7 +7,7 @@
 
 #include "fd_kernel.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -18,7 +18,7 @@
 #include "kernel_types.hpp"
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -14,7 +14,7 @@
 #include "assert.hpp"
 #include "core_coord.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -15,8 +15,7 @@
 #include "core_coord.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -25,7 +25,7 @@
 #include "fabric_types.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "dispatch/system_memory_manager.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -26,7 +26,7 @@
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "dispatch/system_memory_manager.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -11,7 +11,7 @@
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include "dispatch/kernel_config/relay_mux.hpp"
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -12,7 +12,7 @@
 #include "mesh_graph.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include "dispatch/kernel_config/relay_mux.hpp"
 
 namespace tt {

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -13,7 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "tt_align.hpp"
 #include "tt_metal.hpp"
-#include "umd/device/tt_core_coordinates.h"
+#include <umd/device/types/core_coordinates.hpp>
 #include <algorithm>
 #include <tt-metalium/fabric.hpp>
 

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include "assert.hpp"
 #include <tt_stl/aligned_allocator.hpp>
-#include <umd/device/device_api_metal.h>
+#include <umd/device/driver_atomics.hpp>
 
 #include <tt-metalium/vector_aligned.hpp>
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -28,8 +28,7 @@
 #include <umd/device/types/xy_pair.h>
 #include <tracy/Tracy.hpp>
 #include <utils.hpp>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -23,7 +23,7 @@
 // #include <umd/device/driver_atomics.h> - Should be included as it is used here, but the file is missing include
 // guards
 #include <umd/device/tt_io.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tracy/Tracy.hpp>
 #include <utils.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -20,8 +20,6 @@
 #include "command_queue_common.hpp"
 #include "system_memory_cq_interface.hpp"
 #include <tt-logger/tt-logger.hpp>
-// #include <umd/device/driver_atomics.h> - Should be included as it is used here, but the file is missing include
-// guards
 #include <umd/device/tt_io.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -24,7 +24,7 @@
 // guards
 #include <umd/device/tt_io.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tracy/Tracy.hpp>
 #include <utils.hpp>
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -23,7 +23,6 @@
 // #include <umd/device/driver_atomics.h> - Should be included as it is used here, but the file is missing include
 // guards
 #include <umd/device/tt_io.hpp>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
 #include <tracy/Tracy.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -8,7 +8,7 @@
 #include "system_memory_cq_interface.hpp"
 #include <umd/device/chip_helpers/tlb_manager.h>  // needed because tt_io.hpp requires needs TLBManager
 #include <umd/device/tt_io.hpp>                   // for tt::Writer
-#include <umd/device/tt_xy_pair.h>                // for tt_cxy_pair
+#include <umd/device/types/xy_pair.hpp>           // for tt_cxy_pair
 #include <atomic>
 #include <cstdint>
 #include <functional>

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -6,7 +6,7 @@
 
 // needed for private members
 #include "system_memory_cq_interface.hpp"
-#include <umd/device/chip_helpers/tlb_manager.h>  // needed because tt_io.hpp requires needs TLBManager
+#include <umd/device/chip_helpers/tlb_manager.hpp>  // needed because tt_io.hpp requires needs TLBManager
 #include <umd/device/tt_io.hpp>                   // for tt::Writer
 #include <umd/device/types/xy_pair.hpp>           // for tt_cxy_pair
 #include <atomic>

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -31,7 +31,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/fabric.hpp>
 #include "system_memory_manager.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/fabric.hpp>
 #include "system_memory_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -19,7 +19,7 @@
 #include "dispatch/dispatch_settings.hpp"
 #include "size_literals.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -25,8 +25,7 @@
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/tt_xy_pair.h>
-
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -24,7 +24,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -29,7 +29,7 @@
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.h>
 #include "kernel_impl.hpp"
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -30,7 +30,7 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include "kernel_impl.hpp"
 
 namespace tt {

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <string>
 #include <unordered_map>
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -41,7 +41,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>
 #include <tt-metalium/device_pool.hpp>
 #include "tt_cluster.hpp"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -40,7 +40,7 @@
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>
 #include <tt-metalium/device_pool.hpp>

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -42,7 +42,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
-#include <umd/device/wormhole_implementation.h>
+#include <umd/device/arch/wormhole_implementation.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include "tt_cluster.hpp"
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -39,7 +39,7 @@
 #include "tt-metalium/profiler_types.hpp"
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -26,7 +26,6 @@
 #include "tracy/TracyTTDevice.hpp"
 
 namespace tt {
-enum class ARCH;
 namespace tt_metal {
 class IDevice;
 }  // namespace tt_metal

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -53,7 +53,7 @@
 #include "tracy/Tracy.hpp"
 #include "tracy/TracyTTDevice.hpp"
 #include <tt-metalium/distributed.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -54,7 +54,7 @@
 #include "tracy/TracyTTDevice.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -54,7 +54,6 @@
 #include "tracy/TracyTTDevice.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
 
 namespace tt {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -57,7 +57,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -58,7 +58,7 @@
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -25,7 +25,7 @@
 #include "dispatch/worker_config_buffer.hpp"
 #include "trace/trace_node.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -73,7 +73,7 @@
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "util.hpp"
 #include "utils.hpp"

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -74,7 +74,7 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "util.hpp"
 #include "utils.hpp"
 #include "host_api.hpp"

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -22,7 +22,7 @@
 #include "tt-metalium/sub_device_types.hpp"
 #include "tt_metal.hpp"
 
-#include <umd/device/tt_core_coordinates.h>             // CoreType
+#include <umd/device/types/core_coordinates.hpp>        // CoreType
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 
 #include <atomic>

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -23,7 +23,7 @@
 #include "tt_metal.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>        // CoreType
-#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 
 #include <atomic>
 #include <bitset>

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include "distributed/mesh_trace.hpp"
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "vector_aligned.hpp"
 
 using MeshTraceId = tt::tt_metal::distributed::MeshTraceId;

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -28,7 +28,7 @@
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include <tt-metalium/control_plane.hpp>
 #include "distributed/mesh_trace.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "vector_aligned.hpp"
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -32,7 +32,7 @@
 #include "profiler_state.hpp"
 #include "tt_cluster.hpp"
 #include "tt_metal/llrt/tt_elffile.hpp"
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -16,10 +16,6 @@
 #include "llrt/hal.hpp"
 #include "jit_build_options.hpp"
 
-namespace tt {
-enum class ARCH;
-}  // namespace tt
-
 namespace tt::tt_metal {
 
 static constexpr uint32_t CACHE_LINE_ALIGNMENT = 64;

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -25,7 +25,7 @@
 #include "jit_build/build.hpp"
 #include "metal_soc_descriptor.h"
 #include "dispatch/system_memory_manager.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "build.hpp"
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -30,9 +30,6 @@
 #include "impl/context/metal_context.hpp"
 
 enum class UnpackToDestMode : uint8_t;
-namespace tt {
-enum class ARCH;
-}  // namespace tt
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/lite_fabric/host_util.hpp
+++ b/tt_metal/lite_fabric/host_util.hpp
@@ -8,7 +8,7 @@
 
 #include "tt_cluster.hpp"
 #include "core_coord.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/control_plane.hpp>
 
 namespace lite_fabric {

--- a/tt_metal/lite_fabric/hw/inc/host_interface.hpp
+++ b/tt_metal/lite_fabric/hw/inc/host_interface.hpp
@@ -15,7 +15,7 @@
 #if !(defined(KERNEL_BUILD) || defined(FW_BUILD))
 
 #include <fmt/ranges.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 #endif

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -24,7 +24,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_simulation_device.h>
 #include <umd/device/types/arch.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -21,7 +21,7 @@
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/control_plane.hpp>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_simulation_device.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_simulation_device.h>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -22,7 +22,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/control_plane.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_simulation_device.h>
+#include <umd/device/simulation/simulation_device.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -25,7 +25,7 @@
 #include <umd/device/tt_simulation_device.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"
 
 namespace tt {

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -10,7 +10,7 @@
 #include "llrt/rtoptions.hpp"
 #include <umd/device/pcie/pci_device.hpp>
 #include <umd/device/soc_descriptor.hpp>
-#include <umd/device/tt_simulation_device.h>
+#include <umd/device/simulation/simulation_device.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -9,7 +9,7 @@
 #include "assert.hpp"
 #include "llrt/rtoptions.hpp"
 #include <umd/device/pci_device.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/tt_simulation_device.h>
 
 namespace tt::tt_metal {

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -8,7 +8,7 @@
 
 #include "assert.hpp"
 #include "llrt/rtoptions.hpp"
-#include <umd/device/pci_device.hpp>
+#include <umd/device/pcie/pci_device.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/tt_simulation_device.h>
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -11,7 +11,7 @@
 
 #include "hal/generated/dev_msgs.hpp"
 #include "hal_types.hpp"
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 
 namespace tt {
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -27,8 +27,8 @@
 #include "hal/generated/dev_msgs.hpp"
 
 #include <tt_stl/overloaded.hpp>
+#include <umd/device/types/core_coordinates.hpp>
 
-enum class CoreType;
 enum class AddressableCoreType : uint8_t;
 
 namespace tt {

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -33,8 +33,6 @@ enum class AddressableCoreType : uint8_t;
 
 namespace tt {
 
-enum class ARCH;
-
 namespace tt_metal {
 
 // Struct of core type, processor class, and processor type to uniquely identify any processor.

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -16,7 +16,7 @@
 #include "eth_fw_api.h"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "noc/noc_parameters.h"
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t)&(((mailboxes_t*)MEM_AERISC_MAILBOX_BASE)->x))

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -16,7 +16,7 @@
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t)&(((mailboxes_t*)MEM_IERISC_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -14,7 +14,7 @@
 #include "llrt_common/mailbox.hpp"
 #include "noc/noc_parameters.h"
 #include "tensix.h"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t)&(((mailboxes_t*)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -11,7 +11,7 @@
 #include "llrt_common/mailbox.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "wormhole/wh_hal.hpp"
 #include "wormhole/wh_hal_eth_asserts.hpp"
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -12,7 +12,7 @@
 #include "llrt_common/mailbox.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "wormhole/wh_hal.hpp"
 #include "wormhole/wh_hal_eth_asserts.hpp"
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -11,7 +11,7 @@
 #include "llrt_common/mailbox.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include "wormhole/wh_hal.hpp"
 #include "wormhole/wh_hal_tensix_asserts.hpp"
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -29,8 +29,7 @@
 #include "hal_types.hpp"
 #include "llrt.hpp"
 #include "metal_soc_descriptor.h"
-// #include <umd/device/driver_atomics.h> - This should be included as it is used here, but the file is missing include
-// guards
+#include <umd/device/driver_atomics.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -31,7 +31,7 @@
 #include "metal_soc_descriptor.h"
 // #include <umd/device/driver_atomics.h> - This should be included as it is used here, but the file is missing include
 // guards
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -19,7 +19,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
 #include <umd/device/types/cluster_descriptor_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"
 
 struct go_msg_t;

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -18,7 +18,6 @@
 #include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -18,7 +18,7 @@
 #include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -13,7 +13,7 @@
 #include <string>
 
 #include "assert.hpp"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 using std::vector;
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -22,7 +22,7 @@
 #include "core_coord.hpp"
 #include "dispatch_core_common.hpp"  // For DispatchCoreConfig
 #include "tt_target_device.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -23,6 +23,7 @@
 #include "dispatch_core_common.hpp"  // For DispatchCoreConfig
 #include "tt_target_device.hpp"
 #include <umd/device/types/xy_pair.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -14,12 +14,12 @@
 #include "core_coord.hpp"
 #include "metal_soc_descriptor.h"
 #include "tt_backend_api_types.hpp"
-#include <umd/device/blackhole_implementation.h>
+#include <umd/device/arch/blackhole_implementation.hpp>
 #include <umd/device/cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
-#include <umd/device/wormhole_implementation.h>
+#include <umd/device/arch/wormhole_implementation.hpp>
 
 namespace ll_api {
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -18,7 +18,7 @@
 #include <umd/device/cluster.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>
 
 namespace ll_api {

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -17,7 +17,6 @@
 #include <umd/device/blackhole_implementation.h>
 #include <umd/device/cluster.h>
 #include <umd/device/tt_core_coordinates.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/xy_pair.h>
 #include <umd/device/wormhole_implementation.h>

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -17,7 +17,7 @@
 #include <umd/device/blackhole_implementation.h>
 #include <umd/device/cluster.h>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -16,7 +16,7 @@
 #include "tt_backend_api_types.hpp"
 #include <umd/device/blackhole_implementation.h>
 #include <umd/device/cluster.h>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/wormhole_implementation.h>

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -15,7 +15,7 @@
 #include "metal_soc_descriptor.h"
 #include "tt_backend_api_types.hpp"
 #include <umd/device/blackhole_implementation.h>
-#include <umd/device/cluster.h>
+#include <umd/device/cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 
 #include <umd/device/device_api_metal.h>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 class tt_device;
 namespace tt {

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -11,7 +11,6 @@
 #include <umd/device/cluster.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
-class tt_device;
 struct metal_SocDescriptor;
 
 namespace ll_api {

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -12,9 +12,6 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 class tt_device;
-namespace tt {
-enum class ARCH;
-}  // namespace tt
 struct metal_SocDescriptor;
 
 namespace ll_api {

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -8,7 +8,7 @@
 #include <tt_backend_api_types.hpp>
 #include <unordered_map>
 
-#include <umd/device/device_api_metal.h>
+#include <umd/device/cluster.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 class tt_device;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -35,7 +35,7 @@
 #include <umd/device/hugepage.h>
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_simulation_device.h>
-#include <umd/device/types/arch.h>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/cluster_types.h>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -33,7 +33,7 @@
 #include "tt_metal/llrt/tlb_config.hpp"
 #include <umd/device/cluster.h>
 #include <umd/device/hugepage.h>
-#include <umd/device/tt_cluster_descriptor.h>
+#include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/tt_simulation_device.h>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -31,7 +31,7 @@
 #include "sanitize_noc_host.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_metal/llrt/tlb_config.hpp"
-#include <umd/device/cluster.h>
+#include <umd/device/cluster.hpp>
 #include <umd/device/hugepage.h>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/tt_simulation_device.h>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -38,7 +38,7 @@
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/cluster_types.h>
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <unistd.h>
 
 static constexpr uint32_t HOST_MEM_CHANNELS = 4;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -36,7 +36,7 @@
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_simulation_device.h>
 #include <umd/device/types/arch.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/cluster_types.h>
 #include <umd/device/types/xy_pair.hpp>
 #include <unistd.h>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -35,7 +35,6 @@
 #include <umd/device/hugepage.h>
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_simulation_device.h>
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/cluster_types.h>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -32,7 +32,6 @@
 #include "tracy/Tracy.hpp"
 #include "tt_metal/llrt/tlb_config.hpp"
 #include <umd/device/cluster.hpp>
-#include <umd/device/hugepage.h>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/simulation/simulation_device.hpp>
 #include <umd/device/types/arch.hpp>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -34,7 +34,7 @@
 #include <umd/device/cluster.hpp>
 #include <umd/device/hugepage.h>
 #include <umd/device/cluster_descriptor.hpp>
-#include <umd/device/tt_simulation_device.h>
+#include <umd/device/simulation/simulation_device.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/cluster_types.h>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -37,7 +37,7 @@
 #include <umd/device/simulation/simulation_device.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
-#include <umd/device/types/cluster_types.h>
+#include <umd/device/types/cluster_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <unistd.h>
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -26,7 +26,7 @@
 #include "assert.hpp"
 #include "core_coord.hpp"
 #include <umd/device/cluster.hpp>
-#include <umd/device/device_api_metal.h>
+#include <umd/device/driver_atomics.hpp>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_io.hpp>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -25,7 +25,7 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
-#include <umd/device/cluster.h>
+#include <umd/device/cluster.hpp>
 #include <umd/device/device_api_metal.h>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -31,7 +31,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_io.hpp>
 #include <umd/device/tt_silicon_driver_common.hpp>
-#include <umd/device/tt_soc_descriptor.h>
+#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/harvesting.h>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -28,7 +28,7 @@
 #include <umd/device/cluster.h>
 #include <umd/device/device_api_metal.h>
 #include <umd/device/tt_cluster_descriptor.h>
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_io.hpp>
 #include <umd/device/tt_silicon_driver_common.hpp>
 #include <umd/device/tt_soc_descriptor.h>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -33,7 +33,7 @@
 #include <umd/device/tt_silicon_driver_common.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
-#include <umd/device/types/cluster_descriptor_types.h>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/harvesting.h>
 #include <umd/device/types/cluster_types.hpp>
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -30,7 +30,7 @@
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_io.hpp>
-#include <umd/device/tt_silicon_driver_common.hpp>
+#include <umd/device/types/tensix_soft_reset_options.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -34,7 +34,7 @@
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
-#include <umd/device/types/harvesting.h>
+#include <umd/device/types/harvesting.hpp>
 #include <umd/device/types/cluster_types.hpp>
 
 namespace tt {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -38,7 +38,6 @@
 #include <umd/device/types/cluster_types.hpp>
 
 namespace tt {
-enum class ARCH;
 namespace llrt {
 class RunTimeOptions;
 }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -32,7 +32,7 @@
 #include <umd/device/tt_io.hpp>
 #include <umd/device/tt_silicon_driver_common.hpp>
 #include <umd/device/tt_soc_descriptor.h>
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/harvesting.h>
 #include <umd/device/types/cluster_types.hpp>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -35,6 +35,7 @@
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/harvesting.h>
+#include <umd/device/types/cluster_types.hpp>
 
 namespace tt {
 enum class ARCH;
@@ -49,7 +50,6 @@ namespace tt_metal {
 class Hal;
 }
 }  // namespace tt
-struct tt_device_params;
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -27,7 +27,7 @@
 #include "core_coord.hpp"
 #include <umd/device/cluster.h>
 #include <umd/device/device_api_metal.h>
-#include <umd/device/tt_cluster_descriptor.h>
+#include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/tt_io.hpp>
 #include <umd/device/tt_silicon_driver_common.hpp>

--- a/tt_metal/programming_examples/matmul/matmul_common/bmm_op.hpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/bmm_op.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
-#include <umd/device/tt_xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 
 #include <tt-metalium/work_split.hpp>
 

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -15,7 +15,7 @@
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "metal_soc_descriptor.h"
-#include <umd/device/tt_core_coordinates.h>
+#include <umd/device/types/core_coordinates.hpp>
 
 void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -51,7 +51,7 @@
 #include "program/program_impl.hpp"
 #include "semaphore.hpp"
 #include "tracy/Tracy.hpp"
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include "utils.hpp"
 #include "fabric/hw/inc/fabric_routing_mode.h"
 #include <tt-metalium/graph_tracking.hpp>

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -32,7 +32,7 @@
 #include "data_types.hpp"
 #include "llrt/tt_cluster.hpp"
 #include <umd/device/cluster.h>
-#include <umd/device/tt_cluster_descriptor.h>
+#include <umd/device/cluster_descriptor.hpp>
 #include <filesystem>
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -51,7 +51,6 @@
 #include "program/program_impl.hpp"
 #include "semaphore.hpp"
 #include "tracy/Tracy.hpp"
-#include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"
 #include "fabric/hw/inc/fabric_routing_mode.h"

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -31,7 +31,7 @@
 #include "circular_buffer_config.hpp"
 #include "data_types.hpp"
 #include "llrt/tt_cluster.hpp"
-#include <umd/device/cluster.h>
+#include <umd/device/cluster.hpp>
 #include <umd/device/cluster_descriptor.hpp>
 #include <filesystem>
 #include "device.hpp"

--- a/tt_telemetry/include/hal/hal.hpp
+++ b/tt_telemetry/include/hal/hal.hpp
@@ -10,7 +10,7 @@
  * Thin wrapper around TT-Metal's HAL, without requiring a Metal context.
  */
 
-#include <third_party/umd/device/api/umd/device/cluster.h>
+#include <third_party/umd/device/api/umd/device/cluster.hpp>
 #include <llrt/hal.hpp>
 #include <llrt/rtoptions.hpp>
 

--- a/tt_telemetry/include/telemetry/ethernet/chip_identifier.hpp
+++ b/tt_telemetry/include/telemetry/ethernet/chip_identifier.hpp
@@ -14,8 +14,8 @@
 #include <ostream>
 #include <fmt/format.h>
 
-#include <third_party/umd/device/api/umd/device/cluster.h>
-#include <third_party/umd/device/api/umd/device/types/cluster_descriptor_types.h>
+#include <third_party/umd/device/api/umd/device/cluster.hpp>
+#include <third_party/umd/device/api/umd/device/types/cluster_descriptor_types.hpp>
 
 struct GalaxyUbbIdentifier {
     uint32_t tray_id;

--- a/tt_telemetry/include/telemetry/ethernet/ethernet_helpers.hpp
+++ b/tt_telemetry/include/telemetry/ethernet/ethernet_helpers.hpp
@@ -13,7 +13,7 @@
 #include <map>
 #include <unordered_map>
 
-#include <third_party/umd/device/api/umd/device/cluster.h>
+#include <third_party/umd/device/api/umd/device/cluster.hpp>
 
 #include <telemetry/ethernet/ethernet_endpoint.hpp>
 

--- a/tt_telemetry/include/telemetry/ethernet/ethernet_metrics.hpp
+++ b/tt_telemetry/include/telemetry/ethernet/ethernet_metrics.hpp
@@ -15,7 +15,7 @@
  #include <string>
  #include <vector>
 
-#include <third_party/umd/device/api/umd/device/cluster.h>
+#include <third_party/umd/device/api/umd/device/cluster.hpp>
 #include <llrt/hal.hpp>
 
 #include <telemetry/metric.hpp>

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <third_party/umd/device/api/umd/device/cluster.h>
+#include <third_party/umd/device/api/umd/device/cluster.hpp>
 
 enum class MetricUnit : uint16_t {
     UNITLESS = 0,

--- a/ttnn/cpp/ttnn-pybind/types.cpp
+++ b/ttnn/cpp/ttnn-pybind/types.cpp
@@ -20,7 +20,8 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
-enum class CoreType;
+#include <umd/device/types/core_coordinates.hpp>
+
 namespace ttnn::types {
 
 void py_module_types(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <map>
 
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 
 namespace ttnn {
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
-#include <umd/device/types/xy_pair.h>
+#include <umd/device/types/xy_pair.hpp>
 #include <cstdint>
 #include <string>
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -8,7 +8,7 @@
 #include <variant>
 #include <tuple>
 #include <optional>
-#include "umd/device/types/arch.h"
+#include <umd/device/types/arch.hpp>
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/constants.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -10,7 +10,7 @@
 #include <ttnn/operations/functions.hpp>
 #include "tools/profiler/op_profiler.hpp"
 
-#include <umd/device/tt_cluster_descriptor.h>  // tt_ClusterDescriptor
+#include <umd/device/cluster_descriptor.hpp>  // tt_ClusterDescriptor
 
 namespace tt {
 using namespace constants;


### PR DESCRIPTION
### Ticket
Related to several issues all covered by: https://github.com/tenstorrent/tt-umd/pull/1240

### Problem description
**This PR shouldn't have any functional changes.**
A couple of renaming patterns were applied in umd, we want to switch to a new more consistent naming scheme.
Currently umd contains both names (which is why this commit doesn't contain a umd bump).
Since all of these changes touch many files, I decided to do them at once in tt_metal.
I did this in a lot of stages, which you can see in the list of commits (hopefully this makes it easier to rebase once I get needed approvals).

### What's changed
- All umd classes now live in tt::umd namespace
- Previous also means that many tt_ prefixes are now unnecessary
- I've avoided adding many tt::umd:: prefixes now, instead I've added some explicit using statements.
- Added tt::umd:: in a few cases
- Many header files were moved around
- All header files now end in .hpp
- device_api_metal was removed
- Removed all forward declarations, since all umd type header files are rather small and scoped now - I imagine this was not the case a while back.
- Changed all "" to <> in umd includes

### Checklist
No pipelines needed, all changes affect compile time only.
All runs on brosko/metal_change_fiels :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/17700502705