### PR TITLE
#28046: [skip ci] Add PCIe bandwidth tests to profiler container for Blackhole. Thanks Nigel

### DIFF
--- a/tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
+++ b/tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
@@ -8,3 +8,6 @@ echo "[upstream-profiler-tests] Running BH ethernet profiler tests"
 eth_api_iterations=5
 ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py::test_erisc_latency_uni_dir --num-iterations $eth_api_iterations
 ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py::test_erisc_bw_uni_dir --num-iterations $eth_api_iterations
+
+echo "[upstream-profiler-tests] Running BH PCIe bandwidth tests"
+build/tools/mem_bench --benchmark_filter="Device (Reading|Writing) Host"


### PR DESCRIPTION
… 

### Ticket

#28046 

### Problem description

Our wonderful @nhuang-tt has delivered PCIe b/w tests for BH

### What's changed

Let's put her in1!! Looks like it's profiler build we need

### Checklist
- [ ] upstream https://github.com/tenstorrent/tt-metal/actions/runs/17625503113
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes