### PR TITLE
Fix for microbenchmarks after TensorAccessor migration

### DIFF
--- a/tests/scripts/test_moreh_microbenchmark.py
+++ b/tests/scripts/test_moreh_microbenchmark.py
@@ -801,8 +801,8 @@ def test_dram_read_all_core(arch, test_vector, num_tests, nblock, data_format, n
     data.append([throughput])
     # check within range
     dev_freq = get_device_freq()
-    bw_lower_bound = 340.0
-    bw_upper_bound = 400.0
+    bw_lower_bound = 240.0
+    bw_upper_bound = 340.0
     assert bw_lower_bound <= throughput
     assert throughput <= bw_upper_bound
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -18,28 +18,28 @@ void kernel_main() {
     uint32_t last_block_h = get_arg_val<uint32_t>(4);
 
     // COMPILE TIME ARGS
-    // interleaved accessor args
-    constexpr auto in0_args = TensorAccessorArgs<0>();
-
     // in0 tensor args
-    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(1);
-    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(2);
-    constexpr uint32_t in0_tensor_next_block_stride = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in0_tensor_next_block_stride = get_compile_time_arg_val(2);
     // in0 block args
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(4);
-    constexpr uint32_t in0_block_h = get_compile_time_arg_val(5);
-    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(3);
+    constexpr uint32_t in0_block_h = get_compile_time_arg_val(4);
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(5);
     // in0/in1 common args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(6);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_dest_noc_start_x = get_compile_time_arg_val(8);
-    constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(9);
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(11));
-    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(12);
+    constexpr uint32_t in0_mcast_dest_noc_start_x = get_compile_time_arg_val(7);
+    constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(8);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(11);
     // batch args
-    constexpr uint32_t MtKt = get_compile_time_arg_val(13);  // if 0
-    constexpr uint32_t batch = get_compile_time_arg_val(14);
+    constexpr uint32_t MtKt = get_compile_time_arg_val(12);  // if 0
+    constexpr uint32_t batch = get_compile_time_arg_val(13);
+
+    // interleaved accessor args
+    constexpr auto in0_args = TensorAccessorArgs<14>();
 
     constexpr uint32_t cb_id_in0 = 0;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -26,35 +26,32 @@ void kernel_main() {
     uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(9);
 
     // COMPILE TIME ARGS
-    // interleaved accessor args
-    constexpr auto out_args = TensorAccessorArgs<0>();
-
     // READER
     // in1 block args
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(0);
     // in0/in1 common args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(1);
     // in1 mcast args
-    constexpr uint32_t in1_mcast_sender_noc_y = get_compile_time_arg_val(3);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
+    constexpr uint32_t in1_mcast_sender_noc_y = get_compile_time_arg_val(2);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
     // batch args
-    constexpr uint32_t batch = get_compile_time_arg_val(6);
+    constexpr uint32_t batch = get_compile_time_arg_val(5);
 
     // WRITER
     // out tensor args
-    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(7);
-    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(8);
-    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(9);
-    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(6);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(7);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(8);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(9);
 
     // out subblock args
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(11);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(12);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(13);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(10);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(11);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(12);
 
     // batch args
-    constexpr uint32_t MtNt = get_compile_time_arg_val(14);  // if 0
+    constexpr uint32_t MtNt = get_compile_time_arg_val(13);  // if 0
     // Don't need batch; same as batch from READER args
 
 #ifdef FUSE_BIAS
@@ -62,12 +59,12 @@ void kernel_main() {
     uint32_t in3_mcast_sender_noc_x = get_arg_val<uint32_t>(10);
 
     // in3 block args
-    constexpr uint32_t in3_block_w = get_compile_time_arg_val(15);
+    constexpr uint32_t in3_block_w = get_compile_time_arg_val(14);
 
     // in3 mcast args
-    constexpr uint32_t in3_mcast_sender_noc_y = get_compile_time_arg_val(16);
-    uint32_t in3_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(17));
-    uint32_t in3_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(18));
+    constexpr uint32_t in3_mcast_sender_noc_y = get_compile_time_arg_val(15);
+    uint32_t in3_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    uint32_t in3_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(17));
     constexpr uint32_t cb_id_in3 = 3;
     volatile tt_l1_ptr uint32_t* in3_mcast_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in3_mcast_receiver_semaphore_addr);
@@ -86,6 +83,13 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
+
+    // interleaved accessor args
+#ifdef FUSE_BIAS
+    constexpr auto out_args = TensorAccessorArgs<18>();
+#else
+    constexpr auto out_args = TensorAccessorArgs<14>();
+#endif
 
     // WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr, output_single_tile_size_bytes);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -32,44 +32,40 @@ void kernel_main() {
     uint32_t padded_block_tiles_w_skip = get_arg_val<uint32_t>(13);
 
     // COMPILE TIME ARGS
-    // interleaved accessor args
-    constexpr auto in1_args = TensorAccessorArgs<0>();
-    constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
-
     // READER
     // in1 tensor args
-    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(2);
-    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(3);
-    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(2);
     // in1 block args
-    constexpr uint32_t in1_block_w = get_compile_time_arg_val(5);
-    constexpr uint32_t in1_block_h = get_compile_time_arg_val(6);
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(3);
+    constexpr uint32_t in1_block_h = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
     // in0/in1 common args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(8);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(6);
     // in1 mcast args
-    constexpr uint32_t in1_mcast_dest_noc_start_y = get_compile_time_arg_val(9);
-    constexpr uint32_t in1_mcast_dest_noc_end_y = get_compile_time_arg_val(10);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(11));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));
-    constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(13);
+    constexpr uint32_t in1_mcast_dest_noc_start_y = get_compile_time_arg_val(7);
+    constexpr uint32_t in1_mcast_dest_noc_end_y = get_compile_time_arg_val(8);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
+    constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(11);
     // batch args
