### PR TITLE
#26435: Fix Conv DRAM Weights Prep

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -385,7 +385,7 @@ def test_prepare_bias(
     tt_bias_tensor_formatted = (
         ttnn.prepare_conv_bias(
             bias_tensor=tt_bias_tensor,
-            input_memory_config=tt_input_tensor.memory_config(),
+            input_memory_config=ttnn.L1_MEMORY_CONFIG,
             **conv_kwargs,
             input_dtype=ttnn.bfloat16,
         )

--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -8,7 +8,6 @@ import torch
 import pytest
 from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 import ttnn
-from models.utility_functions import skip_for_blackhole
 
 
 def prepare_conv_weights_func(
@@ -76,6 +75,8 @@ def prepare_conv_weights_func(
         enable_kernel_stride_folding=enable_kernel_stride_folding,
     )
     compute_config = ttnn.init_device_compute_kernel_config(device.arch())
+    if slice_config:
+        compute_config.throttle_level = ttnn.ThrottleLevel(3)
     if config_override and "act_block_h" in config_override:
         conv_config.act_block_h_override = config_override["act_block_h"]
 
@@ -105,12 +106,13 @@ def prepare_conv_weights_func(
         "slice_config": slice_config,
     }
 
+    input_memory_config = ttnn.DRAM_MEMORY_CONFIG if slice_config else ttnn.L1_MEMORY_CONFIG
     tt_input_tensor = ttnn.to_device(tt_input_tensor, device)
 
     tt_weight_tensor_formatted = ttnn.prepare_conv_weights(
         weight_tensor=tt_weight_tensor,
         weights_format="OIHW",
-        input_memory_config=ttnn.L1_MEMORY_CONFIG,
+        input_memory_config=input_memory_config,
         has_bias=has_bias,
         **conv_kwargs,
         input_dtype=ttnn.bfloat16,
@@ -118,7 +120,7 @@ def prepare_conv_weights_func(
     tt_bias_tensor_formatted = (
         ttnn.prepare_conv_bias(
             bias_tensor=tt_bias_tensor,
-            input_memory_config=tt_input_tensor.memory_config(),
+            input_memory_config=input_memory_config,
             **conv_kwargs,
             input_dtype=ttnn.bfloat16,
         )
@@ -418,7 +420,6 @@ SliceHeight = ttnn.Conv2dSliceHeight
 SliceWidth = ttnn.Conv2dSliceWidth
 
 
-@pytest.mark.skip("#26435: prepare weights is broken for dram sliced convs")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, input_channels, output_channels, input_height, input_width, slice_type, num_slices, kernel, stride, padding, dilation, act_block_h_override",

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -1225,9 +1225,13 @@ def test_ttnn_slice_whisper(input_shape, input_start, input_ends, input_steps, m
 @pytest.mark.parametrize("slice_dim", [1, 2])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
-def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, cores, layout, input_dtype):
+@pytest.mark.parametrize("pad_value", [16, 32])
+def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, cores, layout, input_dtype, pad_value):
     if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is not supported in row major layout")
+
+    if pad_value == 16 and layout == ttnn.TILE_LAYOUT:
+        pytest.skip("Tile layout has alignment of 32.")
 
     orientation = ttnn.ShardOrientation.ROW_MAJOR
     core_grid = device.compute_with_storage_grid_size()
@@ -1250,7 +1254,7 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
     parallel_config = ttnn.SlidingWindowParallelConfig(
         grid=core_range, shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED, shard_orientation=orientation
     )
-    padded_channels = round_up(dims[-1], 32)
+    padded_channels = round_up(dims[-1], pad_value)
     padded_torch_input = torch.nn.functional.pad(torch_input, (0, padded_channels - dims[-1]))
     torch.set_printoptions(sci_mode=False, precision=2)
     for i in range(num_slices):
@@ -1260,7 +1264,7 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
         ends[slice_dim] = (i + 1) * slice_size
         this_torch_output = padded_torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2]]
         output_shape = this_torch_output.shape
-        output_shape = [1, 1, output_shape[0] * output_shape[1] * output_shape[2], round_up(output_shape[3], 32)]
+        output_shape = [1, 1, output_shape[0] * output_shape[1] * output_shape[2], round_up(output_shape[3], pad_value)]
 
         memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
             output_shape, parallel_config, 1

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import is_grayskull
+from models.utility_functions import is_grayskull, is_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from .test_utils import round_up
 import math
@@ -1229,6 +1229,9 @@ def test_ttnn_slice_whisper(input_shape, input_start, input_ends, input_steps, m
 def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, cores, layout, input_dtype, pad_value):
     if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is not supported in row major layout")
+
+    if pad_value == 16 and is_blackhole():
+        pytest.skip("Blackhole has DRAM Alignment of 64 bytes, or 32 elements for bfloat16.")
 
     if pad_value == 16 and layout == ttnn.TILE_LAYOUT:
         pytest.skip("Tile layout has alignment of 32.")

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -207,6 +207,7 @@ Result conv2d_DRAM(
                         .weights_datatype = conv_config.weights_dtype.value_or(weight_tensor.dtype()),
                         .input_datatype = input_tensor.dtype(),
                         .output_datatype = output_dtype,
+                        .input_layout = input_tensor.layout(),
                         .enable_bias = bias_tensor.has_value(),
                         .mm_conv = mm_conv,
                     },
@@ -419,9 +420,8 @@ Result conv2d_DRAM(
             ttnn::Shape({batch_size, output_slice_height, output_slice_width, out_channels}),
             mm_conv,
             compute_grid_size,
-            // Setting layout to TILE forces input_channels_alignment to 32.
-            //  The padded_slice op needs aligned reads from L1.
-            Layout::TILE));
+            input_tensor_on_device.layout(),
+            BufferType::DRAM));
 
         Tensor sliced_input_tensor = ttnn::experimental::padded_slice(
             input_tensor_on_device,
@@ -612,6 +612,7 @@ Result conv2d_L1(
     const uint32_t input_channels_alignment = get_input_channels_alignment(
         input_tensor_post_tm.memory_config().memory_layout(),
         input_tensor.layout(),
+        input_tensor.memory_config().buffer_type(),
         mm_conv,
         input_tensor_post_tm.memory_config());
     const uint32_t in_channels_padded = tt::round_up(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -75,6 +75,7 @@ uint32_t find_closest_largest_divisor_with_num_padding_and_mult(uint32_t num, ui
 uint32_t get_input_channels_alignment(
     const TensorMemoryLayout input_tensor_memory_layout,
     Layout input_tensor_layout,
+    BufferType input_tensor_buffer_type,
     bool is_mm_conv,
     const std::optional<MemoryConfig>& input_memory_config) {
     if (!is_mm_conv && input_tensor_memory_layout != TensorMemoryLayout::WIDTH_SHARDED &&
@@ -90,6 +91,10 @@ uint32_t get_input_channels_alignment(
             } else {
                 return tt::constants::TILE_WIDTH;
             }
+        } else if (input_tensor_buffer_type == BufferType::DRAM) {
+            // DRAM accesses needs 32 byte alignment, which corresponds to 16 elements for bfloat16 data type.
+            // This is due to a limitation of padded slice, which needs to be removed. #28689
+            return tt::tt_metal::hal::get_dram_alignment() / 2;
         } else {
             // The minimum valid value for input channels alignment is 8.
             // This requirement comes from the L1 alignment, which is 16 bytes.
@@ -97,7 +102,7 @@ uint32_t get_input_channels_alignment(
             // (2 bytes per element), we need at least 8 elements (8 * 2 bytes = 16 bytes) in the input channel
             // dimension. This ensures that one channel (or "stick") can be efficiently transferred over the NoC
             // (Network on Chip) in a single, aligned operation.
-            return 8U;
+            return tt::tt_metal::hal::get_l1_alignment() / 2;
         }
     }
     return tt::constants::TILE_WIDTH;
@@ -496,10 +501,11 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig> determine_input_memory_config(
     bool is_mm_conv,
     CoreCoord compute_grid_size,
     Layout input_tensor_layout,
+    BufferType input_tensor_buffer_type,
     const std::optional<ParallelConfig>& input_tensor_parallel_config,
     std::optional<uint32_t> act_block_h_override) {
-    const uint32_t input_channels_alignment =
-        get_input_channels_alignment(shard_layout, input_tensor_layout, is_mm_conv, std::nullopt);
+    const uint32_t input_channels_alignment = get_input_channels_alignment(
+        shard_layout, input_tensor_layout, input_tensor_buffer_type, is_mm_conv, std::nullopt);
     ParallelConfig parallel_config;
     if (input_tensor_parallel_config.has_value()) {
         parallel_config = input_tensor_parallel_config.value();
@@ -571,8 +577,12 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
 
     const ttnn::MemoryConfig& input_memory_config = input_tensor_.memory_config();
     const tt::tt_metal::TensorMemoryLayout input_shard_scheme = input_memory_config.memory_layout();
-    const uint32_t input_channels_alignment =
-        get_input_channels_alignment(input_shard_scheme, input_tensor_.layout(), is_mm_conv, input_memory_config);
+    const uint32_t input_channels_alignment = get_input_channels_alignment(
+        input_shard_scheme,
+        input_tensor_.layout(),
+        input_tensor_.memory_config().buffer_type(),
+        is_mm_conv,
+        input_memory_config);
 
     ParallelConfig input_tensor_parallel_config;
     if (!input_tensor_on_device) {
@@ -676,6 +686,7 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
             is_mm_conv,
             device->compute_with_storage_grid_size(),
             input_tensor.layout(),
+            input_tensor.memory_config().buffer_type(),
             parallel_config,
             conv_config.act_block_h_override);
         return {input_padded_shape, input_tensor_sharded_memory_config, needs_shard_or_reshard};
@@ -880,7 +891,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
         }
 
         const uint32_t input_channels_alignment =
-            get_input_channels_alignment(shard_layout, input_layout, is_mm_conv, std::nullopt);
+            get_input_channels_alignment(shard_layout, input_layout, BufferType::DRAM, is_mm_conv, std::nullopt);
         const uint32_t in_channels_aligned = tt::round_up(in_channels, input_channels_alignment);
         const uint32_t output_channels_padded = tt::round_up(out_channels, tt::constants::TILE_WIDTH);
         // Note: These are not exact shapes for weights as prepare_conv_weights will pad the weights depending on the
@@ -957,7 +968,9 @@ Conv2dConfig determine_conv_config_for_auto_shard(
             ttnn::Shape({batch_size, output_height, output_width, out_channels}),
             is_mm_conv,
             compute_grid_size,
-            Layout::TILE,
+            input_layout,
+            input_memory_config.has_value() ? input_memory_config.value().buffer_type()
+                                            : BufferType::L1,  // Overestimate L1 memory usage for auto shard.
             input_parallel_config,
             conv_config.act_block_h_override));
 
@@ -1144,7 +1157,7 @@ uint32_t calculate_conv_dram_slice_L1_usage(
                 conv_config.output_layout,
                 params.input_datatype,
                 params.output_datatype,
-                std::nullopt,
+                DRAM_MEMORY_CONFIG,
                 params.kernel_size,
                 params.dilation,
                 {0, 0, 0, 0},
@@ -1163,9 +1176,8 @@ uint32_t calculate_conv_dram_slice_L1_usage(
             ttnn::Shape({params.batch_size, output_slice_height, output_slice_width, params.out_channels}),
             params.mm_conv,
             device->compute_with_storage_grid_size(),
-            // Setting layout to TILE forces input_channels_alignment to 32.
-            //  The padded_slice op needs aligned reads from L1.
-            Layout::TILE,
+            params.input_layout,
+            BufferType::DRAM,
             std::nullopt,
             conv_config.act_block_h_override));
 
@@ -1201,7 +1213,11 @@ uint32_t calculate_conv_dram_slice_L1_usage(
             .input_hw = {params.input_height, params.input_width},
             .window_hw = {params.kernel_size[0], params.kernel_size[1]}};
         const uint32_t input_channels_alignment = get_input_channels_alignment(
-            conv_config.shard_layout.value(), conv_config.output_layout, params.mm_conv, std::nullopt);
+            conv_config.shard_layout.value(),
+            conv_config.output_layout,
+            BufferType::DRAM,
+            params.mm_conv,
+            std::nullopt);
         const uint32_t in_channels_padded = tt::round_up(
             params.in_channels,
             get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -33,6 +33,7 @@ uint32_t find_closest_largest_divisor_with_num_padding(uint32_t num1, uint32_t n
 uint32_t get_input_channels_alignment(
     TensorMemoryLayout input_tensor_memory_layout,
     Layout input_tensor_layout,
+    BufferType input_tensor_buffer_type,
     bool is_mm_conv,
     const std::optional<MemoryConfig>& input_memory_config);
 
@@ -159,6 +160,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig> determine_input_memory_config(
     bool is_mm_conv,
     CoreCoord compute_grid_size,
     Layout input_tensor_layout,
+    BufferType input_tensor_buffer_type,
     const std::optional<sliding_window::ParallelConfig>& input_tensor_parallel_config = std::nullopt,
     std::optional<uint32_t> act_block_h_override = std::nullopt);
 
@@ -249,6 +251,7 @@ struct ConvDRAMParamters {
     DataType weights_datatype;
     DataType input_datatype;
     DataType output_datatype;
+    Layout input_layout;
     bool enable_bias;
     bool mm_conv;
 };

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1003,8 +1003,12 @@ static OptimizedConvBlockConfig get_opt_block_config(
     if (input_memory_config.is_sharded() && !conv_config.reshard_if_not_optimal) {
         conv_config.shard_layout = input_memory_config.memory_layout();
     }
-    const uint32_t in_channels_alignment =
-        get_input_channels_alignment(conv_config.shard_layout.value(), input_layout, mm_conv, input_memory_config);
+    const uint32_t in_channels_alignment = get_input_channels_alignment(
+        conv_config.shard_layout.value(),
+        input_layout,
+        input_memory_config.buffer_type(),
+        mm_conv,
+        input_memory_config);
 
     ParallelConfig parallel_config;
     if (input_memory_config.shard_spec().has_value() && !conv_config.reshard_if_not_optimal) {
@@ -1173,8 +1177,12 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
         conv_config.shard_layout = input_memory_config.memory_layout();
     }
 
-    const uint32_t input_channels_alignment =
-        get_input_channels_alignment(conv_config.shard_layout.value(), input_layout, mm_conv, input_memory_config);
+    const uint32_t input_channels_alignment = get_input_channels_alignment(
+        conv_config.shard_layout.value(),
+        input_layout,
+        input_memory_config.buffer_type(),
+        mm_conv,
+        input_memory_config);
     ParallelConfig parallel_config;
     if (input_memory_config.shard_spec().has_value() && !conv_config.reshard_if_not_optimal) {
         parallel_config = {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -180,6 +180,45 @@ struct Conv2dWeightsBiasPrepConfig {
     const std::array<uint32_t, 4> padding_n4;
     // This conv will go through auto shard codepath for matmul based convs
     const bool interleaved_mm_conv;
+
+    static constexpr auto attribute_names = std::make_tuple(
+        "input_channels_alignment",
+        "weights_bias_dtype",
+        "weight_block_h_ntiles",
+        "weight_block_w_ntiles",
+        "input_parallel_config",
+        "output_parallel_config",
+        "groups",
+        "act_block_h_ntiles",
+        "input_width",
+        "has_bias",
+        "parameters_on_device",
+        "enable_kernel_stride_folding",
+        "full_inner_dim",
+        "kernel_size",
+        "stride",
+        "padding_n4",
+        "interleaved_mm_conv");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->input_channels_alignment),
+            std::cref(this->weights_bias_dtype),
+            std::cref(this->weight_block_h_ntiles),
+            std::cref(this->weight_block_w_ntiles),
+            std::cref(this->input_parallel_config),
+            std::cref(this->output_parallel_config),
+            std::cref(this->groups),
+            std::cref(this->act_block_h_ntiles),
+            std::cref(this->input_width),
+            std::cref(this->has_bias),
+            std::cref(this->parameters_on_device),
+            std::cref(this->enable_kernel_stride_folding),
+            std::cref(this->full_inner_dim),
+            std::cref(this->kernel_size),
+            std::cref(this->stride),
+            std::cref(this->padding_n4),
+            std::cref(this->interleaved_mm_conv));
+    }
 };
 
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -192,6 +192,7 @@ Result conv_transpose2d(
     const uint32_t input_channels_alignment = get_input_channels_alignment(
         input_tensor_post_tm.memory_config().memory_layout(),
         input_tensor.layout(),
+        input_tensor.memory_config().buffer_type(),
         mm_conv,
         input_tensor_post_tm.memory_config());
     uint32_t in_channels_padded = tt::round_up(


### PR DESCRIPTION
### Ticket
#26435 

### Problem description
Conv DRAM fails with PCC error when using preprocessed weights

### What's changed
Conv DRAM needs input_channels_alignment always set to 32. Fixed the tests by correctly passing the input memory config, and setting input_channels_alignment correctly.

Setting throttle for Conv DRAM tests to prevent hangs, similar to test_conv2d.py

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17832907908)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17903462123) (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17839323030)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17839318186)
- [x] Frequent models [same as](https://github.com/tenstorrent/tt-metal/actions/runs/17877763785) [main](https://github.com/tenstorrent/tt-metal/actions/runs/17831199688/job/50701233817)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17832928579)
- [x] New/Existing tests provide coverage for changes