### PR TITLE
SFPI v6.21.0 Change package name convention

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -336,27 +336,28 @@ install_sfpi() {
 	exit 1
     fi
     local $(grep -v '^#' $version_file)
-    local sfpi_arch_os=$(uname -m)_$(uname -s)
-    local sfpi_pkg_md5=$(eval echo "\$sfpi_${sfpi_arch_os}_${pkg}_md5")
+    local sfpi_arch=$(uname -m)
+    local sfpi_pkg_md5=$(eval echo "\$sfpi_${sfpi_arch}_${pkg}_md5")
     if [ -z $(eval echo "$sfpi_${pkg}_md5") ] ; then
-	echo "[ERROR] SFPI $pkg package for ${sfpi_arch_os} is not available" >&2
+	echo "[ERROR] SFPI $sfpi_version $pkg package for ${sfpi_arch} is not available" >&2
 	exit 1
     fi
     local TEMP_DIR=$(mktemp -d)
-    wget -P $TEMP_DIR "$sfpi_url/$sfpi_version/sfpi-${sfpi_arch_os}.${pkg}"
-    if [ $(md5sum -b "${TEMP_DIR}/sfpi-${sfpi_arch_os}.${pkg}" | cut -d' ' -f1) \
+    local filename="sfpi_${sfpi_version}_${sfpi_arch}.${pkg}"
+    wget -P $TEMP_DIR "$sfpi_url/v$sfpi_version/$filename"
+    if [ $(md5sum -b "${TEMP_DIR}/$filename" | cut -d' ' -f1) \
 	     != "$sfpi_pkg_md5" ] ; then
-	echo "[ERROR] SFPI sfpi-${sfpi_arch_os}.${pkg} md5 mismatch" >&2
+	echo "[ERROR] SFPI $filename md5 mismatch" >&2
 	rm -rf $TEMP_DIR
 	exit 1
     fi
     # we must select exactly this version
     case "$pkg" in
 	deb)
-	    apt-get install -y --allow-downgrades $TEMP_DIR/sfpi-${sfpi_arch_os}.deb
+	    apt-get install -y --allow-downgrades $TEMP_DIR/$filename
 	    ;;
 	rpm)
-	    rpm --upgrade --force $TEMP_DIR/sfpi-${sfpi_arch_os}.rpm
+	    rpm --upgrade --force $TEMP_DIR/$filename
 	    ;;
     esac
     rm -rf $TEMP_DIR

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -30,7 +30,7 @@ set(IRAM_OPTIONS
 
 # Get the appropriate SFPI tarball
 file(STRINGS "../sfpi-version.sh" SFPI)
-set(SFPI_arch_os "${CMAKE_HOST_SYSTEM_PROCESSOR}_${CMAKE_HOST_SYSTEM_NAME}")
+set(SFPI_arch "${CMAKE_HOST_SYSTEM_PROCESSOR}")
 foreach(tuple ${SFPI})
     string(STRIP ${tuple} pair)
     string(REPLACE "=" ";" pair ${pair})
@@ -42,21 +42,21 @@ foreach(tuple ${SFPI})
             set(SFPI_VERSION "${value}")
         elseif(key STREQUAL "sfpi_url")
             set(SFPI_URL "${value}")
-        elseif(key STREQUAL "sfpi_${SFPI_arch_os}_txz_md5")
+        elseif(key STREQUAL "sfpi_${SFPI_arch}_txz_md5")
             set(SFPI_TXZ_MD5 "${value}")
         endif()
     endif()
 endforeach()
 
 if(NOT DEFINED SFPI_TXZ_MD5)
-    message(FATAL_ERROR "SFPI tarball for ${SFPI_arch_os} is not available")
+    message(FATAL_ERROR "SFPI tarball for ${SFPI_arch} is not available")
 endif()
 
 include(FetchContent)
 FetchContent_Declare(
     sfpi
     URL
-        "${SFPI_URL}/${SFPI_VERSION}/sfpi-${SFPI_arch_os}.txz"
+        "${SFPI_URL}/v${SFPI_VERSION}/sfpi_${SFPI_VERSION}_${SFPI_arch}.txz"
     URL_HASH "MD5=${SFPI_TXZ_MD5}"
     SOURCE_DIR
     "${PROJECT_SOURCE_DIR}/runtime/sfpi"

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,10 +1,10 @@
 # set SFPI release version information
 
-sfpi_version=v6.20.0
+sfpi_version=6.21.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
-# sed 's/^\([0-9a-f]*\) \*sfpi-\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_x86_64_Linux_txz_md5=5477bb04519888447600495a34aafaa4
-sfpi_x86_64_Linux_deb_md5=e2c0ab55970400de8df4ea4ccdcfda72
-sfpi_x86_64_Linux_rpm_md5=2ecc1385c8042dce8f9be793840ec4f0
+# sed 's/^\([0-9a-f]*\) \*sfpi_[-.0-9a-zA-Z]*_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
+sfpi_x86_64_txz_md5=ea758c1a5e553b88689286499e1d3fa4
+sfpi_x86_64_deb_md5=5e6ffbb5c720719510019e0ebce44c54
+sfpi_x86_64_rpm_md5=575d1157c04f58e47c9c743203e2781a


### PR DESCRIPTION
### Ticket
NA

### Problem description
Packaging team want the version number in the package file name -- so they can all be in the same directory I guess.
(hi @knauth)

### What's changed
Update installer & cmake scripts to deal with the new name.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes