### PR TITLE
Revert "Get device arch without opening device (#27805)"

### DIFF
--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -370,12 +370,5 @@ bool ReadFromDeviceL1(
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
-/**
- * Return the name of the architecture present.
- *
- * Return value: std::string
- */
-std::string get_physical_architecture_name();
-
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -57,7 +57,6 @@
 #include "fabric/hw/inc/fabric_routing_mode.h"
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
-#include "get_platform_architecture.hpp"
 
 namespace tt {
 
@@ -354,10 +353,6 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(
         &regval, tt_cxy_pair(device->id(), worker_core), address);
     return true;
-}
-
-std::string get_physical_architecture_name() {
-    return tt::get_string_lowercase(tt::tt_metal::get_physical_architecture());
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -518,10 +518,7 @@ void device_module(py::module& m_device) {
         +------------------+----------------------------------+-----------------------+-------------+----------+
     )doc");
 
-    m_device.def(
-        "get_arch_name",
-        &tt::tt_metal::detail::get_physical_architecture_name,
-        "Return the name of the architecture present.");
+    m_device.def("get_arch_name", &tt::tt_metal::hal::get_arch_name, "Return the name of the architecture present.");
 
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);
     m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);


### PR DESCRIPTION
Going directly through UMD to get arch name stopped instantiating metal context which led to this issue: https://github.com/tenstorrent/tt-metal/issues/28216

This reverts commit ef5273ca4a189ef82c5a313c13e4dad83e1c2a57.

### Ticket
Fixes this https://github.com/tenstorrent/tt-metal/issues/28202

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17595097225)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17595108520)