### PR TITLE
#0: Allow all-gather on all-gather tensors

### DIFF
--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -35,29 +35,34 @@ using ::tt::tt_metal::TensorSpec;
 
 using BigMeshDualRankTest2x4 = tt::tt_metal::MeshDevice2x4Fixture;
 
+int count_local_buffers(const Tensor& tensor) {
+    int count = 0;
+    tensor.host_storage().buffer().apply([&count](const auto&) { count++; });
+    return count;
+}
+
 TEST_F(BigMeshDualRankTest2x4, HostAllGather) {
-    constexpr int num_devices = 8;
-    ASSERT_EQ(mesh_device_->num_devices(), num_devices);
+    constexpr int kNumDevices = 8;
+    ASSERT_EQ(mesh_device_->num_devices(), kNumDevices);
 
     std::vector<float> test_data;
-    for (int i = 0; i < num_devices; i++) {
+    for (int i = 0; i < kNumDevices; i++) {
         test_data.insert(test_data.end(), {i * 1.F, i * 2.F, i * 3.F});
     }
     Tensor input_tensor = Tensor::from_vector(
         test_data,
         TensorSpec(
-            ttnn::Shape{1, num_devices, 3, 1}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{})));
+            ttnn::Shape{1, kNumDevices, 3, 1}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{})));
 
     auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
     Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
 
-    std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
-    ASSERT_EQ(device_tensors.size(), 8);
+    ASSERT_EQ(count_local_buffers(sharded_tensor), kNumDevices / 2);
 
     // Perform all-gather on host and validate the data at each host.
     auto all_gather_tensor = host_ccl::all_gather(sharded_tensor);
     EXPECT_EQ(all_gather_tensor.storage_type(), tt::tt_metal::StorageType::HOST);
-    EXPECT_THAT(get_device_tensors(all_gather_tensor), SizeIs(num_devices));
+    EXPECT_EQ(count_local_buffers(all_gather_tensor), kNumDevices);
 
     auto composer = concat_mesh_to_tensor_composer(*mesh_device_, /*dim=*/0);
 
