### PR TITLE
Pool ops should support channel last input format whether it is flattened or unflattened

### DIFF
--- a/tests/sweep_framework/sweep_utils/max_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_common.py
@@ -70,14 +70,12 @@ def run_max_pool2d(
 
     act_shape = [in_n, in_c, in_h, in_w]
     act = torch.randn(act_shape, dtype=torch.bfloat16)
-    act_shape = (1, 1, in_n * in_h * in_w, in_c)
     act_permuted = torch.permute(act, (0, 2, 3, 1))
-    act_reshaped = act_permuted.reshape(act_shape)
 
     if dtype == ttnn.bfloat8_b:
-        ttact = ttnn.from_torch(act_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
+        ttact = ttnn.from_torch(act_permuted, dtype, layout=ttnn.TILE_LAYOUT)
     else:
-        ttact = ttnn.from_torch(act_reshaped, dtype)
+        ttact = ttnn.from_torch(act_permuted, dtype)
 
     ttact_device = ttnn.to_device(ttact, device)
     start_time = start_measuring_time()

--- a/tests/sweep_framework/sweep_utils/max_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_common.py
@@ -73,7 +73,9 @@ def run_max_pool2d(
     act_permuted = torch.permute(act, (0, 2, 3, 1))
 
     if dtype == ttnn.bfloat8_b:
-        ttact = ttnn.from_torch(act_permuted, dtype, layout=ttnn.TILE_LAYOUT)
+        act_shape = (1, 1, in_n * in_h * in_w, in_c)
+        act_reshaped = act_permuted.reshape(act_shape)
+        ttact = ttnn.from_torch(act_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
     else:
         ttact = ttnn.from_torch(act_permuted, dtype)
 

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -171,14 +171,13 @@ def run_avg_pool2d(
     # 1x256x56x56 tensor with divisor_override=5 and 5x5 kernel resulting in rtol=0.015 for that element
     torch.manual_seed(1e3)
     torch_input = randomize_tensor(tensor_map, input_shape)
-    ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
     torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
     if in_dtype == ttnn.bfloat8_b:
         ttnn_input = ttnn.from_torch(torch_input_reshaped, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     else:
         ttnn_input = ttnn.from_torch(
-            torch_input_reshaped, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+            torch_input_permuted, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
         )
 
     # run ttnn avg_pool2d

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -172,7 +172,7 @@ def run_avg_pool2d(
     torch.manual_seed(1e3)
     torch_input = randomize_tensor(tensor_map, input_shape)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
-    if dtype == ttnn.bfloat8_b:
+    if in_dtype == ttnn.bfloat8_b:
         ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
         torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
         ttnn_input = ttnn.from_torch(torch_input_reshaped, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -172,8 +172,9 @@ def run_avg_pool2d(
     torch.manual_seed(1e3)
     torch_input = randomize_tensor(tensor_map, input_shape)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
-    torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
-    if in_dtype == ttnn.bfloat8_b:
+    if dtype == ttnn.bfloat8_b:
+        ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
+        torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
         ttnn_input = ttnn.from_torch(torch_input_reshaped, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     else:
         ttnn_input = ttnn.from_torch(

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -146,13 +146,13 @@ def run_max_pool(
             compute_grid_size=device.compute_with_storage_grid_size(),
             block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
             enable_channels_padding=False,
-            is_shard_height_tile_multiple=dtype == ttnn.bfloat8_b,
-            is_shard_width_tile_multiple=dtype == ttnn.bfloat8_b,
+            is_shard_height_tile_multiple=in_dtype == ttnn.bfloat8_b,
+            is_shard_width_tile_multiple=in_dtype == ttnn.bfloat8_b,
         )
         sharded_memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
             tensor_shape=ttnn_input.shape,
             parallel_config=parallel_config,
-            tile_size=32 if dtype == ttnn.bfloat8_b else 1,
+            tile_size=32 if in_dtype == ttnn.bfloat8_b else 1,
         )
         ttnn_input = ttnn.to_memory_config(ttnn_input, sharded_memory_config)
 

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -133,29 +133,6 @@ def run_max_pool(
     else:
         ttnn_input = ttnn.from_torch(torch_input_permuted, in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-    pre_shard = shard_scheme == None
-    if pre_shard:
-        parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
-            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            batch_size=in_n,
-            input_channels=in_c,
-            output_height=out_h,
-            output_width=out_w,
-            output_channels=in_c,
-            input_channels_alignment=32,
-            compute_grid_size=device.compute_with_storage_grid_size(),
-            block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            enable_channels_padding=False,
-            is_shard_height_tile_multiple=in_dtype == ttnn.bfloat8_b,
-            is_shard_width_tile_multiple=in_dtype == ttnn.bfloat8_b,
-        )
-        sharded_memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
-            tensor_shape=ttnn_input.shape,
-            parallel_config=parallel_config,
-            tile_size=32 if in_dtype == ttnn.bfloat8_b else 1,
-        )
-        ttnn_input = ttnn.to_memory_config(ttnn_input, sharded_memory_config)
-
     # run ttnn maxpool2d
     ttnn_output = ttnn.max_pool2d(
         input_tensor=ttnn_input,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -161,7 +161,8 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         if (!is_tensor_already_flattened) {
             const auto flattened_input_shape = conv::flatten_4d_shape(input_tensor.logical_shape());
             const auto flattened_padded_input_shape = conv::flatten_4d_shape(input_tensor.padded_shape());
-            input_tensor_sharded = ttnn::reshape(input_tensor, flattened_input_shape, flattened_padded_input_shape);
+            input_tensor_sharded =
+                ttnn::reshape(input_tensor_sharded, flattened_input_shape, flattened_padded_input_shape);
             input_tensor_shape = flattened_input_shape;
         }
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -425,6 +425,7 @@ void validate_input_params(
         (input_shape[0] == batch_size && input_shape[1] == input_h && input_shape[2] == input_w &&
          input_shape[3] == channels);
 
+    // Unflattened tesnor currently supported for non_block formats only.
     TT_FATAL(
         is_flattened_format || (is_nhwc_format && !is_input_block_format),
         "Input tensor shape {} does not match expected shape. For block format inputs (bfloat8_b/bfloat4_b) only "

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -415,6 +415,8 @@ void validate_input_params(
     // tensor shape validation against provided NHWC dimensions
     const uint32_t nhw = batch_size * input_h * input_w;
     const auto& input_shape = input_tensor.logical_shape();
+    bool is_input_block_format =
+        input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B;
 
     // Support both (1, 1, nhw, c) and (n, h, w, c) formats
     bool is_flattened_format =
@@ -424,8 +426,10 @@ void validate_input_params(
          input_shape[3] == channels);
 
     TT_FATAL(
-        is_flattened_format || is_nhwc_format,
-        "Input tensor shape {} does not match expected shape (1, 1, {}, {}) or ({}, {}, {}, {})",
+        is_flattened_format || (is_nhwc_format && !is_input_block_format),
+        "Input tensor shape {} does not match expected shape. For block format inputs (bfloat8_b/bfloat4_b) only "
+        "flattened format (1, 1, {}, {}) is supported. Unflattened format ({}, {}, {}, {}) is not supported for block "
+        "format inputs.",
         input_shape,
         nhw,
         channels,

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -415,14 +415,26 @@ void validate_input_params(
     // tensor shape validation against provided NHWC dimensions
     const uint32_t nhw = batch_size * input_h * input_w;
     const auto& input_shape = input_tensor.logical_shape();
+
+    // Support both (1, 1, nhw, c) and (n, h, w, c) formats
+    bool is_flattened_format =
+        (input_shape[0] == 1 && input_shape[1] == 1 && input_shape[2] == nhw && input_shape[3] == channels);
+    bool is_nhwc_format =
+        (input_shape[0] == batch_size && input_shape[1] == input_h && input_shape[2] == input_w &&
+         input_shape[3] == channels);
+
     TT_FATAL(
-        input_shape[0] == 1 && input_shape[1] == 1 && input_shape[2] == nhw && input_shape[3] == channels,
-        "Input tensor shape {} does not match expected shape (1, 1, {}, {})",
+        is_flattened_format || is_nhwc_format,
+        "Input tensor shape {} does not match expected shape (1, 1, {}, {}) or ({}, {}, {}, {})",
         input_shape,
         nhw,
+        channels,
+        batch_size,
+        input_h,
+        input_w,
         channels);
 
-    if (is_in_tiled) {
+    if (is_in_tiled && is_flattened_format) {
         const uint32_t padded_channels = tt::round_up(channels, tt::constants::TILE_WIDTH);
         const uint32_t padded_nhw = tt::round_up(nhw, tt::constants::TILE_HEIGHT);
         const auto& padded_input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -415,8 +415,6 @@ void validate_input_params(
     // tensor shape validation against provided NHWC dimensions
     const uint32_t nhw = batch_size * input_h * input_w;
     const auto& input_shape = input_tensor.logical_shape();
-    bool is_input_block_format =
-        input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B;
 
     // Support both (1, 1, nhw, c) and (n, h, w, c) formats
     bool is_flattened_format =
@@ -427,7 +425,7 @@ void validate_input_params(
 
     // Unflattened tesnor currently supported for non_block formats only.
     TT_FATAL(
-        is_flattened_format || (is_nhwc_format && !is_input_block_format),
+        is_flattened_format || (is_nhwc_format && !is_block_float(input_tensor.dtype())),
         "Input tensor shape {} does not match expected shape. For block format inputs (bfloat8_b/bfloat4_b) only "
         "flattened format (1, 1, {}, {}) is supported. Unflattened format ({}, {}, {}, {}) is not supported for block "
         "format inputs.",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15281

### Problem description
Pools expect flattened input tensor format only. We want to support the unflattened one as well as long as it is channel last.

### What's changed
Added reshape call in the input tensor in dram path for non block format inputs. So when sharding the tensor we can reshape the sharded version without changing the original tensor. This implies change in validate functions where we need to check if we are validating the flattened or unflattened input tensor. As well need for reshape in pool test is non-existant so this is removed in order to test that the behavior remained the same.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17946654179)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17920145931)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17920193676)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17920189180/job/50953616396)