### PR TITLE
Switch dispatch to row in BH for fabric with tensix extension

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -364,7 +364,10 @@ def set_fabric(fabric_config, fabric_tensix_config=None):
 
     # If fabric_config is not None, set it to fabric_config
     if fabric_config:
-        # Apply default logic for fabric_tensix_config
+        # Apply default logic for fabric_tensix_config,
+        # fabric_tensix_config is used for enabling tensix extensions for the fabric router,
+        # some sender channels in the fabric router are moved to the fabric tensix extension
+        # (currently the extension is mux kernel, can have other kernels in future as well).
         if fabric_tensix_config is None:
             fabric_tensix_config = get_default_fabric_tensix_config()
 

--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -280,14 +280,23 @@ def get_updated_device_params(device_params):
     dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
     fabric_tensix_config = new_device_params.get("fabric_tensix_config", None)
 
-    # If fabric_tensix_config is not specified but fabric_config is specified on Blackhole,
-    # default to MUX mode
-    if fabric_tensix_config is None and ttnn.device.is_blackhole():
+    if ttnn.device.is_blackhole():
+        # If fabric_tensix_config is not specified but fabric_config is specified on Blackhole,
+        # default to MUX mode
         fabric_config = new_device_params.get("fabric_config", None)
-        if fabric_config is not None:
+        if fabric_config and not fabric_tensix_config:
             fabric_tensix_config = ttnn.FabricTensixConfig.MUX
+            dispatch_core_axis = ttnn.DispatchCoreAxis.ROW
             new_device_params["fabric_tensix_config"] = fabric_tensix_config
-            logger.info("Blackhole with fabric enabled, defaulting to fabric_tensix_config=MUX")
+            logger.warning(
+                "Blackhole with fabric enabled, defaulting to fabric_tensix_config=MUX and use DispatchCoreAxis.ROW"
+            )
+        elif not fabric_config and not fabric_tensix_config:
+            if dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
+                logger.warning(
+                    "when fabric_tensix_config disabled, blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead."
+                )
+                dispatch_core_axis = ttnn.DispatchCoreAxis.COL
 
     dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis, fabric_tensix_config)
     new_device_params["dispatch_core_config"] = dispatch_core_config

--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -278,12 +278,18 @@ def get_updated_device_params(device_params):
 
     dispatch_core_axis = new_device_params.pop("dispatch_core_axis", None)
     dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
+    fabric_tensix_config = new_device_params.get("fabric_tensix_config", None)
 
-    if ttnn.device.is_blackhole() and dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
-        logger.warning("blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead.")
-        dispatch_core_axis = ttnn.DispatchCoreAxis.COL
+    # If fabric_tensix_config is not specified but fabric_config is specified on Blackhole,
+    # default to MUX mode
+    if fabric_tensix_config is None and ttnn.device.is_blackhole():
+        fabric_config = new_device_params.get("fabric_config", None)
+        if fabric_config is not None:
+            fabric_tensix_config = ttnn.FabricTensixConfig.MUX
+            new_device_params["fabric_tensix_config"] = fabric_tensix_config
+            logger.info("Blackhole with fabric enabled, defaulting to fabric_tensix_config=MUX")
 
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis, fabric_tensix_config)
     new_device_params["dispatch_core_config"] = dispatch_core_config
 
     return new_device_params

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -180,6 +180,7 @@ public:
     void set_num_iters_between_teardown_checks(size_t new_val);
     void set_wait_for_fabric_endpoint_ready(bool wait_for_ready);
     void set_fabric_endpoint_channel_num_buffers(size_t num_buffers);
+    void set_fabric_endpoint_status_address(size_t address);
 
     size_t get_memory_map_end_address() const;
 
@@ -227,6 +228,7 @@ private:
     size_t num_iters_between_teardown_checks_ = default_num_iters_between_teardown_checks;
     mutable bool wait_for_fabric_endpoint_ready_ = false;
     mutable size_t fabric_endpoint_channel_num_buffers_ = 0;
