### PR TITLE
Matmul - Create Documentation for Program Configs

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -82,6 +82,20 @@ Matrix Multiplication
 
    ttnn.matmul
    ttnn.linear
+   ttnn.matmul_batched_weights
+   ttnn.addmm
+   ttnn.sparse_matmul
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+   :template: class.rst
+
+   ttnn.MatmulMultiCoreReuseProgramConfig
+   ttnn.MatmulMultiCoreReuseMultiCastProgramConfig
+   ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig
+   ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+
 
 Pointwise Unary
 ================

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -52,10 +52,10 @@ void py_module(py::module& module) {
         "in0_block_w", &MatmulMultiCoreReuseProgramConfig::in0_block_w, R"doc(
         Block width for both input tensors along the K dimension (shared inner dimension).
 
-        This parameter controls how the K dimension is divided into blocks for both input_tensor_a
-        and input_tensor_b, since they share this dimension in matrix multiplication. Must be a
-        divisor of the K dimension and affects memory usage and compute efficiency for both tensors.
-        Typically set to multiples of 32 for optimal tile alignment.
+        This parameter determines the granularity of data blocks by specifying how many tiles wide
+        each block is along the K dimension. It affects the size of data chunks processed together
+        and impacts memory usage and compute efficiency for both tensors. Must be a divisor of the
+        K dimension. Suggested to be a multiple of 32 for tile alignment.
     )doc");
     matmul_multi_core_reuse_program_config.def_readwrite(
         "out_subblock_h", &MatmulMultiCoreReuseProgramConfig::out_subblock_h, R"doc(
@@ -151,10 +151,10 @@ void py_module(py::module& module) {
         "in0_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::in0_block_w, R"doc(
         Block width for both input tensors along the K dimension (shared inner dimension).
 
-        Controls how the K dimension is divided into blocks for both input_tensor_a and
-        input_tensor_b in multicast operations. Must be a divisor of the K dimension.
-        Smaller blocks can improve load balancing but may increase communication overhead
-        in multicast scenarios.
+        Determines the data granularity by specifying how many tiles wide each block is along
+        the K dimension for both input_tensor_a and input_tensor_b in multicast operations.
+        Must be a divisor of the K dimension. Smaller blocks can improve load balancing but
+        may increase communication overhead in multicast scenarios.
     )doc");
     matmul_multi_core_reuse_multicast_program_config.def_readwrite(
         "out_subblock_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_h, R"doc(
@@ -302,10 +302,10 @@ void py_module(py::module& module) {
         .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).
 
-            Controls the blocking of both input_tensor_a and input_tensor_b along the inner
-            dimension. This parameter is crucial for 1D multicast performance as it determines
-            the granularity of data that is broadcast across cores and affects memory access
-            patterns for both tensors.
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b. This parameter
+            impacts 1D multicast performance as it affects the size of data chunks that
+            are broadcast across cores and memory access patterns for both tensors.
         )doc")
         .def_readwrite("out_subblock_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_h, R"doc(
             Height of output subblocks in tiles.
@@ -407,10 +407,10 @@ void py_module(py::module& module) {
         .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::in0_block_w, R"doc(
             Block width for both input tensors along the K dimension (shared inner dimension).
 
-            Controls the blocking of both input_tensor_a and input_tensor_b along the inner
-            dimension for DRAM-sharded operations. This parameter must be carefully chosen to
-            align with the DRAM sharding strategy and optimize memory bandwidth utilization
-            for both tensors.
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b in DRAM-sharded
+            operations. This parameter must be chosen to align with the DRAM sharding
+            strategy and optimize memory bandwidth utilization for both tensors.
         )doc")
         .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_M, R"doc(
             Number of output tiles each core processes along the M dimension.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -26,93 +26,211 @@ void py_module(py::module& module) {
 
     auto matmul_multi_core_reuse_program_config =
         tt_serializable_class<MatmulMultiCoreReuseProgramConfig>(module, "MatmulMultiCoreReuseProgramConfig", R"doc(
-        Class defining matmul multi core reuse program config
+        Configuration class for multi-core reusable matmul operations.
+
+        This program config is used for basic multi-core matmul operations that can reuse
+        intermediate results across cores for better performance.
     )doc");
 
-    matmul_multi_core_reuse_program_config
-        .def(
-            py::init<CoreCoord, std::size_t, std::size_t, std::size_t, std::size_t, std::size_t>(),
-            py::kw_only(),
-            py::arg("compute_with_storage_grid_size"),
-            py::arg("in0_block_w").noconvert(),
-            py::arg("out_subblock_h").noconvert(),
-            py::arg("out_subblock_w").noconvert(),
-            py::arg("per_core_M").noconvert(),
-            py::arg("per_core_N").noconvert())
-        .def_readwrite(
-            "compute_with_storage_grid_size", &MatmulMultiCoreReuseProgramConfig::compute_with_storage_grid_size)
-        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseProgramConfig::in0_block_w)
-        .def_readwrite("out_subblock_h", &MatmulMultiCoreReuseProgramConfig::out_subblock_h)
-        .def_readwrite("out_subblock_w", &MatmulMultiCoreReuseProgramConfig::out_subblock_w)
-        .def_readwrite("per_core_M", &MatmulMultiCoreReuseProgramConfig::per_core_M)
-        .def_readwrite("per_core_N", &MatmulMultiCoreReuseProgramConfig::per_core_N);
+    matmul_multi_core_reuse_program_config.def(
+        py::init<CoreCoord, std::size_t, std::size_t, std::size_t, std::size_t, std::size_t>(),
+        py::kw_only(),
+        py::arg("compute_with_storage_grid_size"),
+        py::arg("in0_block_w").noconvert(),
+        py::arg("out_subblock_h").noconvert(),
+        py::arg("out_subblock_w").noconvert(),
+        py::arg("per_core_M").noconvert(),
+        py::arg("per_core_N").noconvert());
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "compute_with_storage_grid_size", &MatmulMultiCoreReuseProgramConfig::compute_with_storage_grid_size, R"doc(
+        Grid size for compute cores with storage capability.
+
+        Specifies the 2D grid of cores (x, y) that will be used for computation and have
+        access to storage. This determines how the computation is distributed across cores.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "in0_block_w", &MatmulMultiCoreReuseProgramConfig::in0_block_w, R"doc(
+        Block width for the first input tensor (input_tensor_a) along the K dimension.
+
+        This parameter controls how the K dimension of input_tensor_a is divided into blocks.
+        Must be a divisor of the K dimension and affects memory usage and compute efficiency.
+        Typically set to multiples of 32 for optimal tile alignment.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "out_subblock_h", &MatmulMultiCoreReuseProgramConfig::out_subblock_h, R"doc(
+        Height of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the M dimension.
+        Smaller values can reduce memory usage but may decrease efficiency. Must divide evenly
+        into the output block height.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "out_subblock_w", &MatmulMultiCoreReuseProgramConfig::out_subblock_w, R"doc(
+        Width of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the N dimension.
+        Smaller values can reduce memory usage but may decrease efficiency. Must divide evenly
+        into the output block width.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "per_core_M", &MatmulMultiCoreReuseProgramConfig::per_core_M, R"doc(
+        Number of output tiles each core processes along the M dimension.
+
+        Determines how the M dimension of the output is distributed across cores.
+        Larger values mean fewer cores are used but each core does more work.
+        Must be chosen such that (total_M / per_core_M) cores are available.
+    )doc");
+    matmul_multi_core_reuse_program_config.def_readwrite(
+        "per_core_N", &MatmulMultiCoreReuseProgramConfig::per_core_N, R"doc(
+        Number of output tiles each core processes along the N dimension.
+
+        Determines how the N dimension of the output is distributed across cores.
+        Larger values mean fewer cores are used but each core does more work.
+        Must be chosen such that (total_N / per_core_N) cores are available.
+    )doc");
 
     auto matmul_multi_core_reuse_multicast_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCastProgramConfig>(
             module, "MatmulMultiCoreReuseMultiCastProgramConfig", R"doc(
-        Class defining matmul multi core reuse multi cast program config
+        The "2D" matmul program config is used for block sharded tensors, and general interleaved tensors.
     )doc");
 
-    matmul_multi_core_reuse_multicast_program_config
-        .def(
-            py::init([](CoreCoord compute_with_storage_grid_size,
-                        std::size_t in0_block_w,
-                        std::size_t out_subblock_h,
-                        std::size_t out_subblock_w,
-                        std::optional<std::size_t> out_block_h,
-                        std::optional<std::size_t> out_block_w,
-                        std::size_t per_core_M,
-                        std::size_t per_core_N,
-                        bool transpose_mcast,
-                        std::optional<UnaryWithParam> fused_activation,
-                        bool fuse_batch) {
-                // Set out_block_h and out_block_w to defaults if they are not provided
-                std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
-                std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
+    matmul_multi_core_reuse_multicast_program_config.def(
+        py::init([](CoreCoord compute_with_storage_grid_size,
+                    std::size_t in0_block_w,
+                    std::size_t out_subblock_h,
+                    std::size_t out_subblock_w,
+                    std::optional<std::size_t> out_block_h,
+                    std::optional<std::size_t> out_block_w,
+                    std::size_t per_core_M,
+                    std::size_t per_core_N,
+                    bool transpose_mcast,
+                    std::optional<UnaryWithParam> fused_activation,
+                    bool fuse_batch) {
+            // Set out_block_h and out_block_w to defaults if they are not provided
+            std::size_t actual_out_block_h = out_block_h.value_or(per_core_M);
+            std::size_t actual_out_block_w = out_block_w.value_or(per_core_N);
 
-                return MatmulMultiCoreReuseMultiCastProgramConfig(
-                    compute_with_storage_grid_size,
-                    in0_block_w,
-                    out_subblock_h,
-                    out_subblock_w,
-                    actual_out_block_h,
-                    actual_out_block_w,
-                    per_core_M,
-                    per_core_N,
-                    transpose_mcast,
-                    std::move(fused_activation),
-                    fuse_batch);
-            }),
-            py::kw_only(),
-            py::arg("compute_with_storage_grid_size"),
-            py::arg("in0_block_w").noconvert(),
-            py::arg("out_subblock_h").noconvert(),
-            py::arg("out_subblock_w").noconvert(),
-            py::arg("out_block_h") = py::none(),
-            py::arg("out_block_w") = py::none(),
-            py::arg("per_core_M").noconvert(),
-            py::arg("per_core_N").noconvert(),
-            py::arg("transpose_mcast").noconvert(),
-            py::arg("fused_activation"),
-            py::arg("fuse_batch").noconvert() = true)
-        .def_readwrite(
-            "compute_with_storage_grid_size",
-            &MatmulMultiCoreReuseMultiCastProgramConfig::compute_with_storage_grid_size)
-        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::in0_block_w)
-        .def_readwrite("out_subblock_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_h)
-        .def_readwrite("out_subblock_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_w)
-        .def_readwrite("out_block_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_h)
-        .def_readwrite("out_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_w)
-        .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_M)
-        .def_readwrite("per_core_N", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_N)
-        .def_readwrite("transpose_mcast", &MatmulMultiCoreReuseMultiCastProgramConfig::transpose_mcast)
-        .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCastProgramConfig::fused_activation)
-        .def_readwrite("fuse_batch", &MatmulMultiCoreReuseMultiCastProgramConfig::fuse_batch);
+            return MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size,
+                in0_block_w,
+                out_subblock_h,
+                out_subblock_w,
+                actual_out_block_h,
+                actual_out_block_w,
+                per_core_M,
+                per_core_N,
+                transpose_mcast,
+                std::move(fused_activation),
+                fuse_batch);
+        }),
+        py::kw_only(),
+        py::arg("compute_with_storage_grid_size"),
+        py::arg("in0_block_w").noconvert(),
+        py::arg("out_subblock_h").noconvert(),
+        py::arg("out_subblock_w").noconvert(),
+        py::arg("out_block_h") = py::none(),
+        py::arg("out_block_w") = py::none(),
+        py::arg("per_core_M").noconvert(),
+        py::arg("per_core_N").noconvert(),
+        py::arg("transpose_mcast").noconvert(),
+        py::arg("fused_activation"),
+        py::arg("fuse_batch").noconvert() = true);
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "compute_with_storage_grid_size",
+        &MatmulMultiCoreReuseMultiCastProgramConfig::compute_with_storage_grid_size,
+        R"doc(
+        Grid size for compute cores with storage capability.
+
+        Specifies the 2D grid of cores (x, y) that will be used for computation and have
+        access to storage. This determines how the computation is distributed across cores
+        and affects multicast communication patterns.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "in0_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::in0_block_w, R"doc(
+        Block width for the first input tensor (input_tensor_a) along the K dimension.
+
+        Controls how the K dimension of input_tensor_a is divided into blocks for multicast.
+        Must be a divisor of the K dimension. Smaller blocks can improve load balancing
+        but may increase communication overhead in multicast scenarios.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "out_subblock_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_h, R"doc(
+        Height of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the M dimension.
+        Must divide evenly into out_block_h. Affects memory usage and compute scheduling
+        in the multicast implementation.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "out_subblock_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_subblock_w, R"doc(
+        Width of output subblocks in tiles.
+
+        Controls the granularity of computation within each output block along the N dimension.
+        Must divide evenly into out_block_w. Affects memory usage and compute scheduling
+        in the multicast implementation.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "out_block_h", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_h, R"doc(
+        Height of output blocks in tiles.
+
+        Specifies the block size for output tensor along the M dimension. If not provided,
+        defaults to per_core_M. Must be divisible by out_subblock_h and should be chosen
+        to optimize multicast efficiency and memory usage.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "out_block_w", &MatmulMultiCoreReuseMultiCastProgramConfig::out_block_w, R"doc(
+        Width of output blocks in tiles.
+
+        Specifies the block size for output tensor along the N dimension. If not provided,
+        defaults to per_core_N. Must be divisible by out_subblock_w and should be chosen
+        to optimize multicast efficiency and memory usage.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "per_core_M", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_M, R"doc(
+        Number of output tiles each core processes along the M dimension.
+
+        Determines how the M dimension is distributed across cores in the multicast setup.
+        Used as the default value for out_block_h if not explicitly specified.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "per_core_N", &MatmulMultiCoreReuseMultiCastProgramConfig::per_core_N, R"doc(
+        Number of output tiles each core processes along the N dimension.
+
+        Determines how the N dimension is distributed across cores in the multicast setup.
+        Used as the default value for out_block_w if not explicitly specified.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "transpose_mcast", &MatmulMultiCoreReuseMultiCastProgramConfig::transpose_mcast, R"doc(
+        Whether to transpose the multicast communication pattern.
+
+        When true, the multicast direction is transposed, which can be beneficial for
+        certain tensor shapes and grid configurations. This affects how data is broadcast
+        across cores and can impact performance depending on the access patterns.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "fused_activation", &MatmulMultiCoreReuseMultiCastProgramConfig::fused_activation, R"doc(
+        Optional fused activation function to apply to the output.
+
+        If provided, the specified activation function (e.g., ReLU, GELU) is applied
+        directly during the matmul computation, avoiding the need for a separate activation
+        operation and improving performance.
+    )doc");
+    matmul_multi_core_reuse_multicast_program_config.def_readwrite(
+        "fuse_batch", &MatmulMultiCoreReuseMultiCastProgramConfig::fuse_batch, R"doc(
+        Whether to fuse batch dimensions into the matrix dimensions.
+
+        When true, batch dimensions are fused with the M dimension, allowing for more
+        efficient processing of batched matrix multiplications. This can improve performance
+        for operations with large batch sizes. Defaults to true.
+    )doc");
 
     auto matmul_multi_core_reuse_multicast_1d_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCast1DProgramConfig>(
             module, "MatmulMultiCoreReuseMultiCast1DProgramConfig", R"doc(
-        Class defining matmul multi core reuse multi cast 1D program config
+        Configuration class for 1D multicast matmul operations with advanced features.
+
+        This program config is for use with width and height sharded tensors, or very narrow interleaved tensors.
     )doc");
 
     matmul_multi_core_reuse_multicast_1d_program_config
@@ -171,27 +289,117 @@ void py_module(py::module& module) {
             py::arg("untilize_out").noconvert() = false)
         .def_readwrite(
             "compute_with_storage_grid_size",
-            &MatmulMultiCoreReuseMultiCast1DProgramConfig::compute_with_storage_grid_size)
-        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w)
-        .def_readwrite("out_subblock_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_h)
-        .def_readwrite("out_subblock_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_w)
-        .def_readwrite("out_block_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_h)
-        .def_readwrite("out_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_w)
-        .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_M)
-        .def_readwrite("per_core_N", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_N)
-        .def_readwrite("fuse_batch", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fuse_batch)
-        .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation)
-        .def_readwrite("mcast_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::mcast_in0)
-        .def_readwrite("gather_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::gather_in0)
-        .def_readwrite("hop_cores", &MatmulMultiCoreReuseMultiCast1DProgramConfig::hop_cores)
+            &MatmulMultiCoreReuseMultiCast1DProgramConfig::compute_with_storage_grid_size,
+            R"doc(
+            Grid size for compute cores with storage capability.
+
+            Defines the 2D grid of cores that will be used for computation. In 1D multicast,
+            this grid is used to determine the communication pattern for broadcasting data
+            along one dimension while distributing computation.
+        )doc")
+        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::in0_block_w, R"doc(
+            Block width for the first input tensor along the K dimension.
+
+            Controls the blocking of input_tensor_a along the inner dimension. This parameter
+            is crucial for 1D multicast performance as it determines the granularity of
+            data that is broadcast across cores.
+        )doc")
+        .def_readwrite("out_subblock_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_h, R"doc(
+            Height of output subblocks in tiles.
+
+            Controls computation granularity within output blocks along the M dimension.
+            In 1D multicast, this affects how computation is scheduled and memory usage
+            patterns across the participating cores.
+        )doc")
+        .def_readwrite("out_subblock_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_subblock_w, R"doc(
+            Width of output subblocks in tiles.
+
+            Controls computation granularity within output blocks along the N dimension.
+            This parameter affects the efficiency of the 1D multicast communication pattern
+            and compute scheduling.
+        )doc")
+        .def_readwrite("out_block_h", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_h, R"doc(
+            Height of output blocks in tiles.
+
+            Defines the output block size along the M dimension. If not specified, defaults
+            to per_core_M. This parameter is important for optimizing the 1D multicast
+            pattern and memory access efficiency.
+        )doc")
+        .def_readwrite("out_block_w", &MatmulMultiCoreReuseMultiCast1DProgramConfig::out_block_w, R"doc(
+            Width of output blocks in tiles.
+
+            Defines the output block size along the N dimension. If not specified, defaults
+            to per_core_N. This affects the efficiency of data distribution in the 1D
+            multicast implementation.
+        )doc")
+        .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines the workload distribution along the M dimension in the 1D multicast
+            pattern. This affects both load balancing and communication efficiency.
+        )doc")
+        .def_readwrite("per_core_N", &MatmulMultiCoreReuseMultiCast1DProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines the workload distribution along the N dimension in the 1D multicast
+            pattern. This parameter is crucial for achieving optimal performance in
+            1D multicast scenarios.
+        )doc")
+        .def_readwrite("fuse_batch", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fuse_batch, R"doc(
+            Whether to fuse batch dimensions into matrix dimensions.
+
+            When true, batch dimensions are incorporated into the matrix computation,
+            allowing for more efficient processing of batched operations in the 1D
+            multicast implementation.
+        )doc")
+        .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the matmul
+            operation, eliminating the need for a separate activation pass and improving
+            overall performance in 1D multicast scenarios.
+        )doc")
+        .def_readwrite("mcast_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::mcast_in0, R"doc(
+            Whether to multicast the first input tensor (input_tensor_a).
+
+            When true, input_tensor_a is broadcast across cores using the 1D multicast
+            pattern, which can significantly reduce memory bandwidth requirements for
+            certain matrix shapes and improve performance.
+        )doc")
+        .def_readwrite("gather_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::gather_in0, R"doc(
+            Whether to use gather operation for the first input tensor.
+
+            When true, enables gather-based data movement for input_tensor_a, which can
+            be more efficient than traditional data movement in certain scenarios.
+            Defaults to false.
+        )doc")
+        .def_readwrite("hop_cores", &MatmulMultiCoreReuseMultiCast1DProgramConfig::hop_cores, R"doc(
+            Set of core ranges for hopping operations.
+
+            Defines the cores that participate in data hopping operations during the
+            1D multicast. This advanced feature allows for optimized data movement
+            patterns in complex multi-core scenarios. Defaults to empty set.
+        )doc")
         .def_readwrite(
-            "num_global_cb_receivers", &MatmulMultiCoreReuseMultiCast1DProgramConfig::num_global_cb_receivers)
-        .def_readwrite("untilize_out", &MatmulMultiCoreReuseMultiCast1DProgramConfig::untilize_out);
+            "num_global_cb_receivers", &MatmulMultiCoreReuseMultiCast1DProgramConfig::num_global_cb_receivers, R"doc(
+            Number of cores that receive data through global circular buffers.
+
+            Specifies how many cores participate as receivers in the global circular buffer
+            communication pattern. This parameter affects memory usage and communication
+            efficiency in 1D multicast operations. Defaults to 1.
+        )doc")
+        .def_readwrite("untilize_out", &MatmulMultiCoreReuseMultiCast1DProgramConfig::untilize_out, R"doc(
+            Whether to untilize the output tensor.
+
+            When true, the output is converted from tiled layout to row-major layout during
+            the operation. This can be useful when the subsequent operation expects row-major
+            data and can eliminate a separate untilization pass. Defaults to false.
+        )doc");
 
     auto matmul_multi_core_reuse_multicast_dram_sharded_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
             module, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig", R"doc(
-        Class defining matmul multi core reuse multi cast DRAM sharded program config
+        This program config is a specialized config for very narrow tensors stored in DRAM.
     )doc");
 
     matmul_multi_core_reuse_multicast_dram_sharded_program_config
@@ -202,10 +410,35 @@ void py_module(py::module& module) {
             py::arg("per_core_M").noconvert(),
             py::arg("per_core_N").noconvert(),
             py::arg("fused_activation"))
-        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::in0_block_w)
-        .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_M)
-        .def_readwrite("per_core_N", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_N)
-        .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::fused_activation);
+        .def_readwrite("in0_block_w", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::in0_block_w, R"doc(
+            Block width for the first input tensor along the K dimension.
+
+            Controls the blocking of input_tensor_a along the inner dimension for DRAM-sharded
+            operations. This parameter must be carefully chosen to align with the DRAM sharding
+            strategy and optimize memory bandwidth utilization.
+        )doc")
+        .def_readwrite("per_core_M", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines how the M dimension is distributed across cores in DRAM-sharded
+            scenarios. This must align with the DRAM sharding pattern to ensure optimal
+            performance and avoid memory access conflicts.
+        )doc")
+        .def_readwrite("per_core_N", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines how the N dimension is distributed across cores in DRAM-sharded
+            scenarios. This parameter affects the multicast efficiency and must be
+            compatible with the DRAM sharding configuration.
+        )doc")
+        .def_readwrite(
+            "fused_activation", &MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the DRAM-sharded
+            matmul operation. This can provide significant performance benefits by avoiding
+            additional memory round-trips in DRAM-based operations.
+        )doc");
 
     bind_registered_operation(
         module,
@@ -575,7 +808,7 @@ void py_module(py::module& module) {
             alpha (float): multiplier for mat1_tensor @ mat2_tensor
             beta (float): multiplier for input_tensor
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
-            dtype (ttnn.DataType): the data type of the output tensor. Supported types: `ttnn.bfloat16`, `ttnn.float32`, `ttnn.bfloat8_b`  Defaults to `None` which means it will default to highest precision of `input_tensor`, `mat1_tensor` or `mat2_tensor.
+            dtype (ttnn.DataType): the data type of the output tensor. Supported types: `ttnn.bfloat16`, `ttnn.float32`, `ttnn.bfloat8_b`  Defaults to `None` which means it will default to highest precision of `input_tensor`, `mat1_tensor` or `mat2_tensor`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.


### PR DESCRIPTION
### Ticket
[#25633](https://github.com/tenstorrent/tt-metal/issues/25633)

### Problem description
Matmul program configs documentation was missing. Certain existing matmul documentation (e.g. sparse matmul) was not being generated or published either.

### What's changed
Created program config documentation, updated rst files to publish all of the documentation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17586461362)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes