### PR TITLE
Unet models E2E performance fix

### DIFF
--- a/models/demos/segformer/README.md
+++ b/models/demos/segformer/README.md
@@ -33,7 +33,7 @@ Semantic segmentation: [source](https://huggingface.co/nvidia/segformer-b0-finet
 
 ### Performant Model with Trace+2CQ
 #### Single Device (BS=1):
-- end-2-end perf is 103 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- end-2-end perf is 105 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 Use the following command to run Model performant running with Trace+2CQ
 ```
@@ -41,7 +41,7 @@ pytest models/demos/segformer/tests/perf/test_e2e_performant.py::test_segformer_
 ```
 
 #### Multi Device (DP=2, n300):
-- end-2-end perf is 165 FPS
+- end-2-end perf is 182 FPS
 
 Use the following command to run Model performant running with Trace+2CQ
 ```

--- a/models/demos/segformer/README.md
+++ b/models/demos/segformer/README.md
@@ -33,7 +33,7 @@ Semantic segmentation: [source](https://huggingface.co/nvidia/segformer-b0-finet
 
 ### Performant Model with Trace+2CQ
 #### Single Device (BS=1):
-- end-2-end perf is 88 FPS
+- end-2-end perf is 103 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 Use the following command to run Model performant running with Trace+2CQ
 ```
@@ -41,7 +41,7 @@ pytest models/demos/segformer/tests/perf/test_e2e_performant.py::test_segformer_
 ```
 
 #### Multi Device (DP=2, n300):
-- end-2-end perf is 171 FPS
+- end-2-end perf is 165 FPS
 
 Use the following command to run Model performant running with Trace+2CQ
 ```

--- a/models/demos/segformer/runner/performant_runner_infra.py
+++ b/models/demos/segformer/runner/performant_runner_infra.py
@@ -169,7 +169,7 @@ class SegformerTestInfra:
         output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
         output_tensor = output_tensor.reshape((self.torch_output_tensor.logits).shape)
 
-        valid_pcc = 0.9777
+        valid_pcc = 0.977
         self.pcc_passed, self.pcc_message = assert_with_pcc(
             self.torch_output_tensor.logits, output_tensor, pcc=valid_pcc
         )

--- a/models/demos/segformer/tests/perf/test_e2e_performant.py
+++ b/models/demos/segformer/tests/perf/test_e2e_performant.py
@@ -22,16 +22,14 @@ def run_segformer_trace_2cqs_inference(
     input_shape = (batch_size, channels, resolution[0], resolution[1])
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
     inference_iter_count = 10
-    inference_time_iter = []
+    t0 = time.time()
     for iter in range(0, inference_iter_count):
-        t0 = time.time()
-        output = segformer_trace_2cq.run(torch_input_tensor)
-        if iter + 1 == inference_iter_count:
-            ttnn.synchronize_device(device)
-        t1 = time.time()
-        inference_time_iter.append(t1 - t0)
+        _ = segformer_trace_2cq.run(torch_input_tensor)
+    ttnn.synchronize_device(device)
+    t1 = time.time()
+
     segformer_trace_2cq.release_segformer_trace_2cqs_inference()
-    inference_time_avg = round(sum(inference_time_iter) / len(inference_time_iter), 6)
+    inference_time_avg = round((t1 - t0) / inference_iter_count, 6)
     logger.info(
         f"ttnn_segformer_512x512_batch_size_{batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
     )

--- a/models/demos/sentence_bert/README.md
+++ b/models/demos/sentence_bert/README.md
@@ -28,13 +28,13 @@ pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_be
 > **Note:** SentenceBERT uses BERT-base as its backbone model.
 
 #### Single Device (BS=8):
-- End-to-end performance with mean-pooling post-processing is **408 sentences per second**
+- End-to-end performance with mean-pooling post-processing is **431 sentences per second**
 ```
 pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert
 ```
 
 #### Multi Device (DP=2, n300):
-- End-to-end performance with mean-pooling post-processing is **757 sentences per second**
+- End-to-end performance with mean-pooling post-processing is **772 sentences per second**
 ```
 pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert_dp
 ```

--- a/models/demos/sentence_bert/README.md
+++ b/models/demos/sentence_bert/README.md
@@ -28,7 +28,7 @@ pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_be
 > **Note:** SentenceBERT uses BERT-base as its backbone model.
 
 #### Single Device (BS=8):
-- End-to-end performance with mean-pooling post-processing is **431 sentences per second**
+- End-to-end performance with mean-pooling post-processing is **433 sentences per second**
 ```
 pytest --disable-warnings models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py::test_e2e_performant_sentencebert
 ```

--- a/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
+++ b/models/demos/sentence_bert/tests/perf/test_sentence_bert_e2e_performant.py
@@ -24,16 +24,15 @@ def run_e2e_performant_sentencebert(
         model_location_generator=model_location_generator,
     )
     performant_runner._capture_sentencebert_trace_2cqs()
-    inference_times = []
-    for _ in range(50):
-        t0 = time.time()
+    inference_iter_count = 50
+    t0 = time.time()
+    for _ in range(inference_iter_count):
         _ = performant_runner.run()
-        t1 = time.time()
-        inference_times.append(t1 - t0)
-
+    ttnn.synchronize_device(device)
+    t1 = time.time()
     performant_runner.release()
 
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    inference_time_avg = round((t1 - t0) / inference_iter_count, 6)
     logger.info(
         f"ttnn_sentencebert_batch_size: {batch_size}, One inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size * device.get_num_devices()/inference_time_avg)}"
     )

--- a/models/demos/vanilla_unet/README.md
+++ b/models/demos/vanilla_unet/README.md
@@ -20,7 +20,7 @@ Use the following command to run the inference pipeline:
 ### Model performant running with Trace+2CQs
 #### Single Device (BS=1):
 
-- For `480x640`, end-2-end perf is `72` FPS
+- For `480x640`, end-2-end perf is `60` FPS
 
     ```sh
     pytest models/demos/vanilla_unet/tests/perf/test_e2e_performant.py::test_e2e_performant
@@ -28,7 +28,7 @@ Use the following command to run the inference pipeline:
 
 #### Multi Device (DP=2, N300):
 
-- For `480x640`, end-2-end perf is `263` FPS
+- For `480x640`, end-2-end perf is `119` FPS
 
     ```sh
     pytest models/demos/vanilla_unet/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
+++ b/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
@@ -33,19 +33,17 @@ def run_e2e_performant(
     )
     iterations_count = 10
     inference_times = []
+    input_shape = (total_batch_size, channels, *resolution)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    t0 = time.time()
     for i in range(iterations_count):
-        input_shape = (total_batch_size, channels, *resolution)
-        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
-
-        t0 = time.time()
         _ = performant_runner.run(torch_input_tensor)
-        if i + 1 == iterations_count:
-            ttnn.synchronize_device(device)
-        t1 = time.time()
-        inference_times.append(t1 - t0)
+    ttnn.synchronize_device(device)
+    t1 = time.time()
+    inference_times.append(t1 - t0)
     performant_runner.release()
 
-    inference_time_avg = round(sum(inference_times) / len(inference_times), 6)
+    inference_time_avg = round((t1 - t0) / iterations_count, 6)
 
     tolerance = 0.03
     expected_inference_time = get_expected_times("ttnn_vanilla_unet")

--- a/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
+++ b/models/demos/vanilla_unet/tests/perf/test_e2e_performant.py
@@ -32,7 +32,6 @@ def run_e2e_performant(
         model_location_generator=model_location_generator,
     )
     iterations_count = 10
-    inference_times = []
     input_shape = (total_batch_size, channels, *resolution)
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
     t0 = time.time()
@@ -40,7 +39,6 @@ def run_e2e_performant(
         _ = performant_runner.run(torch_input_tensor)
     ttnn.synchronize_device(device)
     t1 = time.time()
-    inference_times.append(t1 - t0)
     performant_runner.release()
 
     inference_time_avg = round((t1 - t0) / iterations_count, 6)

--- a/models/demos/vgg_unet/README.md
+++ b/models/demos/vgg_unet/README.md
@@ -28,7 +28,7 @@ Use the following command to run the e2e perf with trace 2cq:
 ```sh
 pytest models/demos/vgg_unet/tests/perf/test_e2e_performant.py::test_vgg_unet_e2e
 ```
-- end-2-end perf with Trace+2CQs is 183 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- end-2-end perf with Trace+2CQs is 185 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 #### Multi Device (DP=2, n300):
 Use the following command to run the e2e perf with trace 2cq:

--- a/models/demos/vgg_unet/tests/perf/test_e2e_performant.py
+++ b/models/demos/vgg_unet/tests/perf/test_e2e_performant.py
@@ -25,15 +25,13 @@ def run_vgg_unet_e2e(device, device_batch_size, model_location_generator, channe
     torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
     inference_iter_count = 10
     inference_time_iter = []
+    t0 = time.time()
     for iter in range(0, inference_iter_count):
-        t0 = time.time()
         output = vgg_unet_trace_2cq.run(torch_input_tensor)
-        if iter + 1 == inference_iter_count:
-            ttnn.synchronize_device(device)
-        t1 = time.time()
-        inference_time_iter.append(t1 - t0)
+    ttnn.synchronize_device(device)
+    t1 = time.time()
     vgg_unet_trace_2cq.release_vgg_unet_trace_2cqs_inference()
-    inference_time_avg = round(sum(inference_time_iter) / len(inference_time_iter), 6)
+    inference_time_avg = round((t1 - t0) / inference_iter_count, 6)
     logger.info(
         f"ttnn_vgg_unet_256x256_batch_size_{batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
     )


### PR DESCRIPTION
### Problem description
Observed significant end-to-end (e2e) performance fluctuations in UNet models

### What's changed
Fixed the fluctuations issue by changing the test_e2e_perfomant.py code in both vanilla_unet and vgg_unet models. Observed consistent e2e performance across various runs.

- [x] [model perf for segformer, SBERT, UNET(Vanilla & vgg_unet)
](https://github.com/tenstorrent/tt-metal/actions/runs/17939358530) - Passed