### PR TITLE
[skip ci] Run tt-triage for pytest timeouts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1022,7 +1022,10 @@ def run_debug_script():
 
     try:
         logger.info("Running debug script to check system state")
-        debug_result = run_process_and_get_result(f"python {debug_script_path}")
+        extra_env = {
+            "LD_LIBRARY_PATH": None,
+        }
+        debug_result = run_process_and_get_result(f"python {debug_script_path}", extra_env)
 
         logger.info(f"Debug script status: {debug_result.returncode}")
         if debug_result.stdout:

--- a/conftest.py
+++ b/conftest.py
@@ -931,11 +931,6 @@ def pytest_runtest_teardown(item, nextitem):
         test_failed = report.get("call", None) and report["call"].failed
         if test_failed:
             logger.info(f"In custom teardown, open device ids: {set(item.pci_ids)}")
-            # Run debug script before reset for failed tests
-            try:
-                run_debug_script()
-            except Exception as e:
-                logger.error(f"Failed to run debug script during teardown: {e}")
             reset_tensix(set(item.pci_ids))
 
 
@@ -994,11 +989,6 @@ def pytest_timeout_set_timer(item, settings):
 # then it should get cleaned up by the controller through this fixture
 @pytest.hookimpl(tryfirst=True)
 def pytest_handlecrashitem(crashitem, report, sched):
-    # Run debug script before reset for crashed workers
-    try:
-        run_debug_script()
-    except Exception as e:
-        logger.error(f"Failed to run debug script during crash handling: {e}")
     reset_tensix()
 
 
@@ -1014,7 +1004,9 @@ def run_debug_script():
         )
         return
 
-    debug_script_path = os.path.join(os.getenv("TT_METAL_HOME", "."), "scripts", "debugging_scripts", "tt-triage.py")
+    debug_script_path = os.path.join(
+        os.getenv("TT_METAL_HOME", "."), "scripts", "debugging_scripts", "tt-triage.py", "--active_cores"
+    )
 
     if not os.path.exists(debug_script_path):
         logger.warning(f"Debug script not found at {debug_script_path}. Skipping debug collection.")

--- a/conftest.py
+++ b/conftest.py
@@ -1004,7 +1004,6 @@ def pytest_handlecrashitem(crashitem, report, sched):
 
 def run_debug_script():
     """Run the tt-triage.py debug script to check system state before cleanup."""
-    import shutil
 
     # Check if ttexalens module is available
     try:

--- a/conftest.py
+++ b/conftest.py
@@ -1022,6 +1022,7 @@ def run_debug_script():
 
     try:
         logger.info("Running debug script to check system state")
+        # Remove LD_LIBRARY_PATH to avoid conflicts with prebuilt libraries
         extra_env = {
             "LD_LIBRARY_PATH": None,
         }

--- a/conftest.py
+++ b/conftest.py
@@ -741,12 +741,6 @@ def pytest_addoption(parser):
         default=None,
         help="Size of chip grid for the test to run on. Grid size is defined by number of cores in row x number of cores in column, e.g., 8x8",
     )
-    parser.addoption(
-        "--enable-debug-script",
-        action="store_true",
-        default=False,
-        help="Enable debug script (tt-triage.py) execution before test cleanup on failures/timeouts",
-    )
 
 
 @pytest.fixture
@@ -938,12 +932,10 @@ def pytest_runtest_teardown(item, nextitem):
         if test_failed:
             logger.info(f"In custom teardown, open device ids: {set(item.pci_ids)}")
             # Run debug script before reset for failed tests
-            debug_enabled = item.config.getoption("--enable-debug-script")
-            if debug_enabled:
-                try:
-                    run_debug_script()
-                except Exception as e:
-                    logger.error(f"Failed to run debug script during teardown: {e}")
+            try:
+                run_debug_script()
+            except Exception as e:
+                logger.error(f"Failed to run debug script during teardown: {e}")
             reset_tensix(set(item.pci_ids))
 
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -100,7 +100,12 @@ RUN umask 000 && python3 -m pip config set global.extra-index-url https://downlo
 
 COPY /scripts/install_debugger.sh /opt/tt_metal_infra/scripts/install_debugger.sh
 COPY /scripts/ttexalens_ref.txt /opt/tt_metal_infra/scripts/ttexalens_ref.txt
-RUN if [ "$UBUNTU_VERSION" = "22.04" ]; then /opt/tt_metal_infra/scripts/install_debugger.sh; fi
+RUN if [ "$UBUNTU_VERSION" = "22.04" ]; then \
+        echo "Installing debugger for Ubuntu 22.04..." && \
+        /opt/tt_metal_infra/scripts/install_debugger.sh && \
+        echo "Debugger installation completed" && \
+        python3 -c "import ttexalens; print('ttexalens successfully imported')" || echo "ttexalens import failed"; \
+    fi
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -82,6 +82,7 @@ ENV CCACHE_TEMPDIR=/tmp/ccache
 
 FROM ci-build AS ci-test
 
+ARG UBUNTU_VERSION=22.04
 ARG TT_METAL_INFRA_DIR=/opt/tt_metal_infra
 
 # Create directories for infra

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -631,6 +631,9 @@ def test_demo_text(
     """
     Simple demo with limited dependence on reference code.
     """
+    # DEBUG: Intentional failure for CI debugging
+    assert False, "This test is intentionally failing for CI debugging purposes"
+
     test_id = request.node.callspec.id
     if is_ci_env:
         if not ci_only:

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -631,9 +631,6 @@ def test_demo_text(
     """
     Simple demo with limited dependence on reference code.
     """
-    # DEBUG: Intentional failure for CI debugging
-    assert False, "This test is intentionally failing for CI debugging purposes"
-
     test_id = request.node.callspec.id
     if is_ci_env:
         if not ci_only:

--- a/tests/scripts/common.py
+++ b/tests/scripts/common.py
@@ -83,7 +83,13 @@ def is_test_suite_type_that_uses_silicon(test_suite_type: TestSuiteType) -> bool
 
 def run_process_and_get_result(command, extra_env={}, capture_output=True):
     full_env = copy.deepcopy(os.environ)
-    full_env.update(extra_env)
+
+    # Handle None values in extra_env - remove keys with None values
+    for key, value in extra_env.items():
+        if value is None:
+            full_env.pop(key, None)  # Remove the key if it exists
+        else:
+            full_env[key] = value
 
     result = sp.run(command, shell=True, capture_output=capture_output, env=full_env)
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/27970

### Problem description
When pytests fail or hang, it is often very difficult to understand why.

### What's changed
This PR integrates the new tt-triage tool into CI, so we can aim to get feedback to developers earlier in the debug process.

### Checklist
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17749390198)
- [x] New/Existing tests provide coverage for changes