@@ -66,7 +71,7 @@ TEST_F(BigMeshDualRankTest2x4, HostAllGather) {
     // Calling `all_gather` again should be a no-op.
     all_gather_tensor = host_ccl::all_gather(all_gather_tensor);
     EXPECT_EQ(all_gather_tensor.storage_type(), tt::tt_metal::StorageType::HOST);
-    EXPECT_THAT(get_device_tensors(all_gather_tensor), SizeIs(num_devices));
+    EXPECT_EQ(count_local_buffers(all_gather_tensor), kNumDevices);
 
     EXPECT_THAT(aggregate_tensor(all_gather_tensor, *composer).to_vector<float>(), Pointwise(FloatEq(), test_data));
 }

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -85,7 +85,6 @@ Tensor all_gather(const Tensor& tensor) {
 
         // Only broadcast if at least one host is missing the shard.
         if (any_host_missing_shard) {
-            std::cout << "any_host_missing_shard true: " << shard_idx << std::endl;
             if (local_shard.has_value() && *lowest_rank_with_shard == this_rank) {
                 ctx->broadcast(
                     local_shard->view_bytes(), tt::tt_metal::distributed::multihost::Rank(*lowest_rank_with_shard));
@@ -97,7 +96,6 @@ Tensor all_gather(const Tensor& tensor) {
                 all_gather_buffer.emplace_shard(coord, [&buffer]() { return std::move(buffer); });
             }
         } else {
-            std::cout << "any_host_missing_shard false: " << shard_idx << std::endl;
             TT_FATAL(local_shard.has_value(), "Expected all hosts to have shard at coordinate {}", coord);
             all_gather_buffer.emplace_shard(coord, [&local_shard]() { return *local_shard; });
         }

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -13,6 +13,7 @@
 #include <ttnn/tensor/storage.hpp>
 #include <ttnn/tensor/tensor.hpp>
 
+#include "tt_stl/span.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
 
 namespace ttnn::distributed::host_ccl {
@@ -35,28 +36,70 @@ Tensor all_gather(const Tensor& tensor) {
     // Destination buffer for all-gather data is fully local on each host.
     auto all_gather_buffer = DistributedHostBuffer::create(tensor.host_storage().buffer().shape());
 
-    for (const auto& coord : tensor.host_storage().buffer().shard_coords()) {
+    // Prepare shard presence data: first element is rank, rest are 1/0 for shard presence
+    const int this_rank = *ctx->rank();
+    constexpr int kShardPresent = 1;
+    constexpr int kShardAbsent = 0;
+
+    // Note the use of `std::set` is required to ensure the ordering of the shard coordinates.
+    const std::set<distributed::MeshCoordinate>& shard_coords = tensor.host_storage().buffer().shard_coords();
+    std::vector<int> local_shard_info;
+    local_shard_info.reserve(1 + shard_coords.size());
+    local_shard_info.push_back(this_rank);
+
+    for (const auto& coord : shard_coords) {
         auto shard = tensor.host_storage().buffer().get_shard(coord);
+        local_shard_info.push_back(shard.has_value() ? kShardPresent : kShardAbsent);
+    }
 
-        // Run all-reduce to determine which rank has data for this shard.
-        int has_data = shard.has_value() ? *ctx->rank() : -1;
-        int has_data_rank = -1;
+    std::vector<int> global_shard_info(local_shard_info.size() * *ctx->size());
+    ctx->all_gather(
+        ttsl::as_writable_bytes(ttsl::make_span(local_shard_info)),
+        ttsl::as_writable_bytes(ttsl::make_span(global_shard_info)));
 
-        ctx->all_reduce(
-            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&has_data), sizeof(int)),
-            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&has_data_rank), sizeof(int)),
-            tt::tt_metal::distributed::multihost::ReduceOp::MAX,
-            tt::tt_metal::distributed::multihost::DType::INT32);
+    auto find_shard_distribution = [&](size_t shard_index) -> std::pair<std::optional<int>, bool> {
+        std::optional<int> lowest_rank_with_shard;
+        bool any_host_missing = false;
 
-        TT_FATAL(has_data_rank != -1, "Failed to find shard for rank {}", *ctx->rank());
+        for (int host = 0; host < *ctx->size(); ++host) {
+            int base_idx = host * local_shard_info.size();
+            int rank = global_shard_info[base_idx];
+            int has_shard = global_shard_info[base_idx + 1 + shard_index];
 
-        if (shard.has_value()) {
-            ctx->broadcast(shard->view_bytes(), tt::tt_metal::distributed::multihost::Rank(has_data_rank));
-            all_gather_buffer.emplace_shard(coord, [&shard]() { return *shard; });
+            if (has_shard) {
+                lowest_rank_with_shard = std::min(lowest_rank_with_shard.value_or(rank), rank);
+            } else {
+                any_host_missing = true;
+            }
+        }
+
+        return {lowest_rank_with_shard, any_host_missing};
+    };
+
+    size_t shard_idx = 0;
+    for (const auto& coord : shard_coords) {
+        auto local_shard = tensor.host_storage().buffer().get_shard(coord);
+
+        const auto [lowest_rank_with_shard, any_host_missing_shard] = find_shard_distribution(shard_idx++);
+        TT_FATAL(lowest_rank_with_shard.has_value(), "No host has shard at coordinate {}", coord);
+
+        // Only broadcast if at least one host is missing the shard.
+        if (any_host_missing_shard) {
+            std::cout << "any_host_missing_shard true: " << shard_idx << std::endl;
+            if (local_shard.has_value() && *lowest_rank_with_shard == this_rank) {
+                ctx->broadcast(
+                    local_shard->view_bytes(), tt::tt_metal::distributed::multihost::Rank(*lowest_rank_with_shard));
+                all_gather_buffer.emplace_shard(coord, [&local_shard]() { return *local_shard; });
+            } else {
+                HostBuffer buffer = tt::tt_metal::tensor_impl::allocate_host_buffer(tensor.tensor_spec());
+                ctx->broadcast(
+                    buffer.view_bytes(), tt::tt_metal::distributed::multihost::Rank(*lowest_rank_with_shard));
+                all_gather_buffer.emplace_shard(coord, [&buffer]() { return std::move(buffer); });
+            }
         } else {
-            HostBuffer buffer = tt::tt_metal::tensor_impl::allocate_host_buffer(tensor.tensor_spec());
-            ctx->broadcast(buffer.view_bytes(), tt::tt_metal::distributed::multihost::Rank(has_data_rank));
-            all_gather_buffer.emplace_shard(coord, [&buffer]() { return std::move(buffer); });
+            std::cout << "any_host_missing_shard false: " << shard_idx << std::endl;
+            TT_FATAL(local_shard.has_value(), "Expected all hosts to have shard at coordinate {}", coord);
+            all_gather_buffer.emplace_shard(coord, [&local_shard]() { return *local_shard; });
         }
     }
 

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -40,6 +40,9 @@ void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) 
     Tensor cpu_tensor = tensor.cpu();
 
     // Dump tensor to disk from (global) rank 0 host.
+    // Note we use global context as opposed to context embedded to the host-side tensor, since the tensor may already
+    // be fully host-local. In this latter case, host buffer context will consist of a single (local) host rank, and
+    // each host will attempt to flush the serialized tensor file to disk.
     cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
     const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
     if (ctx->rank() == tt::tt_metal::distributed::multihost::Rank(0)) {

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -39,9 +39,9 @@ constexpr std::uint32_t kFlatbufferAlignment = alignof(std::uint64_t);
 void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) {
     Tensor cpu_tensor = tensor.cpu();
 
-    // Dump tensor to disk from rank 0 host.
+    // Dump tensor to disk from (global) rank 0 host.
     cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
-    const auto& ctx = cpu_tensor.host_storage().buffer().context();
+    const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
     if (ctx->rank() == tt::tt_metal::distributed::multihost::Rank(0)) {
         FILE* output_file = fopen(file_name.c_str(), "wb");
         TT_FATAL(output_file != nullptr, "Cannot open \"{}\"", file_name);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
2 issues with the current implementation:
1. Serialization code will fail to produce just 1 file if called on already all-gathered tensors.
2. Performance - running all-reduce on every shard can be optimized to just 1 all-gather operation.

### What's changed
1. Switch from tensor context to global context. Tensors generally can be entirely host local.
2. Change the implementation to call all-gather once, and then broadcast from host with the lowest rank to all other hosts.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17597703999)
- [x] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17597706727)
- [x] New/Existing tests provide coverage for changes