+    mutable size_t fabric_endpoint_status_address_ = 0;
 
     // memory regions
     MemoryRegion status_region_{};

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -150,6 +150,9 @@ public:
     // Returns the compile time args to be passed for the mux kernel
     std::vector<uint32_t> get_fabric_mux_compile_time_args() const;
 
+    // Returns the compile time args for relay mux
+    std::vector<uint32_t> get_fabric_mux_compile_time_args_for_relay_mux() const;
+
     // Returns the base compile time args without stream IDs (for custom stream ID override)
     std::vector<uint32_t> get_fabric_mux_compile_time_main_args(
         const tt::tt_fabric::FabricEriscDatamoverConfig& fabric_router_config) const;
@@ -175,7 +178,7 @@ public:
     size_t get_buffer_index_address(FabricMuxChannelType channel_type, uint8_t channel_id) const;
     void set_num_full_size_channel_iters(size_t new_val);
     void set_num_iters_between_teardown_checks(size_t new_val);
-    void set_wait_for_fabric_endpoint_ready(bool wait_for_ready);
+    void set_wait_for_fabric_endpoint_ready(bool wait_for_ready) const;
     void set_fabric_endpoint_channel_num_buffers(size_t num_buffers) const;
 
     size_t get_memory_map_end_address() const;
@@ -186,6 +189,10 @@ public:
 private:
     void validate_channel_id(FabricMuxChannelType channel_type, uint8_t channel_id) const;
     uint8_t get_channel_global_offset(FabricMuxChannelType channel_type, uint8_t channel_id) const;
+
+    // Helper function to add stream IDs and flags to compile time args
+    void append_default_stream_ids_to_ct_args(std::vector<uint32_t>& ct_args) const;
+    void append_default_persistent_channel_flags_to_ct_args(std::vector<uint32_t>& ct_args) const;
 
     // Private struct for memory management
     struct MemoryRegion {
@@ -218,8 +225,8 @@ private:
 
     size_t num_full_size_channel_iters_ = default_num_full_size_channel_iters;
     size_t num_iters_between_teardown_checks_ = default_num_iters_between_teardown_checks;
-    bool wait_for_fabric_endpoint_ready_ = false;
-    mutable size_t fabric_endpoint_channel_num_buffers_ = 1;  // Default to 1 to avoid assertion failure
+    mutable bool wait_for_fabric_endpoint_ready_ = false;
+    mutable size_t fabric_endpoint_channel_num_buffers_ = 0;
 
     // memory regions
     MemoryRegion status_region_{};

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -153,7 +153,6 @@ public:
     // Returns the base compile time args without stream IDs (for custom stream ID override)
     std::vector<uint32_t> get_fabric_mux_compile_time_main_args(
         const tt::tt_fabric::FabricEriscDatamoverConfig& fabric_router_config) const;
-    std::vector<uint32_t> get_fabric_mux_compile_time_main_args() const;
 
     // Returns the run-time arguments for the mux kernel depending on the connection setup with fabric router
     std::vector<uint32_t> get_fabric_mux_run_time_args(
@@ -176,6 +175,8 @@ public:
     size_t get_buffer_index_address(FabricMuxChannelType channel_type, uint8_t channel_id) const;
     void set_num_full_size_channel_iters(size_t new_val);
     void set_num_iters_between_teardown_checks(size_t new_val);
+    void set_wait_for_fabric_endpoint_ready(bool wait_for_ready);
+    void set_fabric_endpoint_channel_num_buffers(size_t num_buffers) const;
 
     size_t get_memory_map_end_address() const;
 
@@ -217,6 +218,8 @@ private:
 
     size_t num_full_size_channel_iters_ = default_num_full_size_channel_iters;
     size_t num_iters_between_teardown_checks_ = default_num_iters_between_teardown_checks;
+    bool wait_for_fabric_endpoint_ready_ = false;
+    mutable size_t fabric_endpoint_channel_num_buffers_ = 1;  // Default to 1 to avoid assertion failure
 
     // memory regions
     MemoryRegion status_region_{};

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -178,8 +178,8 @@ public:
     size_t get_buffer_index_address(FabricMuxChannelType channel_type, uint8_t channel_id) const;
     void set_num_full_size_channel_iters(size_t new_val);
     void set_num_iters_between_teardown_checks(size_t new_val);
-    void set_wait_for_fabric_endpoint_ready(bool wait_for_ready) const;
-    void set_fabric_endpoint_channel_num_buffers(size_t num_buffers) const;
+    void set_wait_for_fabric_endpoint_ready(bool wait_for_ready);
+    void set_fabric_endpoint_channel_num_buffers(size_t num_buffers);
 
     size_t get_memory_map_end_address() const;
 

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -92,12 +92,12 @@ unharvested:
       storage_cores: # Relative to grid of tensix cores
         []
 
-      # First half for fabric mux, second half for dispatch (13 cores total -> 6/7 each)
+      # First half for fabric mux, second half for dispatch (13 cores total -> 8/5 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -110,12 +110,12 @@ unharvested:
       storage_cores: # Relative to grid of tensix cores
         []
 
-      # First half for fabric mux, second half for dispatch (13 cores total -> 6/7 each)
+      # First half for fabric mux, second half for dispatch (13 cores total -> 8/5 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
 
       dispatch_core_type:
         "tensix"

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -9,6 +9,42 @@
 #     core descriptor config
 
 unharvested:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [13, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (14 cores total -> 7 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1]]
+
+      dispatch_cores:
+        [[7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [13, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (14 cores total -> 7 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1]]
+
+      dispatch_cores:
+        [[7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
+
+      dispatch_core_type:
+        "tensix"
   col:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
@@ -20,10 +56,10 @@ unharvested:
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
@@ -38,15 +74,52 @@ unharvested:
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
 
 1xharvested:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (13 cores total -> 6/7 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+
+      dispatch_cores:
+        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (13 cores total -> 6/7 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+
+      dispatch_cores:
+        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
   col:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
@@ -58,10 +131,10 @@ unharvested:
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
@@ -76,15 +149,52 @@ unharvested:
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
 
 2xharvested:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+
+      dispatch_cores:
+        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
+      fabric_mux_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+
+      dispatch_cores:
+        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1]]
+
+      dispatch_core_type:
+        "tensix"
+
   col:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
@@ -96,10 +206,10 @@ unharvested:
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"
@@ -114,10 +224,10 @@ unharvested:
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
-        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4]]
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
 
       dispatch_cores:
-        [[-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+        [[-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
       dispatch_core_type:
         "tensix"

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -18,12 +18,12 @@ unharvested:
       storage_cores: # Relative to grid of tensix cores
         []
 
-      # First half for fabric mux, second half for dispatch (14 cores total -> 7 each)
+      # First half for fabric mux, second half for dispatch (14 cores total -> 8/6 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -36,12 +36,12 @@ unharvested:
       storage_cores: # Relative to grid of tensix cores
         []
 
-      # First half for fabric mux, second half for dispatch (14 cores total -> 7 each)
+      # First half for fabric mux, second half for dispatch (14 cores total -> 8/6 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
 
       dispatch_core_type:
         "tensix"

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -208,9 +208,9 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args() const 
     if (tensix_config_enabled) {
         const auto& fabric_tensix_config =
             tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_tensix_config();
-        set_fabric_endpoint_channel_num_buffers(fabric_tensix_config.get_num_buffers_per_channel());
+        fabric_endpoint_channel_num_buffers_ = fabric_tensix_config.get_num_buffers_per_channel();
     } else {
-        set_fabric_endpoint_channel_num_buffers(fabric_router_config.sender_channels_num_buffers[0]);
+        fabric_endpoint_channel_num_buffers_ = fabric_router_config.sender_channels_num_buffers[0];
     }
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
@@ -224,8 +224,8 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args_for_rela
         tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().get_fabric_router_config();
 
     // For relay mux, always use fabric router config
-    set_fabric_endpoint_channel_num_buffers(fabric_router_config.sender_channels_num_buffers[0]);
-    set_wait_for_fabric_endpoint_ready(true);
+    fabric_endpoint_channel_num_buffers_ = fabric_router_config.sender_channels_num_buffers[0];
+    wait_for_fabric_endpoint_ready_ = true;
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
     append_default_stream_ids_to_ct_args(ct_args);
@@ -319,11 +319,11 @@ void FabricMuxConfig::set_num_iters_between_teardown_checks(size_t new_val) {
     num_iters_between_teardown_checks_ = new_val;
 }
 
-void FabricMuxConfig::set_wait_for_fabric_endpoint_ready(bool wait_for_ready) const {
+void FabricMuxConfig::set_wait_for_fabric_endpoint_ready(bool wait_for_ready) {
     wait_for_fabric_endpoint_ready_ = wait_for_ready;
 }
 
-void FabricMuxConfig::set_fabric_endpoint_channel_num_buffers(size_t num_buffers) const {
+void FabricMuxConfig::set_fabric_endpoint_channel_num_buffers(size_t num_buffers) {
     fabric_endpoint_channel_num_buffers_ = num_buffers;
 }
 

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -177,6 +177,7 @@ FabricMuxConfig::FabricMuxConfig(
 std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_main_args(
     const tt::tt_fabric::FabricEriscDatamoverConfig& fabric_router_config) const {
     TT_FATAL(fabric_endpoint_channel_num_buffers_ > 0, "fabric_endpoint_channel_num_buffers_ must be larger than 0");
+    TT_FATAL(fabric_endpoint_status_address_ != 0, "fabric_endpoint_status_address_ must not be invalid address 0");
     return std::vector<uint32_t>{
         num_full_size_channels_,
         num_buffers_full_size_channel_,
@@ -190,7 +191,7 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_main_args(
         flow_control_region_.get_address(),
         full_size_channels_region_.get_address(),
         local_fabric_router_status_region_.get_address(),
-        fabric_router_config.edm_status_address,
+        fabric_endpoint_status_address_,
         fabric_endpoint_channel_num_buffers_,
         num_full_size_channel_iters_,
         num_iters_between_teardown_checks_,
@@ -212,6 +213,7 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args() const 
     } else {
         fabric_endpoint_channel_num_buffers_ = fabric_router_config.sender_channels_num_buffers[0];
     }
+    fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
     append_default_stream_ids_to_ct_args(ct_args);
@@ -226,6 +228,7 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args_for_rela
     // For relay mux, always use fabric router config
     fabric_endpoint_channel_num_buffers_ = fabric_router_config.sender_channels_num_buffers[0];
     wait_for_fabric_endpoint_ready_ = true;
+    fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
     append_default_stream_ids_to_ct_args(ct_args);
@@ -326,6 +329,8 @@ void FabricMuxConfig::set_wait_for_fabric_endpoint_ready(bool wait_for_ready) {
 void FabricMuxConfig::set_fabric_endpoint_channel_num_buffers(size_t num_buffers) {
     fabric_endpoint_channel_num_buffers_ = num_buffers;
 }
+
+void FabricMuxConfig::set_fabric_endpoint_status_address(size_t address) { fabric_endpoint_status_address_ = address; }
 
 size_t FabricMuxConfig::get_memory_map_end_address() const { return memory_map_end_address_; }
 

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -54,13 +54,6 @@ static size_t find_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_a
             }
             auto neighbors = control_plane.get_chip_neighbors(fabric_node_id, direction);
 
-            log_info(
-                tt::LogTest,
-                "fabric_node_id {} direction {} active_eth_chans {}",
-                fabric_node_id,
-                direction,
-                active_eth_chans.size());
-
             // assume same neighbor per direction
             TT_FATAL(neighbors.size() == 1, "Multiple neighbor meshes per direction is unsupported");
             TT_FATAL(
@@ -89,8 +82,6 @@ static size_t find_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_a
 
         max_eth_channels = std::max(max_eth_channels, non_dispatch_active_channels.size());
     }
-
-    log_info(tt::LogTest, "max_eth_channels {}", max_eth_channels);
 
     return max_eth_channels;
 }
@@ -158,9 +149,8 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
 
     TT_FATAL(
         num_used_riscs_per_tensix_ == 1,
-        "Currently only support one mux per tensix {} {}",
-        max_eth_channels,
-        logical_fabric_mux_cores_.size());
+        "Currently only support one mux per tensix but got {} muxes per tensix",
+        num_used_riscs_per_tensix_);
 
     // Second pass: create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -142,6 +142,8 @@ void FabricTensixDatamoverConfig::initialize_channel_mappings() {
         (max_eth_channels + logical_fabric_mux_cores_.size() - 1) / logical_fabric_mux_cores_.size();
     num_used_riscs_per_tensix_ = num_configs_per_core_;
 
+    TT_FATAL(num_used_riscs_per_tensix_ == 1, "Currently only support one mux per tensix");
+
     // Second pass: create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {
         auto dev_id = device->id();

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -54,6 +54,13 @@ static size_t find_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_a
             }
             auto neighbors = control_plane.get_chip_neighbors(fabric_node_id, direction);
 
+            log_info(
+                tt::LogTest,
+                "fabric_node_id {} direction {} active_eth_chans {}",
+                fabric_node_id,
+                direction,
+                active_eth_chans.size());
+
             // assume same neighbor per direction
             TT_FATAL(neighbors.size() == 1, "Multiple neighbor meshes per direction is unsupported");
             TT_FATAL(
@@ -82,6 +89,8 @@ static size_t find_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_a
 
         max_eth_channels = std::max(max_eth_channels, non_dispatch_active_channels.size());
     }
+
+    log_info(tt::LogTest, "max_eth_channels {}", max_eth_channels);
 
     return max_eth_channels;
 }
@@ -142,7 +151,11 @@ void FabricTensixDatamoverConfig::initialize_channel_mappings() {
         (max_eth_channels + logical_fabric_mux_cores_.size() - 1) / logical_fabric_mux_cores_.size();
     num_used_riscs_per_tensix_ = num_configs_per_core_;
 
-    TT_FATAL(num_used_riscs_per_tensix_ == 1, "Currently only support one mux per tensix");
+    TT_FATAL(
+        num_used_riscs_per_tensix_ == 1,
+        "Currently only support one mux per tensix {} {}",
+        max_eth_channels,
+        logical_fabric_mux_cores_.size());
 
     // Second pass: create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -471,6 +471,8 @@ std::vector<uint32_t> FabricTensixDatamoverBuilder::get_compile_time_args(tt::tt
         }
     }();
 
+    fabric_mux_config_->set_fabric_endpoint_channel_num_buffers(fabric_router_config.sender_channels_num_buffers[0]);
+    fabric_mux_config_->set_wait_for_fabric_endpoint_ready(true);
     auto ct_args = fabric_mux_config_->get_fabric_mux_compile_time_main_args(fabric_router_config);
 
     // Get topology-specific fabric router stream IDs based on topology

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -483,6 +483,7 @@ std::vector<uint32_t> FabricTensixDatamoverBuilder::get_compile_time_args(tt::tt
 
     fabric_mux_config_->set_fabric_endpoint_channel_num_buffers(fabric_router_config.sender_channels_num_buffers[0]);
     fabric_mux_config_->set_wait_for_fabric_endpoint_ready(true);
+    fabric_mux_config_->set_fabric_endpoint_status_address(fabric_router_config.edm_status_address);
     auto ct_args = fabric_mux_config_->get_fabric_mux_compile_time_main_args(fabric_router_config);
 
     // Get topology-specific fabric router stream IDs based on topology

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -102,7 +102,7 @@ private:
     std::unordered_map<size_t, std::shared_ptr<tt::tt_fabric::FabricMuxConfig>> mux_configs_;
 
     // Helper methods for initialization
-    void initialize_channel_mappings();
+    bool initialize_channel_mappings();
     void calculate_buffer_allocations();
     void create_mux_configs();
 };

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -110,6 +110,7 @@ void forward_data(
     bool has_unsent_payload = get_ptr_val(my_channel_free_slots_stream_id.get()) != NUM_BUFFERS;
     if (has_unsent_payload) {
         size_t buffer_address = channel.get_buffer_address(worker_interface.local_write_counter.get_buffer_index());
+        invalidate_l1_cache();
         auto packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(buffer_address);
 
         fabric_connection.wait_for_empty_write_slot();

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -37,6 +37,9 @@ constexpr size_t NUM_FULL_SIZE_CHANNELS_ITERS = get_compile_time_arg_val(14);
 constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(15);
 
 constexpr ProgrammableCoreType CORE_TYPE = static_cast<ProgrammableCoreType>(get_compile_time_arg_val(16));
+constexpr bool wait_for_fabric_endpoint = get_compile_time_arg_val(17) == 1;
+
+constexpr size_t CHANNEL_STREAM_IDS_START_IDX = 18;
 
 constexpr size_t NOC_ALIGN_PADDING_BYTES = 12;
 
@@ -165,7 +168,6 @@ void kernel_main() {
     std::array<bool, NUM_HEADER_ONLY_CHANNELS> header_only_channel_connection_established;
 
     // Stream IDs
-    constexpr size_t CHANNEL_STREAM_IDS_START_IDX = 17;
     constexpr size_t NUM_TOTAL_CHANNELS = NUM_FULL_SIZE_CHANNELS + NUM_HEADER_ONLY_CHANNELS;
     constexpr std::array<uint32_t, NUM_TOTAL_CHANNELS> channel_stream_ids =
         fill_array_with_next_n_args<uint32_t, CHANNEL_STREAM_IDS_START_IDX, NUM_TOTAL_CHANNELS>();
@@ -214,11 +216,13 @@ void kernel_main() {
         reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(termination_signal_address);
 
     // wait for fabric router to be ready before setting up the connection
-    tt::tt_fabric::wait_for_fabric_endpoint_ready(
-        fabric_connection.edm_noc_x,
-        fabric_connection.edm_noc_y,
-        fabric_router_status_address,
-        local_fabric_router_status_address);
+    if constexpr (wait_for_fabric_endpoint) {
+        tt::tt_fabric::wait_for_fabric_endpoint_ready(
+            fabric_connection.edm_noc_x,
+            fabric_connection.edm_noc_y,
+            fabric_router_status_address,
+            local_fabric_router_status_address);
+    }
 
     constexpr bool use_worker_allocated_credit_address = CORE_TYPE == ProgrammableCoreType::IDLE_ETH;
     fabric_connection.open<use_worker_allocated_credit_address>();

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -50,8 +50,16 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_94(uint32_t n) {
     return (((uint64_t)n * 0xAE4C415D) >> 32) >> 6;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_108(uint32_t n) {
+    return (((uint64_t)n * 0x4BDA12F7) >> 32) >> 5;
+}
+
 inline __attribute__((always_inline)) uint32_t fast_udiv_110(uint32_t n) {
     return (((uint64_t)n * 0x094F2095) >> 32) >> 2;
+}
+
+inline __attribute__((always_inline)) uint32_t fast_udiv_117(uint32_t n) {
+    return (((uint64_t)n * 0x8C08C08D) >> 32) >> 6;
 }
 
 inline __attribute__((always_inline)) uint32_t fast_udiv_120(uint32_t n) {
@@ -59,7 +67,11 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_120(uint32_t n) {
 }
 
 inline __attribute__((always_inline)) uint32_t fast_udiv_124(uint32_t n) {
-    return (((uint64_t)n * 0x08421085) >> 32) >> 2;
+    return (((uint64_t)n * 0x84210843) >> 32) >> 6;
+}
+
+inline __attribute__((always_inline)) uint32_t fast_udiv_126(uint32_t n) {
+    return (((uint64_t)n * 0x82082083) >> 32) >> 6;
 }
 
 inline __attribute__((always_inline)) uint32_t fast_udiv_130(uint32_t n) {
@@ -97,12 +109,18 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
     } else if constexpr (d == 94) {
         // fast divide for 94 divisor. Handles Banked L1 address generation for E75
         return fast_udiv_94(n);
+    } else if constexpr (d == 108) {
+        return fast_udiv_108(n);
     } else if constexpr (d == 110) {
         return fast_udiv_110(n);
+    } else if constexpr (d == 117) {
+        return fast_udiv_117(n);
     } else if constexpr (d == 120) {
         return fast_udiv_120(n);
     } else if constexpr (d == 124) {
         return fast_udiv_124(n);
+    } else if constexpr (d == 126) {
+        return fast_udiv_126(n);
     } else if constexpr (d == 130) {
         return fast_udiv_130(n);
     } else if constexpr (d == 140) {

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -123,7 +123,7 @@ void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool 
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
     std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {
-        7, 12, 20, 48, 56, 63, 70, 72, 80, 94, 110, 120, 124, 130, 140};
+        7, 12, 20, 48, 56, 63, 70, 72, 80, 94, 108, 110, 117, 120, 124, 126, 130, 140};
     bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.count(num_banks) > 0;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -10,8 +10,12 @@
 namespace tt::tt_metal {
 
 DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
-    return (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
-                                                                                  : DispatchCoreAxis::ROW;
+    if (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
+        if (MetalContext::instance().get_fabric_tensix_config() == tt_fabric::FabricTensixConfig::DISABLED) {
+            return DispatchCoreAxis::COL;
+        }
+    }
+    return DispatchCoreAxis::ROW;
 }
 
 DispatchCoreConfig get_dispatch_core_config() {

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -80,8 +80,8 @@ void RelayMux::GenerateStaticConfigs() {
         static_config_.buffer_size_bytes.value(),
         static_config_.buffer_base_address.value(),
         mux_config_core);
-    mux_kernel_config_->set_wait_for_fabric_endpoint_ready(true);
-    mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args();
+
+    mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args_for_relay_mux();
 
     uint32_t mux_buffer_end = mux_kernel_config_->get_memory_map_end_address();
     TT_ASSERT(mux_buffer_end < l1_size, "RelayMux Buffer End {} Exceeds Max L1 {}", mux_buffer_end, l1_size);

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -80,6 +80,7 @@ void RelayMux::GenerateStaticConfigs() {
         static_config_.buffer_size_bytes.value(),
         static_config_.buffer_base_address.value(),
         mux_config_core);
+    mux_kernel_config_->set_wait_for_fabric_endpoint_ready(true);
     mux_ct_args_ = mux_kernel_config_->get_fabric_mux_compile_time_args();
 
     uint32_t mux_buffer_end = mux_kernel_config_->get_memory_map_end_address();

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -138,7 +138,7 @@ from ttnn._ttnn.global_circular_buffer import (
     create_global_circular_buffer,
 )
 
-from ttnn._ttnn.fabric import FabricConfig, FabricReliabilityMode, set_fabric_config
+from ttnn._ttnn.fabric import FabricConfig, FabricReliabilityMode, FabricTensixConfig, set_fabric_config
 
 # Import cluster functions and types
 from ttnn._ttnn import cluster

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -91,12 +91,21 @@ def get_default_dispatch_core_type():
     )
 
 
-def get_default_dispatch_core_axis():
-    return DispatchCoreAxis.COL if is_blackhole() else DispatchCoreAxis.ROW
+def get_default_dispatch_core_axis(fabric_tensix_config=None):
+    """Get default dispatch core axis, considering fabric tensix config if available."""
+    if is_blackhole():
+        # On Blackhole, if fabric tensix MUX is enabled, use ROW; otherwise use COL
+        if fabric_tensix_config == ttnn.FabricTensixConfig.MUX:
+            return DispatchCoreAxis.ROW
+        else:
+            return DispatchCoreAxis.COL
+    else:
+        # Non-Blackhole architectures default to ROW
+        return DispatchCoreAxis.ROW
 
 
 class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
-    def __init__(self, type: DispatchCoreType = None, axis: DispatchCoreAxis = None):
+    def __init__(self, type: DispatchCoreType = None, axis: DispatchCoreAxis = None, fabric_tensix_config=None):
         # Validate user provided args
         if type:
             if not isinstance(type, DispatchCoreType):
@@ -108,8 +117,10 @@ class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
             if not isinstance(axis, DispatchCoreAxis):
                 valid_values = [e for e in DispatchCoreAxis.__members__.values()]
                 raise ValueError(f"Invalid dispatch core axis: {axis}. Valid values are: {valid_values}")
-            if axis == DispatchCoreAxis.ROW and is_blackhole():
-                raise ValueError("ROW dispatch core axis is not supported for blackhole arch")
+            if axis == DispatchCoreAxis.ROW and is_blackhole() and fabric_tensix_config != ttnn.FabricTensixConfig.MUX:
+                raise ValueError(
+                    "ROW dispatch core axis is not supported for blackhole arch unless fabric tensix MUX is enabled"
+                )
         if type and axis:
             # User provided both valid type and axis, check if they are compatible
             self.type = type
@@ -117,7 +128,7 @@ class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
         elif type:
             # User provided only valid type
             self.type = type
-            self.axis = get_default_dispatch_core_axis()
+            self.axis = get_default_dispatch_core_axis(fabric_tensix_config)
             logger.info(f"Using default dispatch core axis for this system: {self.axis}")
         elif axis:
             self.axis = axis
@@ -136,7 +147,7 @@ class DispatchCoreConfig(ttnn._ttnn.device.DispatchCoreConfig):
             # User provided no valid type or axis, use default for their system
             self.type = get_default_dispatch_core_type()
             logger.info(f"Using default dispatch core type for this system: {self.type}")
-            self.axis = get_default_dispatch_core_axis()
+            self.axis = get_default_dispatch_core_axis(fabric_tensix_config)
             logger.info(f"Using default dispatch core axis for this system: {self.axis}")
         super().__init__(self.type, self.axis)
 


### PR DESCRIPTION
### issue
https://github.com/tenstorrent/tt-metal/issues/28028

### Problem description
We need to enable tensix extension on blackhole by default for python level, thus free user from enabling it themselves, thus as a first step towards speed up fabric on BH.
We also need to move dispatch to a row, so later we can share the row with fabric tensix extension.


### What's changed
on blackhole, use mux extension in fabric by default, unless user override it.
when use mux extension, use row instead of col for dispatch cores and mux extension cores.
fix multi-mux chaining hang.

### Checklist
- [x] [Blackhole Post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/17861235968 - failure unrelate
- [x] BH nightly https://github.com/tenstorrent/tt-metal/actions/runs/17861240164
- [x] APC https://github.com/tenstorrent/tt-metal/actions/runs/17861299758 - failure unrelated
- [x] BH demo https://github.com/tenstorrent/tt-metal/actions/runs/17861775481