### PR TITLE
Semaphores out of bounds fix

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -148,7 +148,7 @@ void try_creating_more_than_max_num_semaphores(
 }
 
 void try_creating_semaphores_out_of_bounds(
-    std::shared_ptr<distributed::MeshDevice> mesh_device, distributed::MeshWorkload& workload) {
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     // Get mesh dimensions and use an out-of-bounds coordinate
     CoreRange core_range({0, 0}, {0, 20});

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -151,8 +151,7 @@ void try_creating_semaphores_out_of_bounds(
     std::shared_ptr<distributed::MeshDevice> mesh_device, distributed::MeshWorkload& workload) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     // Get mesh dimensions and use an out-of-bounds coordinate
-    auto mesh_shape = mesh_device->logical_mesh_shape();
-    CoreRange core_range({0, 0}, {0, mesh_shape.y}); // mesh_shape.y is out of bounds (max valid is mesh_shape.y - 1)
+    CoreRange core_range({0, 0}, {0, 20});
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
     constexpr static uint32_t val = 5;

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -150,7 +150,9 @@ void try_creating_more_than_max_num_semaphores(
 void try_creating_semaphores_out_of_bounds(
     std::shared_ptr<distributed::MeshDevice> mesh_device, distributed::MeshWorkload& workload) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    CoreRange core_range({0, 0}, {0, 20});
+    // Get mesh dimensions and use an out-of-bounds coordinate
+    auto mesh_shape = mesh_device->logical_mesh_shape();
+    CoreRange core_range({0, 0}, {0, mesh_shape.y}); // mesh_shape.y is out of bounds (max valid is mesh_shape.y - 1)
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
     constexpr static uint32_t val = 5;

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -181,9 +181,9 @@ TEST_F(MeshDeviceFixture, TensixInitializeIllegalSemaphores) {
         tt_metal::Program program = tt_metal::CreateProgram();
         workload.add_program(device_range, std::move(program));
         CoreRange core_range({0, 0}, {1, 1});
+        unit_tests::initialize_semaphores::try_creating_semaphores_out_of_bounds(devices_.at(id), workload);
         unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
             devices_.at(id), workload, core_range);
-        unit_tests::initialize_semaphores::try_creating_semaphores_out_of_bounds(devices_.at(id), workload);
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -147,6 +147,16 @@ void try_creating_more_than_max_num_semaphores(
     ASSERT_ANY_THROW(tt_metal::CreateSemaphore(program, core_range, val));
 }
 
+void try_creating_semaphores_out_of_bounds(
+    std::shared_ptr<distributed::MeshDevice> mesh_device, distributed::MeshWorkload& workload) {
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    CoreRange core_range({0, 0}, {0, 20});
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto& program = workload.get_programs().at(device_range);
+    constexpr static uint32_t val = 5;
+    ASSERT_ANY_THROW(tt_metal::CreateSemaphore(program, core_range, val));
+}
+
 }  // namespace unit_tests::initialize_semaphores
 
 namespace tt::tt_metal {
@@ -173,6 +183,7 @@ TEST_F(MeshDeviceFixture, TensixInitializeIllegalSemaphores) {
         CoreRange core_range({0, 0}, {1, 1});
         unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
             devices_.at(id), workload, core_range);
+        unit_tests::initialize_semaphores::try_creating_semaphores_out_of_bounds(devices_.at(id), workload);
     }
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1430,4 +1430,9 @@ void MetalContext::erisc_send_exit_signal(ChipId device_id, CoreCoord virtual_co
     }
 };
 
