### PR TITLE
Use an all equals check for combine/dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py
@@ -590,10 +590,9 @@ def check_results(test_tensor, ref_tensor, data_map):
         for b in range(ref_tensor.shape[1]):
             for s in range(ref_tensor.shape[2]):
                 if data_map[k, b, s].item() == 1:
-                    assert_with_pcc(test_tensor[k, b, s, :], ref_tensor[k, b, s, :])
                     assert (
                         torch.equal(test_tensor[k, b, s, :], ref_tensor[k, b, s, :]),
-                        f"Equal check failed for k={k}, b={b}, s={s}",
+                        f"Equal check failed for k={k}, b={b}, s={s} with test_tensor {test_tensor[k, b, s, :]} and ref_tensor {ref_tensor[k, b, s, :]}",
                     )
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py
@@ -591,6 +591,10 @@ def check_results(test_tensor, ref_tensor, data_map):
             for s in range(ref_tensor.shape[2]):
                 if data_map[k, b, s].item() == 1:
                     assert_with_pcc(test_tensor[k, b, s, :], ref_tensor[k, b, s, :])
+                    assert (
+                        torch.equal(test_tensor[k, b, s, :], ref_tensor[k, b, s, :]),
+                        f"Equal check failed for k={k}, b={b}, s={s}",
+                    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
@@ -443,7 +443,8 @@ def run_all_to_all_dispatch_test(
         selected_experts_k = tt_metadata_tensor.shape[3]
 
         metadata_all_close = torch.allclose(tt_metadata_tensor, output_metadata_goldens_list[tensor_index])
-        if not metadata_all_close:
+        metadata_all_equal = torch.equal(tt_metadata_tensor, output_metadata_goldens_list[tensor_index])
+        if not metadata_all_close or not metadata_all_equal:
             metadata_passed = False
             first_failed_metadata_index = tensor_index
             failed_metadata_indices = torch.where(tt_metadata_tensor != output_metadata_goldens_list[tensor_index])
@@ -468,12 +469,15 @@ def run_all_to_all_dispatch_test(
                             is_all_close = torch.allclose(
                                 tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[tensor_index][d, b, s, :]
                             )
+                            is_all_equal = torch.equal(
+                                tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[tensor_index][d, b, s, :]
+                            )
                             if not is_all_close:
                                 logger.info(
                                     f"Output tensor {tensor_index} mismatch at batch {b}, sequence {s}, expert {expert_id}, device {d}"
                                 )
 
-                            if not eq or not is_all_close:
+                            if not eq or not is_all_close or not is_all_equal:
                                 passed = False
                                 first_failed_tensor_index = tensor_index
                                 first_failed_batch_index = b

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
@@ -425,7 +425,6 @@ def run_all_to_all_dispatch_test(
     first_failed_metadata_index = None
     failed_indices = []
     failed_metadata_indices = []
-    expected_pcc = get_pcc_threshold(dtype)
 
     for tensor_index in range(len(tt_out_tensor_list)):
         tt_torch_tensor = ttnn.to_torch(
@@ -461,23 +460,15 @@ def run_all_to_all_dispatch_test(
                     expert_id = tt_metadata_tensor[0, b, s, k]
                     for d in range(devices):
                         if torch_expert_mappings[tensor_index][0, 0, expert_id, d] == 1:
-                            eq, output_results = comp_pcc(
-                                tt_torch_tensor[d, b, s, :],
-                                output_tensor_goldens_list[tensor_index][d, b, s, :],
-                                expected_pcc,
-                            )
-                            is_all_close = torch.allclose(
-                                tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[tensor_index][d, b, s, :]
-                            )
                             is_all_equal = torch.equal(
                                 tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[tensor_index][d, b, s, :]
                             )
-                            if not is_all_close:
+                            if not is_all_equal:
                                 logger.info(
                                     f"Output tensor {tensor_index} mismatch at batch {b}, sequence {s}, expert {expert_id}, device {d}"
                                 )
 
-                            if not eq or not is_all_close or not is_all_equal:
+                            if not is_all_equal:
                                 passed = False
                                 first_failed_tensor_index = tensor_index
                                 first_failed_batch_index = b


### PR DESCRIPTION
We should be using all equals for pure data movement on bfp16.

T3K frequent https://github.com/tenstorrent/tt-metal/actions/runs/17555716419