-    constexpr uint32_t KtNt = get_compile_time_arg_val(14);
-    constexpr uint32_t batch = get_compile_time_arg_val(15);
-    constexpr uint32_t bcast_B = get_compile_time_arg_val(16);
+    constexpr uint32_t KtNt = get_compile_time_arg_val(12);
+    constexpr uint32_t batch = get_compile_time_arg_val(13);
+    constexpr uint32_t bcast_B = get_compile_time_arg_val(14);
 
     // WRITER
     // out tensor args
-    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(19);
-    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(20);
+    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(15);
+    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(16);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(17);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(18);
     // out subblock args
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(21);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(19);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(20);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
     // batch args
-    constexpr uint32_t MtNt = get_compile_time_arg_val(24);  // if 0
+    constexpr uint32_t MtNt = get_compile_time_arg_val(22);  // if 0
     // Don't need batch; same as batch from READER args
 
 #ifdef FUSE_BIAS
@@ -79,13 +75,13 @@ void kernel_main() {
     uint32_t in3_mcast_dest_noc_start_x = get_arg_val<uint32_t>(16);
     uint32_t in3_mcast_dest_noc_end_x = get_arg_val<uint32_t>(17);
     // in3 mcast args
-    constexpr bool in3_is_dram = get_compile_time_arg_val(25) == 1;
-    constexpr uint32_t in3_tensor_stride_w = get_compile_time_arg_val(26);
-    constexpr uint32_t in3_mcast_dest_noc_start_y = get_compile_time_arg_val(27);
-    constexpr uint32_t in3_mcast_dest_noc_end_y = get_compile_time_arg_val(28);
-    uint32_t in3_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(29));
-    uint32_t in3_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(30));
-    constexpr uint32_t in3_mcast_num_dests = get_compile_time_arg_val(31);
+    constexpr bool in3_is_dram = get_compile_time_arg_val(23) == 1;
+    constexpr uint32_t in3_tensor_stride_w = get_compile_time_arg_val(24);
+    constexpr uint32_t in3_mcast_dest_noc_start_y = get_compile_time_arg_val(25);
+    constexpr uint32_t in3_mcast_dest_noc_end_y = get_compile_time_arg_val(26);
+    uint32_t in3_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(27));
+    uint32_t in3_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(28));
+    constexpr uint32_t in3_mcast_num_dests = get_compile_time_arg_val(29);
 
     constexpr uint32_t cb_id_in3 = 3;
     const uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
@@ -119,9 +115,19 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
 #endif
+
+    // interleaved accessor args
+#ifdef FUSE_BIAS
+    constexpr auto in1_args = TensorAccessorArgs<30>();
+    constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+    constexpr auto in3_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+#else
+    constexpr auto in1_args = TensorAccessorArgs<23>();
+    constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+#endif
+
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
 #ifdef FUSE_BIAS
-    constexpr auto in3_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     const auto s3 = TensorAccessor(in3_args, in3_tensor_addr, bias_single_tile_size_bytes);
 #endif
     // WRITER

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -220,7 +220,6 @@ tt_metal::Program create_program_mcast_in0_in1(
         in3_is_dram = bias_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     }
     std::vector<uint32_t> in0_sender_compile_time_args = {
-
         // in0 tensor args
         (std::uint32_t)1,            // in0_tensor_stride_w
         (std::uint32_t)K,            // in0_tensor_stride_h
@@ -243,7 +242,6 @@ tt_metal::Program create_program_mcast_in0_in1(
     };
     tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(in0_sender_compile_time_args);
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
-
         // READER
         // in1 tensor args
         (std::uint32_t)1,                // in1_tensor_stride_w
@@ -282,6 +280,7 @@ tt_metal::Program create_program_mcast_in0_in1(
     tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(in1_sender_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(in1_sender_writer_compile_time_args);
     if (bias_buffer != nullptr) {
+        tt::tt_metal::TensorAccessorArgs(bias_buffer).append_to(in1_sender_writer_compile_time_args);
         // in3 mcast args
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)in3_is_dram);
         // in1 tensor args
@@ -307,7 +306,6 @@ tt_metal::Program create_program_mcast_in0_in1(
         (std::uint32_t)B  // batch
     };
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
-
         // READER
         // in1 block args
         (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
@@ -333,7 +331,6 @@ tt_metal::Program create_program_mcast_in0_in1(
         // batch args
         (std::uint32_t)M * N  // MtNt
     };
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(in1_receiver_writer_compile_time_args);
     if (bias_buffer != nullptr) {
         // in3 mcast args
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)per_core_N);
@@ -341,11 +338,8 @@ tt_metal::Program create_program_mcast_in0_in1(
             (std::uint32_t)top_left_core_physical.y);  // in1_mcast_sender_noc_y
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in3_mcast_sender_semaphore_id);
         in1_receiver_writer_compile_time_args.push_back((std::uint32_t)in3_mcast_receiver_semaphore_id);
-    } else {
-        in1_receiver_writer_compile_time_args.push_back(0);  // Placeholder; not used
     }
-    // no fusion
-    in1_receiver_writer_compile_time_args.push_back(0);
+    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(in1_receiver_writer_compile_time_args);
 
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;


### PR DESCRIPTION
### Ticket

### Problem description
"Run microbenchmarks" was broken on CI after the PR which ported tests to use TensorAccessor

### What's changed
Updated related kernels and setup code, which was modified incorrectly in the migration PR

### Checklist
- [x] [Microbenchmarks CI passing](https://github.com/tenstorrent/tt-metal/actions/runs/17536577608)
- [x] New/Existing tests provide coverage for changes