### PR TITLE
[tt-transformers] Fix Llama3.1-8B OOM in DRAM

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -118,19 +118,29 @@ class Generator:
                 model_id=model_id,
                 **local_kwargs,
             )
-            # out_list.append(logits)
+            # if data parallel is greater than 1, we need to add logits to out_list and do the processing after all the prefill are done
+            # otherwise, we can process the logits after prefill immediately
+            if self.data_parallel > 1:
+                out_list.append(logits)
+            else:
+                output_logits[idx] = self.model[model_id].process_output_prefill(
+                    logits, last_token_idx=(last_token_idx % 32)
+                )
+                del logits
 
-            seq_len = int(prompt_lens[idx])
-            last_token_idx = seq_len - 1
-            user_id = empty_slots[idx]
-            model_id = user_id // max_batch_size_per_model
+        # Process the logits after all the prefill are done in data parallel mode
+        if self.data_parallel > 1:
+            for idx, out in enumerate(out_list):
+                seq_len = int(prompt_lens[idx])
+                last_token_idx = seq_len - 1
+                user_id = empty_slots[idx]
+                model_id = user_id // max_batch_size_per_model
 
-            # Since we give unpadded_seq_len, only the tile containing the last token is returned
-            output_logits[idx] = self.model[model_id].process_output_prefill(
-                logits, last_token_idx=(last_token_idx % 32)
-            )
-            # deallocate logits
-            del logits
+                # Since we give unpadded_seq_len, only the tile containing the last token is returned
+                output_logits[idx] = self.model[model_id].process_output_prefill(
+                    out, last_token_idx=(last_token_idx % 32)
+                )
+                del outs
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -140,7 +140,6 @@ class Generator:
                 output_logits[idx] = self.model[model_id].process_output_prefill(
                     out, last_token_idx=(last_token_idx % 32)
                 )
-                del outs
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -118,16 +118,19 @@ class Generator:
                 model_id=model_id,
                 **local_kwargs,
             )
-            out_list.append(logits)
+            # out_list.append(logits)
 
-        for idx, out in enumerate(out_list):
             seq_len = int(prompt_lens[idx])
             last_token_idx = seq_len - 1
             user_id = empty_slots[idx]
             model_id = user_id // max_batch_size_per_model
 
             # Since we give unpadded_seq_len, only the tile containing the last token is returned
-            output_logits[idx] = self.model[model_id].process_output_prefill(out, last_token_idx=(last_token_idx % 32))
+            output_logits[idx] = self.model[model_id].process_output_prefill(
+                logits, last_token_idx=(last_token_idx % 32)
+            )
+            # deallocate logits
+            del logits
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         return output_logits


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23854

### Problem description
Llama3.1-8B was getting OOM in DRAM when executed on N150. 

### What's changed
Since we are very tight on DRAM memory due to weights + kv_cache are taking almost whole DRAM storage, minimal changes in model could cause OOM in DRAM. 

**Past behaviour** -  Run batch_size consecutive prefills and pile up logits for each user on device. Once prefills are done, logits are read from device to host and deallocated. 
**New behaviour** - After each prefill logits are read from device to host and deallocated. This way there won't be any unnecessary memory usage depending on batch_size but constant memory usage for each prefill. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17557379855)
- [x] [Blackhole Demo](https://github.com/tenstorrent/tt-metal/actions/runs/17557266563)
- [ ] [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/17557331960)
- [ ] [Single Card](https://github.com/tenstorrent/tt-metal/actions/runs/17557351366)
- [ ] [Galaxy Demo](https://github.com/tenstorrent/tt-metal/actions/runs/17557670350)

- [x] [TT-shield CI run](https://github.com/tenstorrent/tt-shield/actions/runs/17549722214)