### PR TITLE
SFPI v6.20.0

### DIFF
--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,13 +1,10 @@
 # set SFPI release version information
 
-sfpi_version=v6.19.0
+sfpi_version=v6.20.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi-\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_Linux_txz_md5=44e56071c26de2a70058678c67ae2af2
-sfpi_aarch64_Linux_deb_md5=b3f8f87bcd26e7256f999de4a4070636
-sfpi_aarch64_Linux_rpm_md5=c428878af205dcfda389de6c96725c59
-sfpi_x86_64_Linux_txz_md5=1b1ad0eaade8a51424e44b3eb56723ce
-sfpi_x86_64_Linux_deb_md5=f08cd0f5091a51ef7f2cad7520c55361
-sfpi_x86_64_Linux_rpm_md5=4857f98a3b5ac1804d36dec6e04dbc70
+sfpi_x86_64_Linux_txz_md5=5477bb04519888447600495a34aafaa4
+sfpi_x86_64_Linux_deb_md5=e2c0ab55970400de8df4ea4ccdcfda72
+sfpi_x86_64_Linux_rpm_md5=2ecc1385c8042dce8f9be793840ec4f0


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25182

### Problem description
Provide context for the problem.

### What's changed
Fixes a code gen bug.
Implements some preparatory work for gcc-15 update

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes