### PR TITLE
Update include in nlp_concat_heads_decode.hpp to fix MemoryConfig compilation error

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "ttnn/run_operation.hpp"
+#include "ttnn/decorators.hpp"
 
 namespace ttnn {
 namespace operations::experimental::transformer {


### PR DESCRIPTION
### Problem description
When trying to include nlp_concat_heads_decode.hpp in tt-mlir, I get the following error:
`error: unknown type name 'MemoryConfig'; did you mean 'tt::tt_metal::MemoryConfig'?`

### What's changed
Changed the include in the file to `#include "ttnn/decorators.hpp"`, which fixes the error.