### PR TITLE
Yolov4 640X640 opt 

### DIFF
--- a/models/demos/yolo_eval/README.md
+++ b/models/demos/yolo_eval/README.md
@@ -7,7 +7,7 @@
 ### The below observations are for ttnn_model vs dataset(ground truth data):
 
 The following model is evaluated (mAPval 50-95) for `500 samples` :-
--   YOLOv4 (320x320 resolution) - **0.7562**
+-   YOLOv4 (320x320 resolution) - **0.6834**
 -   YOLOv4 (640x640 resolution) - **0.7535**
 -   YOLOv8s_World (640x640 resolution) - **0.7338**
 -   YOLOv8x (640x640 resolution) - **0.7254**

--- a/models/demos/yolov4/README.md
+++ b/models/demos/yolov4/README.md
@@ -25,21 +25,21 @@ pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4.py::test_yolov4[1-pretrain
 #### Single Device (BS=1):
 - For `320x320`, end-2-end perf is `156` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```
-  models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution0-103-1-act_dtype0-weight_dtype0-device_params0]
+  pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution0-125-1-act_dtype0-weight_dtype0-device_params0]
   ```
-- For `640x640`, end-2-end perf is `74` FPS  (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640`, end-2-end perf is `79` FPS  (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```
-  models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution1-46-1-act_dtype0-weight_dtype0-device_params0]
+  pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant[resolution1-65-1-act_dtype0-weight_dtype0-device_params0]
   ```
 
 #### Multi Device (DP=2, N300):
-- For `320x320`, end-2-end perf is `223` FPS
+- For `320x320`, end-2-end perf is `225` FPS
   ```
   pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant_dp[wormhole_b0-resolution0-103-1-act_dtype0-weight_dtype0-device_params0]
   ```
-- For `640x640`, end-2-end perf is `113` FPS
+- For `640x640`, end-2-end perf is `117` FPS
   ```
-  pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant_dp[wormhole_b0-resolution1-46-1-act_dtype0-weight_dtype0-device_params0]
+  pytest models/demos/yolov4/tests/perf/test_e2e_performant.py::test_e2e_performant_dp[wormhole_b0-resolution1-113-1-act_dtype0-weight_dtype0-device_params0]
   ```
 
 

--- a/models/demos/yolov4/tt/downsample4.py
+++ b/models/demos/yolov4/tt/downsample4.py
@@ -176,9 +176,8 @@ class Down4:
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
         output_tensor_left = ttnn.sharded_to_interleaved(output_tensor_left, ttnn.L1_MEMORY_CONFIG)
-        # if self.parameters.resolution[0] == 640:
-        #     output_tensor = ttnn.add(output_tensor, 0.0, dtype=ttnn.bfloat8_b)
-        #     output_tensor_left = ttnn.add(output_tensor_left, 0.0, dtype=ttnn.bfloat8_b)
+        if self.parameters.resolution[0] == 640:
+            output_tensor = ttnn.add(output_tensor, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat([output_tensor, output_tensor_left], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(output_tensor_left)
 

--- a/models/demos/yolov4/tt/head.py
+++ b/models/demos/yolov4/tt/head.py
@@ -205,6 +205,8 @@ class TtHead:
         if self.parameters.resolution[0] == 320:
             output_tensor = ttnn.add(output_tensor, 0.0, dtype=ttnn.bfloat8_b)
             outfromNeck2 = ttnn.add(outfromNeck2, 0.0, dtype=ttnn.bfloat8_b)
+        if self.parameters.resolution[0] == 640:
+            output_tensor = ttnn.add(output_tensor, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat([output_tensor, outfromNeck2], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         output_tensor = self.conv12(output_tensor)

--- a/models/demos/yolov4/tt/model_preprocessing.py
+++ b/models/demos/yolov4/tt/model_preprocessing.py
@@ -111,8 +111,7 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     if resolution == (320, 320):
@@ -124,16 +123,14 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c2["deallocate_activation"] = True
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["deallocate_activation"] = False
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c3["dtype"] = ttnn.bfloat8_b
+    conv_args.c3["dtype"] = ttnn.bfloat8_b
     conv_args.c3["num_cores_nhw"] = None
     if resolution == (640, 640):
         conv_args.c3["act_block_h"] = 1024
@@ -142,8 +139,7 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c4["deallocate_activation"] = True
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
     if resolution == (640, 640):
         conv_args.c4["act_block_h"] = 1024
@@ -152,8 +148,7 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c5["deallocate_activation"] = False
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
     if resolution == (640, 640):
         conv_args.c5["act_block_h"] = 1024
@@ -167,16 +162,14 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c6["deallocate_activation"] = True
     conv_args.c6["reshard_if_not_optimal"] = False
     conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c6["dtype"] = ttnn.bfloat8_b
+    conv_args.c6["dtype"] = ttnn.bfloat8_b
     conv_args.c6["num_cores_nhw"] = None
 
     conv_args.c7["act_block_h"] = None
     conv_args.c7["deallocate_activation"] = True
     conv_args.c7["reshard_if_not_optimal"] = False
     conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7["dtype"] = ttnn.bfloat8_b
+    conv_args.c7["dtype"] = ttnn.bfloat8_b
     conv_args.c7["num_cores_nhw"] = None
     if resolution == (640, 640):
         conv_args.c7["act_block_h"] = 1024
@@ -185,8 +178,7 @@ def _create_ds1_model_parameters(conv_args, resolution):
     conv_args.c8["deallocate_activation"] = True
     conv_args.c8["reshard_if_not_optimal"] = False
     conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c8["dtype"] = ttnn.bfloat8_b
+    conv_args.c8["dtype"] = ttnn.bfloat8_b
     conv_args.c8["num_cores_nhw"] = None
     if resolution == (640, 640):
         conv_args.c8["act_block_h"] = 1024
@@ -212,56 +204,49 @@ def _create_ds2_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c3["dtype"] = ttnn.bfloat8_b
+    conv_args.c3["dtype"] = ttnn.bfloat8_b
     conv_args.c3["num_cores_nhw"] = None
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["0"]["num_cores_nhw"] = None
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["3"]["num_cores_nhw"] = None
 
 
@@ -285,56 +270,49 @@ def _create_ds3_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = False
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c3["dtype"] = ttnn.bfloat8_b
+    conv_args.c3["dtype"] = ttnn.bfloat8_b
     conv_args.c3["num_cores_nhw"] = None
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
 
     conv_args.res["0"]["act_block_h"] = None
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["0"]["num_cores_nhw"] = None
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["3"]["num_cores_nhw"] = None
 
 
@@ -368,8 +346,7 @@ def _create_ds4_model_parameters(conv_args, resolution):
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
@@ -402,16 +379,14 @@ def _create_ds4_model_parameters(conv_args, resolution):
     conv_args.res["0"]["deallocate_activation"] = False
     conv_args.res["0"]["reshard_if_not_optimal"] = False
     conv_args.res["0"]["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["0"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["0"]["num_cores_nhw"] = None
 
     conv_args.res["3"]["act_block_h"] = None
     conv_args.res["3"]["deallocate_activation"] = True
     conv_args.res["3"]["reshard_if_not_optimal"] = False
     conv_args.res["3"]["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
+    conv_args.res["3"]["dtype"] = ttnn.bfloat8_b
     conv_args.res["3"]["num_cores_nhw"] = None
 
 
@@ -435,16 +410,14 @@ def _create_ds5_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = False
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["deallocate_activation"] = False
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
@@ -461,16 +434,14 @@ def _create_ds5_model_parameters(conv_args, resolution):
     conv_args.c4["deallocate_activation"] = False
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
 
     conv_args.res["0"]["act_block_h"] = None
@@ -514,160 +485,140 @@ def _create_neck_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = True
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["deallocate_activation"] = True
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["num_cores_nhw"] = None
 
     conv_args.c3["act_block_h"] = None
     conv_args.c3["deallocate_activation"] = True
     conv_args.c3["reshard_if_not_optimal"] = False
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c3["dtype"] = ttnn.bfloat8_b
+    conv_args.c3["dtype"] = ttnn.bfloat8_b
     conv_args.c3["num_cores_nhw"] = None
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["deallocate_activation"] = True
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
 
     conv_args.c6["act_block_h"] = None
     conv_args.c6["deallocate_activation"] = True
     conv_args.c6["reshard_if_not_optimal"] = False
     conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c6["dtype"] = ttnn.bfloat8_b
+    conv_args.c6["dtype"] = ttnn.bfloat8_b
     conv_args.c6["num_cores_nhw"] = None
 
     conv_args.c7["act_block_h"] = None
     conv_args.c7["deallocate_activation"] = False
     conv_args.c7["reshard_if_not_optimal"] = False
     conv_args.c7["shard_layout"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7["dtype"] = ttnn.bfloat8_b
+    conv_args.c7["dtype"] = ttnn.bfloat8_b
     conv_args.c7["num_cores_nhw"] = None
 
     conv_args.c7_2["act_block_h"] = None
     conv_args.c7_2["deallocate_activation"] = True
     conv_args.c7_2["reshard_if_not_optimal"] = False
     conv_args.c7_2["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7_2["dtype"] = ttnn.bfloat8_b
+    conv_args.c7_2["dtype"] = ttnn.bfloat8_b
     conv_args.c7_2["num_cores_nhw"] = None
 
     conv_args.c7_3["act_block_h"] = None
     conv_args.c7_3["deallocate_activation"] = True
     conv_args.c7_3["reshard_if_not_optimal"] = False
     conv_args.c7_3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7_3["dtype"] = ttnn.bfloat8_b
+    conv_args.c7_3["dtype"] = ttnn.bfloat8_b
     conv_args.c7_3["num_cores_nhw"] = None
 
     conv_args.c7_4["act_block_h"] = None
     conv_args.c7_4["deallocate_activation"] = True
     conv_args.c7_4["reshard_if_not_optimal"] = False
     conv_args.c7_4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7_4["dtype"] = ttnn.bfloat8_b
+    conv_args.c7_4["dtype"] = ttnn.bfloat8_b
     conv_args.c7_4["num_cores_nhw"] = None
 
     conv_args.c7_5["act_block_h"] = None
     conv_args.c7_5["deallocate_activation"] = True
     conv_args.c7_5["reshard_if_not_optimal"] = False
     conv_args.c7_5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c7_5["dtype"] = ttnn.bfloat8_b
+    conv_args.c7_5["dtype"] = ttnn.bfloat8_b
     conv_args.c7_5["num_cores_nhw"] = None
 
     conv_args.c8["act_block_h"] = None
     conv_args.c8["deallocate_activation"] = True
     conv_args.c8["reshard_if_not_optimal"] = False
     conv_args.c8["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c8["dtype"] = ttnn.bfloat8_b
+    conv_args.c8["dtype"] = ttnn.bfloat8_b
     conv_args.c8["num_cores_nhw"] = None
 
     conv_args.c8_2["act_block_h"] = None
     conv_args.c8_2["deallocate_activation"] = True
     conv_args.c8_2["reshard_if_not_optimal"] = False
     conv_args.c8_2["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c8_2["dtype"] = ttnn.bfloat8_b
+    conv_args.c8_2["dtype"] = ttnn.bfloat8_b
     conv_args.c8_2["num_cores_nhw"] = None
 
     conv_args.c9["act_block_h"] = None
     conv_args.c9["deallocate_activation"] = False
     conv_args.c9["reshard_if_not_optimal"] = False
     conv_args.c9["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c9["dtype"] = ttnn.bfloat8_b
+    conv_args.c9["dtype"] = ttnn.bfloat8_b
     conv_args.c9["num_cores_nhw"] = None
 
     conv_args.c9_2["act_block_h"] = None
     conv_args.c9_2["deallocate_activation"] = True
     conv_args.c9_2["reshard_if_not_optimal"] = False
     conv_args.c9_2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c9_2["dtype"] = ttnn.bfloat8_b
+    conv_args.c9_2["dtype"] = ttnn.bfloat8_b
     conv_args.c9_2["num_cores_nhw"] = None
 
     conv_args.c9_3["act_block_h"] = None
     conv_args.c9_3["deallocate_activation"] = True
     conv_args.c9_3["reshard_if_not_optimal"] = False
     conv_args.c9_3["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c9_3["dtype"] = ttnn.bfloat8_b
+    conv_args.c9_3["dtype"] = ttnn.bfloat8_b
     conv_args.c9_3["num_cores_nhw"] = None
 
     conv_args.c9_4["act_block_h"] = None
     conv_args.c9_4["deallocate_activation"] = True
     conv_args.c9_4["reshard_if_not_optimal"] = False
     conv_args.c9_4["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c9_4["dtype"] = ttnn.bfloat8_b
+    conv_args.c9_4["dtype"] = ttnn.bfloat8_b
     conv_args.c9_4["num_cores_nhw"] = None
 
     conv_args.c9_5["act_block_h"] = None
     conv_args.c9_5["deallocate_activation"] = True
     conv_args.c9_5["reshard_if_not_optimal"] = False
     conv_args.c9_5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c9_5["dtype"] = ttnn.bfloat8_b
+    conv_args.c9_5["dtype"] = ttnn.bfloat8_b
     conv_args.c9_5["num_cores_nhw"] = None
 
     conv_args.c10["act_block_h"] = None
     conv_args.c10["deallocate_activation"] = True
     conv_args.c10["reshard_if_not_optimal"] = False
     conv_args.c10["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c10["dtype"] = ttnn.bfloat8_b
+    conv_args.c10["dtype"] = ttnn.bfloat8_b
     conv_args.c10["num_cores_nhw"] = None
 
     conv_args.c10_2["act_block_h"] = None
     conv_args.c10_2["deallocate_activation"] = True
     conv_args.c10_2["reshard_if_not_optimal"] = False
     conv_args.c10_2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c10_2["dtype"] = ttnn.bfloat8_b
+    conv_args.c10_2["dtype"] = ttnn.bfloat8_b
     conv_args.c10_2["num_cores_nhw"] = None
 
 
@@ -693,16 +644,14 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c1["deallocate_activation"] = False
     conv_args.c1["reshard_if_not_optimal"] = True
     conv_args.c1["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c1["dtype"] = ttnn.bfloat8_b
+    conv_args.c1["dtype"] = ttnn.bfloat8_b
     conv_args.c1["num_cores_nhw"] = None
 
     conv_args.c2["act_block_h"] = None
     conv_args.c2["deallocate_activation"] = True
     conv_args.c2["reshard_if_not_optimal"] = False
     conv_args.c2["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-    if resolution == (320, 320):
-        conv_args.c2["dtype"] = ttnn.bfloat8_b
+    conv_args.c2["dtype"] = ttnn.bfloat8_b
     conv_args.c2["out_channels"] = 256
     conv_args.c2["num_cores_nhw"] = None
 
@@ -710,32 +659,28 @@ def _create_head_model_parameters(conv_args, resolution):
     conv_args.c3["deallocate_activation"] = False
     conv_args.c3["reshard_if_not_optimal"] = True
     conv_args.c3["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c3["dtype"] = ttnn.bfloat8_b
+    conv_args.c3["dtype"] = ttnn.bfloat8_b
     conv_args.c3["num_cores_nhw"] = None
 
     conv_args.c4["act_block_h"] = None
     conv_args.c4["deallocate_activation"] = True
     conv_args.c4["reshard_if_not_optimal"] = False
     conv_args.c4["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c4["dtype"] = ttnn.bfloat8_b
+    conv_args.c4["dtype"] = ttnn.bfloat8_b
     conv_args.c4["num_cores_nhw"] = None
 
     conv_args.c5["act_block_h"] = None
     conv_args.c5["deallocate_activation"] = True
     conv_args.c5["reshard_if_not_optimal"] = False
     conv_args.c5["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c5["dtype"] = ttnn.bfloat8_b
+    conv_args.c5["dtype"] = ttnn.bfloat8_b
     conv_args.c5["num_cores_nhw"] = None
 
     conv_args.c6["act_block_h"] = None
     conv_args.c6["deallocate_activation"] = True
     conv_args.c6["reshard_if_not_optimal"] = False
     conv_args.c6["shard_layout"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
-    if resolution == (320, 320):
-        conv_args.c6["dtype"] = ttnn.bfloat8_b
+    conv_args.c6["dtype"] = ttnn.bfloat8_b
     conv_args.c6["num_cores_nhw"] = None
 
     conv_args.c7["act_block_h"] = None
@@ -753,7 +698,6 @@ def _create_head_model_parameters(conv_args, resolution):
     if resolution == (320, 320):
         conv_args.c8["dtype"] = ttnn.bfloat8_b
     conv_args.c8["num_cores_nhw"] = None
-
     conv_args.c9["act_block_h"] = None
     conv_args.c9["deallocate_activation"] = False
     conv_args.c9["reshard_if_not_optimal"] = False

--- a/models/demos/yolov4/tt/neck.py
+++ b/models/demos/yolov4/tt/neck.py
@@ -385,10 +385,7 @@ class TtNeck:
         output_tensor = self.conv7_2(outDowSample5)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
-        if self.parameters.resolution[0] == 320:
-            output_tensor_upsample_1 = ttnn.add(output_tensor_upsample_1, 0.0, dtype=ttnn.bfloat8_b)
-        if self.parameters.resolution[0] == 640:
-            output_tensor_upsample_1 = ttnn.add(output_tensor_upsample_1, 0.0, dtype=ttnn.bfloat8_b)
+        output_tensor_upsample_1 = ttnn.add(output_tensor_upsample_1, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat(
             [output_tensor, output_tensor_upsample_1], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG
         )
@@ -498,10 +495,7 @@ class TtNeck:
         output_tensor = self.conv9_2(outDowSample3)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
-        if self.parameters.resolution[0] == 320:
-            output_tensor_upsample_2 = ttnn.add(output_tensor_upsample_2, 0.0, dtype=ttnn.bfloat8_b)
-        if self.parameters.resolution[0] == 640:
-            output_tensor_upsample_2 = ttnn.add(output_tensor_upsample_2, 0.0, dtype=ttnn.bfloat8_b)
+        output_tensor_upsample_2 = ttnn.add(output_tensor_upsample_2, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat(
             [output_tensor, output_tensor_upsample_2], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG
         )

--- a/models/demos/yolov4/tt/neck.py
+++ b/models/demos/yolov4/tt/neck.py
@@ -297,6 +297,8 @@ class TtNeck:
         ttnn.deallocate(pool_1)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+        if self.parameters.resolution[0] == 640:
+            pool_all = ttnn.add(pool_all, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat([pool_all, output_tensor], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         output_tensor = self.conv4(output_tensor)
@@ -384,6 +386,8 @@ class TtNeck:
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
         if self.parameters.resolution[0] == 320:
+            output_tensor_upsample_1 = ttnn.add(output_tensor_upsample_1, 0.0, dtype=ttnn.bfloat8_b)
+        if self.parameters.resolution[0] == 640:
             output_tensor_upsample_1 = ttnn.add(output_tensor_upsample_1, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat(
             [output_tensor, output_tensor_upsample_1], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -495,6 +499,8 @@ class TtNeck:
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
         if self.parameters.resolution[0] == 320:
+            output_tensor_upsample_2 = ttnn.add(output_tensor_upsample_2, 0.0, dtype=ttnn.bfloat8_b)
+        if self.parameters.resolution[0] == 640:
             output_tensor_upsample_2 = ttnn.add(output_tensor_upsample_2, 0.0, dtype=ttnn.bfloat8_b)
         output_tensor = ttnn.concat(
             [output_tensor, output_tensor_upsample_2], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG


### PR DESCRIPTION
### Ticket
[27265](https://github.com/tenstorrent/tt-metal/issues/27265)
### Problem description
Improve E2E Performance.
### What's changed
Describe the approach used to solve the problem.
e2e FPS for single device on N150 - 79 FPS _(on N300, it is around 70 FPS )_
e2e FPS for DP=2, on N300 -   FPS. 117

Approach and process are explained in detail in the issue [#27265](https://github.com/tenstorrent/tt-metal/issues/27265)

Issue blocker: https://github.com/tenstorrent/tt-metal/issues/28745 - Yolov4 320x320 and 640x640 Unary Operator (MIsh) is taking long time thus affecting overall model perf 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18096466876)
- [x] [Perf Tests- n300](https://github.com/tenstorrent/tt-metal/actions/runs/18127499735), [Perf Tests- n150](https://github.com/tenstorrent/tt-metal/actions/runs/18127551629)
- [x] [Single Card Demo](https://github.com/tenstorrent/tt-metal/actions/runs/18097524558)