### PR TITLE
performance-move-constructor-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -163,7 +163,6 @@ Checks: >
   -performance-for-range-copy,
   -performance-inefficient-string-concatenation,
   -performance-move-const-arg,
-  -performance-move-constructor-init,
   -performance-no-int-to-ptr,
   -performance-noexcept-move-constructor,
   -performance-noexcept-swap,

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -21,31 +21,11 @@ Semaphore::Semaphore(const CoreRangeSet& core_range_set, uint32_t id, uint32_t i
 
 Semaphore::Semaphore(const Semaphore& other) = default;
 
-Semaphore& Semaphore::operator=(const Semaphore& other) {
-    if (this != &other) {
-        this->core_range_set_ = other.core_range_set_;
-        this->id_ = other.id_;
-        this->initial_value_ = other.initial_value_;
-        this->core_type_ = other.core_type_;
-    }
-    return *this;
-}
+Semaphore& Semaphore::operator=(const Semaphore& other) = default;
 
-Semaphore::Semaphore(Semaphore&& other) noexcept :
-    core_range_set_(other.core_range_set_),
-    id_(other.id_),
-    initial_value_(other.initial_value_),
-    core_type_(other.core_type_) {}
+Semaphore::Semaphore(Semaphore&& other) noexcept = default;
 
-Semaphore& Semaphore::operator=(Semaphore&& other) noexcept {
-    if (this != &other) {
-        this->core_range_set_ = other.core_range_set_;
-        this->id_ = other.id_;
-        this->initial_value_ = other.initial_value_;
-        this->core_type_ = other.core_type_;
-    }
-    return *this;
-}
+Semaphore& Semaphore::operator=(Semaphore&& other) noexcept = default;
 
 bool Semaphore::initialized_on_logical_core(const CoreCoord& logical_core) const {
     return this->core_range_set_.contains(logical_core);


### PR DESCRIPTION
### Ticket
#22758 
Closes #28284 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/performance/move-constructor-init.html

Only one file failed this check in the whole code base. 

I think we can fix it by just allowing the compiler to generate a more correct definition.

### What's changed
- Enable check
- Allow compiler to generate Semaphore move constructor, move assignment

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17625968495) CI passes
- [x] New/Existing tests provide coverage for changes