### PR TITLE
[skip ci] Revert "Revert "Bring tt-triage into our docker images""

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -97,6 +97,7 @@ jobs:
             tests/sweep_framework/requirements-sweeps.txt \
             tt_metal/python_env/requirements-dev.txt \
             tt_metal/sfpi-version.sh \
+            scripts/ttexalens_ref.txt \
             | sha1sum | cut -d' ' -f1)
           echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
           echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN python3 -m venv $PYTHON_ENV_DIR
+RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
@@ -94,11 +94,13 @@ COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
 COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
-# TODO: Why do we need the chmod?
-RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
+RUN umask 000 && python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
     python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
-    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt && \
-    chmod -R 777 $VIRTUAL_ENV
+    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
+
+COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
+COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
+RUN /bin/bash /opt/tt_metal_infra/scripts/install_debugger.sh
 
 #############################################################
 
@@ -168,9 +170,6 @@ RUN mkdir -p /etc && \
 ARG WHEEL_FILENAME
 ADD $WHEEL_FILENAME $WHEEL_FILENAME
 RUN pip3 install $WHEEL_FILENAME
-
-# Set up virtual environment
-RUN python3 -m venv $PYTHON_ENV_DIR
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -100,7 +100,7 @@ RUN umask 000 && python3 -m pip config set global.extra-index-url https://downlo
 
 COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
 COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
-RUN /bin/bash /opt/tt_metal_infra/scripts/install_debugger.sh
+RUN /opt/tt_metal_infra/scripts/install_debugger.sh
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -100,7 +100,7 @@ RUN umask 000 && python3 -m pip config set global.extra-index-url https://downlo
 
 COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
 COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
-RUN /opt/tt_metal_infra/scripts/install_debugger.sh
+RUN if [ "$UBUNTU_VERSION" = "22.04" ]; then /opt/tt_metal_infra/scripts/install_debugger.sh; fi
 
 #############################################################
 


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#28153

The change in this PR, is that 24.04 containers are now untouched, as tt-triage / tt-exalens do not support 24.04.