### PR TITLE
[skip ci] misc-redundant-expression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -130,7 +130,6 @@ Checks: >
   -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
-  -misc-redundant-expression,
   -misc-unconventional-assign-operator,
   -misc-uniqueptr-reset-release,
   -misc-unused-parameters,

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -642,8 +642,8 @@ void validate_test_config(const TestConfig& config) {
         exit(-1);
     }
 
-    if (config.chunk_n_pkts == 0 || config.chunk_n_pkts == 0 || config.n_chunks == 0 || config.packet_size == 0 ||
-        config.message_size == 0 || config.total_messages == 0 || config.n_workers == 0) {
+    if (config.chunk_n_pkts == 0 || config.n_chunks == 0 || config.packet_size == 0 || config.message_size == 0 ||
+        config.total_messages == 0 || config.n_workers == 0) {
         log_error(
             tt::LogTest,
             "Invalid test config. Found a zero value. The following are all expected to be non-zero: chunk_n_pkts={}, "

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -364,7 +364,7 @@ std::vector<tt::tt_metal::hop_eth_sockets> build_eth_sockets_list(const std::vec
         bool edge_needs_tunneling =
             !is_device_pcie_connected(curr_device->id()) || !is_device_pcie_connected(next_device->id());
 
-        std::size_t conn = (edge_needs_tunneling ? 0 : 0) + n_edge_visits[edge];
+        std::size_t conn = n_edge_visits[edge];
         std::unordered_map<uint64_t, int> edge_link_idx;
         auto const& active_eth_cores = curr_device->get_active_ethernet_cores(true);
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();

--- a/tt_metal/fabric/serialization/.clang-tidy
+++ b/tt_metal/fabric/serialization/.clang-tidy
@@ -1,2 +1,2 @@
 InheritParentConfig: true
-Checks: -bugprone-reserved-identifier,-cppcoreguidelines-prefer-member-initializer
+Checks: -*

--- a/tt_metal/fabric/serialization/.clang-tidy
+++ b/tt_metal/fabric/serialization/.clang-tidy
@@ -1,2 +1,2 @@
 InheritParentConfig: true
-Checks: -*
+Checks: -bugprone-reserved-identifier,-cppcoreguidelines-prefer-member-initializer, -misc-redundant-expression

--- a/ttnn/cpp/ttnn-pybind/.clang-tidy
+++ b/ttnn/cpp/ttnn-pybind/.clang-tidy
@@ -1,2 +1,2 @@
 InheritParentConfig: true
-Checks: -bugprone-unused-raii
+Checks: -bugprone-unused-raii, -misc-redundant-expression


### PR DESCRIPTION
### Ticket
#22758 
Closes #28071 

### Problem description
We had this check disabled.
https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/misc/redundant-expression.html

This check helps flag accidental copy paste errors.


### What's changed
- Enable check
- Disable false positives in generated code / pybind code
- Address violations: `PLEASE CHECK THESE, COULD BE BUGS!`

### Checklist
- Not running any due to simple changes, please let me know if you want something ran.