### PR TITLE
Move t3k profiler tests to CIv2

### DIFF
--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
       - arch-wormhole_b0
       - ${{ inputs.topology }}
       - ${{ inputs.extra-tag }}
-    strategy: 
+    strategy:
       fail-fast: false
     container: *container-config
     defaults: *defaults-config

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -26,10 +26,11 @@ jobs:
     strategy:
       fail-fast: false
     name: "profiler tests"
-    runs-on:
-      - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - ${{ inputs.extra-tag }}
+    # Profiler tests run on CIv2 for t3000 and CIv1 for all others (just WH 6U for now)
+    runs-on: ${{ 
+      inputs.topology == 'config-t3000' && 'tt-ubuntu-2204-N300-llmbox-stable' ||
+      fromJSON(format('["arch-wormhole_b0", "{0}", "{1}"]', inputs.topology, inputs.extra-tag))
+    }}
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -45,7 +45,7 @@ jobs:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
-    
+
     # Anchor the defaults block
     defaults: &defaults-config
       run:

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -97,3 +97,4 @@ jobs:
     container: *container-config
     defaults: *defaults-config
     steps: *steps-sequence
+    

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -1,5 +1,4 @@
 name: "[internal] profiler tests impl"
-
 on:
   workflow_call:
     inputs:
@@ -21,61 +20,68 @@ on:
         type: string
         default: "config-t3000"
 
-x-common-job-config: &common-job-config
-  strategy: 
-    fail-fast: false
-  container:
-    image: ${{ inputs.docker-image }}
-    env:
-      TT_METAL_HOME: /work
-      PYTHONPATH: /work
-      LD_LIBRARY_PATH: /work/build/lib
-      ARCH_NAME: wormhole_b0
-      LOGURU_LEVEL: INFO
-      PROFILER_SCRIPTS_ROOT: /work/tt_metal/tools/profiler
-      PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
-      PROFILER_ARTIFACTS_DIR: /work/generated/profiler
-      PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
-      DONT_USE_VIRTUAL_ENVIRONMENT: 1
-    volumes:
-      - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-      - /dev/hugepages-1G:/dev/hugepages-1G
-      - /mnt/MLPerf:/mnt/MLPerf:ro
-    options: "--device /dev/tenstorrent"
-  defaults:
-    run:
-      shell: bash
-      working-directory: /work # https://github.com/actions/runner/issues/878
-  steps:
-  - name: ⬇️  Setup Job
-    uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-    timeout-minutes: 10
-    with:
-      build-artifact-name: ${{ inputs.build-artifact-name }}
-      wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-  - name: Run profiler regression tests
-    timeout-minutes: 30
-    run: |
-      ./tests/scripts/run_profiler_regressions.sh
-  - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-    if: ${{ failure() }}
-    with:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      owner: U03BJ1L3LUQ # Mo Memarian
-  - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-    timeout-minutes: 10
-    if: ${{ !cancelled() }}
-    with:
-      prefix: "test_reports_"
-  - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-    if: always()
-
 jobs:
+  .profiler-job-template:
+    # Anchor the entire container block
+    container: &container-config
+      image: ${{ inputs.docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: wormhole_b0
+        LOGURU_LEVEL: INFO
+        PROFILER_SCRIPTS_ROOT: /work/tt_metal/tools/profiler
+        PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
+        PROFILER_ARTIFACTS_DIR: /work/generated/profiler
+        PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
+        DONT_USE_VIRTUAL_ENVIRONMENT: 1
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf:ro
+      options: "--device /dev/tenstorrent"
+    
+    # Anchor the defaults block
+    defaults: &defaults-config
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+
+    # Anchor the entire sequence of steps
+    steps: &steps-sequence
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run profiler regression tests
+        timeout-minutes: 30
+        run: |
+          ./tests/scripts/run_profiler_regressions.sh
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U03BJ1L3LUQ # Mo Memarian
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
   profiler-tests-t3000:
     name: "profiler tests t3000"
     if: inputs.topology == 'config-t3000'
     runs-on: tt-ubuntu-2204-N300-llmbox-stable
-    <<: *common-job-config
+    strategy: 
+      fail-fast: false
+    container: *container-config
+    defaults: *defaults-config
+    steps: *steps-sequence
 
   profiler-tests-galaxy:
     name: "profiler tests galaxy"
@@ -84,5 +90,8 @@ jobs:
       - arch-wormhole_b0
       - ${{ inputs.topology }}
       - ${{ inputs.extra-tag }}
-    <<: *common-job-config
-
+    strategy: 
+      fail-fast: false
+    container: *container-config
+    defaults: *defaults-config
+    steps: *steps-sequence

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -81,7 +81,7 @@ jobs:
     name: "profiler tests t3000"
     if: inputs.topology == 'config-t3000'
     runs-on: tt-ubuntu-2204-N300-llmbox-stable
-    strategy: 
+    strategy:
       fail-fast: false
     container: *container-config
     defaults: *defaults-config

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -21,7 +21,8 @@ on:
         default: "config-t3000"
 
 jobs:
-  .profiler-job-template:
+  profiler_job_template:
+    if: false
     runs-on: ubuntu-latest
     # Anchor the entire container block
     container: &container-config

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -21,10 +21,12 @@ on:
         default: "config-t3000"
 
 jobs:
+  # create a template job that is not actually run hence the if: false
   profiler_job_template:
     if: false
+    # runs-on is required by GH even for template jobs. This is never used
     runs-on: ubuntu-latest
-    # Anchor the entire container block
+    # Anchor the container block
     container: &container-config
       image: ${{ inputs.docker-image }}
       env:
@@ -50,7 +52,7 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
 
-    # Anchor the entire sequence of steps
+    # Anchor the steps
     steps: &steps-sequence
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
@@ -97,4 +99,3 @@ jobs:
     container: *container-config
     defaults: *defaults-config
     steps: *steps-sequence
-    

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -90,7 +90,7 @@ jobs:
   profiler-tests-galaxy:
     name: "profiler tests galaxy"
     if: inputs.topology == 'topology-6u'
-    runs-on: 
+    runs-on:
       - arch-wormhole_b0
       - ${{ inputs.topology }}
       - ${{ inputs.extra-tag }}

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   .profiler-job-template:
+    runs-on: ubuntu-latest
     # Anchor the entire container block
     container: &container-config
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -21,58 +21,68 @@ on:
         type: string
         default: "config-t3000"
 
+x-common-job-config: &common-job-config
+  strategy: 
+    fail-fast: false
+  container:
+    image: ${{ inputs.docker-image }}
+    env:
+      TT_METAL_HOME: /work
+      PYTHONPATH: /work
+      LD_LIBRARY_PATH: /work/build/lib
+      ARCH_NAME: wormhole_b0
+      LOGURU_LEVEL: INFO
+      PROFILER_SCRIPTS_ROOT: /work/tt_metal/tools/profiler
+      PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
+      PROFILER_ARTIFACTS_DIR: /work/generated/profiler
+      PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
+      DONT_USE_VIRTUAL_ENVIRONMENT: 1
+    volumes:
+      - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+      - /dev/hugepages-1G:/dev/hugepages-1G
+      - /mnt/MLPerf:/mnt/MLPerf:ro
+    options: "--device /dev/tenstorrent"
+  defaults:
+    run:
+      shell: bash
+      working-directory: /work # https://github.com/actions/runner/issues/878
+  steps:
+  - name: ⬇️  Setup Job
+    uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+    timeout-minutes: 10
+    with:
+      build-artifact-name: ${{ inputs.build-artifact-name }}
+      wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+  - name: Run profiler regression tests
+    timeout-minutes: 30
+    run: |
+      ./tests/scripts/run_profiler_regressions.sh
+  - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+    if: ${{ failure() }}
+    with:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      owner: U03BJ1L3LUQ # Mo Memarian
+  - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+    timeout-minutes: 10
+    if: ${{ !cancelled() }}
+    with:
+      prefix: "test_reports_"
+  - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+    if: always()
+
 jobs:
-  profiler-tests:
-    strategy:
-      fail-fast: false
-    name: "profiler tests"
-    # Profiler tests run on CIv2 for t3000 and CIv1 for all others (just WH 6U for now)
-    runs-on: ${{ 
-      inputs.topology == 'config-t3000' && 'tt-ubuntu-2204-N300-llmbox-stable' ||
-      fromJSON(format('["arch-wormhole_b0", "{0}", "{1}"]', inputs.topology, inputs.extra-tag))
-    }}
-    container:
-      image: ${{ inputs.docker-image }}
-      env:
-        TT_METAL_HOME: /work
-        PYTHONPATH: /work
-        LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: wormhole_b0
-        LOGURU_LEVEL: INFO
-        PROFILER_SCRIPTS_ROOT: /work/tt_metal/tools/profiler
-        PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
-        PROFILER_ARTIFACTS_DIR: /work/generated/profiler
-        PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
-        DONT_USE_VIRTUAL_ENVIRONMENT: 1
-      volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
-    steps:
-      - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-        timeout-minutes: 10
-        with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run profiler regression tests
-        timeout-minutes: 30
-        run: |
-          ./tests/scripts/run_profiler_regressions.sh
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U03BJ1L3LUQ # Mo Memarian
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
-          prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
+  profiler-tests-t3000:
+    name: "profiler tests t3000"
+    if: inputs.topology == 'config-t3000'
+    runs-on: tt-ubuntu-2204-N300-llmbox-stable
+    <<: *common-job-config
+
+  profiler-tests-galaxy:
+    name: "profiler tests galaxy"
+    if: inputs.topology == 'topology-6u'
+    runs-on: 
+      - arch-wormhole_b0
+      - ${{ inputs.topology }}
+      - ${{ inputs.extra-tag }}
+    <<: *common-job-config
+


### PR DESCRIPTION
Moves T3k profiler pipeline to run on CIv2.

Also tries out the newly supported yaml anchors in GHA for workflow file reusability 
https://github.com/actions/runner/issues/1182

- [ ] T3k profiler https://github.com/tenstorrent/tt-metal/actions/runs/17737097222