### PR TITLE
ci: don't run ttsim workflow in case of forks

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -178,9 +178,10 @@ jobs:
   ttsim-integration-tests:
     needs: [ build, find-changed-files ]
     if: ${{
-        github.ref_name == 'main' ||
+        (github.ref_name == 'main' ||
         needs.find-changed-files.outputs.cmake-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-metalium-changed == 'true'
+        needs.find-changed-files.outputs.tt-metalium-changed == 'true') &&
+        github.event.pull_request.head.repo.fork == false
       }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   ttsim-integration:
-    if: github.repository == 'tenstorrent/tt-metal'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   ttsim-integration:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   ttsim-integration:
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Ticket
None

### Problem description
We need to disable running ttsim workflow in case of forks. Previous try didn't fix the issue in case of Jason Davies' PR. See here for more details: https://github.com/tenstorrent/tt-metal/pull/21623
We're already using the same condition in tt-llk to prevent some workflows from running on PRs from forks: https://github.com/tenstorrent/tt-llk/blob/f36ddd9c5594d88409a4ec3727e2ec894846343c/.github/workflows/on-pr.yml#L79

### What's changed
`github.repository` is always the repository where the workflow runs (here: `tenstorrent/tt-metal`).
`github.event.pull_request.head.repo.full_name` is the repository that owns the PR's source branch.

In other words:
- Internal PR (branch inside `tenstorrent/tt-metal`)
`head.repo.full_name == "tenstorrent/tt-metal"` -> condition is true and job runs.

- Fork PR (branch inside e.g. `user123/tt-metal`)
`head.repo.full_name == "user123/tt-metal"`,
`github.repository == "tenstorrent/tt-metal"` -> condition is false and job is skipped.