### PR TITLE
[skip ci] modernize-use-nullptr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -151,7 +151,6 @@ Checks: >
   -modernize-use-integer-sign-comparison,
   -modernize-use-integer-sign-comparison,
   -modernize-use-nodiscard,
-  -modernize-use-nullptr,
   -modernize-use-ranges,
   -modernize-use-starts-ends-with,
   -modernize-use-std-numbers,

--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -26,13 +26,13 @@ constexpr std::false_type always_false{};
 template <class T>
 T parse(const std::string& s) {
     if constexpr (std::is_same_v<T, std::uint32_t>) {
-        return std::stoul(s, 0, 0);
+        return std::stoul(s, nullptr, 0);
     } else if constexpr (std::is_same_v<T, int>) {
-        return std::stoi(s, 0, 0);
+        return std::stoi(s, nullptr, 0);
     } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-        return std::stoull(s, 0, 0);
+        return std::stoull(s, nullptr, 0);
     } else if constexpr (std::is_same_v<T, bool>) {
-        return static_cast<bool>(std::stoi(s, 0, 0));
+        return static_cast<bool>(std::stoi(s, nullptr, 0));
     } else if constexpr (std::is_same_v<T, std::string>) {
         return s;
     } else {
@@ -73,7 +73,7 @@ inline std::uint32_t get_command_option_uint32(
     } else {
         param = get_command_option(test_args, option);
     }
-    return std::stoul(param, 0, 0);
+    return std::stoul(param, nullptr, 0);
 }
 
 inline std::int32_t get_command_option_int32(
@@ -86,7 +86,7 @@ inline std::int32_t get_command_option_int32(
     } else {
         param = get_command_option(test_args, option);
     }
-    return std::stoi(param, 0, 0);
+    return std::stoi(param, nullptr, 0);
 }
 
 inline double get_command_option_double(
@@ -99,7 +99,7 @@ inline double get_command_option_double(
     } else {
         param = get_command_option(test_args, option);
     }
-    return std::stod(param, 0);
+    return std::stod(param, nullptr);
 }
 
 inline bool has_command_option(const std::vector<std::string>& test_args, const std::string& option) {
@@ -138,7 +138,7 @@ inline std::tuple<std::uint32_t, std::vector<std::string>> get_command_option_ui
     } else {
         std::tie(param, remaining_args) = get_command_option_and_remaining_args(test_args, option);
     }
-    return {std::stoul(param, 0, 0), remaining_args};
+    return {std::stoul(param, nullptr, 0), remaining_args};
 }
 
 inline std::tuple<std::uint64_t, std::vector<std::string>> get_command_option_uint64_and_remaining_args(
@@ -154,7 +154,7 @@ inline std::tuple<std::uint64_t, std::vector<std::string>> get_command_option_ui
         std::tie(param, remaining_args) = get_command_option_and_remaining_args(test_args, option);
     }
 
-    return {std::stoull(param, 0, 0), remaining_args};
+    return {std::stoull(param, nullptr, 0), remaining_args};
 }
 
 inline std::tuple<std::int32_t, std::vector<std::string>> get_command_option_int32_and_remaining_args(
@@ -169,7 +169,7 @@ inline std::tuple<std::int32_t, std::vector<std::string>> get_command_option_int
     } else {
         std::tie(param, remaining_args) = get_command_option_and_remaining_args(test_args, option);
     }
-    return {std::stoi(param, 0, 0), remaining_args};
+    return {std::stoi(param, nullptr, 0), remaining_args};
 }
 
 inline std::tuple<double, std::vector<std::string>> get_command_option_double_and_remaining_args(
@@ -184,7 +184,7 @@ inline std::tuple<double, std::vector<std::string>> get_command_option_double_an
     } else {
         std::tie(param, remaining_args) = get_command_option_and_remaining_args(test_args, option);
     }
-    return {std::stod(param, 0), remaining_args};
+    return {std::stod(param, nullptr), remaining_args};
 }
 
 inline std::tuple<bool, std::vector<std::string>> has_command_option_and_remaining_args(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -532,7 +532,7 @@ int main(int argc, char** argv) {
         }
 
         DeviceData device_data(
-            device, all_workers_g, l1_data_addr, dram_data_addr, 0, paged_test, DRAM_DATA_SIZE_WORDS);
+            device, all_workers_g, l1_data_addr, dram_data_addr, nullptr, paged_test, DRAM_DATA_SIZE_WORDS);
 
         if (is_paged_dram_test() && debug_g) {
             initialize_dram_banks(device);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
 
         // Application Setup
-        srand(time(0));
+        srand(time(nullptr));
         uint32_t dram_addr =
             tt::tt_metal::MetalContext::instance().hal().get_dev_addr(tt::tt_metal::HalDramMemAddrType::UNRESERVED);
         uint32_t dram_channel = rand() % 8;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
 
         // Application Setup
-        srand(time(0));
+        srand(time(nullptr));
         size_t core_x = rand() % 8;
         size_t core_y = rand() % 8;
         log_info(LogTest, "Target core (x,y) = ({},{})", core_x, core_y);

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -64,7 +64,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     void** array = (void**)malloc((sizeof(void*) * size));
     size_t s = ::backtrace(array, size);
     char** strings = backtrace_symbols(array, s);
-    if (strings == NULL) {
+    if (strings == nullptr) {
         std::cout << "backtrace_symbols error." << std::endl;
         return bt;
     }

--- a/tt_metal/common/env_lib.hpp
+++ b/tt_metal/common/env_lib.hpp
@@ -23,15 +23,15 @@ T parse_env(const char* env_name, const T& default_value) {
     }
 
     if constexpr (std::is_same_v<T, bool>) {
-        return static_cast<bool>(std::stoi(env_value, 0, 0));
+        return static_cast<bool>(std::stoi(env_value, nullptr, 0));
     } else if constexpr (std::is_same_v<T, std::string>) {
         return std::string{env_value};
     } else if constexpr (std::is_same_v<T, int>) {
-        return std::stoi(env_value, 0, 0);
+        return std::stoi(env_value, nullptr, 0);
     } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-        return std::stoul(env_value, 0, 0);
+        return std::stoul(env_value, nullptr, 0);
     } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-        return std::stoull(env_value, 0, 0);
+        return std::stoull(env_value, nullptr, 0);
     } else {
         static_assert(false_type_t<T>, "No specialization for type");
     }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -288,7 +288,7 @@ void Hal::initialize_bh() {
         uint32_t mailbox_base =
             MEM_SYSENG_ETH_MAILBOX_ADDR + (mailbox_index * (MEM_SYSENG_ETH_MAILBOX_NUM_ARGS + 1) * sizeof(uint32_t));
         return mailbox_base + offsetof(blackhole::EthFwMailbox, arg) +
-               (arg_index * sizeof(((blackhole::EthFwMailbox*)0)->arg[0]));
+               (arg_index * sizeof(((blackhole::EthFwMailbox*)nullptr)->arg[0]));
     };
 
     this->device_features_func_ = [](DispatchFeature feature) -> bool {

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -61,7 +61,7 @@ static void print_stack_trace() {
 
     int size = backtrace(array, 15);
     char** strings = backtrace_symbols(array, size);
-    if (strings != NULL) {
+    if (strings != nullptr) {
         fprintf(stderr, "Obtained %d stack frames.\n", size);
         for (int i = 0; i < size; i++) {
             fprintf(stderr, "%s\n", strings[i]);

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -62,7 +62,7 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional_valu
 
 std::string graph_demangle(const std::string_view name) {
     int status = -4;
-    char* res = abi::__cxa_demangle(name.data(), NULL, NULL, &status);
+    char* res = abi::__cxa_demangle(name.data(), nullptr, nullptr, &status);
     const char* const demangled_name = (status == 0) ? res : name.data();
     std::string ret_val(demangled_name);
     free(res);  // NOLINT(cppcoreguidelines-no-malloc)

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -16,7 +16,7 @@ namespace ttnn::operations::bernoulli {
 using namespace tt;
 using namespace tt::tt_metal;
 
-std::mt19937 rng(std::time(0));
+std::mt19937 rng(std::time(nullptr));
 std::uniform_int_distribution d(1, 1 << 20);
 
 uint32_t get_random_seed() { return d(rng); }

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
@@ -148,8 +148,8 @@ void ExampleMultipleReturnDeviceOperation::SingleCore::override_runtime_argument
     const auto& output_tensor2 = tensor_return_value.at(1);
 
     auto src_buffer = input_tensor.buffer();
-    auto dst_buffer1 = output_tensor1.has_value() ? output_tensor1.value().buffer() : 0;
-    auto dst_buffer2 = output_tensor2.has_value() ? output_tensor2.value().buffer() : 0;
+    auto dst_buffer1 = output_tensor1.has_value() ? output_tensor1.value().buffer() : nullptr;
+    auto dst_buffer2 = output_tensor2.has_value() ? output_tensor2.value().buffer() : nullptr;
 
     {
         auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, CoreCoord{0, 0});

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
@@ -484,8 +484,8 @@ operation::ProgramWithCallbacks paged_tiled_fused_update_cache_multi_core(
             auto dst1_buffer = input_tensors.at(0).buffer();
             auto dst2_buffer = input_tensors.at(2).buffer();
 
-            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
-            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
+            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : nullptr;
+            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : nullptr;
             auto index_tensor_addr = use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             auto page_table_tensor_addr = is_paged_cache ? optional_input_tensors.at(1).value().buffer()->address() : 0;
 
@@ -976,8 +976,8 @@ operation::ProgramWithCallbacks paged_row_major_fused_update_cache_multi_core(
             const auto dst1_buffer = input_tensors.at(0).buffer();
             const auto dst2_buffer = input_tensors.at(2).buffer();
 
-            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : 0;
-            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : 0;
+            auto index_tensor_buffer = use_index_tensor ? optional_input_tensors.at(0).value().buffer() : nullptr;
+            auto page_table_buffer = is_paged_cache ? optional_input_tensors.at(1).value().buffer() : nullptr;
             const auto index_tensor_addr =
                 use_index_tensor ? optional_input_tensors.at(0).value().buffer()->address() : 0;
             const auto page_table_tensor_addr =

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
@@ -233,7 +233,7 @@ void MorehSgdOperation::ProgramFactory::override_runtime_arguments(
     auto param_in_buffer = tensor_args.param_in.buffer();
     auto grad_buffer = tensor_args.grad.buffer();
     auto momentum_buffer_in_buffer =
-        tensor_args.momentum_buffer_in.has_value() ? tensor_args.momentum_buffer_in->buffer() : 0;
+        tensor_args.momentum_buffer_in.has_value() ? tensor_args.momentum_buffer_in->buffer() : nullptr;
 
     auto param_out_buffer = tensor_return_value.at(0)->buffer();
     auto momentum_buffer_out_buffer = tensor_return_value.at(1)->buffer();


### PR DESCRIPTION
### Ticket
#22758 
Closes #28239 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nullptr.html

This is a minor check that keeps our code base consistently using modern constructs for nullptr ... helping the reader infer that they are dealing with pointers.

### What's changed
- Enable Check
- Run FIXITs

### Checklist
- PR Gate + Merge Gate should be good enough
