### PR TITLE
Support for Physical Discovery on QuietBox systems

### DIFF
--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -33,34 +33,54 @@ std::string get_mobo_name() {
     return motherboard;
 }
 
-std::pair<TrayID, ASICLocation> get_asic_position(
-    chip_id_t chip_id, const std::set<uint32_t, std::greater<uint32_t>>& sorted_pcie_slots) {
+TrayID get_tray_id_for_chip(chip_id_t chip_id, const std::string& mobo_name) {
+    std::vector<uint16_t> ordered_bus_ids;
+    if (mobo_name == "SIENAD8-2L2T") {
+        ordered_bus_ids = {0xc1, 0x01, 0x41, 0x42};
+    } else if (mobo_name == "X12DPG-QT6") {
+        ordered_bus_ids = {0xb1, 0xca, 0x31, 0x4b};
+    } else {
+        return TrayID{0};
+    }
+    auto bus_id = tt::tt_metal::MetalContext::instance().get_cluster().get_bus_id(chip_id);
+    auto tray_id =
+        std::distance(ordered_bus_ids.begin(), std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id)) + 1;
+    return TrayID{tray_id};
+}
+
+std::pair<TrayID, ASICLocation> get_asic_position(chip_id_t chip_id) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto cluster_desc = cluster.get_cluster_desc();
     if (cluster_desc->get_board_type(chip_id) == BoardType::UBB) {
+        const std::string ubb_mobo_name = "S7T-MB";
+
+        TT_FATAL(get_mobo_name() == ubb_mobo_name, "UBB systems must use S7T-MB motherboard.");
         auto ubb_id = tt::tt_fabric::get_ubb_id(chip_id);
         return {TrayID{ubb_id.tray_id}, ASICLocation{ubb_id.asic_id}};
-    } else if (cluster_desc->get_board_type(chip_id) == BoardType::N300) {
-        // Derive NID based on the tunnel depth for N300 systems
-        auto mmio_device = cluster.get_associated_mmio_device(chip_id);
-        auto tunnels = cluster.get_tunnels_from_mmio_device(mmio_device);
-        ASICLocation asic_location;
-        for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
-            const auto& devices_on_tunnel = tunnels[tunnel];
-            auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
-            if (device_it != devices_on_tunnel.end()) {
-                asic_location = ASICLocation{device_it - devices_on_tunnel.begin()};
-            }
-        }
-        // Derive Tray ID based on the Physical PCIe slot for N300 systems
-        uint32_t tray_id =
-            1 + std::distance(
-                    sorted_pcie_slots.begin(), sorted_pcie_slots.find(cluster.get_physical_slot(chip_id).value()));
-        return {TrayID{tray_id}, asic_location};
     } else {
-        TT_THROW("Unrecognized board type. Cannot determine asic position.");
+        auto tray_id = get_tray_id_for_chip(chip_id, get_mobo_name());
+        ASICLocation asic_location;
+        if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
+            // Derive ASIC Location based on the tunnel depth for Wormhole systems
+            // TODO: Remove this once UMD populates the ASIC Location for WH systems.
+            auto mmio_device = cluster.get_associated_mmio_device(chip_id);
+            auto tunnels = cluster.get_tunnels_from_mmio_device(mmio_device);
+            for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
+                const auto& devices_on_tunnel = tunnels[tunnel];
+                auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
+                if (device_it != devices_on_tunnel.end()) {
+                    asic_location = ASICLocation{device_it - devices_on_tunnel.begin()};
+                    break;
+                }
+            }
+        } else if (cluster.arch() == tt::ARCH::BLACKHOLE) {
+            // Query ASIC Location from the Cluster Descriptor for BH.
+            asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
+        } else {
+            TT_THROW("Unrecognized Architecture. Cannot determine asic location.");
+        }
+        return {tray_id, asic_location};
     }
-    return {};
 }
 
 struct EthEndpoint {
@@ -171,18 +191,13 @@ void PhysicalSystemDescriptor::run_local_discovery() {
     host_to_mobo_name_[hostname] = get_mobo_name();
     host_to_rank_[hostname] = my_rank;
 
-    std::set<uint32_t, std::greater<uint32_t>> sorted_pcie_slots = {};
     auto& asic_graph = system_graph_.asic_connectivity_graph[hostname];
     auto& exit_nodes = exit_node_connection_table_[hostname];
-
-    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
-        sorted_pcie_slots.insert(cluster.get_physical_slot(chip_id).value());
-    }
 
     for (const auto& [src, conn] : eth_connections) {
         auto src_unique_id = AsicID{chip_unique_ids.at(src)};
         // Populate ASIC Descriptor with Physical Information
-        auto [tray_id, asic_location] = get_asic_position(src, sorted_pcie_slots);
+        auto [tray_id, asic_location] = get_asic_position(src);
         asic_descriptors_[src_unique_id] =
             ASICDescriptor{TrayID{tray_id}, asic_location, cluster_desc->get_board_type(src), src_unique_id, hostname};
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -44,12 +44,9 @@ TrayID get_tray_id_for_chip(chip_id_t chip_id, const std::string& mobo_name) {
     }
     const auto& ordered_bus_ids = mobo_to_bus_ids.at(mobo_name);
     auto bus_id = tt::tt_metal::MetalContext::instance().get_cluster().get_bus_id(chip_id);
-    TT_FATAL(
-        std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id) != ordered_bus_ids.end(),
-        "Bus ID {} not found.",
-        bus_id);
-    auto tray_id =
-        std::distance(ordered_bus_ids.begin(), std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id)) + 1;
+    auto bus_id_it = std::find(ordered_bus_ids.begin(), ordered_bus_ids.end(), bus_id);
+    TT_FATAL(bus_id_it != ordered_bus_ids.end(), "Bus ID {} not found.", bus_id);
+    auto tray_id = std::distance(ordered_bus_ids.begin(), bus_id_it) + 1;
     return TrayID{tray_id};
 }
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
  - Current Tray ID derivation in Physical Discover only works for WH N300 and 6U systems
  - We need to support more systems and architectures as part of BH QB bringup

### What's changed
  - Derive Tray ID from Bus ID for supported Mobos
  - This is more robust than the previous approach which assumed that derived tray ID based on board type (overfit for 6U and N300)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes