### PR TITLE
#23562: Update tanh accurate to use exp_21f

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1585,8 +1585,8 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype, atol",
     [
-        (torch.float32, ttnn.float32, 0.016),
-        (torch.bfloat16, ttnn.bfloat16, 0.016),
+        (torch.float32, ttnn.float32, 0.002),
+        (torch.bfloat16, ttnn.bfloat16, 0.008),
     ],
 )
 def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -62,8 +62,8 @@ void MAIN {
             copy_tile(cb_input, 0, 0);
 
             mul_unary_tile(0, two);
-            exp_tile_init<1u>();
-            exp_tile<1u>(0);
+            exp_tile_init();
+            exp_tile(0);
 
             tile_regs_commit();
             tile_regs_wait();


### PR DESCRIPTION
### Ticket
Link to Github Issue #23562

### Performance results:
- Tanh_accurate (without exp_21f) : 5371ns
- Tanh_accurate (with exp_21f) : 7886ns (~46% slower)
- Tanh approx :1789ns ( ~66% faster)

 
### Atol after exp21f:
- bfoat16 : 0.008 (earlier 0.016)
- float32 : 0.002

### What's changed:
Update tanh accurate to use exp_21f