### PR TITLE
Optimize reshape operation with dual kernel support for RM tensors

### DIFF
--- a/models/demos/mnist/tests/test_perf_mnist.py
+++ b/models/demos/mnist/tests/test_perf_mnist.py
@@ -111,7 +111,7 @@ def test_perf_device_bare_metal(batch_size, reset_seeds):
     subdir = "ttnn_mnist"
     num_iterations = 1
     margin = 0.04
-    expected_perf = 890000
+    expected_perf = 1029400
 
     command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py::test_mnist"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_s", 6.4),
+        (1, "Swin_s", 6.7),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -209,9 +209,6 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
             tt::tt_metal::Buffer* src_buffer = input_tensors.at(0).buffer();
             tt::tt_metal::Buffer* dst_buffer = output_tensors.at(0).buffer();
 
-            std::cout << "ReshapeOperation::rm_reshape_preparer override_runtime_args_callback"
-                      << std::endl;  // --- IGNORE ---
-
             for (int core_x = 0; core_x < num_cores_x; core_x++) {
                 for (int core_y = 0; core_y < num_cores_y; core_y++) {
                     CoreCoord core = {core_x, core_y};

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include <math.h>
 
-#include "tt-metalium/kernel_types.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operation.hpp"
@@ -158,8 +157,7 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
                         second_write_pos = write_start_page + half_output_pages;
                     }
 
-                    // Common args template: {src_addr, dst_addr, read_size, start_read, end_read, write_pos, 0, 0}
-                    const std::vector<uint32_t> first_args = {
+                    std::vector<uint32_t> runtime_args = {
                         src_buffer->address(),
                         dst_buffer->address(),
                         source_read_size_bytes,
@@ -168,18 +166,14 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
                         write_start_page,
                         0,
                         0};
-                    const std::vector<uint32_t> second_args = {
-                        src_buffer->address(),
-                        dst_buffer->address(),
-                        source_read_size_bytes,
-                        mid_read,
-                        end_of_read,
-                        second_write_pos,
-                        0,
-                        0};
 
-                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, first_args);
-                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, second_args);
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+
+                    runtime_args[3] = mid_read;
+                    runtime_args[4] = end_of_read;
+                    runtime_args[5] = second_write_pos;
+
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, runtime_args);
                 } else {
                     // Original single kernel approach (remove dead code)
                     const std::vector<uint32_t> reader_runtime_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -174,7 +174,7 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
 
                     tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, runtime_args);
                 } else {
-                    // Original single kernel approach (remove dead code)
+                    // Original single kernel approach
                     const std::vector<uint32_t> reader_runtime_args = {
                         src_buffer->address(),
                         dst_buffer->address(),

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -56,7 +56,6 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
     uint32_t source_read_size_bytes = ((source_page_size_bytes - 1) & MASK_64) + 128;
     uint32_t read_start_page = 0;
     uint32_t write_start_page = 0;
-    uint32_t write_start_offset = 0;
     tt::tt_metal::Buffer* src_buffer = input.buffer();
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");


### PR DESCRIPTION
### Problem description
Reshape operation for Row Major input uses single RISC kernel.

### What's changed
  - Added dual kernel optimization: Automatically enables when page sizes are cleanly divisible, splitting work between two kernels for improved throughput
  -  work splitting:
    - Splits by input pages when source_page_size >= dest_page_size
    - Splits by output pages when dest_page_size > source_page_size
    - Falls back to single kernel when page sizes aren't cleanly divisible
  - Remove redundancies from runtime args callback
  - MNIST and Swin-S performance improved 15%  and 4% respectively, approx.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17753967709)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17753975591)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17576869215) [Latest](https://github.com/tenstorrent/tt-metal/actions/runs/17753971248).
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17753969315)
- [X] [(Single-card) Frequent model and ttnn tests ] CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17550195642)