### PR TITLE
Make find_closest_largest_divisor_with_num_padding_and_mult less restrictive

### DIFF
--- a/models/demos/yolov7/tests/perf/test_perf.py
+++ b/models/demos/yolov7/tests/perf/test_perf.py
@@ -19,7 +19,7 @@ sys.modules["models.yolo"] = yolov7_model
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 119.35],
+        [1, 121.7],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -1846,7 +1846,9 @@ def test_unet_conv_wh(
         (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}),
         (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}),
         (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 16 * 32}),
-        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32}),
+        # Issue #28172 fix bug with weights preparation in case conv maps to matmul
+        # and input tensor is interleaved and auto shard is used.
+        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32} if is_wormhole_b0() else None),
     ),
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -64,7 +64,7 @@ uint32_t find_closest_largest_divisor_with_num_padding_and_mult(uint32_t num, ui
     uint32_t divisor = start_divisor;
     uint32_t big_divisor = divisor * mult;
     uint32_t padded_num = tt::round_up(num, big_divisor);
-    while ((padded_num - num) >= (int)(padded_num / big_divisor) and divisor > 1) {
+    while ((padded_num - num) >= (int)(padded_num / divisor) && divisor > 1) {
         divisor = divisor - 1;
         big_divisor = divisor * mult;
         padded_num = tt::round_up(num, big_divisor);


### PR DESCRIPTION
Make find_closest_largest_divisor_with_num_padding_and_mult less restrictive

Currently find_closest_largest_divisor_with_num_padding_and_mult is overly restrictive and can in some cases reduce the amount of tensix cores convolutions get mapped to.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17549431192)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17583669474)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17558227899l)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17549423889) 
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17558221710)