### PR TITLE
Replace riscv_id_t and DebugHartFlags with HAL type

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <memory>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <functional>
@@ -10,7 +11,6 @@
 #include <string>
 #include <utility>
 #include <variant>
-#include <vector>
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -19,6 +19,7 @@
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
 #include "gtest/gtest.h"
+#include "hal_types.hpp"
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
@@ -37,9 +38,8 @@ class IDevice;
 using namespace tt;
 using namespace tt::tt_metal;
 
-namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-const std::string golden_output =
+const std::string golden_output_data0 =
     R"(Test Debug Print: Data0
 Basic Types:
 101-1.618@0.122559
@@ -69,7 +69,9 @@ SLICE:
 0.365234375 0.373046875 0.380859375 0.388671875 1.4609375 1.4921875 1.5234375 1.5546875
 <TileSlice data truncated due to exceeding max count (32)>
 Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
-Test Debug Print: Unpack
+)";
+const std::string golden_output_compute =
+    R"(Test Debug Print: Unpack
 Basic Types:
 101-1.618@0.122559
 e5551234569123456789
@@ -149,7 +151,9 @@ SLICE:
 0.365234375 0.373046875 0.380859375 0.388671875 1.4609375 1.4921875 1.5234375 1.5546875
 <TileSlice data truncated due to exceeding max count (32)>
 Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
-Test Debug Print: Data1
+)";
+const std::string golden_output_data1 =
+    R"(Test Debug Print: Data1
 Basic Types:
 101-1.618@0.122559
 e5551234569123456789
@@ -177,9 +181,13 @@ SLICE:
 0.245117188 0.249023438 0.255859375 0.263671875 0.98046875 0.99609375 1.0234375 1.0546875
 0.365234375 0.373046875 0.380859375 0.388671875 1.4609375 1.4921875 1.5234375 1.5546875
 <TileSlice data truncated due to exceeding max count (32)>
-Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b))";
+Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b)
+)";
 
-void RunTest(DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice> mesh_device) {
+void RunTest(
+    DPrintMeshFixture* fixture,
+    std::shared_ptr<distributed::MeshDevice> mesh_device,
+    const std::string& golden_output) {
     // Set up program and command queue
     constexpr CoreCoord core = {0, 0}; // Print on first core only
     distributed::MeshWorkload workload;
@@ -231,11 +239,83 @@ void RunTest(DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice
     // Check that the expected print messages are in the log file
     EXPECT_TRUE(FilesMatchesString(DPrintMeshFixture::dprint_file_name, golden_output));
 }
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
 
-TEST_F(DPrintMeshFixture, TensixTestPrintFromAllHarts) {
+struct TestParams {
+    std::string test_name;
+    std::vector<HalProcessorIdentifier> enabled_processors;
+    std::string golden_output;
+};
+
+using enum HalProgrammableCoreType;
+using enum HalProcessorClassType;
+
+class PrintAllHartsFixture : public DPrintMeshFixture, public ::testing::WithParamInterface<TestParams> {
+private:
+    HalProcessorSet original_enabled_processors_;
+
+protected:
+    void ExtraSetUp() override {
+        original_enabled_processors_ = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_processors(
+            tt::llrt::RunTimeDebugFeatureDprint);
+        HalProcessorSet processor_set;
+        for (const auto& proc : GetParam().enabled_processors) {
+            processor_set.add(
+                proc.core_type,
+                tt::tt_metal::MetalContext::instance().hal().get_processor_index(
+                    proc.core_type, proc.processor_class, proc.processor_type));
+        }
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_processors(
+            tt::llrt::RunTimeDebugFeatureDprint, processor_set);
+    }
+    void ExtraTearDown() override {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_processors(
+            tt::llrt::RunTimeDebugFeatureDprint, original_enabled_processors_);
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    PrintAllHartsTests,
+    PrintAllHartsFixture,
+    ::testing::Values(
+        TestParams{
+            "All",
+            {
+                {TENSIX, DM, 0},
+                {TENSIX, DM, 1},
+                {TENSIX, COMPUTE, 0},
+                {TENSIX, COMPUTE, 1},
+                {TENSIX, COMPUTE, 2},
+            },
+            golden_output_data0 + golden_output_compute + golden_output_data1,
+        },
+        TestParams{
+            "Brisc",
+            {
+                {TENSIX, DM, 0},
+            },
+            golden_output_data0,
+        },
+        TestParams{
+            "BriscCompute",
+            {
+                // DPRINT server timeout if BRISC is disabled.
+                {TENSIX, DM, 0},
+                {TENSIX, COMPUTE, 0},
+                {TENSIX, COMPUTE, 1},
+                {TENSIX, COMPUTE, 2},
+            },
+            golden_output_data0 + golden_output_compute,
+        }),
+    [](const ::testing::TestParamInfo<TestParams>& info) { return info.param.test_name; });
+
+TEST_P(PrintAllHartsFixture, TensixTestPrint) {
     for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(CMAKE_UNIQUE_NAMESPACE::RunTest, mesh_device);
+        this->RunTestOnDevice(
+            [](DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice> mesh_device) {
+                RunTest(fixture, mesh_device, GetParam().golden_output);
+            },
+            mesh_device);
     }
 }
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -37,7 +37,7 @@ namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 // Some machines will run this test on different virtual cores, so wildcard the exact coordinates.
 const std::string golden_output =
-    R"(DPRINT server timed out on Device ?, worker core (x=?,y=?), riscv 4, waiting on a RAISE signal: 1
+    R"(DPRINT server timed out on Device ?, worker core (x=?,y=?), riscv 0, waiting on a RAISE signal: 1
 )";
 
 void RunTest(DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice> mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -167,8 +168,13 @@ void RunDelayTestOnCore(
     tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         msg.data(), msg.size(), {device->id(), virtual_core}, read_addr);
 
-    uint32_t msg_u32_value = *(reinterpret_cast<const uint32_t*>(msg.data()));
-    log_info(tt::LogTest, "Read back debug_insert_delays: 0x{:x}", msg_u32_value);
+    log_info(
+        tt::LogTest,
+        "Read back debug_insert_delays: {:x},{:x},{:x},{:x}",
+        msg.view().read_delay_processor_mask(),
+        msg.view().write_delay_processor_mask(),
+        msg.view().atomic_delay_processor_mask(),
+        msg.view().feedback());
     EXPECT_TRUE(msg.view().feedback() == 0x3);
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -33,13 +33,13 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
         tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
 
     // This works for tensix only, will need to be updated for eth
-    std::vector<uint64_t> print_buffer_addrs = {
-        reinterpret_cast<uint64_t>(&dprint_msg->data[DPRINT_RISCV_INDEX_NC]),
-        reinterpret_cast<uint64_t>(&dprint_msg->data[DPRINT_RISCV_INDEX_BR]),
-        reinterpret_cast<uint64_t>(&dprint_msg->data[DPRINT_RISCV_INDEX_TR0]),
-        reinterpret_cast<uint64_t>(&dprint_msg->data[DPRINT_RISCV_INDEX_TR1]),
-        reinterpret_cast<uint64_t>(&dprint_msg->data[DPRINT_RISCV_INDEX_TR2]),
-    };
+    auto num_processors = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX);
+    std::vector<uint64_t> print_buffer_addrs;
+    print_buffer_addrs.reserve(num_processors);
+    for (int i = 0; i < num_processors; i++) {
+        print_buffer_addrs.push_back(reinterpret_cast<uint64_t>(&dprint_msg->data[i]));
+    }
     for (const auto& worker_core : worker_cores_used_in_program) {
         for (const auto& buffer_addr : print_buffer_addrs) {
             std::vector<std::uint32_t> profile_buffer;

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -24,28 +24,6 @@ using CommonDataFormat = DataFormat;
 #include <cstddef>
 
 constexpr static std::uint32_t DPRINT_BUFFER_SIZE = 204;  // per thread
-// TODO: when device specific headers specify number of processors
-// (and hal abstracts them on host), get these from there
-// DPRINT_BUFFERS_COUNT should be less for eth cores but this file doesn't use compile time defines on host
-// and we need the addresses to be the same between host and device
-constexpr static std::uint32_t DPRINT_BUFFERS_COUNT = 5;
-
-// Used to index into the DPRINT buffers. Erisc is separate because it only has one buffer.
-enum DebugPrintHartIndex : unsigned int {
-    DPRINT_RISCV_INDEX_NC = 0,
-    DPRINT_RISCV_INDEX_TR0 = 1,
-    DPRINT_RISCV_INDEX_TR1 = 2,
-    DPRINT_RISCV_INDEX_TR2 = 3,
-    DPRINT_RISCV_INDEX_BR = 4,
-    DPRINT_RISCV_INDEX_ER = 0,
-    DPRINT_RISCV_INDEX_ER1 = 1,
-};
-#define DPRINT_NRISCVS 5
-#ifdef ARCH_BLACKHOLE
-#define DPRINT_NRISCVS_ETH 2
-#else
-#define DPRINT_NRISCVS_ETH 1
-#endif
 
 #define DPRINT_TYPES            \
     DPRINT_PREFIX(CSTR)         \

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -88,7 +88,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12752
+#define MEM_MAILBOX_SIZE 12768
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 
@@ -166,7 +166,7 @@
 #define MEM_MAX_NUM_CONCURRENT_TRANSACTIONS 8
 #define MEM_ERISC_SYNC_INFO_SIZE (160 + 16 * MEM_MAX_NUM_CONCURRENT_TRANSACTIONS)
 #define MEM_ERISC_FABRIC_ROUTER_CONFIG_SIZE 2064
-#define MEM_ERISC_MAILBOX_SIZE 12752
+#define MEM_ERISC_MAILBOX_SIZE 12768
 #define MEM_ERISC_KERNEL_CONFIG_SIZE (25 * 1024)
 #define MEM_ERISC_BASE 0
 

--- a/tt_metal/hw/inc/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/debug/dprint_buffer.h
@@ -11,27 +11,5 @@
 
 // Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.
 inline volatile tt_l1_ptr DebugPrintMemLayout* get_debug_print_buffer() {
-#if defined(COMPILE_FOR_NCRISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_NC]);
-#elif defined(COMPILE_FOR_BRISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_BR]);
-#elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 0)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
-#elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 1)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER1]);
-#elif (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
-#elif (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 1)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER1]);
-#elif defined(COMPILE_FOR_ERISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
-#elif defined(UCK_CHLKC_UNPACK)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR0]);
-#elif defined(UCK_CHLKC_MATH)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR1]);
-#elif defined(UCK_CHLKC_PACK)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR2]);
-#else
-    return 0;
-#endif
+    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[PROCESSOR_INDEX]);
 }

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -587,9 +587,9 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 
     bool delay = false;
     switch (transaction_type) {
-        case TransactionRead: delay = (v[0].read_delay_riscv_mask & (1 << debug_get_which_riscv())) != 0; break;
-        case TransactionWrite: delay = (v[0].write_delay_riscv_mask & (1 << debug_get_which_riscv())) != 0; break;
-        case TransactionAtomic: delay = (v[0].atomic_delay_riscv_mask & (1 << debug_get_which_riscv())) != 0; break;
+        case TransactionRead: delay = (v[0].read_delay_processor_mask & (1u << PROCESSOR_INDEX)) != 0; break;
+        case TransactionWrite: delay = (v[0].write_delay_processor_mask & (1u << PROCESSOR_INDEX)) != 0; break;
+        case TransactionAtomic: delay = (v[0].atomic_delay_processor_mask & (1u << PROCESSOR_INDEX)) != 0; break;
         default: break;
     }
     if (delay) {

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -21,26 +21,6 @@ void disable_erisc_app();
 
 #endif
 
-inline uint32_t debug_get_which_riscv() {
-#if defined(COMPILE_FOR_BRISC)
-    return DebugBrisc;
-#elif defined(COMPILE_FOR_NCRISC)
-    return DebugNCrisc;
-#elif (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0)
-    return DebugErisc;
-#elif (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 1)
-    return DebugSubordinateErisc;
-#elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 0)
-    return DebugIErisc;
-#elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 1)
-    return DebugSubordinateIErisc;
-#elif defined(COMPILE_FOR_ERISC)
-    return DebugErisc;
-#else
-    return DebugTrisc0 + COMPILE_FOR_TRISC;
-#endif
-}
-
 inline void clear_previous_launch_message_entry_for_watcher() {
     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
     // Before the read pointer has been incremented, clear the watcher info 1 entries before to ensure that we don't

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -235,13 +235,14 @@ struct debug_sanitize_noc_addr_msg_t {
     volatile uint8_t is_target;
     volatile uint8_t pad;  // CODEGEN:skip
 };
+static_assert(sizeof(debug_sanitize_noc_addr_msg_t) % sizeof(uint32_t) == 0);
 
 // Host -> device. Populated with the information on where we want to insert delays.
 struct debug_insert_delays_msg_t {
-    volatile uint8_t read_delay_riscv_mask = 0;    // Which Riscs will delay their reads
-    volatile uint8_t write_delay_riscv_mask = 0;   // Which Riscs will delay their writes
-    volatile uint8_t atomic_delay_riscv_mask = 0;  // Which Riscs will delay their atomics
-    volatile uint8_t feedback = 0;                 // Stores the feedback about delays (used for testing)
+    volatile uint32_t read_delay_processor_mask = 0;    // Which processors will delay their reads
+    volatile uint32_t write_delay_processor_mask = 0;   // Which processors will delay their writes
+    volatile uint32_t atomic_delay_processor_mask = 0;  // Which processors will delay their atomics
+    volatile uint32_t feedback = 0;                     // Stores the feedback about delays (used for testing)
 };
 
 enum debug_sanitize_noc_return_code_enum {
@@ -273,21 +274,6 @@ enum debug_assert_type_t {
     DebugAssertNCriscNOCNonpostedWritesSentTripped = 5,
     DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped = 6,
     DebugAssertNCriscNOCPostedWritesSentTripped = 7
-};
-
-// XXXX TODO(PGK): why why why do we not have this standardized
-enum riscv_id_t {
-    DebugBrisc = 0,
-    DebugNCrisc = 1,
-    DebugTrisc0 = 2,
-    DebugTrisc1 = 3,
-    DebugTrisc2 = 4,
-    DebugErisc = 5,
-    DebugSubordinateErisc = 6,
-    DebugIErisc = 7,
-    DebugSubordinateIErisc = 8,
-    DebugNumUniqueRiscs = 9,
-    DebugDebugMaxRiscvId = 15,  // For alignment requirements
 };
 
 enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -332,7 +332,7 @@ struct watcher_msg_t {
 // TODO: DebugPrintMemLayout not visible by codegen
 // To be fixed by HAL work on dprint buffers.
 struct dprint_buf_msg_t {
-    DebugPrintMemLayout data[DPRINT_BUFFERS_COUNT];
+    DebugPrintMemLayout data[NUM_PROCESSORS_PER_CORE_TYPE];
     uint32_t pad;  // to 1024 bytes
 };
 #endif

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -76,7 +76,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12752
+#define MEM_MAILBOX_SIZE 12768
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 8)

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -257,6 +257,7 @@ MetalContext::MetalContext() {
     bool is_base_routing_fw_enabled =
         Cluster::is_base_routing_fw_enabled(Cluster::get_cluster_type_from_cluster_desc(rtoptions_, cluster_desc.get()));
     hal_ = std::make_unique<Hal>(get_platform_architecture(rtoptions_), is_base_routing_fw_enabled);
+    rtoptions_.ParseAllFeatureEnv(*hal_);
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
     distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -149,6 +149,53 @@ uint32_t generate_risc_startup_addr(uint32_t firmware_base) {
     return jal_offset | opcode;
 }
 
+HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
+    HalProcessorSet set;
+
+    // TODO: might need a new syntax for new architectures.
+    // Current syntax hardcodes the RISC-V names for WH/BH.
+    // Either keep this syntax but move it to hal/tt-1xx, and create the new one in hal/tt-2xx,
+    // or break compatibility and use the new syntax for all architectures.
+    if (spec.find("BR") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 0);
+    }
+    if (spec.find("NC") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 1);
+    }
+    if (spec.find("TR0") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 2);
+    }
+    if (spec.find("TR1") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 3);
+    }
+    if (spec.find("TR2") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 4);
+    }
+    if (spec.find("TR*") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::TENSIX, 2);
+        set.add(HalProgrammableCoreType::TENSIX, 3);
+        set.add(HalProgrammableCoreType::TENSIX, 4);
+    }
+    if (spec.find("ER0") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::ACTIVE_ETH, 0);
+        set.add(HalProgrammableCoreType::IDLE_ETH, 0);
+    }
+    if (spec.find("ER1") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::ACTIVE_ETH, 1);
+        set.add(HalProgrammableCoreType::IDLE_ETH, 1);
+    }
+    if (spec.find("ER*") != std::string_view::npos) {
+        set.add(HalProgrammableCoreType::ACTIVE_ETH, 0);
+        set.add(HalProgrammableCoreType::ACTIVE_ETH, 1);
+        set.add(HalProgrammableCoreType::IDLE_ETH, 0);
+        set.add(HalProgrammableCoreType::IDLE_ETH, 1);
+    }
+    if (set.empty()) {
+        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*.", spec);
+    }
+    return set;
+}
+
 }  // namespace tt_metal
 }  // namespace tt
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27263

### Problem description

1. riscv_id_t and DebugHartFlags identify processors by RISCV names.  This is not portable to Quasar.
2. The values in riscv_id_t do not match the bit flag values in DebugHartFlags.  This means enabling the watcher_delay feature on a set of processors will enable it on a wrong set of processors.

### What's changed

1. Create a HAL type that represents a set of processors, and use that in host code instead.
2. Device code use a bitmask of processor indices instead.
3. Delete riscv_id_t and DebugHartFlags.

> [!NOTE]
> The syntax for the env vars that specify a set of processors, unfortunately used a non-portable naming scheme: BR,NC,TR,ER, etc.
> This PR does not change that, so as to preserve compatibility.  I think we should decide later if only Quasar will use a different scheme, or break the compatibility and make all architectures use the same generic scheme.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17602674364) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17536508397) CI with demo tests passes (if applicable)