### PR TITLE
TT_METAL_WATCHER_RUNTIME_KERNELS to enable Watcher on Fabric+Dispatch kernels

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_enablement_mode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize_delays.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_enablement_mode.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_enablement_mode.cpp
@@ -1,0 +1,449 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Watcher Enablement Mode Tests
+//
+// This test file validates the watcher's selective enablement feature, which allows
+// enabling watcher monitoring for specific kernel types (USER, DISPATCH, FABRIC).
+//
+// The file contains TWO complementary test suites:
+//
+// 1. WatcherEnablementModeTests (Non-USER modes):
+//    - Tests: DISPATCH only, DISPATCH+FABRIC
+//    - Verifies: User kernels do NOT trigger asserts when USER mode is disabled
+//    - Test count: 4 tests (2 modes × 2 core types: TENSIX, ACTIVE_ETH)
+//
+// 2. WatcherUserEnabledTests (USER mode enabled):
+//    - Tests: USER only, ALL (USER+DISPATCH+FABRIC)
+//    - Verifies: User kernels DO trigger asserts when USER mode is enabled
+//    - Test count: 4 tests (2 modes × 2 core types: TENSIX, ACTIVE_ETH)
+//
+// Together, these tests provide comprehensive coverage of the watcher enablement
+// mode feature, ensuring it correctly enables/disables monitoring based on kernel type.
+// Total: 8 focused test cases covering the key scenarios.
+//////////////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt_stl/assert.hpp>
+#include "debug_tools_fixture.hpp"
+#include "hal_types.hpp"
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+class MeshWatcherNonUserFixture : public MeshWatcherFixture {
+public:
+    llrt::WatcherEnablementMode previous_enablement_mode_{};
+    llrt::WatcherEnablementMode test_enablement_mode_{};
+
+    void SetEnablementMode(llrt::WatcherEnablementMode mode) { test_enablement_mode_ = mode; }
+
+    void SetUp() override {
+        previous_enablement_mode_ = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enablement_mode();
+
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enablement_mode(test_enablement_mode_);
+
+        log_info(
+            LogTest,
+            "Watcher enablement mode set to: 0x{:02x} (DISPATCH={}, FABRIC={}, USER={})",
+            static_cast<uint8_t>(test_enablement_mode_),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH) != llrt::WatcherEnablementMode::DISABLED,
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC) != llrt::WatcherEnablementMode::DISABLED,
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER) != llrt::WatcherEnablementMode::DISABLED);
+
+        MeshWatcherFixture::SetUp();
+    }
+
+    void TearDown() override {
+        MeshWatcherFixture::TearDown();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enablement_mode(previous_enablement_mode_);
+    }
+};
+
+static void RunTest(
+    MeshWatcherFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    HalProgrammableCoreType programmable_core_type,
+    llrt::WatcherEnablementMode enablement_mode) {
+    ASSERT_EQ(enablement_mode & llrt::WatcherEnablementMode::USER, llrt::WatcherEnablementMode::DISABLED)
+        << "Test configuration error: USER mode should not be enabled for this test";
+    ASSERT_NE(
+        enablement_mode & (llrt::WatcherEnablementMode::DISPATCH | llrt::WatcherEnablementMode::FABRIC),
+        llrt::WatcherEnablementMode::DISABLED)
+        << "Test configuration error: At least DISPATCH or FABRIC should be enabled";
+
+    // Set up program
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto device = mesh_device->get_devices()[0];
+
+    // Choose a core to run the test on
+    CoreCoord logical_core, virtual_core;
+    switch (programmable_core_type) {
+        case HalProgrammableCoreType::TENSIX:
+            logical_core = {0, 0};
+            virtual_core = device->worker_core_from_logical_core(logical_core);
+            break;
+        case HalProgrammableCoreType::ACTIVE_ETH:
+            if (device->get_active_ethernet_cores(true).empty()) {
+                log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+                GTEST_SKIP();
+            }
+            logical_core = *(device->get_active_ethernet_cores(true).begin());
+            virtual_core = device->ethernet_core_from_logical_core(logical_core);
+            break;
+        case HalProgrammableCoreType::IDLE_ETH:
+            if (device->get_inactive_ethernet_cores().empty()) {
+                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+                GTEST_SKIP();
+            }
+            logical_core = *(device->get_inactive_ethernet_cores().begin());
+            virtual_core = device->ethernet_core_from_logical_core(logical_core);
+            break;
+        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
+    }
+
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+
+    // Create a kernel that would normally trigger an assert
+    KernelHandle assert_kernel;
+    switch (programmable_core_type) {
+        case HalProgrammableCoreType::TENSIX:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+            break;
+        case HalProgrammableCoreType::ACTIVE_ETH:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+            break;
+        case HalProgrammableCoreType::IDLE_ETH:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+            break;
+        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
+    }
+
+    // Write runtime args that would normally trip an assert (a == b)
+    // Since watcher is disabled for USER kernels, this should NOT trigger an assert
+    const std::vector<uint32_t> assert_args = {3, 3, static_cast<uint32_t>(dev_msgs::DebugAssertTripped)};
+    SetRuntimeArgs(program_, assert_kernel, logical_core, assert_args);
+
+    // Run the kernel - it should complete successfully without triggering watcher assert
+    // because watcher is only enabled for DISPATCH/FABRIC, not USER kernels
+    log_info(LogTest, "Running user kernel with assert condition (a==b, would normally trip ASSERT)...");
+    log_info(
+        LogTest,
+        "Since watcher is disabled for USER kernels (mode=0x{:02x}), no assert should trigger.",
+        static_cast<uint8_t>(enablement_mode));
+
+    fixture->RunProgram(mesh_device, workload, true);
+
+    log_info(LogTest, "User kernel completed without triggering watcher assert.");
+
+    // Verify that no watcher exception was raised
+    std::string exception = MetalContext::instance().watcher_server()->exception_message();
+    EXPECT_TRUE(exception.empty()) << "Expected no watcher exception, but got: " << exception;
+}
+
+// Test function for when USER mode IS enabled - expects assert to trigger
+static void RunTestWithUserEnabled(
+    MeshWatcherFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    HalProgrammableCoreType programmable_core_type,
+    llrt::WatcherEnablementMode enablement_mode) {
+    // Verify that USER mode IS enabled
+    ASSERT_NE(enablement_mode & llrt::WatcherEnablementMode::USER, llrt::WatcherEnablementMode::DISABLED)
+        << "Test configuration error: USER mode should be enabled for this test";
+
+    // Set up program
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto device = mesh_device->get_devices()[0];
+
+    // Choose a core to run the test on
+    CoreCoord logical_core, virtual_core;
+    std::string risc;
+    switch (programmable_core_type) {
+        case HalProgrammableCoreType::TENSIX:
+            logical_core = {0, 0};
+            virtual_core = device->worker_core_from_logical_core(logical_core);
+            risc = " brisc";
+            break;
+        case HalProgrammableCoreType::ACTIVE_ETH:
+            if (device->get_active_ethernet_cores(true).empty()) {
+                log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+                GTEST_SKIP();
+            }
+            logical_core = *(device->get_active_ethernet_cores(true).begin());
+            virtual_core = device->ethernet_core_from_logical_core(logical_core);
+            risc = "erisc";
+            break;
+        case HalProgrammableCoreType::IDLE_ETH:
+            if (device->get_inactive_ethernet_cores().empty()) {
+                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+                GTEST_SKIP();
+            }
+            logical_core = *(device->get_inactive_ethernet_cores().begin());
+            virtual_core = device->ethernet_core_from_logical_core(logical_core);
+            risc = "erisc";
+            break;
+        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
+    }
+
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+
+    // Create a kernel that will trigger an assert
+    KernelHandle assert_kernel;
+    switch (programmable_core_type) {
+        case HalProgrammableCoreType::TENSIX:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+            break;
+        case HalProgrammableCoreType::ACTIVE_ETH:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+            break;
+        case HalProgrammableCoreType::IDLE_ETH:
+            assert_kernel = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                logical_core,
+                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+            break;
+        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
+    }
+
+    // First, run with safe args to verify kernel works
+    const std::vector<uint32_t> safe_args = {3, 4, static_cast<uint32_t>(dev_msgs::DebugAssertTripped)};
+    SetRuntimeArgs(program_, assert_kernel, logical_core, safe_args);
+
+    log_info(LogTest, "Running kernel with safe args (should complete normally)...");
+    fixture->RunProgram(mesh_device, workload, true);
+    log_info(LogTest, "Safe run completed successfully.");
+
+    const std::vector<uint32_t> assert_args = {3, 3, static_cast<uint32_t>(dev_msgs::DebugAssertTripped)};
+    SetRuntimeArgs(program_, assert_kernel, logical_core, assert_args);
+
+    log_info(LogTest, "Running user kernel with assert condition (a==b, SHOULD trip ASSERT)...");
+    log_info(
+        LogTest,
+        "Since watcher is enabled for USER kernels (mode=0x{:02x}), assert should trigger.",
+        static_cast<uint8_t>(enablement_mode));
+
+    fixture->RunProgram(mesh_device, workload);
+
+    // We should be able to find the expected watcher error in the log
+    const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
+    const uint32_t line_num = 67;
+    std::string expected = fmt::format(
+        "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. "
+        "Note that file name reporting is not yet implemented, and the reported line number for the assert may be "
+        "from a different file. Current kernel: {}.",
+        device->id(),
+        (programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
+        logical_core.x,
+        logical_core.y,
+        virtual_core.x,
+        virtual_core.y,
+        risc,
+        line_num,
+        kernel);
+
+    std::string exception = "";
+    do {
+        exception = MetalContext::instance().watcher_server()->exception_message();
+    } while (exception.empty());
+
+    log_info(LogTest, "Watcher correctly caught the assert in user kernel.");
+    EXPECT_EQ(expected, exception);
+}
+
+// Fixture for testing USER mode enabled
+class MeshWatcherUserEnabledFixture : public MeshWatcherFixture {
+public:
+    llrt::WatcherEnablementMode previous_enablement_mode_{};
+    llrt::WatcherEnablementMode test_enablement_mode_{};
+
+    void SetEnablementMode(llrt::WatcherEnablementMode mode) { test_enablement_mode_ = mode; }
+
+    void SetUp() override {
+        previous_enablement_mode_ = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enablement_mode();
+
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enablement_mode(test_enablement_mode_);
+
+        log_info(
+            LogTest,
+            "Watcher enablement mode set to: 0x{:02x} (DISPATCH={}, FABRIC={}, USER={})",
+            static_cast<uint8_t>(test_enablement_mode_),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH) != llrt::WatcherEnablementMode::DISABLED,
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC) != llrt::WatcherEnablementMode::DISABLED,
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER) != llrt::WatcherEnablementMode::DISABLED);
+
+        MeshWatcherFixture::SetUp();
+    }
+
+    void TearDown() override {
+        MeshWatcherFixture::TearDown();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enablement_mode(previous_enablement_mode_);
+    }
+};
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
+// Test parameters
+struct WatcherEnablementModeTestParams {
+    std::string test_name;
+    HalProgrammableCoreType core_type;
+    llrt::WatcherEnablementMode enablement_mode;
+};
+
+class WatcherEnablementModeTest : public CMAKE_UNIQUE_NAMESPACE::MeshWatcherNonUserFixture,
+                                  public ::testing::WithParamInterface<WatcherEnablementModeTestParams> {
+protected:
+    void SetUp() override {
+        const auto& params = GetParam();
+        this->SetEnablementMode(params.enablement_mode);
+        MeshWatcherNonUserFixture::SetUp();
+    }
+};
+
+TEST_P(WatcherEnablementModeTest, TestWatcherNonUserModeDoesNotAssertUserKernels) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
+
+    const auto& params = GetParam();
+
+    if (this->slow_dispatch_) {
+        GTEST_SKIP();
+    }
+
+    this->RunTestOnDevice(
+        [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            RunTest(fixture, mesh_device, params.core_type, params.enablement_mode);
+        },
+        this->devices_[0]);
+}
+
+namespace {
+
+using enum HalProgrammableCoreType;
+using llrt::WatcherEnablementMode;
+
+// Test combinations: DISPATCH only and DISPATCH+FABRIC
+// In all cases, USER mode should NOT be enabled, so user kernels should not trigger asserts
+// Only test TENSIX and ACTIVE_ETH cores
+INSTANTIATE_TEST_SUITE_P(
+    WatcherEnablementModeTests,
+    WatcherEnablementModeTest,
+    ::testing::Values(
+        // Test with DISPATCH only - user kernels should not assert
+        WatcherEnablementModeTestParams{"Tensix_DispatchOnly", TENSIX, WatcherEnablementMode::DISPATCH},
+        WatcherEnablementModeTestParams{"ActiveEth_DispatchOnly", ACTIVE_ETH, WatcherEnablementMode::DISPATCH},
+
+        // Test with DISPATCH + FABRIC - user kernels should not assert
+        WatcherEnablementModeTestParams{"Tensix_DispatchFabric", TENSIX, WatcherEnablementMode::DISPATCH_FABRIC},
+        WatcherEnablementModeTestParams{
+            "ActiveEth_DispatchFabric", ACTIVE_ETH, WatcherEnablementMode::DISPATCH_FABRIC}),
+    [](const ::testing::TestParamInfo<WatcherEnablementModeTestParams>& info) { return info.param.test_name; });
+
+}  // namespace
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Test suite for USER mode ENABLED - verifies asserts DO trigger
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// Test parameters for USER-enabled tests
+struct WatcherUserEnabledTestParams {
+    std::string test_name;
+    HalProgrammableCoreType core_type;
+    llrt::WatcherEnablementMode enablement_mode;
+};
+
+class WatcherUserEnabledTest : public CMAKE_UNIQUE_NAMESPACE::MeshWatcherUserEnabledFixture,
+                               public ::testing::WithParamInterface<WatcherUserEnabledTestParams> {
+protected:
+    void SetUp() override {
+        const auto& params = GetParam();
+        this->SetEnablementMode(params.enablement_mode);
+        MeshWatcherUserEnabledFixture::SetUp();
+    }
+};
+
+TEST_P(WatcherUserEnabledTest, TestWatcherUserModeDoesAssertUserKernels) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;
+
+    const auto& params = GetParam();
+
+    if (this->slow_dispatch_) {
+        GTEST_SKIP();
+    }
+
+    this->RunTestOnDevice(
+        [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            RunTestWithUserEnabled(fixture, mesh_device, params.core_type, params.enablement_mode);
+        },
+        this->devices_[0]);
+}
+
+namespace {
+
+using enum HalProgrammableCoreType;
+using llrt::WatcherEnablementMode;
+
+// Test combinations with USER mode enabled - user kernels SHOULD trigger asserts
+// Only test TENSIX and ACTIVE_ETH cores
+INSTANTIATE_TEST_SUITE_P(
+    WatcherUserEnabledTests,
+    WatcherUserEnabledTest,
+    ::testing::Values(
+        // Test with USER only - user kernels should assert
+        WatcherUserEnabledTestParams{"Tensix_UserOnly", TENSIX, WatcherEnablementMode::USER},
+        WatcherUserEnabledTestParams{"ActiveEth_UserOnly", ACTIVE_ETH, WatcherEnablementMode::USER},
+
+        // Test with ALL (USER + DISPATCH + FABRIC) - user kernels should assert
+        WatcherUserEnabledTestParams{"Tensix_All", TENSIX, WatcherEnablementMode::ALL},
+        WatcherUserEnabledTestParams{"ActiveEth_All", ACTIVE_ETH, WatcherEnablementMode::ALL}),
+    [](const ::testing::TestParamInfo<WatcherUserEnabledTestParams>& info) { return info.param.test_name; });
+
+}  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_enablement_mode.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_enablement_mode.cpp
@@ -64,9 +64,9 @@ public:
             LogTest,
             "Watcher enablement mode set to: 0x{:02x} (DISPATCH={}, FABRIC={}, USER={})",
             static_cast<uint8_t>(test_enablement_mode_),
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH) != llrt::WatcherEnablementMode::DISABLED,
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC) != llrt::WatcherEnablementMode::DISABLED,
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER) != llrt::WatcherEnablementMode::DISABLED);
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER));
 
         MeshWatcherFixture::SetUp();
     }
@@ -82,13 +82,6 @@ static void RunTest(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     HalProgrammableCoreType programmable_core_type,
     llrt::WatcherEnablementMode enablement_mode) {
-    ASSERT_EQ(enablement_mode & llrt::WatcherEnablementMode::USER, llrt::WatcherEnablementMode::DISABLED)
-        << "Test configuration error: USER mode should not be enabled for this test";
-    ASSERT_NE(
-        enablement_mode & (llrt::WatcherEnablementMode::DISPATCH | llrt::WatcherEnablementMode::FABRIC),
-        llrt::WatcherEnablementMode::DISABLED)
-        << "Test configuration error: At least DISPATCH or FABRIC should be enabled";
-
     // Set up program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -183,7 +176,7 @@ static void RunTestWithUserEnabled(
     HalProgrammableCoreType programmable_core_type,
     llrt::WatcherEnablementMode enablement_mode) {
     // Verify that USER mode IS enabled
-    ASSERT_NE(enablement_mode & llrt::WatcherEnablementMode::USER, llrt::WatcherEnablementMode::DISABLED)
+    ASSERT_TRUE(enablement_mode & llrt::WatcherEnablementMode::USER)
         << "Test configuration error: USER mode should be enabled for this test";
 
     // Set up program
@@ -317,9 +310,9 @@ public:
             LogTest,
             "Watcher enablement mode set to: 0x{:02x} (DISPATCH={}, FABRIC={}, USER={})",
             static_cast<uint8_t>(test_enablement_mode_),
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH) != llrt::WatcherEnablementMode::DISABLED,
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC) != llrt::WatcherEnablementMode::DISABLED,
-            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER) != llrt::WatcherEnablementMode::DISABLED);
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::DISPATCH),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::FABRIC),
+            (test_enablement_mode_ & llrt::WatcherEnablementMode::USER));
 
         MeshWatcherFixture::SetUp();
     }

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -20,6 +20,8 @@
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include <fmt/ranges.h>
+#include "tt_metal/impl/kernels/kernel_impl.hpp"
+#include "tt_metal/impl/program/program_impl.hpp"
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000
@@ -507,6 +509,9 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
                     .compile_args = ct_args,
                     .defines = defines,
                     .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+
+            auto kernel_ptr = fabric_program_ptr->impl().get_kernel(kernel);
+            tt::tt_metal::KernelImpl::from(*kernel_ptr).set_is_runtime_kernel(true);
 
             tt::tt_metal::SetRuntimeArgs(*fabric_program_ptr, kernel, eth_logical_core, rt_args);
         }

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -511,7 +511,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
                     .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
 
             auto kernel_ptr = fabric_program_ptr->impl().get_kernel(kernel);
-            tt::tt_metal::KernelImpl::from(*kernel_ptr).set_is_runtime_kernel(true);
+            tt::tt_metal::KernelImpl::from(*kernel_ptr).set_kernel_type(tt::tt_metal::KernelImpl::KernelType::FABRIC);
 
             tt::tt_metal::SetRuntimeArgs(*fabric_program_ptr, kernel, eth_logical_core, rt_args);
         }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -4,12 +4,14 @@
 
 #include "watcher_server.hpp"
 
+#include <fmt/ranges.h>
 #include <unistd.h>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <condition_variable>
+#include <enchantum/entries.hpp>
 #include <filesystem>
 #include <future>
 #include <map>
@@ -517,7 +519,19 @@ void WatcherServer::Impl::poll_watcher_data() {
     } else {
         disabled_features = "None";
     }
-    log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
+    const auto enabled_kernel_types = rtoptions.get_watcher_enablement_mode();
+    std::cout << "enabled_kernel_types = " << std::hex << (uint32_t)enabled_kernel_types << "\n";
+    std::vector<std::string> enabled_kernel_type_names;
+    for (const auto [val, name] : enchantum::entries_generator<tt::llrt::WatcherEnablementMode>) {
+        if (enabled_kernel_types & val) {
+            enabled_kernel_type_names.push_back(std::string{name});
+        }
+    }
+    log_info(
+        LogLLRuntime,
+        "Watcher server initialized, disabled features: {}, enabled kernel types: {}",
+        disabled_features,
+        fmt::join(enabled_kernel_type_names.begin(), enabled_kernel_type_names.end(), ", "));
 
     while (true) {
         std::unique_lock<std::mutex> lock(watch_mutex_);

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -187,7 +187,7 @@ KernelHandle FDKernel::configure_kernel_variant(
     }
 
     auto kernel = program_->impl().get_kernel(kernel_handle);
-    tt::tt_metal::KernelImpl::from(*kernel).set_is_runtime_kernel(true);
+    tt::tt_metal::KernelImpl::from(*kernel).set_kernel_type(tt::tt_metal::KernelImpl::KernelType::DISPATCH);
 
     return kernel_handle;
 }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -482,6 +482,9 @@ void PrefetchKernel::CreateKernel() {
     }
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
+    const auto watcher_enablement_mode =
+        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enablement_mode();
+    const auto enabled_for_prefetch = (watcher_enablement_mode & llrt::WatcherEnablementMode::DISPATCH);
     configure_kernel_variant(
         dispatch_kernel_file_names[PREFETCH],
         {},
@@ -490,8 +493,7 @@ void PrefetchKernel::CreateKernel() {
         true,
         // TEMP: Disable function inlining on Prefetcher when watcher is enabled but no_inline is not specified to
         // respect code space
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fw_watcher_enabled() &&
-            (not tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()),
+        enabled_for_prefetch && (not tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()),
         optimization_level);
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -490,7 +490,7 @@ void PrefetchKernel::CreateKernel() {
         true,
         // TEMP: Disable function inlining on Prefetcher when watcher is enabled but no_inline is not specified to
         // respect code space
-        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
+        tt::tt_metal::MetalContext::instance().rtoptions().get_fw_watcher_enabled() &&
             (not tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()),
         optimization_level);
 }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -587,6 +587,35 @@ void KernelImpl::set_binaries(uint32_t build_key, std::vector<const ll_api::memo
     }
 }
 
+void KernelImpl::set_kernel_type(KernelType kernel_type) {
+    this->kernel_type_ = kernel_type;
+    const auto enablement_mode = MetalContext::instance().rtoptions().get_watcher_enablement_mode();
+    const bool enable_watcher = [&]() {
+        if (enablement_mode == llrt::WatcherEnablementMode::DISABLED) {
+            return false;
+        }
+
+        uint8_t flag_to_check = 0;
+        switch (kernel_type) {
+            case tt::tt_metal::KernelImpl::KernelType::USER:
+                flag_to_check = static_cast<uint8_t>(llrt::WatcherEnablementMode::USER);
+                break;
+            case tt::tt_metal::KernelImpl::KernelType::DISPATCH:
+                flag_to_check = static_cast<uint8_t>(llrt::WatcherEnablementMode::DISPATCH);
+                break;
+            case tt::tt_metal::KernelImpl::KernelType::FABRIC:
+                flag_to_check = static_cast<uint8_t>(llrt::WatcherEnablementMode::FABRIC);
+                break;
+        }
+
+        return (static_cast<uint8_t>(enablement_mode) & flag_to_check) != 0;
+    }();
+    this->watcher_enabled_ = enable_watcher;
+    if (enable_watcher) {
+        this->add_defines({{"WATCHER_ENABLED", "1"}});
+    }
+}
+
 void DataMovementKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -588,10 +588,11 @@ void KernelImpl::set_binaries(uint32_t build_key, std::vector<const ll_api::memo
 }
 
 void KernelImpl::set_kernel_type(KernelType kernel_type) {
-    this->kernel_type_ = kernel_type;
+    const auto watcher_enabled = MetalContext::instance().rtoptions().get_watcher_enabled();
     const auto enablement_mode = MetalContext::instance().rtoptions().get_watcher_enablement_mode();
+
     const bool enable_watcher = [&]() {
-        if (enablement_mode == llrt::WatcherEnablementMode::DISABLED) {
+        if (!watcher_enabled) {
             return false;
         }
 
@@ -610,7 +611,7 @@ void KernelImpl::set_kernel_type(KernelType kernel_type) {
 
         return (static_cast<uint8_t>(enablement_mode) & flag_to_check) != 0;
     }();
-    this->watcher_enabled_ = enable_watcher;
+
     if (enable_watcher) {
         this->add_defines({{"WATCHER_ENABLED", "1"}});
     }

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -180,10 +180,8 @@ public:
 
     void register_kernel_elf_paths_with_watcher(IDevice& device) const;
 
-    KernelType get_kernel_type() const { return this->kernel_type_; }
     // This needs to be set before compiling the kernel
     void set_kernel_type(KernelType kernel_type);
-    bool is_watcher_enabled() const { return this->watcher_enabled_; }
 
     static KernelImpl& from(Kernel& kernel) {
         // KernelImpl and subclasses are the only implementations of Kernel.
@@ -220,12 +218,6 @@ protected:
     std::unordered_map<ChipId, std::vector<const ll_api::memory*>> binaries_;
 
     std::vector<std::string> file_paths(IDevice& device) const;
-
-private:
-    // The kernel type
-    KernelType kernel_type_ = KernelType::USER;
-    // If watcher is enabled for this kernel
-    bool watcher_enabled_ = false;
 };
 
 class DataMovementKernel : public KernelImpl {

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -174,6 +174,10 @@ public:
 
     void register_kernel_elf_paths_with_watcher(IDevice& device) const;
 
+    bool get_is_runtime_kernel() const { return this->is_runtime_kernel_; }
+    // This can be set before compiling the kernel
+    void set_is_runtime_kernel(bool is_runtime_kernel) { this->is_runtime_kernel_ = is_runtime_kernel; }
+
     static KernelImpl& from(Kernel& kernel) {
         // KernelImpl and subclasses are the only implementations of Kernel.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
@@ -202,13 +206,18 @@ protected:
             core_range_set,
             compile_args,
             defines,
-            named_compile_args) {}
+            named_compile_args),
+        is_runtime_kernel_{false} {}
     // DataMovement kernels have one binary each and Compute kernels have three binaries
     // Different set of binaries per device because kernel compilation is device dependent
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
     std::unordered_map<ChipId, std::vector<const ll_api::memory*>> binaries_;
 
     std::vector<std::string> file_paths(IDevice& device) const;
+
+private:
+    // Dispatch / Fabric kernels
+    bool is_runtime_kernel_;
 };
 
 class DataMovementKernel : public KernelImpl {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -163,6 +163,18 @@ void GenerateBinaries(IDevice* device, JitBuildOptions& build_options, const std
     // ZoneScoped;
     // const std::string tracyPrefix = "GenerateBinaries_";
     // ZoneName((tracyPrefix + build_options.name).c_str(), build_options.name.length() + tracyPrefix.length());
+
+    // Setup Watcher
+    {
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        const auto& kernel_impl = tt::tt_metal::KernelImpl::from(*kernel);
+        // Enable for user kernels. Only enable for firmware kernels if watcher fw is enabled.
+        if (rtoptions.get_watcher_enabled() &&
+            (!kernel_impl.get_is_runtime_kernel() || rtoptions.get_fw_watcher_enabled())) {
+            kernel->add_defines({{"WATCHER_ENABLED", "1"}});
+        }
+    }
+
     try {
         jit_build_genfiles_descriptors(
             BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, build_options);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -164,17 +164,6 @@ void GenerateBinaries(IDevice* device, JitBuildOptions& build_options, const std
     // const std::string tracyPrefix = "GenerateBinaries_";
     // ZoneName((tracyPrefix + build_options.name).c_str(), build_options.name.length() + tracyPrefix.length());
 
-    // Setup Watcher
-    {
-        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-        const auto& kernel_impl = tt::tt_metal::KernelImpl::from(*kernel);
-        // Enable for user kernels. Only enable for firmware kernels if watcher fw is enabled.
-        if (rtoptions.get_watcher_enabled() &&
-            (!kernel_impl.get_is_runtime_kernel() || rtoptions.get_fw_watcher_enabled())) {
-            kernel->add_defines({{"WATCHER_ENABLED", "1"}});
-        }
-    }
-
     try {
         jit_build_genfiles_descriptors(
             BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, build_options);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -202,9 +202,8 @@ void JitBuildEnv::init(
         this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
     }
 
-    if (rtoptions.get_watcher_enabled()) {
-        this->defines_ += "-DWATCHER_ENABLED ";
-    }
+    // WATCHER_ENABLED needs to be aware if the kernel is an internal runtime kernel or a user kernel.
+    // This define is set in program.cpp
     if (rtoptions.get_watcher_noinline()) {
         this->defines_ += "-DWATCHER_NOINLINE ";
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -354,6 +354,7 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_settings.interval_ms = sleep_val;
     }
 
+    watcher_settings.fw_enabled = (getenv("TT_METAL_WATCHER_RUNTIME_KERNELS") != nullptr);
     watcher_settings.dump_all = (getenv("TT_METAL_WATCHER_DUMP_ALL") != nullptr);
     watcher_settings.append = (getenv("TT_METAL_WATCHER_APPEND") != nullptr);
     watcher_settings.noinline = (getenv("TT_METAL_WATCHER_NOINLINE") != nullptr);
@@ -620,6 +621,7 @@ uint32_t RunTimeOptions::get_watcher_hash() const {
     hash_str += std::to_string(watcher_feature_disabled(watcher_dispatch_str));
     hash_str += std::to_string(get_watcher_noc_sanitize_linked_transaction());
     hash_str += std::to_string(get_watcher_enabled());
+    hash_str += std::to_string(get_fw_watcher_enabled());
     std::hash<std::string> hash_fn;
     return hash_fn(hash_str);
 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <cstring>
+#include <enchantum/entries.hpp>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -354,7 +355,28 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_settings.interval_ms = sleep_val;
     }
 
-    watcher_settings.fw_enabled = (getenv("TT_METAL_WATCHER_RUNTIME_KERNELS") != nullptr);
+    watcher_settings.enablement_mode = WatcherEnablementMode::DISABLED;
+    const char* watcher_enablement_mode_str = getenv("TT_METAL_WATCHER_KERNELS");
+    // Split by comma
+    std::vector<std::string> enablement_modes;
+    if (watcher_enablement_mode_str != nullptr) {
+        std::stringstream ss(watcher_enablement_mode_str);
+        std::string mode;
+        while (std::getline(ss, mode, ',')) {
+            enablement_modes.push_back(mode);
+        }
+    }
+    for (const auto& mode : enablement_modes) {
+        if (mode == "USER") {
+            watcher_settings.enablement_mode |= llrt::WatcherEnablementMode::USER;
+        } else if (mode == "DISPATCH") {
+            watcher_settings.enablement_mode |= llrt::WatcherEnablementMode::DISPATCH;
+        } else if (mode == "FABRIC") {
+            watcher_settings.enablement_mode |= llrt::WatcherEnablementMode::FABRIC;
+        } else {
+            TT_THROW("Invalid watcher enablement mode: {}", mode);
+        }
+    }
     watcher_settings.dump_all = (getenv("TT_METAL_WATCHER_DUMP_ALL") != nullptr);
     watcher_settings.append = (getenv("TT_METAL_WATCHER_APPEND") != nullptr);
     watcher_settings.noinline = (getenv("TT_METAL_WATCHER_NOINLINE") != nullptr);
@@ -621,7 +643,7 @@ uint32_t RunTimeOptions::get_watcher_hash() const {
     hash_str += std::to_string(watcher_feature_disabled(watcher_dispatch_str));
     hash_str += std::to_string(get_watcher_noc_sanitize_linked_transaction());
     hash_str += std::to_string(get_watcher_enabled());
-    hash_str += std::to_string(get_fw_watcher_enabled());
+    hash_str += std::to_string(enchantum::to_underlying(get_watcher_enablement_mode()));
     std::hash<std::string> hash_fn;
     return hash_fn(hash_str);
 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -355,14 +355,16 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_settings.interval_ms = sleep_val;
     }
 
-    watcher_settings.enablement_mode = WatcherEnablementMode::DISABLED;
+    watcher_settings.enablement_mode = WatcherEnablementMode::ALL;
     const char* watcher_enablement_mode_str = getenv("TT_METAL_WATCHER_KERNELS");
     // Split by comma
     std::vector<std::string> enablement_modes;
+    log_info(tt::LogMetal, "watcher_enablement_mode_str {}", watcher_enablement_mode_str);
     if (watcher_enablement_mode_str != nullptr) {
         std::stringstream ss(watcher_enablement_mode_str);
         std::string mode;
         while (std::getline(ss, mode, ',')) {
+            log_info(tt::LogMetal, "Enabling watcher for {}", mode);
             enablement_modes.push_back(mode);
         }
     }
@@ -374,7 +376,7 @@ void RunTimeOptions::ParseWatcherEnv() {
         } else if (mode == "FABRIC") {
             watcher_settings.enablement_mode |= llrt::WatcherEnablementMode::FABRIC;
         } else {
-            TT_THROW("Invalid watcher enablement mode: {}", mode);
+            TT_THROW("Invalid TT_METAL_WATCHER_KERNELS value {}", mode);
         }
     }
     watcher_settings.dump_all = (getenv("TT_METAL_WATCHER_DUMP_ALL") != nullptr);

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -73,7 +73,10 @@ struct TargetSelection {
 };
 
 struct WatcherSettings {
+    // Enabled for user kernels
     bool enabled = false;
+    // Enabled for dispatch + fabric. If this is true then enabled must also be true.
+    bool fw_enabled = false;
     bool dump_all = false;
     bool append = false;
     bool auto_unpause = false;
@@ -251,6 +254,8 @@ public:
     void set_watcher_enabled(bool enabled) { watcher_settings.enabled = enabled; }
     // Return a hash of which watcher features are enabled
     uint32_t get_watcher_hash() const;
+    bool get_fw_watcher_enabled() const { return watcher_settings.fw_enabled; }
+    void set_fw_watcher_enabled(bool enabled) { watcher_settings.fw_enabled = enabled; }
     int get_watcher_interval() const { return watcher_settings.interval_ms; }
     void set_watcher_interval(int interval_ms) { watcher_settings.interval_ms = interval_ms; }
     int get_watcher_dump_all() const { return watcher_settings.dump_all; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -56,14 +56,14 @@ enum RunTimeDebugClass {
 };
 
 enum WatcherEnablementMode : uint8_t {
-    // Watcher is disabled
-    DISABLED = 0,
     // Enable watcher for user kernels
     USER = 1 << 0,
     // Enable watcher for dispatch
     DISPATCH = 1 << 1,
     // Enable watcher for fabric
     FABRIC = 1 << 2,
+    // Last value for counting / iterating purposes
+    COUNT = 1 << 3,
 
     // Common combinations (bitwise OR)
     // Enable watcher for user and dispatch kernels
@@ -108,7 +108,7 @@ struct TargetSelection {
 
 struct WatcherSettings {
     bool enabled = false;
-    WatcherEnablementMode enablement_mode = WatcherEnablementMode::DISABLED;
+    WatcherEnablementMode enablement_mode = WatcherEnablementMode::ALL;
     bool dump_all = false;
     bool append = false;
     bool auto_unpause = false;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -55,6 +55,40 @@ enum RunTimeDebugClass {
     RunTimeDebugClassCount
 };
 
+enum WatcherEnablementMode : uint8_t {
+    // Watcher is disabled
+    DISABLED = 0,
+    // Enable watcher for user kernels
+    USER = 1 << 0,
+    // Enable watcher for dispatch
+    DISPATCH = 1 << 1,
+    // Enable watcher for fabric
+    FABRIC = 1 << 2,
+
+    // Common combinations (bitwise OR)
+    // Enable watcher for user and dispatch kernels
+    USER_DISPATCH = USER | DISPATCH,  // 0x03
+    // Enable watcher for user and fabric kernels
+    USER_FABRIC = USER | FABRIC,  // 0x05
+    // Enable watcher for dispatch and fabric kernels
+    DISPATCH_FABRIC = DISPATCH | FABRIC,  // 0x06
+    // Enable watcher all kernels
+    ALL = USER | DISPATCH | FABRIC,  // 0x07
+};
+
+inline WatcherEnablementMode operator|(WatcherEnablementMode lhs, WatcherEnablementMode rhs) {
+    return static_cast<WatcherEnablementMode>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+}
+
+inline WatcherEnablementMode operator&(WatcherEnablementMode lhs, WatcherEnablementMode rhs) {
+    return static_cast<WatcherEnablementMode>(static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs));
+}
+
+inline WatcherEnablementMode operator|=(WatcherEnablementMode& lhs, WatcherEnablementMode rhs) {
+    lhs = lhs | rhs;
+    return lhs;
+}
+
 extern const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount];
 extern const char* RunTimeDebugClassNames[RunTimeDebugClassCount];
 
@@ -73,10 +107,8 @@ struct TargetSelection {
 };
 
 struct WatcherSettings {
-    // Enabled for user kernels
     bool enabled = false;
-    // Enabled for dispatch + fabric. If this is true then enabled must also be true.
-    bool fw_enabled = false;
+    WatcherEnablementMode enablement_mode = WatcherEnablementMode::DISABLED;
     bool dump_all = false;
     bool append = false;
     bool auto_unpause = false;
@@ -254,8 +286,10 @@ public:
     void set_watcher_enabled(bool enabled) { watcher_settings.enabled = enabled; }
     // Return a hash of which watcher features are enabled
     uint32_t get_watcher_hash() const;
-    bool get_fw_watcher_enabled() const { return watcher_settings.fw_enabled; }
-    void set_fw_watcher_enabled(bool enabled) { watcher_settings.fw_enabled = enabled; }
+    WatcherEnablementMode get_watcher_enablement_mode() const { return watcher_settings.enablement_mode; }
+    void set_watcher_enablement_mode(WatcherEnablementMode enablement_mode) {
+        watcher_settings.enablement_mode = enablement_mode;
+    }
     int get_watcher_interval() const { return watcher_settings.interval_ms; }
     void set_watcher_interval(int interval_ms) { watcher_settings.interval_ms = interval_ms; }
     int get_watcher_dump_all() const { return watcher_settings.dump_all; }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28218

### Problem description
- Watcher is intended to be a user feature. Dispatch and Fabric shouldn't have any issues in mission mode.

### What's changed
- Watcher to only be enabled on user kernels by adding a KernelType enum to KernelImpl which says if the kernel is User, Dispatch, or Fabric.
- Enable watcher for internal kernels (fabric + dispatch) with an additional flag.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes