### PR TITLE
#28185: Improve elu accuracy 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
@@ -24,7 +24,7 @@ def test_elu_arange_masking(device):
     input_tensor = input_tensor[mask]
 
     # Mask NaN, special value where selu has ULP>1. Exclude a small range around 0 for this elu test where error is higher. This range is verified in test_elu_allclose
-    mask = torch.isnan(input_tensor) | (input_tensor == 3.3895313892515355e38)
+    mask = torch.isnan(input_tensor)
     input_tensor[mask] = 1.0
     mask_failed = (input_tensor >= -0.28515625) & (input_tensor <= 1.1663108012064884e-38)
     input_tensor[mask_failed] = 1.0

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import math
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def test_elu_arange_masking(device):
+    # elu Working range - Underflow after -88(<0) as in exp
+    high = math.inf
+    low = -88.0
+
+    # Generate all possible bit patterns for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # masking to working range
+    mask = (input_tensor >= low) & (input_tensor <= high)
+    input_tensor = input_tensor[mask]
+
+    # Mask NaN, special value where selu has ULP>1. Exclude a small range around 0 for this elu test where error is higher. This range is verified in test_elu_allclose
+    mask = torch.isnan(input_tensor) | (input_tensor == 3.3895313892515355e38)
+    input_tensor[mask] = 1.0
+    mask_failed = (input_tensor >= -0.28515625) & (input_tensor <= 1.1663108012064884e-38)
+    input_tensor[mask_failed] = 1.0
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.elu)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.elu(tt_in)
+    result = ttnn.to_torch(tt_result)
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize(
+    "low, high, expected_atol, expected_rtol",
+    [
+        (-0.28515625, 1.1663108012064884e-38, 0.002, 0.02),
+        (-88.0, 1.6 * 10**38, 0.0, 0.0),  # bf16 working range for elu
+    ],
+)
+def test_elu_allclose(low, high, expected_atol, expected_rtol, device):
+    num_elements = math.prod(torch.Size([1, 3, 320, 320]))
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))
+
+    golden_function = ttnn.get_golden_function(ttnn.elu)
+    golden = golden_function(torch_input, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.elu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert torch.allclose(golden, result, atol=expected_atol, rtol=expected_rtol)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -303,27 +303,6 @@ def test_unary_gtz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
-def test_unary_elu_ttnn(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.elu(input_tensor, alpha=alpha, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.nn.functional.elu(in_data, alpha)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 @pytest.mark.parametrize("fast_and_approx", [False, True])
 def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -4,19 +4,30 @@
 
 #pragma once
 
-#include "ckernel_sfpu_elu.h"
+#include "ckernel_sfpu_exp.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, ITERATIONS>(slope);
-}
-
-template <bool APPROXIMATION_MODE>
-void elu_init() {
-    _init_elu_<APPROXIMATION_MODE>();
+    sfpi::vFloat s = Converter::as_float(slope);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v < 0.0f) {
+            sfpi::vFloat v_exp =
+                _sfpu_exp_21f_<true>(v) - sfpi::vConst1;  // is_fp32_dest_acc_en set to true to avoid rounding as it has
+                                                          // to be done at the end of operation
+            sfpi::vFloat result = s * v_exp;
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
+        }
+        v_endif;
+        sfpi::dst_reg++;
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
@@ -14,13 +14,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_elu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>(sfpu::elu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_elu(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_elu<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::calculate_elu<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, (int)VectorMode::RC, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -4,19 +4,30 @@
 
 #pragma once
 
-#include "ckernel_sfpu_elu.h"
+#include "ckernel_sfpu_exp.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, ITERATIONS>(slope);
-}
-
-template <bool APPROXIMATION_MODE>
-void elu_init() {
-    _init_elu_<APPROXIMATION_MODE>();
+    sfpi::vFloat s = Converter::as_float(slope);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v < 0.0f) {
+            sfpi::vFloat v_exp =
+                _sfpu_exp_21f_<true>(v) - sfpi::vConst1;  // is_fp32_dest_acc_en set to true to avoid rounding as it has
+                                                          // to be done at the end of operation
+            sfpi::vFloat result = s * v_exp;
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
+        }
+        v_endif;
+        sfpi::dst_reg++;
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_elu.h
@@ -14,13 +14,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_elu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>(sfpu::elu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::elu, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_elu(uint dst_index, uint param0) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_elu<APPROXIMATE>, dst_index, (int)VectorMode::RC, param0);
+        ckernel::sfpu::calculate_elu<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, (int)VectorMode::RC, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/elu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/elu.h
@@ -26,11 +26,13 @@ namespace ckernel {
  *
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | slope          | slope used in elu calculation                                              | uint32_t | Greater than 0                                        | True     |
  */
- // clang-format on
-ALWI void elu_tile(uint32_t idst, uint32_t param0) { MATH((llk_math_eltwise_unary_sfpu_elu<APPROX>(idst, param0))); }
+// clang-format on
+ALWI void elu_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_elu<APPROX, DST_ACCUM_MODE>(idst, param0)));
+}
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
#28185, #26993

### Problem description
Improve elu accuracy

### What's changed

Update:
- **ULP Data** : 
  - Tested for the entire 16-bit range of bfloat16 (0 through 2¹⁶), covering all possible values. Test passes with ULP 1 except for below mentioned cases
  -  Attached ULP Graphs, TTNN vs Torch, Values causing higher ULP : [Graphs](https://docs.google.com/document/d/1jSSbH0YpiJtgrWaiOrpEkK_lmz5TyilARTx8QhAnJFA/edit?tab=t.0#heading=h.izwu3smpowhm)
  - Below listed are the failing cases
    - **Single-Value ULP Anomaly**: 
      - For Input: 3.3895313892515355e+38
      - Calculated: 3.3895313892515355e+38
      - Golden:       3.3895313892515355e+38 
      - ULP: nan
      - Explanation : 
        - ULP is computed by taking the difference between two tensors divided by the spacing between representable values. This spacing (ulp_value = ulp(golden.type(calculated.dtype))) is zero.
        - Numerator : |3.3895313892515355e+38-3.3895313892515355e+38| = 0. Hence Nan
        - **Note** : Both results match exactly. The ULP metric breaks down at this edge case.
    - Excluding anomaly case
      - Main Branch
        - Input range with ULP>1 : ( -4.46875, 1.1663108012064884e-38)
        - Max ULP Delta : 3.946145612486469e+35 : [Mismatch details](https://drive.google.com/file/d/1Eaqi3jFLkx_tmpAcLEBzn4GgROSyp_Na/view?usp=drive_link) 
      - Updated branch
        - Input range with ULP>1 : ( -0.28515625, 1.1663108012064884e-38)
          - Max ULP Delta: 1.8775345440461937e+37 :  [Mismatch details](https://drive.google.com/file/d/1zeqQykY5GWK8k3V-E1eKJE4bzMOj0vPm/view?usp=drive_link)
          - Max ATOL :  0.001953125  
- **Edge case behaviour** : 

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
**INPUT** | **TORCH RESULT** | **TT RESULT (Main)** | **TT RESULT (Updated)**
-- | -- | -- | --
inf | inf | inf | inf
-inf | -1 | -1 | -1
nan | nan | inf | inf
-0.0 | 0 | -3.62E-05 | 0.0017
0 | 0 | 0 | 0

- **Single tile Performance analysis** : Kernel duration has increased by about **34%**.
  - Main branch : [main_elu.csv](https://github.com/user-attachments/files/22235386/main_elu.csv)
  - Updated branch : [updated_elu.csv](https://github.com/user-attachments/files/22235392/updated_elu.csv)
  
<img width="422" height="132" alt="Image" src="https://github.com/user-attachments/assets/b52f7892-cdac-4eef-9db5-b5b5e0d9edad" />



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17785043356)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17785045062)
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17785046763) - Fails as in main
- [x] [Blackhole post-commit tests (watcher enabled)](https://github.com/tenstorrent/tt-metal/actions/runs/17788432457)- Fails as in main
- [x] [Single card pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17788324775)- Fails as in main
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17788338408)- Fails as in main
- [x] [T3K Pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17853464507)
- [x] New/Existing tests provide coverage for changes