+bool MetalContext::is_coord_in_range(CoreCoord coord, CoreType core_type) {
+    CoreCoord logical_grid_size = cluster_->get_soc_desc(0).get_grid_size(core_type);
+    return (logical_grid_size.x >= coord.x) && (logical_grid_size.y >= coord.y);
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1431,8 +1431,9 @@ void MetalContext::erisc_send_exit_signal(ChipId device_id, CoreCoord virtual_co
 };
 
 bool MetalContext::is_coord_in_range(CoreCoord coord, CoreType core_type) {
-    CoreCoord logical_grid_size = cluster_->get_soc_desc(0).get_grid_size(core_type);
-    return (logical_grid_size.x >= coord.x) && (logical_grid_size.y >= coord.y);
+    chip_id_t id = *cluster_->all_chip_ids().begin();
+    CoreCoord virtual_coord = cluster_->get_virtual_coordinate_from_logical_coordinates(id, coord, core_type);
+    return cluster_->is_ethernet_core(virtual_coord, id) || cluster_->is_worker_core(virtual_coord, id);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1432,6 +1432,10 @@ void MetalContext::erisc_send_exit_signal(ChipId device_id, CoreCoord virtual_co
 
 bool MetalContext::is_coord_in_range(CoreCoord coord, CoreType core_type) {
     ChipId id = *cluster_->all_chip_ids().begin();
+    if (core_type == CoreType::ACTIVE_ETH || core_type == CoreType::IDLE_ETH) {
+        core_type = CoreType::ETH;
+    }
+
     CoreCoord virtual_coord = cluster_->get_virtual_coordinate_from_logical_coordinates(id, coord, core_type);
     return cluster_->is_ethernet_core(virtual_coord, id) || cluster_->is_worker_core(virtual_coord, id);
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1431,7 +1431,7 @@ void MetalContext::erisc_send_exit_signal(ChipId device_id, CoreCoord virtual_co
 };
 
 bool MetalContext::is_coord_in_range(CoreCoord coord, CoreType core_type) {
-    chip_id_t id = *cluster_->all_chip_ids().begin();
+    ChipId id = *cluster_->all_chip_ids().begin();
     CoreCoord virtual_coord = cluster_->get_virtual_coordinate_from_logical_coordinates(id, coord, core_type);
     return cluster_->is_ethernet_core(virtual_coord, id) || cluster_->is_worker_core(virtual_coord, id);
 }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -101,6 +101,9 @@ public:
     using CommandQueueIdStack = std::vector<uint8_t>;
     CommandQueueIdStack& get_command_queue_id_stack_for_thread();
     const CommandQueueIdStack& get_command_queue_id_stack_for_thread() const;
+    
+    // Utilities
+    bool is_coord_in_range(CoreCoord coord, CoreType core_type);
 
 private:
     friend class tt::stl::Indestructible<MetalContext>;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -101,7 +101,7 @@ public:
     using CommandQueueIdStack = std::vector<uint8_t>;
     CommandQueueIdStack& get_command_queue_id_stack_for_thread();
     const CommandQueueIdStack& get_command_queue_id_stack_for_thread() const;
-    
+
     // Utilities
     bool is_coord_in_range(CoreCoord coord, CoreType core_type);
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -568,20 +568,20 @@ const std::unordered_set<CoreCoord>& Cluster::get_virtual_eth_cores(ChipId chip_
 
 CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
     ChipId chip_id, CoreCoord logical_coord, const CoreType& core_type) const {
+    // TBD: Remove when all WORKER are rewritten to TENSIX
+    CoreType core_type_to_use = core_type;
+    if (core_type_to_use == CoreType::WORKER) {
+        core_type_to_use = CoreType::TENSIX;
+    }
+
     // Keeping the old behavior, although UMD does define translation for other cores as well.
-    if (core_type != CoreType::WORKER && core_type != CoreType::DRAM && core_type != CoreType::ETH) {
+    if (core_type_to_use != CoreType::TENSIX && core_type != CoreType::DRAM && core_type != CoreType::ETH) {
         TT_THROW("Undefined conversion for core type.");
     }
 
     auto& soc_desc = this->get_soc_desc(chip_id);
     if (core_type == CoreType::DRAM) {
         return soc_desc.get_physical_dram_core_from_logical(logical_coord);
-    }
-
-    // TBD: Remove when all WORKER are rewritten to TENSIX
-    CoreType core_type_to_use = core_type;
-    if (core_type_to_use == CoreType::WORKER) {
-        core_type_to_use = CoreType::TENSIX;
     }
 
     tt::umd::CoreCoord translated_coord =

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1198,10 +1198,9 @@ uint32_t CreateSemaphore(
         },
         core_spec);
     std::optional<uint32_t> semaphore_id;
-    TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");
+    TT_FATAL(!crs.ranges().empty(), "Expecting a non-empty CoreRangeSet!");
     TT_FATAL(
-        tt::tt_metal::MetalContext::instance().is_coord_in_range(
-            (crs.ranges()[crs.ranges().size() - 1]).end_coord, core_type),
+        tt::tt_metal::MetalContext::instance().is_coord_in_range((crs.ranges().back()).end_coord, core_type),
         "Coordinates out of range");
     for (const auto& core_range : crs.ranges()) {
         std::optional<uint32_t> semaphore_id_candidate = get_semaphore_id(program, core_range, core_type);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1198,7 +1198,11 @@ uint32_t CreateSemaphore(
         },
         core_spec);
     std::optional<uint32_t> semaphore_id;
-    TT_FATAL(!crs.ranges().empty(), "Expecting a non-empty CoreRangeSet!");
+    TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");
+    TT_FATAL(
+        tt::tt_metal::MetalContext::instance().is_coord_in_range(
+            (crs.ranges()[crs.ranges().size() - 1]).end_coord, core_type),
+        "Coordinates out of range");
     for (const auto& core_range : crs.ranges()) {
         std::optional<uint32_t> semaphore_id_candidate = get_semaphore_id(program, core_range, core_type);
         if (!semaphore_id.has_value()) {


### PR DESCRIPTION
### Ticket
[Semaphores out of bounds](https://github.com/tenstorrent/tt-metal/issues/22411?reload=1?reload=1)

### Problem description
There was no verification that whatever coordinates were provided to the CreateSemaphore are, in fact, valid

### What's changed
Added function to verify the coordinates into metal context. The function relies on the fact that currently all the devices have the same bounds. Added a call to it in CreateSemaphor with the end of range coord. Added a check in the unit test.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes