### PR TITLE
Panoptic-Deeplab functional full network 

### DIFF
--- a/models/experimental/panoptic_deeplab/reference/aspp.py
+++ b/models/experimental/panoptic_deeplab/reference/aspp.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import torch
+
+
+class PanopticDeeplabASPPModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.ASPP_0_Conv = nn.Sequential(nn.Conv2d(2048, 256, 1, 1, bias=False), nn.BatchNorm2d(256), nn.ReLU())
+        self.ASPP_1_Depthwise = nn.Sequential(
+            nn.Conv2d(2048, 2048, 3, 1, 6, 6, 2048, bias=False), nn.BatchNorm2d(2048), nn.ReLU()
+        )
+        self.ASPP_1_pointwise = nn.Sequential(nn.Conv2d(2048, 256, 1, 1, bias=False), nn.BatchNorm2d(256), nn.ReLU())
+
+        self.ASPP_2_Depthwise = nn.Sequential(
+            nn.Conv2d(2048, 2048, 3, 1, 12, 12, 2048, bias=False), nn.BatchNorm2d(2048), nn.ReLU()
+        )
+        self.ASPP_2_pointwise = nn.Sequential(nn.Conv2d(2048, 256, 1, 1, bias=False), nn.BatchNorm2d(256), nn.ReLU())
+
+        self.ASPP_3_Depthwise = nn.Sequential(
+            nn.Conv2d(2048, 2048, 3, 1, 18, 18, 2048, bias=False), nn.BatchNorm2d(2048), nn.ReLU()
+        )
+        self.ASPP_3_pointwise = nn.Sequential(nn.Conv2d(2048, 256, 1, 1, bias=False), nn.BatchNorm2d(256), nn.ReLU())
+
+        self.ASPP_4_avg_pool = torch.nn.AvgPool2d((32, 64), stride=1, count_include_pad=True)
+        self.ASPP_4_Conv_1 = nn.Sequential(
+            nn.Conv2d(2048, 256, 1, 1),
+            nn.ReLU(),
+        )
+        self.ASPP_project = nn.Sequential(nn.Conv2d(1280, 256, 1, 1, bias=False), nn.BatchNorm2d(256), nn.ReLU())
+
+    def forward(self, x):
+        t0 = self.ASPP_0_Conv(x)
+        t1 = self.ASPP_1_Depthwise(x)
+        t2 = self.ASPP_2_Depthwise(x)
+        t3 = self.ASPP_3_Depthwise(x)
+        t4 = self.ASPP_4_avg_pool(x)
+
+        t4 = self.ASPP_4_Conv_1(t4)
+        t4 = nn.functional.interpolate(t4, (32, 64), mode="bilinear")
+
+        t1 = self.ASPP_1_pointwise(t1)
+        t2 = self.ASPP_2_pointwise(t2)
+        t3 = self.ASPP_3_pointwise(t3)
+
+        y = torch.cat((t0, t1, t2, t3, t4), dim=1)
+        y = self.ASPP_project(y)
+
+        return y

--- a/models/experimental/panoptic_deeplab/reference/decoder.py
+++ b/models/experimental/panoptic_deeplab/reference/decoder.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from models.experimental.panoptic_deeplab.reference.aspp import PanopticDeeplabASPPModel as ASPPModel
+from models.experimental.panoptic_deeplab.reference.head import HeadModel
+from models.experimental.panoptic_deeplab.reference.res_block import ResModel
+
+
+class DecoderModel(torch.nn.Module):
+    def __init__(self, in_channels, res3_intermediate_channels, res2_intermediate_channels, out_channels, name):
+        super().__init__()
+        self.name = name
+        self.aspp = ASPPModel()
+        if name == "Semantics_head":
+            self.res3 = ResModel(512, 320, 256)
+            self.res2 = ResModel(256, 288, 256)
+            self.head_1 = HeadModel(256, 256, 19)
+        else:
+            self.res3 = ResModel(512, 320, 128)
+            self.res2 = ResModel(256, 160, 128)
+            self.head_1 = HeadModel(128, 32, 2)
+            self.head_2 = HeadModel(128, 32, 1)
+
+    def forward(self, x, res3, res2):
+        y = self.aspp(x)
+        y = self.res3(y, res3)
+        y = self.res2(y, res2)
+        out = self.head_1(y)
+
+        if self.name == "instance_head":
+            y_2 = self.head_2(y)
+            return out, y_2
+        return out, None

--- a/models/experimental/panoptic_deeplab/reference/head.py
+++ b/models/experimental/panoptic_deeplab/reference/head.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import torch
+
+
+class HeadModel(torch.nn.Module):
+    def __init__(self, in_channels, intermediate_channels, out_channels):
+        super().__init__()
+
+        if out_channels == 1:  # instance center head
+            self.conv1 = nn.Sequential(
+                nn.Conv2d(in_channels, in_channels, 3, 1, 1, 1), nn.BatchNorm2d(in_channels), nn.ReLU()
+            )
+
+            self.conv2 = nn.Sequential(
+                nn.Conv2d(in_channels, intermediate_channels, 3, 1, 1, 1),
+                nn.BatchNorm2d(intermediate_channels),
+                nn.ReLU(),
+            )
+        else:  # instance offset head
+            self.conv1 = nn.Sequential(
+                nn.Conv2d(in_channels, in_channels, 5, 1, 2, 1, in_channels), nn.BatchNorm2d(in_channels), nn.ReLU()
+            )
+            self.conv2 = nn.Sequential(
+                nn.Conv2d(in_channels, intermediate_channels, 1, 1), nn.BatchNorm2d(intermediate_channels), nn.ReLU()
+            )
+        self.conv3 = nn.Sequential(nn.Conv2d(intermediate_channels, out_channels, 1, 1))
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.conv2(out)
+        out = self.conv3(out)
+        out = nn.functional.interpolate(out, scale_factor=4, mode="bilinear")
+        return out

--- a/models/experimental/panoptic_deeplab/reference/panoptic_deeplab.py
+++ b/models/experimental/panoptic_deeplab/reference/panoptic_deeplab.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+from typing import Dict
+
+from models.experimental.panoptic_deeplab.reference.resnet52_backbone import ResNet52BackBone
+from models.experimental.panoptic_deeplab.reference.decoder import DecoderModel
+
+
+class TorchPanopticDeepLab(nn.Module):
+    """
+    Panoptic DeepLab model using modular decoder architecture.
+    Combines semantic segmentation and instance segmentation with panoptic fusion.
+    """
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+        # Backbone
+        self.backbone = ResNet52BackBone()
+
+        # Semantic segmentation decoder
+        self.semantic_decoder = DecoderModel(
+            in_channels=2048,
+            res3_intermediate_channels=320,
+            res2_intermediate_channels=288,
+            out_channels=19,
+            name="Semantics_head",
+        )
+
+        # Instance segmentation decoders
+        self.instance_decoder = DecoderModel(
+            in_channels=2048,
+            res3_intermediate_channels=320,
+            res2_intermediate_channels=160,
+            out_channels=(2, 1),
+            name="instance_head",
+        )
+
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """
+        Forward pass of Panoptic DeepLab.
+
+        Args:
+            x: Input tensor of shape [B, C, H, W]
+
+        Returns:
+            semantic_logits: Semantic segmentation logits
+            instance_logits: Instance segmentation logits - offset head
+            instance_logits_2: Instance segmentation logits - center head
+        """
+
+        # Extract features from backbone
+        features = self.backbone(x)
+
+        # Extract specific feature maps
+        backbone_features = features["res_5"]
+        res3_features = features["res_3"]
+        res2_features = features["res_2"]
+
+        # Semantic segmentation branch
+        semantic_logits, _ = self.semantic_decoder(backbone_features, res3_features, res2_features)
+
+        # Instance segmentation branch
+        instance_logits, instance_logits_2 = self.instance_decoder(backbone_features, res3_features, res2_features)
+
+        return semantic_logits, instance_logits, instance_logits_2

--- a/models/experimental/panoptic_deeplab/reference/res_block.py
+++ b/models/experimental/panoptic_deeplab/reference/res_block.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import torch
+
+
+class ResModel(torch.nn.Module):
+    def __init__(self, in_channels, intermediate_channels, out_channels):
+        super().__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(in_channels, in_channels // 8, 1, 1, bias=False), nn.BatchNorm2d(in_channels // 8), nn.ReLU()
+        )
+        self.conv2 = nn.Sequential(
+            nn.Conv2d(intermediate_channels, intermediate_channels, 5, 1, 2, 1, intermediate_channels, bias=False),
+            nn.BatchNorm2d(intermediate_channels),
+            nn.ReLU(),
+        )
+        self.conv3 = nn.Sequential(
+            nn.Conv2d(intermediate_channels, out_channels, 1, 1, bias=False), nn.BatchNorm2d(out_channels), nn.ReLU()
+        )
+
+    def forward(self, x, res2):
+        out = nn.functional.interpolate(x, scale_factor=2, mode="bilinear")
+        res2 = self.conv1(res2)
+        out = torch.cat((res2, out), dim=1)
+        out = self.conv2(out)
+        out = self.conv3(out)
+        return out

--- a/models/experimental/panoptic_deeplab/reference/resnet52_backbone.py
+++ b/models/experimental/panoptic_deeplab/reference/resnet52_backbone.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from torchvision.models.resnet import Bottleneck
+import torch.nn as nn
+from typing import Callable, List, Optional
+from torch import Tensor
+from models.experimental.panoptic_deeplab.reference.resnet52_stem import DeepLabStem
+
+
+class ResNet52BackBone(nn.Module):
+    def __init__(
+        self,
+        block=Bottleneck,
+        layers=[3, 4, 6, 3],
+        groups: int = 1,
+        width_per_group: int = 64,
+        dialate_layer_config: Optional[List[List[int]]] = None,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+        out_features: Optional[List[str]] = None,
+    ) -> None:
+        super().__init__()
+
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 128
+        if dialate_layer_config is None:
+            # each element in the tuple indicates the dialtaion to be used
+            # in the 3x3 conv for each layer
+            dialate_layer_config = [[1] * num_layers for num_layers in layers]
+        if len(dialate_layer_config) != len(layers):
+            raise ValueError(
+                "dialate_layer_config should be None " f"or a {len(layers)}-element tuple, got {dialate_layer_config}"
+            )
+        self.groups = groups
+        self.base_width = width_per_group
+        self.stem = DeepLabStem(in_channels=3, out_channels=self.inplanes, stride=1)
+        self.layer1 = self._make_layer(block, 64, layers[0], stride=1, dialate_config=dialate_layer_config[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2, dialate_config=dialate_layer_config[1])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2, dialate_config=dialate_layer_config[2])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=1, dialate_config=[2, 4, 8])
+
+    def _make_layer(
+        self,
+        block: Bottleneck,
+        planes: int,
+        blocks: int,
+        stride: int = 1,
+        dialate_config: Optional[List[int]] = None,
+    ) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        if dialate_config is None:
+            dialate_config = [1] * blocks
+        downsample = None
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                nn.Conv2d(self.inplanes, planes * block.expansion, kernel_size=1, stride=stride, bias=False),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(
+            block(
+                self.inplanes, planes, stride, downsample, self.groups, self.base_width, dialate_config[0], norm_layer
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for block_index in range(1, blocks):
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=dialate_config[block_index],
+                    norm_layer=norm_layer,
+                )
+            )
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.stem(x)
+
+        res_2 = self.layer1(x)
+        res_3 = self.layer2(res_2)
+        res_4 = self.layer3(res_3)
+        res_5 = self.layer4(res_4)
+        out = {"res_2": res_2, "res_3": res_3, "res_5": res_5}
+
+        return out

--- a/models/experimental/panoptic_deeplab/reference/resnet52_stem.py
+++ b/models/experimental/panoptic_deeplab/reference/resnet52_stem.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from torch import nn
+
+
+class CNNBlockBase(nn.Module):
+    """
+    A CNN block is assumed to have input channels, output channels and a stride.
+    The input and output of `forward()` method must be NCHW tensors.
+    The method can perform arbitrary computation but must match the given
+    channels and stride specification.
+
+    Attribute:
+        in_channels (int):
+        out_channels (int):
+        stride (int):
+    """
+
+    def __init__(self, in_channels, out_channels, stride):
+        """
+        The `__init__` method of any subclass should also contain these arguments.
+
+        Args:
+            in_channels (int):
+            out_channels (int):
+            stride (int):
+        """
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.stride = stride
+
+
+class DeepLabStem(CNNBlockBase):
+    """
+    DeepLab ResNet stem module that processes the input image before the first residual block.
+
+    This stem consists of three 3x3 convolution layers with intermediate Batch Normalization and ReLU,
+    followed by a 3x3 max pooling operation. The design reduces spatial resolution while increasing
+    the number of channels to prepare features for deeper layers.
+
+    Attributes:
+        conv1 (nn.Conv2d): First convolution layer with stride 2 and out_channels // 2 filters.
+        bn1 (nn.BatchNorm2d): Batch normalization applied after conv1.
+        conv2 (nn.Conv2d): Second convolution layer maintaining channel size.
+        bn2 (nn.BatchNorm2d): Batch normalization applied after conv2.
+        conv3 (nn.Conv2d): Third convolution layer increasing to final out_channels.
+        bn3 (nn.BatchNorm2d): Batch normalization applied after conv3.
+        relu (nn.ReLU): In-place ReLU activation function.
+        maxpool (nn.MaxPool2d): 3x3 max pooling with stride 2 and padding 1.
+
+    Args:
+        in_channels (int): Number of input channels. Default is 3 for RGB images.
+        out_channels (int): Number of output channels. Default is 128.
+        stride (int): Stride used for conv2 and conv3. Default is 1.
+
+    Returns:
+        torch.Tensor: Output feature map after the stem block with reduced spatial resolution
+        and increased channel depth.
+    """
+
+    def __init__(self, in_channels=3, out_channels=128, stride=1):
+        """
+        Initialize the DeepLabStem module.
+
+        Args:
+            in_channels (int): Number of input channels. Default is 3 (e.g., RGB image).
+            out_channels (int): Number of output channels after the stem. Default is 128.
+            stride (int): Stride value for the second and third convolutions. Default is 1.
+        """
+        super().__init__(in_channels, out_channels, 1)
+        self.in_channels = in_channels
+        self.conv1 = nn.Conv2d(
+            in_channels,
+            out_channels // 2,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        self.bn1 = nn.BatchNorm2d(out_channels // 2)
+        self.conv2 = nn.Conv2d(
+            out_channels // 2,
+            out_channels // 2,
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+        )
+        self.bn2 = nn.BatchNorm2d(out_channels // 2)
+        self.conv3 = nn.Conv2d(
+            out_channels // 2,
+            out_channels,
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+        )
+        self.bn3 = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.conv2(x)
+        x = self.bn2(x)
+        x = self.relu(x)
+        x = self.conv3(x)
+        x = self.bn3(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+        return x

--- a/models/experimental/panoptic_deeplab/tests/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/test_aspp.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+from models.experimental.panoptic_deeplab.reference.aspp import (
+    PanopticDeeplabASPPModel,
+)
+from models.experimental.panoptic_deeplab.tt.aspp import PanopticDeeplabASPP
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class AsppTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        model_config,
+    ):
+        super().__init__()
+        if not hasattr(self, "_model_initialized"):
+            torch.manual_seed(42)  # Only seed once
+            self._model_initialized = True
+            torch.cuda.manual_seed_all(42)
+            torch.backends.cudnn.deterministic = True
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        # torch model
+        torch_model = PanopticDeeplabASPPModel().eval()
+        self.fake_tensor_1 = torch.randn((1, 2048, 32, 64), dtype=torch.float16)
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+        torch_model.to(torch.bfloat16)
+        self.fake_tensor_1 = self.fake_tensor_1.to(torch.bfloat16)
+
+        # golden
+        self.torch_output_tensor = torch_model(self.fake_tensor_1)
+
+        # ttnn
+        tt_host_tensor_1 = ttnn.from_torch(
+            self.fake_tensor_1.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat8_b,
+            device=device,
+            mesh_mapper=self.inputs_mesh_mapper,
+        )
+
+        self.ttnn_model = PanopticDeeplabASPP(parameters, model_config)
+        self.input_tensor_1 = ttnn.to_layout(tt_host_tensor_1, ttnn.TILE_LAYOUT)
+        self.input_tensor_1 = ttnn.to_device(tt_host_tensor_1, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        # run and validate
+        self.run()
+        self.validate()
+        ttnn.deallocate(self.output_tensor)
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor = self.ttnn_model(self.input_tensor_1, self.device)
+        return self.output_tensor
+
+    def validate(self, output_tensor=None, output_tensor1=None):
+        """Validate outputs"""
+
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+        batch_size = self.batch_size
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Modular Panoptic DeepLab ASPP - batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size",
+    [
+        (1),
+    ],
+)
+def test_aspp(
+    device,
+    batch_size,
+):
+    AsppTestInfra(
+        device,
+        batch_size,
+        model_config,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_decoder.py
+++ b/models/experimental/panoptic_deeplab/tests/test_decoder.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
+import ttnn
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.tt.decoder import (
+    TTDecoder,
+    decoder_layer_optimisations,
+)
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+from models.experimental.panoptic_deeplab.reference.decoder import (
+    DecoderModel,
+)
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class HeadTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        res3_intermediate_channels,
+        res2_intermediate_channels,
+        out_channels,
+        upsample_channels,
+        height,
+        width,
+        name,
+    ):
+        super().__init__()
+        if not hasattr(self, "_model_initialized"):
+            torch.manual_seed(42)
+            self._model_initialized = True
+            torch.cuda.manual_seed_all(42)
+            torch.backends.cudnn.deterministic = True
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.in_channels = in_channels
+        self.res3_intermediate_channels = res3_intermediate_channels
+        self.res2_intermediate_channels = res2_intermediate_channels
+        self.out_channels = out_channels
+        self.upsample_channels = upsample_channels
+        self.height = height
+        self.width = width
+        self.name = name
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        # Create input tensors
+        self.torch_input_tensor = torch.randn(
+            (self.batch_size, self.in_channels, self.height, self.width), dtype=torch.float32
+        )
+
+        # Create res3 and res2 feature maps with appropriate dimensions
+        self.torch_res3_tensor = torch.randn(
+            (self.batch_size, 512, self.height * 2, self.width * 2), dtype=torch.float32
+        )
+
+        self.torch_res2_tensor = torch.randn(
+            (self.batch_size, upsample_channels, self.height * 4, self.width * 4), dtype=torch.float32
+        )
+
+        # torch model
+        torch_model = DecoderModel(
+            self.in_channels,
+            self.res3_intermediate_channels,
+            self.res2_intermediate_channels,
+            self.out_channels,
+            self.name,
+        ).eval()
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+
+        parameters.conv_args = {}
+        # For ASPP
+        aspp_args = infer_ttnn_module_args(
+            model=torch_model.aspp, run_model=lambda model: model(self.torch_input_tensor), device=None
+        )
+        if hasattr(parameters, "aspp"):
+            parameters.aspp.conv_args = aspp_args
+
+        # For res3
+        res3_output = torch_model.aspp(self.torch_input_tensor)
+        res3_args = infer_ttnn_module_args(
+            model=torch_model.res3, run_model=lambda model: model(res3_output, self.torch_res3_tensor), device=None
+        )
+        if hasattr(parameters, "res3"):
+            parameters.res3.conv_args = res3_args
+
+        # For res2
+        res2_input = torch_model.res3(res3_output, self.torch_res3_tensor)
+        res2_args = infer_ttnn_module_args(
+            model=torch_model.res2, run_model=lambda model: model(res2_input, self.torch_res2_tensor), device=None
+        )
+        if hasattr(parameters, "res2"):
+            parameters.res2.conv_args = res2_args
+
+        # For head
+        head_input = torch_model.res2(res2_input, self.torch_res2_tensor)
+        head_1_args = infer_ttnn_module_args(
+            model=torch_model.head_1, run_model=lambda model: model(head_input), device=None
+        )
+        if hasattr(parameters, "head_1"):
+            parameters.head_1.conv_args = head_1_args
+
+        if "instance" in name:
+            head_2_args = infer_ttnn_module_args(
+                model=torch_model.head_2, run_model=lambda model: model(head_input), device=None
+            )
+            if hasattr(parameters, "head_2"):
+                parameters.head_2.conv_args = head_2_args
+
+        # Convert to bfloat16
+        torch_model.to(torch.bfloat16)
+        self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+        self.torch_res3_tensor = self.torch_res3_tensor.to(torch.bfloat16)
+        self.torch_res2_tensor = self.torch_res2_tensor.to(torch.bfloat16)
+
+        # Get torch output with all three inputs
+        self.torch_output_tensor, self.torch_output_tensor_2 = torch_model(
+            self.torch_input_tensor, self.torch_res3_tensor, self.torch_res2_tensor
+        )
+
+        # Convert torch tensors to TTNN host tensors
+        def to_ttnn_host(tensor):
+            return ttnn.from_torch(
+                tensor.permute(0, 2, 3, 1),
+                dtype=ttnn.bfloat8_b,
+                device=device,
+                mesh_mapper=self.inputs_mesh_mapper,
+            )
+
+        tt_host_tensor = to_ttnn_host(self.torch_input_tensor)
+        tt_res3_tensor = to_ttnn_host(self.torch_res3_tensor)
+        tt_res2_tensor = to_ttnn_host(self.torch_res2_tensor)
+
+        # Move TTNN host tensors to device
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.res3_tensor = ttnn.to_device(tt_res3_tensor, device)
+        self.res2_tensor = ttnn.to_device(tt_res2_tensor, device)
+
+        # ttnn model
+        logger.info("Initializing TTNN model...")
+        self.ttnn_model = TTDecoder(
+            parameters, model_config, layer_optimisations=decoder_layer_optimisations[self.name], name=self.name
+        )
+
+        # run and validate
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    # Compute golden output for the selected block using a helper function
+    def run(self):
+        self.output_tensor, self.output_tensor_2 = self.ttnn_model(
+            self.input_tensor,
+            self.res3_tensor,
+            self.res2_tensor,
+            self.upsample_channels,
+            self.device,
+        )
+
+        return self.output_tensor, self.output_tensor_2
+
+    def validate(self, output_tensor=None):
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+        batch_size = output_tensor.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"{self.name},  batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        if "instance" in self.name:
+            output_tensor = self.output_tensor_2
+            output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+            expected_shape = self.torch_output_tensor_2.shape
+            output_tensor = torch.reshape(
+                output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+            )
+            output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+            batch_size = output_tensor.shape[0]
+
+            valid_pcc = 0.97
+            self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor_2, output_tensor, pcc=valid_pcc)
+            assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+            logger.info(
+                f"{self.name},  batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+            )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, in_channels, res3_intermediate_channels, res2_intermediate_channels, out_channels, upsample_channels, height, width, name",
+    [
+        (1, 2048, 320, 288, (19,), 256, 32, 64, "Semantics_head"),  # semantic head
+        (1, 2048, 320, 160, (2, 1), 256, 32, 64, "instance_head"),  # instance offset head
+    ],
+)
+def test_decoder(
+    device,
+    batch_size,
+    in_channels,
+    res3_intermediate_channels,
+    res2_intermediate_channels,
+    out_channels,
+    upsample_channels,
+    height,
+    width,
+    name,
+):
+    HeadTestInfra(
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        res3_intermediate_channels,
+        res2_intermediate_channels,
+        out_channels,
+        upsample_channels,
+        height,
+        width,
+        name,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_head.py
+++ b/models/experimental/panoptic_deeplab/tests/test_head.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
+import ttnn
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.tt.head import (
+    TTHead,
+    head_layer_optimisations,
+)
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+from models.experimental.panoptic_deeplab.reference.head import (
+    HeadModel,
+)
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class HeadTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        intermediate_channels,
+        out_channels,
+        height,
+        width,
+        name,
+    ):
+        super().__init__()
+        if not hasattr(self, "_model_initialized"):
+            torch.manual_seed(42)
+            self._model_initialized = True
+            torch.cuda.manual_seed_all(42)
+            torch.backends.cudnn.deterministic = True
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.in_channels = in_channels
+        self.intermediate_channels = intermediate_channels
+        self.out_channels = out_channels
+        self.height = height
+        self.width = width
+        self.name = name
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        self.torch_input_tensor = torch.randn(
+            (self.batch_size, self.in_channels, self.height, self.width), dtype=torch.float32
+        )
+
+        # torch model
+        torch_model = HeadModel(self.in_channels, self.intermediate_channels, self.out_channels).eval()
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+        parameters.conv_args = {}
+        parameters.conv_args = infer_ttnn_module_args(
+            model=torch_model, run_model=lambda model: model(self.torch_input_tensor), device=None
+        )
+
+        # run torch model
+        torch_model.to(torch.bfloat16)
+        self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+        self.torch_output_tensor = torch_model(self.torch_input_tensor)
+
+        # Convert torch tensors to TTNN host tensors (NHWC, bfloat8_b)
+        def to_ttnn_host(tensor):
+            return ttnn.from_torch(
+                tensor.permute(0, 2, 3, 1),
+                dtype=ttnn.bfloat8_b,
+                device=device,
+                mesh_mapper=self.inputs_mesh_mapper,
+            )
+
+        tt_host_tensor = to_ttnn_host(self.torch_input_tensor)
+
+        # Move TTNN host tensors to device
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+
+        # ttnn model
+        self.ttnn_model = TTHead(parameters, model_config, layer_optimisations=head_layer_optimisations[self.name])
+
+        # run and validate
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor = self.ttnn_model(self.input_tensor, self.device)
+
+        return self.output_tensor
+
+    def validate(self, output_tensor=None):
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+        batch_size = output_tensor.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Head {self.name},  batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, in_channels, intermediate_channels, out_channels, height, width, name",
+    [
+        (1, 256, 256, 19, 128, 256, "semantic_head"),  # semantic head
+        (1, 128, 32, 2, 128, 256, "instance_offset_head"),  # instance offset head
+        (1, 128, 32, 1, 128, 256, "instance_center_head"),  # instance center head
+    ],
+)
+def test_head(
+    device,
+    batch_size,
+    in_channels,
+    intermediate_channels,
+    out_channels,
+    height,
+    width,
+    name,
+):
+    HeadTestInfra(
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        intermediate_channels,
+        out_channels,
+        height,
+        width,
+        name,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_panoptic_deeplab.py
+++ b/models/experimental/panoptic_deeplab/tests/test_panoptic_deeplab.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from ttnn.model_preprocessing import preprocess_model_parameters
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+from models.experimental.panoptic_deeplab.reference.panoptic_deeplab import TorchPanopticDeepLab
+from models.experimental.panoptic_deeplab.tt.panoptic_deeplab import TTPanopticDeepLab
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class PanopticDeepLabTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        in_channels,
+        height,
+        width,
+        model_config,
+    ):
+        super().__init__()
+        if not hasattr(self, "_model_initialized"):
+            torch.manual_seed(42)
+            self._model_initialized = True
+            torch.cuda.manual_seed_all(42)
+            torch.backends.cudnn.deterministic = True
+
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.in_channels = in_channels
+        self.height = height
+        self.width = width
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        # Initialize torch model
+        torch_model = TorchPanopticDeepLab().eval()
+
+        # Create input tensor
+        input_shape = (batch_size * self.num_devices, in_channels, height, width)
+        self.torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+
+        # Preprocess model parameters
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+
+        parameters.conv_args = {}
+        sample_x = torch.randn(1, 2048, 32, 64)
+        sample_res3 = torch.randn(1, 512, 64, 128)
+        sample_res2 = torch.randn(1, 256, 128, 256)
+
+        # For semantic decoder
+        if hasattr(parameters, "semantic_decoder"):
+            # ASPP
+            aspp_args = infer_ttnn_module_args(
+                model=torch_model.semantic_decoder.aspp, run_model=lambda model: model(sample_x), device=None
+            )
+            if hasattr(parameters.semantic_decoder, "aspp"):
+                parameters.semantic_decoder.aspp.conv_args = aspp_args
+
+            # Res3
+            aspp_out = torch_model.semantic_decoder.aspp(sample_x)
+            res3_args = infer_ttnn_module_args(
+                model=torch_model.semantic_decoder.res3,
+                run_model=lambda model: model(aspp_out, sample_res3),
+                device=None,
+            )
+            if hasattr(parameters.semantic_decoder, "res3"):
+                parameters.semantic_decoder.res3.conv_args = res3_args
+
+            # Res2
+            res3_out = torch_model.semantic_decoder.res3(aspp_out, sample_res3)
+            res2_args = infer_ttnn_module_args(
+                model=torch_model.semantic_decoder.res2,
+                run_model=lambda model: model(res3_out, sample_res2),
+                device=None,
+            )
+            if hasattr(parameters.semantic_decoder, "res2"):
+                parameters.semantic_decoder.res2.conv_args = res2_args
+
+            # Head
+            res2_out = torch_model.semantic_decoder.res2(res3_out, sample_res2)
+            head_args = infer_ttnn_module_args(
+                model=torch_model.semantic_decoder.head_1, run_model=lambda model: model(res2_out), device=None
+            )
+            if hasattr(parameters.semantic_decoder, "head_1"):
+                parameters.semantic_decoder.head_1.conv_args = head_args
+
+        # For instance decoder
+        if hasattr(parameters, "instance_decoder"):
+            # ASPP
+            aspp_args = infer_ttnn_module_args(
+                model=torch_model.instance_decoder.aspp, run_model=lambda model: model(sample_x), device=None
+            )
+            if hasattr(parameters.instance_decoder, "aspp"):
+                parameters.instance_decoder.aspp.conv_args = aspp_args
+
+            # Res3
+            aspp_out = torch_model.instance_decoder.aspp(sample_x)
+            res3_args = infer_ttnn_module_args(
+                model=torch_model.instance_decoder.res3,
+                run_model=lambda model: model(aspp_out, sample_res3),
+                device=None,
+            )
+            if hasattr(parameters.instance_decoder, "res3"):
+                parameters.instance_decoder.res3.conv_args = res3_args
+
+            # Res2
+            res3_out = torch_model.instance_decoder.res3(aspp_out, sample_res3)
+            res2_args = infer_ttnn_module_args(
+                model=torch_model.instance_decoder.res2,
+                run_model=lambda model: model(res3_out, sample_res2),
+                device=None,
+            )
+            if hasattr(parameters.instance_decoder, "res2"):
+                parameters.instance_decoder.res2.conv_args = res2_args
+
+            # Head
+            res2_out = torch_model.instance_decoder.res2(res3_out, sample_res2)
+            head_args_1 = infer_ttnn_module_args(
+                model=torch_model.instance_decoder.head_1, run_model=lambda model: model(res2_out), device=None
+            )
+            head_args_2 = infer_ttnn_module_args(
+                model=torch_model.instance_decoder.head_2, run_model=lambda model: model(res2_out), device=None
+            )
+            if hasattr(parameters.instance_decoder, "head_1"):
+                parameters.instance_decoder.head_1.conv_args = head_args_1
+            if hasattr(parameters.instance_decoder, "head_2"):
+                parameters.instance_decoder.head_2.conv_args = head_args_2
+
+        # Run torch model with bfloat16
+        logger.info("Running PyTorch model...")
+        self.torch_output_tensor, self.torch_output_tensor_2, self.torch_output_tensor_3 = torch_model(
+            self.torch_input_tensor
+        )
+        torch_model.to(torch.bfloat16)
+        self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+
+        # Convert input to TTNN format (NHWC)
+        logger.info("Converting input to TTNN format...")
+        tt_host_tensor = ttnn.from_torch(
+            self.torch_input_tensor.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat16,
+            mesh_mapper=self.inputs_mesh_mapper,
+        )
+
+        # Initialize TTNN model
+        logger.info("Initializing TTNN model...")
+        print("Initializing TTNN model...")
+        self.ttnn_model = TTPanopticDeepLab(
+            parameters=parameters,
+            model_config=model_config,
+        )
+
+        logger.info("Running first TTNN model pass (JIT configuration)...")
+        # first run configures convs JIT
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+        logger.info("Running optimized TTNN model pass...")
+        # Optimized run
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor, self.output_tensor_2, self.output_tensor_3 = self.ttnn_model(self.input_tensor, self.device)
+        return self.output_tensor, self.output_tensor_2, self.output_tensor_3
+
+    def validate(self, output_tensor=None):
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+        batch_size = output_tensor.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, logger.error(f"Semantic Segmentation Head PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Panoptic DeepLab - Semantic Segmentation Head: batch_size={self.batch_size}, "
+            f"act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, "
+            f"math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}, shape={self.output_tensor.shape}"
+        )
+
+        # Validate instance segmentation head outputs
+        output_tensor = self.output_tensor_2
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor_2.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+        batch_size = output_tensor.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor_2, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, logger.error(f"Instance Segmentation Head PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Panoptic DeepLab - Instance Segmentation Offset Head: batch_size={self.batch_size}, "
+            f"act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, "
+            f"math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}, shape={self.output_tensor_2.shape}"
+        )
+
+        output_tensor = self.output_tensor_3
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor_3.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+        batch_size = output_tensor.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor_3, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, logger.error(f"Instance Segmentation Head 2 PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Panoptic DeepLab - Instance Segmentation Center Head: batch_size={self.batch_size}, "
+            f"act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, "
+            f"math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}, shape={self.output_tensor_3.shape}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, in_channels, height, width",
+    [
+        (1, 3, 512, 1024),
+    ],
+)
+def test_panoptic_deeplab(
+    device,
+    batch_size,
+    in_channels,
+    height,
+    width,
+):
+    PanopticDeepLabTestInfra(
+        device,
+        batch_size,
+        in_channels,
+        height,
+        width,
+        model_config,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_res.py
+++ b/models/experimental/panoptic_deeplab/tests/test_res.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+from ttnn.model_preprocessing import infer_ttnn_module_args, preprocess_model_parameters
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.tt.res_block import (
+    TTRes,
+    res_layer_optimisations,
+)
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+from models.experimental.panoptic_deeplab.reference.res_block import (
+    ResModel,
+)
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class HeadResInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        upsample_channels,
+        intermediate_channels,
+        out_channels,
+        height_res,
+        width_res,
+        height,
+        width,
+        name,
+    ):
+        super().__init__()
+        if not hasattr(self, "_model_initialized"):
+            torch.manual_seed(42)  # Only seed once
+            self._model_initialized = True
+            torch.cuda.manual_seed_all(42)
+            torch.backends.cudnn.deterministic = True
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.in_channels = in_channels
+        self.intermediate_channels = intermediate_channels
+        self.out_channels = out_channels
+        self.height_res = height_res
+        self.width_res = width_res
+        self.height = height
+        self.width = width
+        self.name = name
+        self.upsample_channels = upsample_channels
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        self.torch_input_tensor = torch.randn(
+            (self.batch_size, self.upsample_channels, self.height, self.width), dtype=torch.float32
+        )
+
+        self.torch_res_input_tensor = torch.randn(
+            (self.batch_size, self.in_channels, self.height_res, self.width_res), dtype=torch.float32
+        )
+
+        # torch model
+        torch_model = ResModel(self.in_channels, self.intermediate_channels, self.out_channels).eval()
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+        parameters.conv_args = {}
+        parameters.conv_args = infer_ttnn_module_args(
+            model=torch_model,
+            run_model=lambda model: model(self.torch_input_tensor, self.torch_res_input_tensor),
+            device=None,
+        )
+
+        # Generate input tensors for different model blocks
+        torch_model.to(torch.bfloat16)
+        self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+        self.torch_res_input_tensor = self.torch_res_input_tensor.to(torch.bfloat16)
+        self.torch_output_tensor = torch_model(self.torch_input_tensor, self.torch_res_input_tensor)
+
+        # Convert torch tensors to TTNN host tensors (NHWC, bfloat8_b)
+        def to_ttnn_host(tensor):
+            return ttnn.from_torch(
+                tensor.permute(0, 2, 3, 1),
+                dtype=ttnn.bfloat8_b,
+                device=device,
+                mesh_mapper=self.inputs_mesh_mapper,
+            )
+
+        tt_host_tensor = to_ttnn_host(self.torch_input_tensor)
+        tt_host_res_tensor = to_ttnn_host(self.torch_res_input_tensor)
+
+        # Move TTNN host tensors to device
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.res_input_tensor = ttnn.to_device(tt_host_res_tensor, device)
+
+        # ttnn model
+        self.ttnn_model = TTRes(parameters, model_config, layer_optimisations=res_layer_optimisations[self.name])
+
+        # run and validate
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor = self.ttnn_model(
+            self.input_tensor, self.res_input_tensor, self.upsample_channels, self.device
+        )
+        return self.output_tensor
+
+    def validate(self, output_tensor=None, output_tensor1=None):
+        """Validate outputs"""
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(output_tensor, device=self.device, mesh_composer=self.output_mesh_composer)
+        expected_shape = self.torch_output_tensor.shape
+        output_tensor = torch.reshape(
+            output_tensor, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+        batch_size = self.batch_size
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"Panoptic DeepLab {self.name} - batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, in_channels, upsample_channels, intermediate_channels, out_channels, height_res, width_res, height, width, name",
+    [
+        (1, 512, 256, 320, 256, 64, 128, 32, 64, "semantics_Res3"),  # semantics res3 block
+        (1, 256, 256, 288, 256, 128, 256, 64, 128, "semantics_Res2"),  # semantics res2 block
+        (1, 512, 256, 320, 128, 64, 128, 32, 64, "instance_Res3"),  # instance res3 block
+        (1, 256, 128, 160, 128, 128, 256, 64, 128, "instance_Res2"),  # instance res2 block
+    ],
+)
+def test_res(
+    device,
+    batch_size,
+    in_channels,
+    upsample_channels,
+    intermediate_channels,
+    out_channels,
+    height_res,
+    width_res,
+    height,
+    width,
+    name,
+):
+    HeadResInfra(
+        device,
+        batch_size,
+        model_config,
+        in_channels,
+        upsample_channels,
+        intermediate_channels,
+        out_channels,
+        height_res,
+        width_res,
+        height,
+        width,
+        name,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_resnet52_backbone.py
+++ b/models/experimental/panoptic_deeplab/tests/test_resnet52_backbone.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import tracy
+from loguru import logger
+import ttnn
+from ttnn.model_preprocessing import preprocess_model_parameters
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.reference.resnet52_backbone import ResNet52BackBone as TorchBackbone
+from models.experimental.panoptic_deeplab.tt.backbone import TTBackbone
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class BackboneTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        in_channels,
+        height,
+        width,
+        model_config,
+    ):
+        super().__init__()
+        torch.manual_seed(0)
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        # torch model
+        torch_model = TorchBackbone().eval()
+
+        input_shape = (batch_size * self.num_devices, in_channels, height, width)
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+
+        # golden
+        torch_model.to(torch.bfloat16)
+        try:
+            self.torch_input_tensor = torch.load(f"backbone_{input_shape}_input_tensor.pt")
+            self.torch_output_tensor = torch.load(f"backbone_{input_shape}_output_tensor.pt")
+        except:
+            self.torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+            self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+            self.torch_output_tensor = torch_model(self.torch_input_tensor)
+            torch.save(self.torch_input_tensor, f"backbone_{input_shape}_input_tensor.pt")
+            torch.save(self.torch_output_tensor, f"backbone_{input_shape}_output_tensor.pt")
+
+        tt_host_tensor = ttnn.from_torch(
+            self.torch_input_tensor.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat16,
+            mesh_mapper=self.inputs_mesh_mapper,
+        )
+
+        self.ttnn_model = TTBackbone(
+            parameters=parameters,
+            model_config=model_config,
+            small_tensor=width < 2048,
+        )
+
+        # First run configures convs JIT
+        tracy.signpost(f"Backbone_{input_shape}_compile")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+        # Optimized run
+        tracy.signpost(f"Backbone_{input_shape}_perf")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None  # ttnn.ReplicateTensorToMesh(device) causes unnecessary replication/takes more time on the first pass
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor = self.ttnn_model(
+            self.input_tensor,
+            self.device,
+        )
+        return self.output_tensor
+
+    def validate(self, output_tensor=None):
+        tt_output_tensor = self.output_tensor["res_5"] if output_tensor is None else output_tensor
+        tt_output_tensor_torch = ttnn.to_torch(
+            tt_output_tensor, device=self.device, mesh_composer=self.output_mesh_composer
+        )
+        ttnn.deallocate(tt_output_tensor)
+        expected_shape = self.torch_output_tensor.shape
+        tt_output_tensor_torch = torch.reshape(
+            tt_output_tensor_torch, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        tt_output_tensor_torch = torch.permute(tt_output_tensor_torch, (0, 3, 1, 2))
+
+        batch_size = tt_output_tensor_torch.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(
+            self.torch_output_tensor, tt_output_tensor_torch, pcc=valid_pcc
+        )
+
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"ResNet52 Backbone batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, in_channels, height, width",
+    [
+        (1, 3, 512, 1024),
+    ],
+)
+def test_backbone(
+    device,
+    batch_size,
+    in_channels,
+    height,
+    width,
+):
+    BackboneTestInfra(
+        device,
+        batch_size,
+        in_channels,
+        height,
+        width,
+        model_config,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_resnet52_bottleneck.py
+++ b/models/experimental/panoptic_deeplab/tests/test_resnet52_bottleneck.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+import ttnn
+import tracy
+import time
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from torchvision.models.resnet import Bottleneck
+from models.experimental.panoptic_deeplab.tt.bottleneck import TTBottleneck, bottleneck_layer_optimisations
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class BottleneckTestInfra:
+    def __init__(
+        self,
+        device,
+        batch_size,
+        inplanes,
+        planes,
+        height,
+        width,
+        stride,
+        dilation,
+        downsample,
+        name,
+        model_config,
+        reduced_dims=False,
+    ):
+        super().__init__()
+        torch.manual_seed(0)
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+        self.name = name
+
+        downsample_conv = None
+        if downsample:
+            downsample_conv = torch.nn.Sequential(
+                torch.nn.Conv2d(
+                    inplanes, planes * Bottleneck.expansion, kernel_size=1, stride=stride, padding=0, bias=False
+                ),
+                torch.nn.BatchNorm2d(planes * Bottleneck.expansion),
+            )
+
+        # torch model
+        torch_model = Bottleneck(
+            inplanes=inplanes, planes=planes, stride=stride, dilation=dilation, downsample=downsample_conv
+        ).eval()
+
+        if reduced_dims:
+            input_shape = (batch_size * self.num_devices, inplanes, height // 2, width // 2)
+        else:
+            input_shape = (batch_size * self.num_devices, inplanes, height, width)
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+
+        # golden
+        torch_model.to(torch.bfloat16)
+        try:
+            self.torch_input_tensor = torch.load(f"{name}_{input_shape}_input_tensor.pt")
+            self.torch_output_tensor = torch.load(f"{name}_{input_shape}_output_tensor.pt")
+        except:
+            self.torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+            self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+            self.torch_output_tensor = torch_model(self.torch_input_tensor)
+            torch.save(self.torch_input_tensor, f"{name}_{input_shape}_input_tensor.pt")
+            torch.save(self.torch_output_tensor, f"{name}_{input_shape}_output_tensor.pt")
+
+        # ttnn
+        tt_host_tensor = ttnn.from_torch(
+            self.torch_input_tensor.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat8_b,
+            mesh_mapper=self.inputs_mesh_mapper,
+        )
+
+        self.ttnn_model = TTBottleneck(
+            parameters=parameters,
+            downsample=downsample,
+            stride=stride,
+            model_config=model_config,
+            dilation=dilation,
+            name=name,
+            layer_optimisations=bottleneck_layer_optimisations[name[:7]],
+        )
+
+        # First run configures convs JIT
+        tracy.signpost(f"{name}_{input_shape}_compile")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+        # Optimized run
+        tracy.signpost(f"{name}_{input_shape}_perf")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        t0 = time.time()
+        self.run()
+        t1 = time.time()
+        self.validate()
+
+        inference_time_avg = round((t1 - t0), 6)
+        logger.info(
+            f"Model: ttnn_bottleneck - batch_size: {batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round((batch_size) / inference_time_avg)}"
+        )
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor, _ = self.ttnn_model(
+            self.input_tensor,
+            self.device,
+            self.input_tensor.shape,
+        )
+        return self.output_tensor
+
+    def validate(self, output_tensor=None):
+        tt_output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        tt_output_tensor_torch = ttnn.to_torch(
+            tt_output_tensor, device=self.device, mesh_composer=self.output_mesh_composer
+        )
+        ttnn.deallocate(tt_output_tensor)
+        expected_shape = self.torch_output_tensor.shape
+        tt_output_tensor_torch = torch.reshape(
+            tt_output_tensor_torch, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        tt_output_tensor_torch = torch.permute(tt_output_tensor_torch, (0, 3, 1, 2))
+
+        batch_size = tt_output_tensor_torch.shape[0]
+
+        valid_pcc = 0.97
+        self.pcc_passed, self.pcc_message = check_with_pcc(
+            self.torch_output_tensor, tt_output_tensor_torch, pcc=valid_pcc
+        )
+
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"ResNet50 Bottleneck Block {self.name} - batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, inplanes, planes, height, width, stride, dilation, downsample, name",
+    (
+        # Layer 1
+        (1, 128, 64, 256, 512, 1, 1, True, "layer_1_d"),
+        (1, 256, 64, 256, 512, 1, 1, False, "layer_1_nd"),
+        # Layer 2
+        (1, 256, 128, 256, 512, 2, 1, True, "layer_2_d"),
+        (1, 512, 128, 128, 256, 1, 1, False, "layer_2_nd"),
+        # Layer 3
+        (1, 512, 256, 128, 256, 2, 1, True, "layer_3_d"),
+        (1, 1024, 256, 64, 128, 1, 1, False, "layer_3_nd"),
+        # Layer 4
+        (1, 1024, 512, 64, 128, 1, 2, True, "layer_4_d"),
+        (1, 2048, 512, 64, 128, 1, 4, False, "layer_4_nd_1"),
+        (1, 2048, 512, 64, 128, 1, 8, False, "layer_4_nd_2"),
+    ),
+)
+def test_bottleneck(device, batch_size, inplanes, planes, height, width, stride, dilation, downsample, name):
+    BottleneckTestInfra(
+        device,
+        batch_size,
+        inplanes,
+        planes,
+        height,
+        width,
+        stride,
+        dilation,
+        downsample,
+        name,
+        model_config,
+        reduced_dims=True,
+    )

--- a/models/experimental/panoptic_deeplab/tests/test_resnet52_stem.py
+++ b/models/experimental/panoptic_deeplab/tests/test_resnet52_stem.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import tracy
+from loguru import logger
+from ttnn.model_preprocessing import preprocess_model_parameters
+import ttnn
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.reference.resnet52_stem import DeepLabStem
+from models.experimental.panoptic_deeplab.tt.stem import resnet52Stem, neck_optimisations
+from models.experimental.panoptic_deeplab.tt.custom_preprocessing import create_custom_mesh_preprocessor
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+class Resnet52StemTestInfra:
+    def __init__(self, device, batch_size, inplanes, planes, height, width, stride, model_config):
+        super().__init__()
+        torch.manual_seed(0)
+        self.pcc_passed = False
+        self.pcc_message = "call validate()?"
+        self.device = device
+        self.num_devices = device.get_num_devices()
+        self.batch_size = batch_size
+        self.inputs_mesh_mapper, self.weights_mesh_mapper, self.output_mesh_composer = self.get_mesh_mappers(device)
+
+        # torch model
+        torch_model = DeepLabStem(
+            in_channels=inplanes,
+            out_channels=planes,
+            stride=stride,
+        ).eval()
+
+        input_shape = (batch_size * self.num_devices, inplanes, height, width)
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: torch_model,
+            custom_preprocessor=create_custom_mesh_preprocessor(self.weights_mesh_mapper),
+            device=None,
+        )
+
+        # golden
+        torch_model.to(torch.bfloat16)
+        try:
+            self.torch_input_tensor = torch.load(f"stem_{input_shape}_input_tensor.pt")
+            self.torch_output_tensor = torch.load(f"stem_{input_shape}_output_tensor.pt")
+        except:
+            self.torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+            self.torch_input_tensor = self.torch_input_tensor.to(torch.bfloat16)
+            self.torch_output_tensor = torch_model(self.torch_input_tensor)
+            torch.save(self.torch_input_tensor, f"stem_{input_shape}_input_tensor.pt")
+            torch.save(self.torch_output_tensor, f"stem_{input_shape}_output_tensor.pt")
+
+        # ttnn
+        tt_host_tensor = ttnn.from_torch(
+            self.torch_input_tensor.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat8_b,
+            mesh_mapper=self.inputs_mesh_mapper,
+        )
+
+        layer_optimisations = neck_optimisations["optimization_full_tensor"]
+        if input_shape[-1] == 1024:
+            layer_optimisations = neck_optimisations["optimization_small_tensor"]
+
+        self.ttnn_model = resnet52Stem(
+            parameters=parameters,
+            stride=stride,
+            model_config=model_config,
+            layer_optimisations=layer_optimisations,
+        )
+
+        # First run configures convs JIT
+        tracy.signpost(f"Stem_{input_shape}_compile")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+        # Optimized run
+        tracy.signpost(f"Stem_{input_shape}_perf")
+        self.input_tensor = ttnn.to_device(tt_host_tensor, device)
+        self.run()
+        self.validate()
+
+    def get_mesh_mappers(self, device):
+        if device.get_num_devices() != 1:
+            inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
+            weights_mesh_mapper = None
+            output_mesh_composer = ttnn.ConcatMeshToTensor(device, dim=0)
+        else:
+            inputs_mesh_mapper = None
+            weights_mesh_mapper = None
+            output_mesh_composer = None
+        return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
+
+    def run(self):
+        self.output_tensor = self.ttnn_model(
+            self.input_tensor,
+            self.device,
+        )
+        return self.output_tensor
+
+    def validate(self, output_tensor=None):
+        tt_output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        tt_output_tensor_torch = ttnn.to_torch(
+            tt_output_tensor, device=self.device, mesh_composer=self.output_mesh_composer
+        )
+        ttnn.deallocate(tt_output_tensor)
+        expected_shape = self.torch_output_tensor.shape
+        tt_output_tensor_torch = torch.reshape(
+            tt_output_tensor_torch, (expected_shape[0], expected_shape[2], expected_shape[3], expected_shape[1])
+        )
+        tt_output_tensor_torch = torch.permute(tt_output_tensor_torch, (0, 3, 1, 2))
+
+        batch_size = tt_output_tensor_torch.shape[0]
+
+        valid_pcc = 0.99
+        self.pcc_passed, self.pcc_message = check_with_pcc(
+            self.torch_output_tensor, tt_output_tensor_torch, pcc=valid_pcc
+        )
+
+        assert self.pcc_passed, logger.error(f"PCC check failed: {self.pcc_message}")
+        logger.info(
+            f"ResNet52 Stem Block batch_size={batch_size}, act_dtype={model_config['ACTIVATIONS_DTYPE']}, weight_dtype={model_config['WEIGHTS_DTYPE']}, math_fidelity={model_config['MATH_FIDELITY']}, PCC={self.pcc_message}"
+        )
+
+        return self.pcc_passed, self.pcc_message
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, inplanes, planes, height, width, stride",
+    ((1, 3, 128, 512, 1024, 1),),
+)
+def test_stem(
+    device,
+    batch_size,
+    inplanes,
+    planes,
+    height,
+    width,
+    stride,
+):
+    Resnet52StemTestInfra(
+        device,
+        batch_size,
+        inplanes,
+        planes,
+        height,
+        width,
+        stride,
+        model_config,
+    )

--- a/models/experimental/panoptic_deeplab/tt/aspp.py
+++ b/models/experimental/panoptic_deeplab/tt/aspp.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from loguru import logger
+from models.experimental.panoptic_deeplab.tt.common import TTConv2D, TTUpsample
+
+
+class PanopticDeeplabASPP:
+    def __init__(self, parameters, model_config, layer_optimisations=None) -> None:
+        self.model_config = model_config
+
+        # ASPP_0_Conv
+        self.ASPP_0_Conv = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_0_Conv,
+            kernel_fidelity=model_config,
+            activation="relu",
+            act_block_h=32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_1_Depthwise
+        self.ASPP_1_Depthwise = TTConv2D(
+            kernel_size=3,
+            stride=1,
+            padding=6,
+            dilation=6,
+            groups=2048,
+            parameters=parameters.ASPP_1_Depthwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            act_block_h=64,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            reallocate_halo_output=True,
+            enable_split_reader=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_1_pointwise
+        self.ASPP_1_pointwise = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_1_pointwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_2_Depthwise
+        self.ASPP_2_Depthwise = TTConv2D(
+            kernel_size=3,
+            stride=1,
+            padding=12,
+            dilation=12,
+            groups=2048,
+            parameters=parameters.ASPP_2_Depthwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            act_block_h=1024,
+            shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            reallocate_halo_output=False,
+            enable_split_reader=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_2_pointwise
+        self.ASPP_2_pointwise = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_2_pointwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_3_Depthwise
+        self.ASPP_3_Depthwise = TTConv2D(
+            kernel_size=3,
+            stride=1,
+            padding=18,
+            dilation=18,
+            groups=2048,
+            parameters=parameters.ASPP_3_Depthwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            act_block_h=512,
+            shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            # deallocate_activation=True,
+            enable_split_reader=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP_3_ pointwise
+        self.ASPP_3_pointwise = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_3_pointwise,
+            kernel_fidelity=model_config,
+            activation="relu",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reshard_if_not_optimal=True,
+        )
+        # ASPP_4_Conv_1
+        self.ASPP_4_Conv_1 = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_4_Conv_1,
+            kernel_fidelity=model_config,
+            activation="relu",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            reshard_if_not_optimal=True,
+        )
+
+        # ASPP4_upsample
+        self.ASPP4_upsample = TTUpsample(
+            scale_factor=(32, 64),
+            mode="bilinear",
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+        )
+
+        # ASPP_project
+        self.ASPP_project = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=1,
+            parameters=parameters.ASPP_project,
+            kernel_fidelity=model_config,
+            activation="relu",
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reshard_if_not_optimal=True,
+        )
+
+    def __call__(
+        self,
+        x,
+        device,
+    ):
+        # ASPP branch
+        logger.debug("Running ASPP_0_Conv")
+        aspp0, shape = self.ASPP_0_Conv(device, x, (1, 32, 64, 2048))
+
+        logger.debug("Running ASPP_1_Depthwise")
+        aspp1_dw, shape = self.ASPP_1_Depthwise(device, x, (1, 32, 64, 2048))
+
+        logger.debug("Running ASPP_1_pointwise")
+        aspp1, shape = self.ASPP_1_pointwise(device, aspp1_dw, shape)
+
+        logger.debug("Running ASPP_2_Depthwise")
+        aspp2_dw, shape = self.ASPP_2_Depthwise(device, x, (1, 32, 64, 2048))
+
+        logger.debug("Running ASPP_2_pointwise")
+        aspp2, shape = self.ASPP_2_pointwise(device, aspp2_dw, shape)
+
+        logger.debug("Running ASPP_3_Depthwise")
+        aspp3_dw, shape = self.ASPP_3_Depthwise(device, x, (1, 32, 64, 2048))
+
+        logger.debug("Running ASPP_3_pointwise")
+        aspp3, shape = self.ASPP_3_pointwise(device, aspp3_dw, shape)
+
+        logger.debug("Running ASPP_4_avg_pool")
+        x = ttnn.reshape(x, [1, 1, x.shape[0] * x.shape[1] * x.shape[2], x.shape[-1]])
+
+        aspp4 = ttnn.avg_pool2d(
+            input_tensor=x,
+            batch_size=1,
+            input_h=32,
+            input_w=64,
+            channels=2048,
+            kernel_size=(32, 64),
+            stride=(1, 1),
+            padding=(0, 0),
+            applied_shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            in_place_halo=True,
+            deallocate_input=True,
+            reallocate_halo_output=True,
+        )
+
+        ttnn.deallocate(x, force=True)
+
+        logger.debug("Running ASPP_4_Conv_1")
+        shape = (1, 1, 1, 2048)
+        aspp4_conv, shape = self.ASPP_4_Conv_1(device, aspp4, shape)
+        ttnn.deallocate(aspp4, force=True)
+
+        logger.debug("Running ASPP_4_upsample")
+        aspp4_conv_upsample = self.ASPP4_upsample(
+            device, aspp4_conv, [1, 1, 1, 256], reshape_output=True, dtype=ttnn.bfloat8_b
+        )
+
+        ttnn.deallocate(aspp4_conv, force=True)
+
+        logger.debug("Running ASPP_concat")
+        aspp_concat = ttnn.concat(
+            [aspp0, aspp1, aspp2, aspp3, aspp4_conv_upsample],
+            dim=3,
+        )
+
+        logger.debug("Running ASPP_project")
+        shape = (1, 32, 64, 1280)
+        output, shape = self.ASPP_project(device, aspp_concat, shape)
+
+        logger.debug("finished with ttnn imp")
+
+        return output

--- a/models/experimental/panoptic_deeplab/tt/backbone.py
+++ b/models/experimental/panoptic_deeplab/tt/backbone.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import ttnn
+from typing import List, Optional
+from models.experimental.panoptic_deeplab.tt.bottleneck import TTBottleneck, bottleneck_layer_optimisations
+from models.experimental.panoptic_deeplab.tt.stem import resnet52Stem, neck_optimisations
+
+
+class TTBackbone:
+    def __init__(self, parameters, model_config, reshard_block_inputs: bool = True, small_tensor: bool = False):
+        layers = [3, 4, 6, 3]
+        self.inplanes = 128
+        self.reshard_block_inputs = reshard_block_inputs
+        # stem
+        neck_layer_optimistaion = neck_optimisations["optimization_full_tensor"]
+        if small_tensor:
+            neck_layer_optimistaion = neck_optimisations["optimization_small_tensor"]
+        self.stem = resnet52Stem(
+            parameters.stem,
+            stride=1,
+            model_config=model_config,
+            layer_optimisations=neck_layer_optimistaion,
+        )
+        # Four bottleneck stages (layer1, layer2, layer3, layer4)
+        self.layer1 = self._make_layer(
+            name="layer_1",
+            parameters=parameters.layer1,
+            planes=64,
+            blocks=layers[0],
+            stride=1,
+            dialate_config=None,
+            model_config=model_config,
+            layer_optimisations=bottleneck_layer_optimisations["layer_1"],
+        )
+        self.layer2 = self._make_layer(
+            name="layer_2",
+            parameters=parameters.layer2,
+            planes=128,
+            blocks=layers[1],
+            stride=2,
+            dialate_config=None,
+            model_config=model_config,
+            layer_optimisations=bottleneck_layer_optimisations["layer_2"],
+        )
+        self.layer3 = self._make_layer(
+            name="layer_3",
+            parameters=parameters.layer3,
+            planes=256,
+            blocks=layers[2],
+            stride=2,
+            dialate_config=None,
+            model_config=model_config,
+            layer_optimisations=bottleneck_layer_optimisations["layer_3"],
+        )
+        self.layer4 = self._make_layer(
+            name="layer_4",
+            parameters=parameters.layer4,
+            planes=512,
+            blocks=layers[3],
+            stride=1,
+            dialate_config=[2, 4, 8],
+            model_config=model_config,
+            layer_optimisations=bottleneck_layer_optimisations["layer_4"],
+        )
+
+    def _make_layer(
+        self,
+        name: str,
+        parameters,
+        planes: int,
+        blocks: int,
+        stride: int,
+        dialate_config: Optional[List[int]] = None,
+        model_config=None,
+        layer_optimisations=bottleneck_layer_optimisations["default"],
+    ) -> List[TTBottleneck]:
+        if dialate_config is None:
+            dialate_config = [1] * blocks
+        layers = []
+        layers.append(
+            TTBottleneck(
+                parameters=parameters[0],
+                downsample=stride != 1 or self.inplanes != planes * TTBottleneck.expansion,
+                stride=stride,
+                model_config=model_config,
+                name=f"{name}_d",
+                layer_optimisations=layer_optimisations,
+            )
+        )
+        self.inplanes = planes * TTBottleneck.expansion
+        for block_num in range(1, blocks):
+            layers.append(
+                TTBottleneck(
+                    parameters=parameters[block_num],
+                    downsample=False,
+                    stride=1,
+                    model_config=model_config,
+                    dilation=dialate_config[block_num],
+                    name=f"{name}_nd_{block_num}",
+                    layer_optimisations=layer_optimisations,
+                )
+            )
+        return layers
+
+    def __call__(self, x, device):
+        logger.debug(f"Running RN52_backbone Stem")
+        x = self.stem(x, device)
+        shape = x.shape
+
+        logger.debug(f"Running RN52_backbone Layer1")
+        for index, block in enumerate(self.layer1):
+            x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.reallocate(x)
+            x, shape = block(x, device, shape)
+
+        res_2 = x
+        res_2 = ttnn.to_memory_config(res_2, ttnn.DRAM_MEMORY_CONFIG)
+
+        logger.debug(f"Running RN52_backbone Layer2")
+        for index, block in enumerate(self.layer2):
+            if self.reshard_block_inputs:
+                x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.reallocate(x)
+            x, shape = block(x, device, shape)
+
+        res_3 = x
+        res_3 = ttnn.to_memory_config(res_3, ttnn.DRAM_MEMORY_CONFIG)
+
+        logger.debug(f"Running RN52_backbone Layer3")
+        for index, block in enumerate(self.layer3):
+            x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.reallocate(x)
+            x, shape = block(x, device, shape)
+
+        res_4 = x
+        res_4 = ttnn.to_memory_config(res_4, ttnn.DRAM_MEMORY_CONFIG)
+
+        logger.debug(f"Running RN52_backbone Layer4")
+        for index, block in enumerate(self.layer4):
+            x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.reallocate(x)
+            x, shape = block(x, device, shape)
+
+        res_5 = x
+        res_5 = ttnn.to_memory_config(res_5, ttnn.DRAM_MEMORY_CONFIG)
+
+        return {"res_2": res_2, "res_3": res_3, "res_5": res_5}

--- a/models/experimental/panoptic_deeplab/tt/bottleneck.py
+++ b/models/experimental/panoptic_deeplab/tt/bottleneck.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import ttnn
+from models.experimental.panoptic_deeplab.tt.common import TTConv2D
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class BottleneckOptimizer:
+    conv1: dict()
+    conv2: dict()
+    conv3: dict()
+    downsample: dict()
+
+
+bottleneck_layer_optimisations = {
+    "default": BottleneckOptimizer(
+        conv1={"act_block_h": 32, "memory_config": ttnn.DRAM_MEMORY_CONFIG},
+        conv2={
+            "act_block_h": 32,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+        },
+        downsample={
+            "memory_config": None,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+    ),
+    "layer_1": BottleneckOptimizer(
+        conv1={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "reshard_if_not_optimal": True,
+        },
+        conv2={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+        },
+        downsample={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=2),
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+    ),
+    "layer_2": BottleneckOptimizer(
+        conv1={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "reshard_if_not_optimal": True,
+        },
+        conv2={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+        },
+        downsample={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=2),
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+    ),
+    "layer_3": BottleneckOptimizer(
+        conv1={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "reshard_if_not_optimal": True,
+        },
+        conv2={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+        },
+        downsample={
+            "act_block_h": 32,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+    ),
+    "layer_4": BottleneckOptimizer(
+        conv1={
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "reshard_if_not_optimal": True,
+        },
+        conv2={
+            "act_block_h": 512,
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "deallocate_activation": True,
+            "reshard_if_not_optimal": True,
+            "reallocate_halo_output": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "deallocate_activation": True,
+        },
+        downsample={
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "reshard_if_not_optimal": True,
+            "deallocate_activation": True,
+        },
+    ),
+}
+
+
+class TTBottleneck:
+    expansion: int = 4
+
+    def __init__(
+        self,
+        parameters,
+        downsample,
+        stride,
+        model_config,
+        dilation: int = 1,
+        name: Optional[str] = "",
+        layer_optimisations=bottleneck_layer_optimisations["default"],
+    ) -> None:
+        self.name = name
+        self.conv1 = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dilation=1,
+            parameters=parameters.conv1,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv1,
+        )
+        self.conv2 = TTConv2D(
+            kernel_size=3,
+            stride=stride if downsample else 1,
+            padding=dilation,
+            dilation=dilation,
+            parameters=parameters.conv2,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv2,
+        )
+        self.conv3 = TTConv2D(
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dilation=1,
+            parameters=parameters.conv3,
+            kernel_fidelity=model_config,
+            activation="",
+            **layer_optimisations.conv3,
+        )
+
+        self.downsample = downsample
+        if downsample:
+            self.downsample_conv = TTConv2D(
+                kernel_size=1,
+                stride=stride,
+                padding=0,
+                dilation=1,
+                parameters=parameters.downsample,
+                kernel_fidelity=model_config,
+                activation="",
+                **layer_optimisations.downsample,
+            )
+
+        self.model_config = model_config
+        return
+
+    def __call__(
+        self,
+        x,
+        device,
+        in_shape,
+    ):
+        # Convert to DRAM interleaved for DRAM sliced conv's
+        if self.name in ["layer_1_d", "layer_2_d"]:
+            x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+
+        # conv1 is 1x1 conv
+        logger.debug(f"Running conv1")
+        out, shape = self.conv1(device, x, in_shape)
+
+        if self.name in ["layer_1_d", "layer_2_d", "layer_3_d", "layer_4_d"]:
+            out = ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG)
+
+        # conv2 is 3x3 conv
+        logger.debug(f"Running conv2")
+        out, shape = self.conv2(device, out, shape)
+
+        # conv3 is 1x1 conv
+        logger.debug(f"Running conv3")
+        out, shape = self.conv3(device, out, shape)
+
+        # run downsample conv 1x1 if required
+        if self.downsample:
+            if self.name == "layer_1_d":  # Fix for L1 OOM
+                out = ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG)
+            logger.debug(f"Running downsample")
+            ds_out, _ = self.downsample_conv(device, x, in_shape)
+        else:
+            ds_out = x
+
+        if ds_out.shape != out.shape:
+            ds_out = ttnn.reshape(ds_out, (1, 1, ds_out.shape[0] * ds_out.shape[1] * ds_out.shape[2], ds_out.shape[3]))
+        if ds_out.layout != out.layout:
+            ds_out = ttnn.to_layout(ds_out, out.layout)
+        if ds_out.memory_config() != out.memory_config() and (self.name != "layer_1_nd"):
+            ds_out = ttnn.to_memory_config(ds_out, out.memory_config())
+
+        out = ttnn.add_(
+            out,
+            ds_out,
+            activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)],
+        )
+
+        ttnn.deallocate(ds_out)
+        return out, shape

--- a/models/experimental/panoptic_deeplab/tt/common.py
+++ b/models/experimental/panoptic_deeplab/tt/common.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
+
+
+class TTConv2D:
+    def __init__(
+        self,
+        kernel_size: int = 1,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        parameters: dict | None = None,
+        kernel_fidelity: dict | None = None,
+        *,
+        memory_config=None,
+        act_block_h=None,
+        act_block_w=None,
+        deallocate_activation=False,
+        reallocate_halo_output=False,
+        shard_layout=None,
+        activation="",
+        groups=1,
+        num_cores_nhw=None,
+        is_reshape=False,
+        enable_split_reader=False,
+        enable_act_double_buffer=False,
+        enable_weights_double_buffer=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+        math_approx_mode=False,
+        input_channels_alignment=32,
+        reshard_if_not_optimal=False,
+        slice_config=None,
+        dtype=None,
+        weights_dtype=None,
+        math_fidelity=None,
+    ) -> None:
+        if isinstance(kernel_size, int):
+            self.kernel_size = (kernel_size, kernel_size)
+        elif isinstance(kernel_size, tuple):
+            self.kernel_size = kernel_size
+        else:
+            ValueError("Invalid config")
+        if isinstance(stride, int):
+            self.stride = (stride, stride)
+        elif isinstance(stride, tuple):
+            self.stride = stride
+        else:
+            ValueError("Invalid config")
+        if isinstance(padding, int):
+            self.padding = (padding, padding, padding, padding)
+        elif isinstance(padding, tuple):
+            self.padding = padding
+        else:
+            ValueError("Invalid config")
+        if isinstance(dilation, int):
+            self.dilation = (dilation, dilation)
+        elif isinstance(dilation, tuple):
+            self.dilation = dilation
+        else:
+            ValueError("Invalid config")
+
+        self.kernel_fidelity = kernel_fidelity
+        self.weights = parameters["weight"]
+        self.bias = parameters["bias"]
+        self.deallocate_activation = deallocate_activation
+        self.reallocate_halo_output = reallocate_halo_output
+        self.fp32_dest_acc_en = fp32_dest_acc_en
+        self.packer_l1_acc = packer_l1_acc
+        self.math_approx_mode = math_approx_mode
+        self.input_channels_alignment = input_channels_alignment
+        self.reshard_if_not_optimal = reshard_if_not_optimal
+        self.out_channels = self.weights.shape[0]
+        self.act_block_h = act_block_h
+        self.act_block_w = act_block_w
+        self.groups = groups
+        self.activation = activation
+        self.memory_config = memory_config
+        self.shard_layout = shard_layout
+        self.slice_config = slice_config
+        self.num_cores_nhw = num_cores_nhw
+        self.is_reshape = is_reshape
+        self.enable_split_reader = enable_split_reader
+        self.enable_act_double_buffer = enable_act_double_buffer
+        self.enable_weights_double_buffer = enable_weights_double_buffer
+        if dtype is not None:
+            self.dtype = dtype
+        else:
+            self.dtype = self.kernel_fidelity["ACTIVATIONS_DTYPE"]
+        if weights_dtype is not None:
+            self.weights_dtype = weights_dtype
+        else:
+            self.weights_dtype = self.kernel_fidelity["WEIGHTS_DTYPE"]
+        if math_fidelity is not None:
+            self.math_fidelity = math_fidelity
+        else:
+            self.math_fidelity = self.kernel_fidelity["MATH_FIDELITY"]
+
+    def __call__(self, device, input_tensor, input_shape):
+        conv_config = ttnn.Conv2dConfig(
+            weights_dtype=self.weights_dtype,
+            activation=self.activation,
+            in_place=True,
+            shard_layout=self.shard_layout,
+            reshard_if_not_optimal=self.reshard_if_not_optimal,
+            enable_split_reader=self.enable_split_reader,
+            enable_act_double_buffer=self.enable_act_double_buffer,
+            enable_weights_double_buffer=self.enable_weights_double_buffer,
+            deallocate_activation=self.deallocate_activation,
+            reallocate_halo_output=self.reallocate_halo_output,
+        )
+        compute_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=self.kernel_fidelity["MATH_FIDELITY"],
+            fp32_dest_acc_en=self.fp32_dest_acc_en,
+            packer_l1_acc=self.packer_l1_acc,
+            math_approx_mode=self.math_approx_mode,
+        )
+        if self.num_cores_nhw is not None:
+            shard_grid = get_shard_grid_from_num_cores(self.num_cores_nhw, device)
+            conv_config.core_grid = shard_grid
+            conv_config.override_sharding_config = True
+
+        if self.act_block_h is not None:
+            conv_config.act_block_h_override = self.act_block_h
+        if self.act_block_w is not None:
+            conv_config.act_block_w_div = self.act_block_w
+
+        [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(
+            input_tensor=input_tensor,
+            weight_tensor=self.weights,
+            bias_tensor=self.bias,
+            in_channels=input_shape[-1],
+            out_channels=self.out_channels,
+            device=device,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=input_shape[-4],
+            input_height=input_shape[-3],
+            input_width=input_shape[-2],
+            conv_config=conv_config,
+            compute_config=compute_config,
+            slice_config=self.slice_config,
+            groups=self.groups,
+            return_weights_and_bias=True,
+            return_output_dim=True,
+            dtype=self.dtype,
+            memory_config=self.memory_config,
+        )
+
+        if self.is_reshape:
+            output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+            output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+            output_tensor = ttnn.reshape(
+                output_tensor, (input_tensor.shape[0], _out_height, _out_width, output_tensor.shape[-1])
+            )
+            output_tensor = ttnn.permute(output_tensor, (0, 3, 1, 2))
+        return output_tensor, (input_tensor.shape[0], _out_height, _out_width, output_tensor.shape[-1])
+
+
+class TTUpsample:
+    def __init__(
+        self,
+        scale_factor: int = 1,
+        mode: str = "bilinear",
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+    ) -> None:
+        self.scale_factor = scale_factor
+        self.mode = mode
+        self.memory_config = memory_config
+
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=math_fidelity,
+            math_approx_mode=math_approx_mode,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+        )
+
+    def __call__(
+        self,
+        device,
+        input_tensor,
+        input_shape=None,
+        reshape_output=False,
+        pad_ch_to_32=False,
+        sent_to_dram=False,
+        dtype=ttnn.bfloat8_b,
+    ):
+        if sent_to_dram:
+            input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
+
+        input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor = ttnn.reshape(input_tensor, input_shape)
+
+        if pad_ch_to_32:
+            input_tensor = ttnn.pad(input_tensor, [(0, 0), (0, 0), (0, 0), (0, 32 - input_tensor.shape[-1] % 32)], 0)
+
+        output_tensor = ttnn.upsample(
+            input_tensor,
+            scale_factor=self.scale_factor,
+            mode=self.mode,
+            memory_config=self.memory_config,
+            compute_kernel_config=self.compute_kernel_config,
+        )
+
+        if pad_ch_to_32:
+            output_tensor = ttnn.slice(
+                output_tensor,
+                [0, 0, 0, 0],
+                [output_tensor.shape[0], output_tensor.shape[1], output_tensor.shape[2], input_shape[-1]],
+            )
+
+        if reshape_output:
+            output_tensor = ttnn.from_device(output_tensor)
+            output_tensor = ttnn.to_dtype(output_tensor, dtype)
+            output_tensor = ttnn.to_device(output_tensor, device)
+
+            output_tensor = ttnn.reshape(
+                output_tensor,
+                [
+                    1,
+                    1,
+                    output_tensor.shape[0] * output_tensor.shape[1] * output_tensor.shape[2],
+                    output_tensor.shape[3],
+                ],
+            )
+
+        return output_tensor

--- a/models/experimental/panoptic_deeplab/tt/custom_preprocessing.py
+++ b/models/experimental/panoptic_deeplab/tt/custom_preprocessing.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torchvision
+from ttnn.model_preprocessing import convert_torch_model_to_ttnn_model, fold_batch_norm2d_into_conv2d
+
+import ttnn
+from models.utility_functions import pad_and_fold_conv_filters_for_unity_stride
+from models.experimental.panoptic_deeplab.reference.resnet52_stem import DeepLabStem
+
+from models.experimental.panoptic_deeplab.reference.head import (
+    HeadModel,
+)
+from models.experimental.panoptic_deeplab.reference.res_block import (
+    ResModel,
+)
+from models.experimental.panoptic_deeplab.reference.aspp import (
+    PanopticDeeplabASPPModel,
+)
+from models.experimental.panoptic_deeplab.reference.decoder import (
+    DecoderModel,
+)
+
+
+def preprocess_conv_parameter(parameter, *, dtype):
+    parameter = ttnn.from_torch(parameter, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    return parameter
+
+
+def custom_preprocessor(
+    model, name, ttnn_module_args, convert_to_ttnn, custom_preprocessor_func=None, mesh_mapper=None
+):
+    parameters = {}
+    if isinstance(model, torchvision.models.resnet.Bottleneck):
+        conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.conv1, model.bn1)
+        conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.conv2, model.bn2)
+        conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.conv3, model.bn3)
+        parameters["conv1"] = {}
+        parameters["conv2"] = {}
+        parameters["conv3"] = {}
+        parameters["conv1"]["weight"] = ttnn.from_torch(conv1_weight, mesh_mapper=mesh_mapper)
+        parameters["conv2"]["weight"] = ttnn.from_torch(conv2_weight, mesh_mapper=mesh_mapper)
+        parameters["conv3"]["weight"] = ttnn.from_torch(conv3_weight, mesh_mapper=mesh_mapper)
+        parameters["conv1"]["bias"] = ttnn.from_torch(torch.reshape(conv1_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        parameters["conv2"]["bias"] = ttnn.from_torch(torch.reshape(conv2_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        parameters["conv3"]["bias"] = ttnn.from_torch(torch.reshape(conv3_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        if model.downsample is not None:
+            downsample_weight, downsample_bias = fold_batch_norm2d_into_conv2d(model.downsample[0], model.downsample[1])
+            parameters["downsample"] = {}
+            parameters["downsample"]["weight"] = ttnn.from_torch(downsample_weight, mesh_mapper=mesh_mapper)
+            parameters["downsample"]["bias"] = ttnn.from_torch(
+                torch.reshape(downsample_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper
+            )
+    elif isinstance(model, torchvision.models.resnet.ResNet):
+        conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.conv1, model.bn1)
+        conv1_weight = pad_and_fold_conv_filters_for_unity_stride(conv1_weight, 2, 2)
+        parameters["conv1"] = {}
+        parameters["conv1"]["weight"] = ttnn.from_torch(conv1_weight, mesh_mapper=mesh_mapper)
+        parameters["conv1"]["bias"] = ttnn.from_torch(torch.reshape(conv1_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        named_parameters = tuple((name, parameter) for name, parameter in model.named_parameters() if "." not in name)
+        for child_name, child in tuple(model.named_children()) + named_parameters:
+            if child_name in {"conv1", "bn1"}:
+                continue
+            parameters[child_name] = convert_torch_model_to_ttnn_model(
+                child,
+                name=name,
+                custom_preprocessor=custom_preprocessor_func,
+                convert_to_ttnn=convert_to_ttnn,
+                ttnn_module_args=ttnn_module_args,
+            )
+    elif isinstance(model, DeepLabStem):
+        conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.conv1, model.bn1)
+        conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.conv2, model.bn2)
+        conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.conv3, model.bn3)
+        parameters["conv1"] = {}
+        parameters["conv2"] = {}
+        parameters["conv3"] = {}
+        parameters["conv1"]["weight"] = ttnn.from_torch(conv1_weight, mesh_mapper=mesh_mapper)
+        parameters["conv2"]["weight"] = ttnn.from_torch(conv2_weight, mesh_mapper=mesh_mapper)
+        parameters["conv3"]["weight"] = ttnn.from_torch(conv3_weight, mesh_mapper=mesh_mapper)
+        parameters["conv1"]["bias"] = ttnn.from_torch(torch.reshape(conv1_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        parameters["conv2"]["bias"] = ttnn.from_torch(torch.reshape(conv2_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+        parameters["conv3"]["bias"] = ttnn.from_torch(torch.reshape(conv3_bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+
+    elif isinstance(model, HeadModel):
+        for name, module in model.named_children():
+            if hasattr(module, "__getitem__"):
+                if len(module) > 1 and hasattr(module[0], "weight") and hasattr(module[1], "weight"):
+                    # Assume Conv + BN, fold BN into Conv
+                    weight, bias = fold_batch_norm2d_into_conv2d(module[0], module[1])
+                elif hasattr(module[0], "weight"):
+                    # Just a Conv, no BN
+                    weight = module[0].weight.clone().detach().contiguous()
+                    bias = (
+                        module[0].bias.clone().detach().contiguous()
+                        if module[0].bias is not None
+                        else torch.zeros(module[0].out_channels)
+                    )
+                else:
+                    continue
+            elif hasattr(module, "weight"):
+                # Single Conv2d
+                weight = module.weight.clone().detach().contiguous()
+                bias = (
+                    module.bias.clone().detach().contiguous()
+                    if module.bias is not None
+                    else torch.zeros(module.out_channels)
+                )
+            else:
+                continue
+
+            parameters[name] = {}
+            parameters[name]["weight"] = ttnn.from_torch(weight, mesh_mapper=mesh_mapper)
+            parameters[name]["bias"] = ttnn.from_torch(torch.reshape(bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+
+    elif isinstance(model, PanopticDeeplabASPPModel):
+        for name, module in model.named_children():
+            # For each submodule (e.g., ASPP_0_Conv, ASPP_1_Depthwise, etc.)
+            if hasattr(module, "__getitem__"):
+                # If it's a Sequential or similar
+                if len(module) > 1 and hasattr(module[0], "weight") and hasattr(module[1], "weight"):
+                    # Assume Conv + BN, fold BN into Conv
+                    weight, bias = fold_batch_norm2d_into_conv2d(module[0], module[1])
+                elif hasattr(module[0], "weight"):
+                    # Just a Conv, no BN
+                    weight = module[0].weight.clone().detach().contiguous()
+                    bias = (
+                        module[0].bias.clone().detach().contiguous()
+                        if module[0].bias is not None
+                        else torch.zeros(module[0].out_channels)
+                    )
+                else:
+                    continue
+            elif hasattr(module, "weight"):
+                # Single Conv2d
+                weight = module.weight.clone().detach().contiguous()
+                bias = (
+                    module.bias.clone().detach().contiguous()
+                    if module.bias is not None
+                    else torch.zeros(module.out_channels)
+                )
+            else:
+                continue
+
+            parameters[name] = {}
+            parameters[name]["weight"] = ttnn.from_torch(weight, mesh_mapper=mesh_mapper)
+            parameters[name]["bias"] = ttnn.from_torch(torch.reshape(bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+
+    elif isinstance(model, ResModel):
+        for name, module in model.named_children():
+            if hasattr(module, "__getitem__"):
+                # If it's a Sequential or similar
+                if len(module) > 1 and hasattr(module[0], "weight") and hasattr(module[1], "weight"):
+                    # Assume Conv + BN, fold BN into Conv
+                    weight, bias = fold_batch_norm2d_into_conv2d(module[0], module[1])
+                elif hasattr(module[0], "weight"):
+                    # Just a Conv, no BN
+                    weight = module[0].weight.clone().detach().contiguous()
+                    bias = (
+                        module[0].bias.clone().detach().contiguous()
+                        if module[0].bias is not None
+                        else torch.zeros(module[0].out_channels)
+                    )
+                else:
+                    continue
+            elif hasattr(module, "weight"):
+                # Single Conv2d
+                weight = module.weight.clone().detach().contiguous()
+                bias = (
+                    module.bias.clone().detach().contiguous()
+                    if module.bias is not None
+                    else torch.zeros(module.out_channels)
+                )
+            else:
+                continue
+
+            parameters[name] = {}
+            parameters[name]["weight"] = ttnn.from_torch(weight, mesh_mapper=mesh_mapper)
+            parameters[name]["bias"] = ttnn.from_torch(torch.reshape(bias, (1, 1, 1, -1)), mesh_mapper=mesh_mapper)
+
+    elif isinstance(model, DecoderModel):
+        parameters = {}
+        # Let the sub-modules handle their own preprocessing
+        for child_name, child in model.named_children():
+            parameters[child_name] = convert_torch_model_to_ttnn_model(
+                child,
+                name=f"{name}.{child_name}",
+                custom_preprocessor=custom_preprocessor_func,
+                convert_to_ttnn=convert_to_ttnn,
+                ttnn_module_args=ttnn_module_args,
+            )
+
+    return parameters
+
+
+def create_custom_mesh_preprocessor(mesh_mapper=None):
+    def custom_mesh_preprocessor(model, name, ttnn_module_args, convert_to_ttnn):
+        return custom_preprocessor(
+            model, name, ttnn_module_args, convert_to_ttnn, custom_mesh_preprocessor, mesh_mapper
+        )
+
+    return custom_mesh_preprocessor

--- a/models/experimental/panoptic_deeplab/tt/decoder.py
+++ b/models/experimental/panoptic_deeplab/tt/decoder.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from models.experimental.panoptic_deeplab.tt.aspp import PanopticDeeplabASPP as TTASPP
+from models.experimental.panoptic_deeplab.tt.head import TTHead
+from models.experimental.panoptic_deeplab.tt.res_block import TTRes
+from models.experimental.panoptic_deeplab.tt.res_block import res_layer_optimisations
+from models.experimental.panoptic_deeplab.tt.head import head_layer_optimisations
+from dataclasses import dataclass
+import ttnn
+
+
+@dataclass
+class DecoderOptimizer:
+    res_layer_optimisations: dict
+    head_layer_optimisations: dict
+    shape: tuple
+
+
+decoder_layer_optimisations = {
+    "default": DecoderOptimizer(
+        res_layer_optimisations=res_layer_optimisations["default"],
+        head_layer_optimisations=head_layer_optimisations["default"],
+        shape=(0, 0, 0, 0),
+    ),
+    "Semantics_head": DecoderOptimizer(
+        res_layer_optimisations={
+            "res3": res_layer_optimisations["semantics_Res3"],
+            "res2": res_layer_optimisations["semantics_Res2"],
+        },
+        head_layer_optimisations={
+            "head_1": head_layer_optimisations["semantic_head"],
+        },
+        shape=(1, 128, 256, 256),
+    ),
+    "instance_head": DecoderOptimizer(
+        res_layer_optimisations={
+            "res3": res_layer_optimisations["instance_Res3"],
+            "res2": res_layer_optimisations["instance_Res2"],
+        },
+        head_layer_optimisations={
+            "head_1": head_layer_optimisations["instance_offset_head"],
+            "head_2": head_layer_optimisations["instance_center_head"],
+        },
+        shape=(1, 128, 256, 128),
+    ),
+}
+
+
+class TTDecoder:
+    def __init__(
+        self, parameters, model_config, layer_optimisations=decoder_layer_optimisations["default"], name="default"
+    ) -> None:
+        super().__init__()
+        self.shape = layer_optimisations.shape
+        self.aspp = TTASPP(parameters.aspp, model_config, layer_optimisations=None)
+        self.res3 = TTRes(
+            parameters.res3,
+            model_config,
+            layer_optimisations=layer_optimisations.res_layer_optimisations["res3"],
+        )
+        self.res2 = TTRes(
+            parameters.res2,
+            model_config,
+            layer_optimisations=layer_optimisations.res_layer_optimisations["res2"],
+        )
+        self.head = TTHead(
+            parameters.head_1,
+            model_config,
+            layer_optimisations=layer_optimisations.head_layer_optimisations["head_1"],
+        )
+        self.name = name
+
+        if self.shape[-1] == 128:
+            self.head_2 = TTHead(
+                parameters.head_2,
+                model_config,
+                layer_optimisations=layer_optimisations.head_layer_optimisations["head_2"],
+            )
+        if self.name == "Semantics_head":
+            self.res3_upsample_channels = 256
+            self.res2_upsample_channels = 256
+        else:
+            self.res3_upsample_channels = 256
+            self.res2_upsample_channels = 128
+
+    def __call__(self, x, res3, res2, upsample_channels, device):
+        y = self.aspp(x, device)
+        y = self.res3(y, res3, self.res3_upsample_channels, device)
+        y = self.res2(y, res2, self.res2_upsample_channels, device)
+
+        if self.name == "instance_head":
+            activation_copy = ttnn.clone(y)
+        out = self.head(y, device)
+
+        if self.name == "instance_head":
+            y = self.head_2(activation_copy, device)
+            return out, y
+
+        return out, None

--- a/models/experimental/panoptic_deeplab/tt/head.py
+++ b/models/experimental/panoptic_deeplab/tt/head.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from loguru import logger
+from models.experimental.panoptic_deeplab.tt.common import TTConv2D, TTUpsample
+from dataclasses import dataclass
+
+
+@dataclass
+class HeadOptimizer:
+    conv1: dict()
+    conv2: dict()
+    conv3: dict()
+    shape: tuple
+
+
+head_layer_optimisations = {
+    "default": HeadOptimizer(
+        conv1={"act_block_h": 32, "memory_config": ttnn.DRAM_MEMORY_CONFIG},
+        conv2={
+            "act_block_h": 32,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+        },
+        shape=(0, 0, 0, 0),
+    ),
+    "semantic_head": HeadOptimizer(
+        conv1={
+            "act_block_h": 256,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "reshard_if_not_optimal": True,
+        },
+        conv2={
+            "act_block_h": 32,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        },
+        conv3={
+            "act_block_h": 32,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            #  "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+        },
+        shape=(1, 128, 256, 256),
+    ),
+    "instance_offset_head": HeadOptimizer(
+        conv1={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv2={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+        },
+        shape=(1, 128, 256, 128),
+    ),
+    "instance_center_head": HeadOptimizer(
+        conv1={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv2={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "act_block_h": 64,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "input_channels_alignment": 32,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+        },
+        shape=(1, 128, 256, 128),
+    ),
+}
+
+
+class TTHead:
+    def __init__(
+        self,
+        parameters,
+        model_config,
+        layer_optimisations=head_layer_optimisations["default"],
+    ) -> None:
+        self.layer_optimisations = layer_optimisations
+        # conv1
+        self.conv1 = TTConv2D(
+            kernel_size=parameters.conv_args["conv1"]["0"].kernel_size,
+            stride=parameters.conv_args["conv1"]["0"].stride,
+            padding=parameters.conv_args["conv1"]["0"].padding,
+            dilation=parameters.conv_args["conv1"]["0"].dilation,
+            groups=parameters.conv_args["conv1"]["0"].groups,
+            parameters=parameters.conv1,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv1,
+        )
+        # conv2
+        self.conv2 = TTConv2D(
+            kernel_size=parameters.conv_args["conv2"]["0"].kernel_size,
+            stride=parameters.conv_args["conv2"]["0"].stride,
+            padding=parameters.conv_args["conv2"]["0"].padding,
+            groups=parameters.conv_args["conv2"]["0"].groups,
+            parameters=parameters.conv2,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv2,
+        )
+        # conv3
+        self.conv3 = TTConv2D(
+            kernel_size=parameters.conv_args["conv3"]["0"].kernel_size,
+            stride=parameters.conv_args["conv3"]["0"].stride,
+            padding=parameters.conv_args["conv3"]["0"].padding,
+            groups=parameters.conv_args["conv3"]["0"].groups,
+            parameters=parameters.conv3,
+            kernel_fidelity=model_config,
+            **layer_optimisations.conv3,
+        )
+
+        # upsample
+        self.upsample = TTUpsample(
+            scale_factor=(4),
+            mode="bilinear",
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+        )
+
+    def __call__(
+        self,
+        x,
+        device,
+    ):
+        shape = self.layer_optimisations.shape
+        logger.debug("Running conv1")
+
+        out, shape = self.conv1(device, x, shape)
+
+        logger.debug("Running conv2")
+        out, shape = self.conv2(device, out, shape)
+
+        logger.debug("Running conv3")
+        out, shape = self.conv3(device, out, shape)
+
+        logger.debug("Running final upsample")
+
+        out = self.upsample(device, out, shape, reshape_output=False, pad_ch_to_32=True, sent_to_dram=False)
+        out = ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG)
+        return out

--- a/models/experimental/panoptic_deeplab/tt/panoptic_deeplab.py
+++ b/models/experimental/panoptic_deeplab/tt/panoptic_deeplab.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from loguru import logger
+from typing import Dict
+
+from models.experimental.panoptic_deeplab.tt.backbone import TTBackbone
+from models.experimental.panoptic_deeplab.tt.decoder import TTDecoder, decoder_layer_optimisations
+
+
+class TTPanopticDeepLab:
+    """
+    TTNN implementation of Panoptic DeepLab using backbone and decoder architecture.
+    Combines backbone, semantic segmentation, and instance segmentation.
+    """
+
+    def __init__(
+        self,
+        parameters,
+        model_config,
+    ):
+        self.model_config = model_config
+
+        # Initialize backbone
+        self.backbone = TTBackbone(parameters.backbone, model_config)
+
+        # Initialize semantic segmentation decoder
+        self.semantic_decoder = TTDecoder(
+            parameters.semantic_decoder,
+            model_config,
+            layer_optimisations=decoder_layer_optimisations["Semantics_head"],
+            name="Semantics_head",
+        )
+
+        # Initialize instance segmentation decoder
+        self.instance_decoder = TTDecoder(
+            parameters.instance_decoder,
+            model_config,
+            layer_optimisations=decoder_layer_optimisations["instance_head"],
+            name="instance_head",
+        )
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        device,
+    ) -> Dict[str, ttnn.Tensor]:
+        """
+        Forward pass of TTNN Panoptic DeepLab.
+
+        Args:
+            x: Input tensor of shape [B, H, W, C] in TTNN format
+            device: TTNN device
+
+        Returns:
+            semantic_logits: Semantic segmentation logits
+            instance_logit: Instance segmentation logits - offset head
+            instance_logit_2: Instance segmentation logits - center head
+        """
+
+        logger.debug("Running TT Panoptic DeepLab forward pass")
+
+        # Extract features from backbone
+        logger.debug("Running TTBackbone")
+        features = self.backbone(x, device)
+
+        # Extract the specific feature maps the decoders expect
+        backbone_features = features["res_5"]
+        res3_features = features["res_3"]
+        res2_features = features["res_2"]
+
+        backbone_feature_instance_decoder = ttnn.clone(backbone_features)
+        res3_feature_instance_decoder = ttnn.clone(res3_features)
+        res2_feature_instance_decoder = ttnn.clone(res2_features)
+
+        logger.debug(
+            f"Backbone features shapes - res_5: {backbone_features.shape}, "
+            f"res_3: {res3_features.shape}, res_2: {res2_features.shape}"
+        )
+
+        # Semantic segmentation branch
+        logger.debug("Running semantic segmentation decoder")
+        semantic_logit, _ = self.semantic_decoder(
+            backbone_features,
+            res3_features,
+            res2_features,
+            upsample_channels=256,
+            device=device,
+        )
+
+        # Instance segmentation branch
+        logger.debug("Running instance segmentation decoder")
+
+        instance_logit, instance_logit_2 = self.instance_decoder(
+            backbone_feature_instance_decoder,
+            res3_feature_instance_decoder,
+            res2_feature_instance_decoder,
+            upsample_channels=256,
+            device=device,
+        )
+
+        logger.debug("TT Panoptic DeepLab forward pass completed")
+
+        return semantic_logit, instance_logit, instance_logit_2

--- a/models/experimental/panoptic_deeplab/tt/res_block.py
+++ b/models/experimental/panoptic_deeplab/tt/res_block.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from loguru import logger
+from models.experimental.panoptic_deeplab.tt.common import TTConv2D, TTUpsample
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class ResOptimizer:
+    conv1: Dict[Any, Any]
+    conv2: Dict[Any, Any]
+    conv3: Dict[Any, Any]
+    shape: tuple
+
+
+res_layer_optimisations = {
+    "default": ResOptimizer(
+        conv1={"act_block_h": 32, "memory_config": ttnn.DRAM_MEMORY_CONFIG},
+        conv2={
+            "act_block_h": 32,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+        },
+        shape=(0, 0, 0, 0),
+    ),
+    "instance_Res3": ResOptimizer(
+        conv1={
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+        },
+        conv2={
+            "act_block_h": 512,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "reshard_if_not_optimal": True,
+        },
+        conv3={
+            "act_block_h": 32,
+            "shard_layout": ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        shape=(1, 64, 128, 512),
+    ),
+    "instance_Res2": ResOptimizer(
+        conv1={
+            "act_block_h": 128,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv2={
+            "act_block_h": 32,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv3={
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        shape=(1, 128, 256, 256),
+    ),
+    "semantics_Res3": ResOptimizer(
+        conv1={
+            "act_block_h": 32,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv2={
+            "act_block_h": 512,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "enable_split_reader": True,
+            "reallocate_halo_output": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "act_block_h": 32,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        shape=(1, 64, 128, 512),
+    ),
+    "semantics_Res2": ResOptimizer(
+        conv1={
+            "act_block_h": 32,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        conv2={
+            "act_block_h": 160,
+            "memory_config": ttnn.L1_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "act_block_h": 32,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+        },
+        shape=(1, 128, 256, 256),
+    ),
+}
+
+
+class TTRes:
+    def __init__(
+        self,
+        parameters,
+        model_config,
+        layer_optimisations=res_layer_optimisations["default"],
+    ) -> None:
+        # conv1_upsample
+        self.conv1_upsample = TTUpsample(
+            scale_factor=(2),
+            mode="bilinear",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+        )
+
+        # conv1
+        self.conv1 = TTConv2D(
+            kernel_size=parameters.conv_args["conv1"]["0"].kernel_size,
+            stride=parameters.conv_args["conv1"]["0"].stride,
+            padding=parameters.conv_args["conv1"]["0"].padding,
+            dilation=parameters.conv_args["conv1"]["0"].dilation,
+            groups=parameters.conv_args["conv1"]["0"].groups,
+            parameters=parameters.conv1,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv1,
+        )
+        # conv2
+        self.conv2 = TTConv2D(
+            kernel_size=parameters.conv_args["conv2"]["0"].kernel_size,
+            stride=parameters.conv_args["conv2"]["0"].stride,
+            padding=parameters.conv_args["conv2"]["0"].padding,
+            groups=parameters.conv_args["conv2"]["0"].groups,
+            parameters=parameters.conv2,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv2,
+        )
+        # conv3
+        self.conv3 = TTConv2D(
+            kernel_size=parameters.conv_args["conv3"]["0"].kernel_size,
+            stride=parameters.conv_args["conv3"]["0"].stride,
+            padding=parameters.conv_args["conv3"]["0"].padding,
+            groups=parameters.conv_args["conv3"]["0"].groups,
+            parameters=parameters.conv3,
+            kernel_fidelity=model_config,
+            activation="relu",
+            **layer_optimisations.conv3,
+        )
+        self.shape = layer_optimisations.shape
+
+    def __call__(
+        self,
+        x,
+        res,
+        upsample_channels,
+        device,
+    ):
+        # Decoder: upsample and fuse with res3
+        logger.debug("Running upsample after ASPP project")
+        shape = [self.shape[-4], self.shape[-3] // 2, self.shape[-2] // 2, upsample_channels]
+
+        output = self.conv1_upsample(device, x, shape, sent_to_dram=True, reshape_output=True)
+
+        logger.debug("Running conv1")
+        output_res, shape = self.conv1(device, res, self.shape)
+
+        logger.debug("Running concat for res and ASPP upsampled")
+        output = ttnn.concat([output_res, output], dim=3)
+
+        logger.debug("Running conv2")
+        shape = (self.shape[-4], self.shape[-3], self.shape[-2], upsample_channels + shape[-1])
+        output, shape = self.conv2(device, output, shape)
+
+        logger.debug("Running conv3")
+
+        output, shape = self.conv3(device, output, shape)
+        return output

--- a/models/experimental/panoptic_deeplab/tt/stem.py
+++ b/models/experimental/panoptic_deeplab/tt/stem.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import ttnn
+from models.experimental.panoptic_deeplab.tt.common import TTConv2D
+from dataclasses import dataclass
+
+
+@dataclass
+class NeckOptimizer:
+    conv1: dict()
+    conv2: dict()
+    conv3: dict()
+
+
+neck_optimisations = {
+    "optimization_full_tensor": NeckOptimizer(
+        conv1={
+            "act_block_h": 512,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=4),
+        },
+        conv2={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=4),
+        },
+        conv3={
+            "act_block_h": 32,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=4),
+        },
+    ),
+    "optimization_small_tensor": NeckOptimizer(
+        conv1={
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+            "slice_config": ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceHeight, num_slices=2),
+        },
+        conv2={
+            "act_block_h": 512,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+        conv3={
+            "act_block_h": 128,
+            "shard_layout": ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "deallocate_activation": True,
+            "reallocate_halo_output": True,
+            "reshard_if_not_optimal": True,
+            "enable_split_reader": True,
+            "enable_act_double_buffer": True,
+            "enable_weights_double_buffer": True,
+        },
+    ),
+}
+
+
+class resnet52Stem:
+    def __init__(
+        self,
+        parameters,
+        stride,
+        model_config,
+        layer_optimisations=neck_optimisations["optimization_full_tensor"],
+    ) -> None:
+        self.conv1 = TTConv2D(
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            activation="relu",
+            parameters=parameters.conv1,
+            kernel_fidelity=model_config,
+            **layer_optimisations.conv1,
+        )
+        self.conv2 = TTConv2D(
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+            activation="relu",
+            parameters=parameters.conv2,
+            kernel_fidelity=model_config,
+            **layer_optimisations.conv2,
+        )
+        self.conv3 = TTConv2D(
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+            activation="relu",
+            parameters=parameters.conv3,
+            kernel_fidelity=model_config,
+            **layer_optimisations.conv3,
+        )
+
+    def __call__(
+        self,
+        x,
+        device,
+    ):
+        # conv1 is stride 2 conv 3x3
+        logger.debug(f"Running 3x3 conv1")
+        out, shape = self.conv1(device, x, x.shape)
+
+        # conv2 and 3 are 3x3 conv's with stride 1
+        logger.debug(f"Running 3x3 conv2")
+        out, shape = self.conv2(device, out, shape)
+        logger.debug(f"Running 3x3 conv3")
+        out, shape = self.conv3(device, out, shape)
+
+        out = ttnn.max_pool2d(
+            input_tensor=out,
+            batch_size=shape[-4],
+            input_h=shape[-3],
+            input_w=shape[-2],
+            channels=shape[-1],
+            kernel_size=[3, 3],
+            stride=[2, 2],
+            padding=[1, 1],
+            dilation=[1, 1],
+            in_place_halo=True,
+            applied_shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ceil_mode=False,
+        )
+        out = ttnn.reshape(out, (shape[-4], shape[-3] // 2, shape[-2] // 2, shape[-1]))
+
+        return out


### PR DESCRIPTION
### What's changed
Added TT implementation of Panoptic-Deeplab model in `tt-metal`.

### Note
Code refactoring and optimisation are still in progress.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes