### PR TITLE
tt_telemetry: Fix GUI asset paths

### DIFF
--- a/tt_telemetry/include/server/web_server.hpp
+++ b/tt_telemetry/include/server/web_server.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <future>
+#include <string>
 #include <utility>
 
 #include <telemetry/telemetry_subscriber.hpp>
@@ -15,4 +16,5 @@
  * Built-in web server for broadcasting telemetry data.
  */
 
-std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_web_server(uint16_t port);
+std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_web_server(
+    uint16_t port, const std::string& metal_home = "");


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Asset paths for the web server were not being handled properly (e.g., '/' would correctly fetch 'tt_telemetry/frontend/static/index.html' but the loading of JS modules via relative paths would not work). This has been fixed such that /* fetches from ${TT_METAL_HOME}/tt_telemetry/frontend/static/*. Additionally, a command line override for the TT Metal source directory has been added.

### What's changed

TT_METAL_HOME env var is read and prepended to tt_telemetry/frontend/static when loading assets. The routing is fixed such that any file is read from that path.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes