### PR TITLE
[Skip CI] #0: Update perf numbers in the README

### DIFF
--- a/models/demos/mobilenetv2/README.md
+++ b/models/demos/mobilenetv2/README.md
@@ -22,14 +22,14 @@ pytest models/demos/mobilenetv2/tests/pcc/test_mobilenetv2.py::test_mobilenetv2
 
 ### Performant Model with Trace+2CQ
 #### Single Device (BS=10):
-- End-2-end perf is 2470 FPS
+- End-2-end perf is 3009 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 ```
 pytest models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py:test_mobilenetv2_e2e
 ```
 
 #### Multi Device (DP=2, n300):
-- End-2-end perf is 4933 FPS
+- End-2-end perf is 5146 FPS
 
 ```
 pytest models/demos/mobilenetv2/tests/perf/test_perf_e2e_mobilenetv2.py::test_mobilenetv2_e2e_dp

--- a/models/demos/ufld_v2/README.md
+++ b/models/demos/ufld_v2/README.md
@@ -23,7 +23,7 @@ Use the following command to run the model:
 ### Performant Model with Trace+2CQ
 
 #### Single Device (BS=1):
-- end-2-end perf is `285` FPS
+- end-2-end perf is `365` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
   ```
   pytest --disable-warnings models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py::test_ufldv2_e2e_performant

--- a/models/demos/vgg_unet/README.md
+++ b/models/demos/vgg_unet/README.md
@@ -28,14 +28,14 @@ Use the following command to run the e2e perf with trace 2cq:
 ```sh
 pytest models/demos/vgg_unet/tests/perf/test_e2e_performant.py::test_vgg_unet_e2e
 ```
-- end-2-end perf with Trace+2CQs is 90 FPS
+- end-2-end perf with Trace+2CQs is 183 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 #### Multi Device (DP=2, n300):
 Use the following command to run the e2e perf with trace 2cq:
 ```sh
 pytest models/demos/vgg_unet/tests/perf/test_e2e_performant.py::test_vgg_unet_e2e_dp
 ```
-- end-2-end perf with Trace+2CQs is 158 FPS
+- end-2-end perf with Trace+2CQs is 303 FPS
 
 ### Performant Demo with Trace+2CQ
 #### Single Device (BS=1):

--- a/models/demos/yolov10x/README.md
+++ b/models/demos/yolov10x/README.md
@@ -21,17 +21,17 @@ pytest --disable-warnings models/demos/yolov10x/tests/pcc/test_ttnn_yolov10x.py:
 
 ### Model Performant with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `42` FPS.
+- For `640x640`, end-2-end perf is `48` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
   ```bash
-  pytest --disable-warnings models/demos/yolov10x/tests/test_e2e_performant.py::test_e2e_performant
+  pytest --disable-warnings models/demos/yolov10x/tests/perf/test_e2e_performant.py::test_e2e_performant
   ```
 
 #### Multi Device (DP=2, n300):
 - For `640x640`, end-2-end perf is `83` FPS.
 
   ```bash
-  pytest --disable-warnings models/demos/yolov10x/tests/test_e2e_performant.py::test_e2e_performant_dp
+  pytest --disable-warnings models/demos/yolov10x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp
   ```
 
 ### Demo

--- a/models/demos/yolov11/README.md
+++ b/models/demos/yolov11/README.md
@@ -19,14 +19,14 @@ pytest --disable-warnings models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py::t
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `145` FPS :
+- For `640x640`, end-2-end perf is `179` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 ```
 pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
 
 ### Performant Demo with Trace+2CQ
 #### Multi Device (DP=2, N300):
-- For `640x640`, end-2-end perf is `275` FPS :
+- For `640x640`, end-2-end perf is `290` FPS :
   ```
   pytest --disable-warnings models/demos/yolov11/tests/test_e2e_performant.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov12x/README.md
+++ b/models/demos/yolov12x/README.md
@@ -68,7 +68,7 @@ pytest --disable-warnings models/demos/yolov12x/tests/pcc/test_ttnn_yolov12x.py:
 - Use the following command to run demo for `640x640` resolution :
 
   ```bash
-  pytest --disable-warnings models/demos/yolov11/demo/demo.py::test_demo_dp
+  pytest --disable-warnings models/demos/yolov12x/demo/demo.py::test_demo_dp
   ```
 
 - To use a different image(s) for demo, replace your image(s) in the image path `models/demos/yolov12x/demo/images`.

--- a/models/demos/yolov7/README.md
+++ b/models/demos/yolov7/README.md
@@ -19,13 +19,13 @@ pytest --disable-warnings models/demos/yolov7/tests/pcc/test_ttnn_yolov7.py
 
 ### Model Performant with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `70` FPS.
+- For `640x640`, end-2-end perf is `109` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```bash
   pytest --disable-warnings models/demos/yolov7/tests/perf/test_e2e_performant.py::test_e2e_performant
   ```
 
 #### Multi Device (DP=2, N300):
-- For `640x640`, end-2-end perf is `134` FPS.
+- For `640x640`, end-2-end perf is `188` FPS.
 
   ```bash
   pytest --disable-warnings models/demos/yolov7/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov8s/README.md
+++ b/models/demos/yolov8s/README.md
@@ -21,15 +21,15 @@ pytest --disable-warnings models/demos/yolov8s/tests/pcc/test_yolov8s.py::test_y
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- end-2-end perf is `175` FPS
+- end-2-end perf is `211` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 ```
 pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py
 ```
 
 #### Multi Device (DP=2, n300):
-- end-2-end perf is `370` FPS
+- end-2-end perf is `355` FPS
 ```
-pytest --disable-warnings models/demos/yolov8s/tests/test_e2e_performant.py::test_run_yolov8s_trace_2cqs_dp_inference[wormhole_b0-1-device_params0]
+pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py::test_run_yolov8s_trace_2cqs_dp_inference[wormhole_b0-1-device_params0]
 ```
 
 ### Demo

--- a/models/demos/yolov8x/README.md
+++ b/models/demos/yolov8x/README.md
@@ -19,13 +19,13 @@ pytest --disable-warnings models/demos/yolov8x/tests/pcc/test_yolov8x.py::test_y
 
 ## Model performant running with Trace+2CQ
 ### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `62` FPS:
+- For `640x640`, end-2-end perf is `66` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```
   pytest --disable-warnings models/demos/yolov8x/tests/perf/test_e2e_performant.py::test_run_yolov8x_performant
   ```
 
 ### Multi Device (DP=2, n300):
-- For `640x640`, end-2-end perf is `121` FPS:
+- For `640x640`, end-2-end perf is `124` FPS:
   ```
   pytest --disable-warnings models/demos/yolov8x/tests/perf/test_e2e_performant.py::test_run_yolov8x_performant_dp
   ```


### PR DESCRIPTION
### Problem description
Perf Numbers in the README are outdated.

### What's changed
Updated e2e perf numbers in the README with latest numbers on N150 (WH)