### PR TITLE
Add debug modes for tensor generate in conv and pool

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -80,7 +80,7 @@ def randomize_torch_tensor(
         torch_tensor = torch_tensor_map[cache_key]
     else:
         if mode == "random":
-            torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16).float()
+            torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
             if generate_positive_numbers:
                 torch_tensor = torch.abs(torch_tensor)
         elif mode == "stick":
@@ -90,7 +90,7 @@ def randomize_torch_tensor(
         elif mode == "single":
             if fill_value is None:
                 raise ValueError("fill_value must be provided when mode is 'single'")
-            torch_tensor = torch.full(tensor_shape, fill_value, dtype=torch.bfloat16).float()
+            torch_tensor = torch.full(tensor_shape, fill_value, dtype=torch.bfloat16)
         else:
             raise ValueError(f"Unsupported mode: {mode}. Use 'random', 'stick', or 'single'")
 

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -84,14 +84,9 @@ def randomize_torch_tensor(
             if generate_positive_numbers:
                 torch_tensor = torch.abs(torch_tensor)
         elif mode == "stick":
-            torch_tensor = torch.zeros(tensor_shape, dtype=torch.bfloat16).float()
-            for n in range(tensor_shape[0]):
-                for c in range(tensor_shape[1]):
-                    for h in range(tensor_shape[2]):
-                        for w in range(tensor_shape[3]):
-                            torch_tensor[n, c, h, w] = h * tensor_shape[3] + w
-            if generate_positive_numbers:
-                torch_tensor = torch.abs(torch_tensor)
+            h, w = tensor_shape[2], tensor_shape[3]
+            stick = torch.arange(h * w, dtype=torch.bfloat16).reshape(1, 1, h, w)
+            torch_tensor = stick.expand(tensor_shape)
         elif mode == "single":
             if fill_value is None:
                 raise ValueError("fill_value must be provided when mode is 'single'")

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -11,6 +11,7 @@ import math
 
 from models.common.utility_functions import is_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.nightly.unit_tests.operations.conv.test_conv2d import randomize_torch_tensor
 
 HS = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 BS = ttnn.TensorMemoryLayout.BLOCK_SHARDED
@@ -23,33 +24,6 @@ def tensor_map(request):
     tensor_map = {}
 
     return tensor_map
-
-
-# Creates a tensor with specified mode:
-# - "random": fills tensor with random values using torch.randn
-# - "stick": each stick has same values starting from 0 and increasing
-# - "single": fills entire tensor with the provided value
-def randomize_torch_tensor(tensor_map, tensor_shape, mode="random", fill_value=None):
-    tensor_shape = tuple(tensor_shape)
-    cache_key = (tensor_shape, mode, fill_value)
-    if cache_key in tensor_map.keys():
-        torch_tensor = tensor_map[cache_key]
-    else:
-        if mode == "random":
-            torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
-        elif mode == "stick":
-            h, w = tensor_shape[2], tensor_shape[3]
-            stick = torch.arange(h * w, dtype=torch.bfloat16).reshape(1, 1, h, w)
-            torch_tensor = stick.expand(tensor_shape)
-        elif mode == "single":
-            if fill_value is None:
-                raise ValueError("fill_value must be provided when mode is 'single'")
-            torch_tensor = torch.full(tensor_shape, fill_value, dtype=torch.bfloat16)
-        else:
-            raise ValueError(f"Unsupported mode: {mode}. Use 'random', 'stick', or 'single'")
-        tensor_map[cache_key] = torch_tensor
-
-    return torch_tensor
 
 
 def run_max_pool(

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -38,12 +38,9 @@ def randomize_torch_tensor(tensor_map, tensor_shape, mode="random", fill_value=N
         if mode == "random":
             torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
         elif mode == "stick":
-            torch_tensor = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-            for n in range(tensor_shape[0]):
-                for c in range(tensor_shape[1]):
-                    for h in range(tensor_shape[2]):
-                        for w in range(tensor_shape[3]):
-                            torch_tensor[n, c, h, w] = h * tensor_shape[3] + w
+            h, w = tensor_shape[2], tensor_shape[3]
+            stick = torch.arange(h * w, dtype=torch.bfloat16).reshape(1, 1, h, w)
+            torch_tensor = stick.expand(tensor_shape)
         elif mode == "single":
             if fill_value is None:
                 raise ValueError("fill_value must be provided when mode is 'single'")


### PR DESCRIPTION
### Ticket
/

### What's changed
Added 2 modes (**random** existed although had no name) in `randomize_torch_tensor` function for easier debugging:
- **stick** : each stick is going to have same value, from 0 and then increasing by 1
- **single** : each datum in tensor is same and you need to provide that value

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18411500115) ⏳ 
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18411514328) ⏳