### PR TITLE
[skip ci] fixed wrong pyskip reason in conv test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4001,7 +4001,7 @@ def test_conv2d_act_dealloc(
     num_slices,
 ):
     if shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED and input_layout == ttnn.ROW_MAJOR_LAYOUT and stride == (1,1):
-        pytest.skip("Block sharded conv2d does not support input with row major layout")
+        pytest.skip("Tilize op in conv2d doesn't support height sharded")
     if enable_fenable_kernel_stride_folding and stride != kernel:
         pytest.skip("Kernel stride folding is only supported when stride == kernel size")
     if enable_fenable_kernel_stride_folding and shard_layout is not None:

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4001,7 +4001,7 @@ def test_conv2d_act_dealloc(
     num_slices,
 ):
     if shard_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED and input_layout == ttnn.ROW_MAJOR_LAYOUT and stride == (1,1):
-        pytest.skip("Tilize op in conv2d doesn't support height sharded")
+        pytest.skip("Skipping due to Tilize op HEIGHT SHARDED assertion (called inside ttnn.conv2d)")
     if enable_fenable_kernel_stride_folding and stride != kernel:
         pytest.skip("Kernel stride folding is only supported when stride == kernel size")
     if enable_fenable_kernel_stride_folding and shard_layout is not None:


### PR DESCRIPTION
### Problem description
Current pyskip reason in `test_conv2d_act_dealloc` in test_conv2d.py is incorrect.

### What's changed
- changed pyskip reason to explain that the reason for it is an assert in `ttnn.tilize`