### PR TITLE
Debug change: change softmax kernel to use numeric stable version by …

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
@@ -25,7 +25,7 @@ struct ExecuteSoftmax {
         int dim,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        bool numeric_stable = false);
+        bool numeric_stable = true);
 };
 
 /**
@@ -48,7 +48,7 @@ struct ExecuteScaleMaskSoftmax {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         bool is_causal_mask = false,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        bool numeric_stable = false);
+        bool numeric_stable = true);
 };
 
 /**
@@ -65,7 +65,7 @@ struct ExecuteSoftmaxInPlace {
         int dim = -1,
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        bool numeric_stable = false);
+        bool numeric_stable = true);
 };
 
 /**
@@ -89,7 +89,7 @@ struct ExecuteScaleMaskSoftmaxInPlace {
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
         bool is_causal_mask = false,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        bool numeric_stable = false);
+        bool numeric_stable = true);
 };
 
 /**
@@ -114,7 +114,7 @@ struct ExecuteScaleCausalMaskHWSoftmaxInPlace {
         const std::optional<const Tensor>& mask = std::nullopt,
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        bool numeric_stable = false);
+        bool numeric_stable = true);
 };
 }  // namespace ttnn::operations::normalization
 


### PR DESCRIPTION
…defualt, but use old version for the transformer attention call

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes