### PR TITLE
[skip ci] Bring tt-triage into our docker images

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -97,6 +97,7 @@ jobs:
             tests/sweep_framework/requirements-sweeps.txt \
             tt_metal/python_env/requirements-dev.txt \
             tt_metal/sfpi-version.sh \
+            scripts/ttexalens_ref.txt \
             | sha1sum | cut -d' ' -f1)
           echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
           echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -98,7 +98,9 @@ RUN umask 000 && python3 -m pip config set global.extra-index-url https://downlo
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 
-RUN ./scripts/install_debugger.sh
+COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
+COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
+RUN /bin/bash /opt/tt_metal_infra/scripts/install_debugger.sh
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -98,7 +98,9 @@ RUN python3 -m pip config set global.extra-index-url https://download.pytorch.or
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 
-RUN ./scripts/install_debugger.sh
+COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
+COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
+RUN /bin/bash /opt/tt_metal_infra/scripts/install_debugger.sh
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR && chmod -R 777 $PYTHON_ENV_DIR
+RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN python3 -m venv $PYTHON_ENV_DIR
+RUN python3 -m venv $PYTHON_ENV_DIR && chmod -R 777 $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
@@ -94,11 +94,11 @@ COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
 COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
-# TODO: Why do we need the chmod?
 RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
-    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt && \
-    chmod -R 777 $VIRTUAL_ENV
+    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
+
+RUN ./scripts/install_debugger.sh
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN python3 -m venv $PYTHON_ENV_DIR && chmod -R 777 $PYTHON_ENV_DIR
+RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR && chmod -R 777 $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
@@ -94,13 +94,11 @@ COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
 COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
-RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
+RUN umask 000 && python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 
-COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
-COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
-RUN /bin/bash /opt/tt_metal_infra/scripts/install_debugger.sh
+RUN ./scripts/install_debugger.sh
 
 #############################################################
 
@@ -170,9 +168,6 @@ RUN mkdir -p /etc && \
 ARG WHEEL_FILENAME
 ADD $WHEEL_FILENAME $WHEEL_FILENAME
 RUN pip3 install $WHEEL_FILENAME
-
-# Set up virtual environment
-RUN python3 -m venv $PYTHON_ENV_DIR
 
 #############################################################
 


### PR DESCRIPTION
### Ticket
#27970 

### Problem description
We are requested to start running tt-triage in CI. However, we don't have tt-triage installed in our docker image.
Also, there is a step in our docker image that does a massive chmod. I am hoping this fly by cleanup is valid.

### What's changed
- Add tt-triage to our docker image
- Fly by cleanup

### Checklist
- If PR Gate and Merge Gate pass, this should be good to go.