### PR TITLE
[skip ci] Don't run ttsim integration tests on forks

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   ttsim-integration:
+    if: github.repository == 'tenstorrent/tt-metal'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Ticket
NA

### Problem description
Because the TTSIM repo is private, and public forks cannot access repository secrets, public forks cannot run TTSim integration tests. This means we must disable this workflow entirely for public forks to allow them to be merged directly.

Evidence of problem: https://github.com/tenstorrent/tt-metal/pull/21623

### What's changed
- Don't run ttsim workflow if working on fork.