### PR TITLE
readability-redundant-smartptr-get

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -197,7 +197,6 @@ Checks: >
   -readability-redundant-control-flow,
   -readability-redundant-inline-specifier,
   -readability-redundant-member-init,
-  -readability-redundant-smartptr-get,
   -readability-redundant-string-cstr,
   -readability-redundant-string-init,
   -readability-reference-to-constructed-temporary,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -843,7 +843,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
 
     GlobalSemaphore multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore(
         test_fixture.mesh_device_.get(),
-        test_fixture.mesh_device_.get()->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        test_fixture.mesh_device_->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
         0,                            // initial value
         tt::tt_metal::BufferType::L1  // buffer type
     );

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1811,7 +1811,7 @@ void ControlPlane::initialize_fabric_context(tt_fabric::FabricConfig fabric_conf
 
 FabricContext& ControlPlane::get_fabric_context() const {
     TT_FATAL(this->fabric_context_ != nullptr, "Trying to get un-initialized fabric context");
-    return *this->fabric_context_.get();
+    return *this->fabric_context_;
 }
 
 void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -235,7 +235,7 @@ tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_conf
             switch (fabric_edm_type) {
                 case tt::tt_fabric::FabricEriscDatamoverType::Default:
                     TT_FATAL(this->router_config_ != nullptr, "Error, fabric router config is uninitialized");
-                    return *this->router_config_.get();
+                    return *this->router_config_;
                     break;
                 case tt::tt_fabric::FabricEriscDatamoverType::Dateline:
                     TT_FATAL(
@@ -325,7 +325,7 @@ std::pair<uint32_t, uint32_t> FabricContext::get_fabric_router_termination_addre
 
 tt::tt_fabric::FabricTensixDatamoverConfig& FabricContext::get_tensix_config() const {
     TT_FATAL(tensix_config_ != nullptr, "Error, fabric tensix config is uninitialized");
-    return *tensix_config_.get();
+    return *tensix_config_;
 }
 
 void FabricContext::initialize_tensix_config() {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -29,7 +29,7 @@ DeviceStorage::DeviceStorage(
     coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}
 
 Buffer* DeviceStorage::get_buffer() const {
-    if (this->mesh_buffer.get() != nullptr) {
+    if (this->mesh_buffer != nullptr) {
         return this->mesh_buffer->get_reference_buffer();
     }
     TT_THROW("Buffer is not allocated");
@@ -40,19 +40,17 @@ std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer() const 
     return mesh_buffer;
 }
 
-bool DeviceStorage::is_allocated() const {
-    return this->mesh_buffer.get() != nullptr && this->mesh_buffer->is_allocated();
-}
+bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }
 
 distributed::MeshDevice* DeviceStorage::get_device() const {
-    if (this->mesh_buffer.get() != nullptr) {
+    if (this->mesh_buffer != nullptr) {
         return this->mesh_buffer->device();
     }
     TT_THROW("Buffer is not allocated");
 }
 
 bool DeviceStorage::is_uniform_storage() const {
-    if (mesh_buffer.get() == nullptr) {
+    if (mesh_buffer == nullptr) {
         return true;
     }
     return coords.size() == mesh_buffer->device()->num_devices();


### PR DESCRIPTION
### Ticket
#22758
Closes #28295 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-smartptr-get.html

### What's changed
- Enable the check
- Run FIXITs

### Checklist
- PR Gate + Merge Gate should be good enough