### PR TITLE
Fix missing cb_pop_front()s in layernorm_large_tensor.cpp

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -122,10 +122,11 @@ def test_layer_norm_with_tile_layout(device, h, w):
 
 @pytest.mark.parametrize("h", [1024, 2080])
 @pytest.mark.parametrize("w", [3200, 4128])
-def test_large_layer_norm(device, h, w):
+@pytest.mark.parametrize("d_type", [torch.bfloat16, torch.float32])
+def test_large_layer_norm(device, h, w, d_type):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.rand((h, w), dtype=torch.float32)
+    torch_input_tensor = torch.rand((h, w), dtype=d_type)
     torch_output_tensor = torch.nn.functional.layer_norm(torch_input_tensor, normalized_shape=[w])
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -342,17 +342,15 @@ void MAIN {
                 cb_push_back(cb_out, blk);
             }
         }
-
-        UNPACK(DPRINT << "-----NCHt val: " << NCHt << "---------- ncht" << ncht << ENDL());
-        cb_xmm = tt::CBIndex::c_24;  // x minus mean
-#ifdef RMSNORM
-        cb_pop_front(cb_ex, 1);
-#endif
         // End of
         // Final Val Calc
         //    x-E[X]
         //(---------------*𝛄)+ß
         //  √(Var(X)+ε)
+
+        cb_xmm = tt::CBIndex::c_24;  // x minus mean
+        cb_pop_front(cb_ex, onetile);
+        cb_pop_front(cb_ex2pe, onetile);
     }  // NCHt loop
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
#27126

### Problem description
Certain combinations of h,w were causing garbage results (reflected in the form of very low PCC, ~0.1)

### What's changed
There were a couple missing cb_pop_front() calls at the end of the loop, so the kernel was likely using stale data

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17589015024
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17589020693
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17589024789
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17589028232
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes