### PR TITLE
Added height sharding support for grid sample

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -11,6 +11,242 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+# Constants
+L1_ALIGNMENT_BYTES = 16
+BFLOAT16_BYTES_PER_ELEMENT = 2
+FLOAT32_BYTES_PER_ELEMENT = 4
+PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6
+STANDARD_GRID_ELEMENTS_PER_POINT = 2
+BFLOAT16S_PER_L1_ALIGNMENT = L1_ALIGNMENT_BYTES // BFLOAT16_BYTES_PER_ELEMENT  # 8
+FLOAT32S_PER_L1_ALIGNMENT = L1_ALIGNMENT_BYTES // FLOAT32_BYTES_PER_ELEMENT  # 4
+
+
+# Utility functions
+def div_up(numerator, denominator):
+    """Integer division with ceiling (round up)"""
+    return (numerator + denominator - 1) // denominator
+
+
+def align_to_boundary(value, alignment):
+    """Round up value to the nearest alignment boundary"""
+    return div_up(value, alignment) * alignment
+
+
+def prepare_grid_batching_expected_output(
+    torch_output_nhwc, batch_size, grid_h, grid_w, channels, grid_batching_factor, batch_output_channels
+):
+    """
+    Prepare expected PyTorch output for grid batching scenarios.
+
+    Args:
+        torch_output_nhwc: Original PyTorch output in NHWC format
+        batch_size: Batch size
+        grid_h: Grid height
+        grid_w: Grid width (will be divided by grid_batching_factor)
+        channels: Number of channels
+        grid_batching_factor: Factor by which grid is batched
+        batch_output_channels: Whether to batch channels or width dimension
+
+    Returns:
+        tuple: (expected_shape, torch_expected_nhwc)
+    """
+    new_grid_w = grid_w // grid_batching_factor
+
+    if batch_output_channels:
+        # batch_output_channels=True: output shape (N, H, W, C*K) - channels batched
+        expected_shape = (batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
+        torch_expected_nhwc = (
+            torch_output_nhwc.view(batch_size, grid_h, new_grid_w, grid_batching_factor, channels)
+            .contiguous()
+            .view(batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
+        )
+    else:
+        # batch_output_channels=False: output shape (N, H, W*K, C) - W dimension extended
+        expected_shape = (batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
+        torch_expected_nhwc = torch_output_nhwc.view(batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
+
+    return expected_shape, torch_expected_nhwc
+
+
+def _prepare_grid_tensor_host(torch_grid, use_precomputed_grid, grid_dtype, input_shape_nhwc, grid_batching_factor):
+    """
+    Common grid preparation logic for both interleaved and sharded grids.
+
+    Args:
+        torch_grid: PyTorch grid tensor
+        use_precomputed_grid: Whether to use precomputed grid
+        grid_dtype: Grid data type (ttnn.bfloat16 or ttnn.float32)
+        input_shape_nhwc: Input shape in NHWC format (required for precomputed grid)
+        grid_batching_factor: Optional batching factor for reshaping grid
+
+    Returns:
+        ttnn tensor: Prepared grid tensor on host (not yet on device)
+    """
+    batch_size, grid_h, grid_w, grid_coords = torch_grid.shape
+
+    if use_precomputed_grid:
+        if input_shape_nhwc is None:
+            raise ValueError("input_shape_nhwc is required for precomputed grid")
+
+        # Create precomputed grid
+        ttnn_grid_host = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
+        ttnn_grid_precomputed = ttnn.prepare_grid_sample_grid(
+            ttnn_grid_host, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
+        )
+
+        if grid_batching_factor is not None:
+            # Reshape for grid batching: (N, H, W*K, 6) -> (N, H, W, 6*K)
+            new_grid_w = grid_w // grid_batching_factor
+            final_last_dim = PRECOMPUTED_GRID_ELEMENTS_PER_POINT * grid_batching_factor
+            return ttnn.reshape(ttnn_grid_precomputed, (batch_size, grid_h, new_grid_w, final_last_dim))
+        else:
+            return ttnn_grid_precomputed
+    else:
+        # Create regular grid
+        ttnn_grid_host = ttnn.from_torch(torch_grid, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=grid_dtype)
+
+        if grid_batching_factor is not None:
+            # Reshape for grid batching: (N, H, W*K, 2) -> (N, H, W, 2*K)
+            new_grid_w = grid_w // grid_batching_factor
+            new_last_dim = STANDARD_GRID_ELEMENTS_PER_POINT * grid_batching_factor
+            return ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
+        else:
+            return ttnn_grid_host
+
+
+def prepare_ttnn_grid(
+    torch_grid, device, use_precomputed_grid, grid_dtype, input_shape_nhwc=None, grid_batching_factor=None
+):
+    """
+    Prepare TTNN grid tensor from PyTorch grid.
+
+    Args:
+        torch_grid: PyTorch grid tensor
+        device: TTNN device
+        use_precomputed_grid: Whether to use precomputed grid
+        grid_dtype: Grid data type (ttnn.bfloat16 or ttnn.float32)
+        input_shape_nhwc: Input shape in NHWC format (required for precomputed grid)
+        grid_batching_factor: Optional batching factor for reshaping grid
+
+    Returns:
+        ttnn tensor: Prepared grid tensor on device
+    """
+    ttnn_grid_reshaped = _prepare_grid_tensor_host(
+        torch_grid, use_precomputed_grid, grid_dtype, input_shape_nhwc, grid_batching_factor
+    )
+    return ttnn.to_device(ttnn_grid_reshaped, device)
+
+
+def prepare_sharded_grid_memory_config(
+    device,
+    batch_size,
+    grid_h,
+    grid_w,
+    use_precomputed_grid,
+    grid_dtype,
+    grid_batching_factor=None,
+    core_grid_override=None,
+):
+    """
+    Create sharded memory configuration for grid tensor.
+
+    Args:
+        device: TTNN device
+        batch_size: Batch size
+        grid_h: Grid height
+        grid_w: Grid width
+        use_precomputed_grid: Whether using precomputed grid
+        grid_dtype: Grid data type
+        grid_batching_factor: Optional batching factor
+        core_grid_override: Optional core grid override (for custom sharding)
+
+    Returns:
+        ttnn.MemoryConfig: Sharded memory configuration
+    """
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    if core_grid_override is not None:
+        # Check if device has enough cores for the specified core grid
+        if core_grid_override.y > compute_grid_size.y or core_grid_override.x > compute_grid_size.x:
+            import pytest
+
+            pytest.skip(f"Device grid {compute_grid_size} insufficient for test core grid {core_grid_override}")
+        core_grid = core_grid_override
+    else:
+        # Use full device compute grid by default instead of hardcoded values
+        core_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+
+    # Calculate grid dimensions based on batching
+    if grid_batching_factor is not None:
+        new_grid_w = grid_w // grid_batching_factor
+        grid_total_height = batch_size * grid_h * new_grid_w
+        grid_logical_width = (
+            PRECOMPUTED_GRID_ELEMENTS_PER_POINT * grid_batching_factor
+            if use_precomputed_grid
+            else STANDARD_GRID_ELEMENTS_PER_POINT * grid_batching_factor
+        )
+    else:
+        grid_total_height = batch_size * grid_h * grid_w
+        grid_logical_width = (
+            PRECOMPUTED_GRID_ELEMENTS_PER_POINT if use_precomputed_grid else STANDARD_GRID_ELEMENTS_PER_POINT
+        )
+
+    grid_shard_height = div_up(grid_total_height, core_grid.num_cores)
+
+    # Round up to L1 alignment: width * BYTES_PER_ELEMENT should be multiple of L1_ALIGNMENT_BYTES
+    bytes_per_element = FLOAT32_BYTES_PER_ELEMENT if grid_dtype == ttnn.float32 else BFLOAT16_BYTES_PER_ELEMENT
+    grid_shard_width_aligned = (
+        align_to_boundary(grid_logical_width * bytes_per_element, L1_ALIGNMENT_BYTES) // bytes_per_element
+    )
+
+    return ttnn.create_sharded_memory_config(
+        (grid_shard_height, grid_shard_width_aligned),
+        core_grid,
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def prepare_sharded_ttnn_grid(
+    torch_grid,
+    device,
+    use_precomputed_grid,
+    grid_dtype,
+    input_shape_nhwc=None,
+    grid_batching_factor=None,
+    core_grid_override=None,
+):
+    """
+    Prepare TTNN grid tensor with sharding from PyTorch grid.
+
+    Args:
+        torch_grid: PyTorch grid tensor
+        device: TTNN device
+        use_precomputed_grid: Whether to use precomputed grid
+        grid_dtype: Grid data type (ttnn.bfloat16 or ttnn.float32)
+        input_shape_nhwc: Input shape in NHWC format (required for precomputed grid)
+        grid_batching_factor: Optional batching factor for reshaping grid
+        core_grid_override: Optional core grid override (for custom sharding)
+
+    Returns:
+        ttnn tensor: Prepared sharded grid tensor on device
+    """
+    batch_size, grid_h, grid_w, grid_coords = torch_grid.shape
+
+    # Use common grid preparation logic
+    ttnn_grid_reshaped = _prepare_grid_tensor_host(
+        torch_grid, use_precomputed_grid, grid_dtype, input_shape_nhwc, grid_batching_factor
+    )
+
+    grid_memory_config = prepare_sharded_grid_memory_config(
+        device, batch_size, grid_h, grid_w, use_precomputed_grid, grid_dtype, grid_batching_factor, core_grid_override
+    )
+
+    ttnn_grid_interleaved = ttnn.to_device(ttnn_grid_reshaped, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    return ttnn.to_memory_config(ttnn_grid_interleaved, grid_memory_config)
+
+
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize("use_precomputed_grid", [False, True])
 @pytest.mark.parametrize(
@@ -57,25 +293,16 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
         torch_input_nchw, torch_grid, mode="bilinear", padding_mode="zeros", align_corners=False
     )
 
-    torch_grid_bf16 = torch_grid.to(torch.bfloat16)
-
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
     ttnn_input = ttnn.from_torch(
         torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
 
-    if use_precomputed_grid:
-        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
-        prepared_grid = ttnn.prepare_grid_sample_grid(
-            ttnn_grid, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
-        )
-        prepared_grid = ttnn.to_device(prepared_grid, device)
-        ttnn_output = ttnn.grid_sample(ttnn_input, prepared_grid, use_precomputed_grid=True)
-    else:
-        # Use regular grid
-        ttnn_grid = ttnn.from_torch(torch_grid_bf16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
-        ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid)
+    # Prepare grid tensor
+    ttnn_grid_device = prepare_ttnn_grid(torch_grid, device, use_precomputed_grid, ttnn.bfloat16, input_shape_nhwc)
+
+    ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid)
 
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
@@ -98,62 +325,33 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
 def test_grid_sample_batch_output_channels_flag(
     device, input_shape, grid_shape, grid_batching_factor, batch_output_channels, use_precomputed_grid, grid_dtype
 ):
-    """Test grid sample with batch_output_channels flag - both true and false behaviors"""
-
-    # Skip float32 grid with precomputed grid - not currently supported
     if grid_dtype == ttnn.float32 and use_precomputed_grid:
-        pytest.skip("Precomputed grid with FLOAT32 grid dtype is not currently supported")
+        pytest.skip("Precomputed grid only supports bfloat16")
 
     torch.manual_seed(42)
 
     batch_size, channels, height, width = input_shape
     grid_n, grid_h, grid_w, grid_coords = grid_shape
 
-    # Validate that grid_batching_factor is a divisor of width
-    assert (
-        grid_w % grid_batching_factor == 0
-    ), f"grid_batching_factor {grid_batching_factor} must divide grid width {grid_w}"
-
-    # Create input tensor (NCHW -> NHWC)
     torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
     torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
-    # Generate random grid tensor for PyTorch reference
     grid_tensor = torch.rand(batch_size, grid_h, grid_w, 2, dtype=torch.float32) * 2.0 - 1.0
 
-    # Create PyTorch reference output
     torch_output_nchw = F.grid_sample(
         torch_input_nchw, grid_tensor, mode="bilinear", padding_mode="zeros", align_corners=False
     )
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
 
-    # Prepare TTNN grid with batching
     ttnn_input = ttnn.from_torch(
         torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
 
-    if use_precomputed_grid:
-        # Create precomputed grid
-        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.float32)
-        input_shape_nhwc = [batch_size, height, width, channels]
-        ttnn_grid_precomputed = ttnn.prepare_grid_sample_grid(
-            ttnn_grid_host, input_shape_nhwc, padding_mode="zeros", output_dtype=ttnn.bfloat16
-        )
+    input_shape_nhwc = [batch_size, height, width, channels]
+    ttnn_grid_device = prepare_ttnn_grid(
+        grid_tensor, device, use_precomputed_grid, grid_dtype, input_shape_nhwc, grid_batching_factor
+    )
 
-        # Reshape for grid batching: (N, H, W*K, 6) -> (N, H, W, 6*K)
-        new_grid_w = grid_w // grid_batching_factor
-        final_last_dim = 6 * grid_batching_factor
-        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_precomputed, (batch_size, grid_h, new_grid_w, final_last_dim))
-        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
-    else:
-        # Reshape for grid batching: (N, H, W*K, 2) -> (N, H, W, 2*K)
-        new_grid_w = grid_w // grid_batching_factor
-        new_last_dim = 2 * grid_batching_factor
-        ttnn_grid_host = ttnn.from_torch(grid_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=grid_dtype)
-        ttnn_grid_reshaped = ttnn.reshape(ttnn_grid_host, (batch_size, grid_h, new_grid_w, new_last_dim))
-        ttnn_grid_device = ttnn.to_device(ttnn_grid_reshaped, device)
-
-    # Call TTNN grid_sample with batch_output_channels flag
     ttnn_output = ttnn.grid_sample(
         ttnn_input,
         ttnn_grid_device,
@@ -162,23 +360,136 @@ def test_grid_sample_batch_output_channels_flag(
     )
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
-    # Prepare expected output based on batch_output_channels flag
-    if batch_output_channels:
-        # batch_output_channels=True: output shape (N, H, W, C*K) - channels batched
-        expected_shape = (batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
-        torch_expected_nhwc = (
-            torch_output_nhwc.view(batch_size, grid_h, new_grid_w, grid_batching_factor, channels)
-            .contiguous()
-            .view(batch_size, grid_h, new_grid_w, channels * grid_batching_factor)
-        )
-    else:
-        # batch_output_channels=False: output shape (N, H, W*K, C) - W dimension extended
-        expected_shape = (batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
-        torch_expected_nhwc = torch_output_nhwc.view(batch_size, grid_h, new_grid_w * grid_batching_factor, channels)
+    expected_shape, torch_expected_nhwc = prepare_grid_batching_expected_output(
+        torch_output_nhwc, batch_size, grid_h, grid_w, channels, grid_batching_factor, batch_output_channels
+    )
 
-    # Verify output shape
-    assert ttnn_output_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_output_torch.shape}"
-
-    # Verify numerical correctness
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(pcc_message)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
+@pytest.mark.parametrize("use_precomputed_grid", [True, False])
+@pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "input_shape, grid_shape",
+    [
+        ((1, 256, 48, 160), (1, 1, 25281, 2)),
+        ((48, 64, 32, 64), (48, 15, 15, 2)),
+        ((13, 96, 8, 16), (13, 6, 7, 2)),
+    ],
+)
+@pytest.mark.parametrize(
+    "core_grid",
+    [
+        None,  # Use full device grid
+        ttnn.CoreGrid(y=5, x=4),  # 5,4 is the grid size of the BOS N1 device
+    ],
+)
+def test_grid_sample_sharded(device, input_shape, grid_shape, use_precomputed_grid, grid_dtype, core_grid):
+    """Test grid sample with sharded grid tensor and interleaved input tensor"""
+    # Skip precomputed grid tests for float32 since precomputed grid only supports bfloat16
+    if use_precomputed_grid and grid_dtype == ttnn.float32:
+        pytest.skip("Precomputed grid only supports bfloat16")
+
+    torch.manual_seed(42)
+
+    batch_size, channels, height, width = input_shape
+    grid_n, grid_h, grid_w, grid_coords = grid_shape
+
+    input_shape_nhwc = [batch_size, height, width, channels]
+
+    torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    torch_grid = torch.rand(grid_shape, dtype=torch.float32) * 2 - 1
+
+    torch_output_nchw = F.grid_sample(
+        torch_input_nchw, torch_grid, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    ttnn_grid_device = prepare_sharded_ttnn_grid(
+        torch_grid, device, use_precomputed_grid, grid_dtype, input_shape_nhwc, core_grid_override=core_grid
+    )
+
+    # Call TTNN grid_sample - should automatically use sharded implementation
+    ttnn_output = ttnn.grid_sample(ttnn_input, ttnn_grid_device, use_precomputed_grid=use_precomputed_grid)
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
+@pytest.mark.parametrize("use_precomputed_grid", [True, False])
+@pytest.mark.parametrize("batch_output_channels", [True, False])
+@pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "input_shape, grid_shape, grid_batching_factor",
+    [
+        ((1, 256, 48, 160), (1, 1, 2809 * 7, 2), 7),
+        ((7, 32, 16, 32), (7, 8, 8, 2), 2),
+        ((1, 96, 24, 32), (1, 6, 16, 2), 4),
+    ],
+)
+@pytest.mark.parametrize(
+    "core_grid",
+    [
+        None,  # Use full device grid
+        ttnn.CoreGrid(y=5, x=4),  # Limited core grid (5x4=20 cores)
+    ],
+)
+def test_grid_sample_sharded_batched(
+    device,
+    input_shape,
+    grid_shape,
+    grid_batching_factor,
+    use_precomputed_grid,
+    batch_output_channels,
+    grid_dtype,
+    core_grid,
+):
+    if use_precomputed_grid and grid_dtype == ttnn.float32:
+        pytest.skip("Precomputed grid only supports bfloat16")
+
+    torch.manual_seed(0)
+
+    batch_size, channels, height, width = input_shape
+    grid_n, grid_h, grid_w, grid_coords = grid_shape
+
+    input_shape_nhwc = [batch_size, height, width, channels]
+
+    torch_input_nchw = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    torch_grid = torch.rand(grid_shape, dtype=torch.float32) * 2 - 1
+
+    torch_output_nchw = F.grid_sample(
+        torch_input_nchw, torch_grid, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1).to(torch.bfloat16)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    ttnn_grid_device = prepare_sharded_ttnn_grid(
+        torch_grid, device, use_precomputed_grid, grid_dtype, input_shape_nhwc, grid_batching_factor, core_grid
+    )
+
+    ttnn_output = ttnn.grid_sample(
+        ttnn_input,
+        ttnn_grid_device,
+        use_precomputed_grid=use_precomputed_grid,
+        batch_output_channels=batch_output_channels,
+    )
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    expected_shape, torch_expected_nhwc = prepare_grid_batching_expected_output(
+        torch_output_nhwc, batch_size, grid_h, grid_w, channels, grid_batching_factor, batch_output_channels
+    )
+    pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
@@ -29,6 +29,10 @@ struct GridSample {
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "mode", "padding_mode", "use_precomputed_grid", "batch_output_channels", "output_mem_config");
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            this->mode_,
+            this->padding_mode_,
             this->use_precomputed_grid_,
             this->batch_output_channels_,
             this->output_mem_config_);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_op.hpp
@@ -29,10 +29,6 @@ struct GridSample {
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "mode", "padding_mode", "use_precomputed_grid", "batch_output_channels", "output_mem_config");
-    auto attribute_values() const {
-        return std::forward_as_tuple(
-            this->mode_,
-            this->padding_mode_,
             this->use_precomputed_grid_,
             this->batch_output_channels_,
             this->output_mem_config_);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -274,29 +274,29 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     auto create_compute_kernel = [&](tt::tt_metal::CoreRangeSet cores, uint32_t total_interpolations) {
         // Compute kernel compile-time arguments
         std::vector<uint32_t> compute_compile_time_args = {
-            in_ntiles_c,                        // ct_arg[0]: in_ntiles_c
-            REDUCTION_SIZE,                     // ct_arg[1]: REDUCTION_SIZE
-            enable_split_reader && is_sharded,  // ct_arg[2]: enable_split_reader
-            total_interpolations,               // ct_arg[3]: total_interpolations
-            channels_per_shard,                 // ct_arg[4]: channels_per_shard
-            in_nblocks_c,                       // ct_arg[5]: in_nblocks_c
-            MAX_ROWS_FOR_REDUCTION,             // ct_arg[6]: MAX_ROWS_FOR_REDUCTION
-            input_cb_index_0,                   // ct_arg[7]: input_cb_index_0
-            input_cb_index_1,                   // ct_arg[8]: input_cb_index_1
-            DUMMY_CB_ID,                        // ct_arg[9]: unused
-            DUMMY_CB_ID,                        // ct_arg[10]: unused
-            scalar_cb_index_0,                  // ct_arg[11]: scalar_cb_index_0
-            scalar_cb_index_1,                  // ct_arg[12]: scalar_cb_index_1
-            DUMMY_CB_ID,                        // ct_arg[13]: unused
-            DUMMY_CB_ID,                        // ct_arg[14]: unused
-            output_cb_index,                    // ct_arg[15]: output_cb_index
-            DUMMY_CB_ID,                        // ct_arg[16]: unused
-            ONE_SCALAR_PER_CORE,                // ct_arg[17]: ONE_SCALAR_PER_CORE
-            false,                              // ct_arg[18]: unused
-            pre_tilize_cb_id,                   // ct_arg[19]: pre_tilize_cb_id
-            is_output_tiled ? 1U : 0U,          // ct_arg[20]: is_output_tiled
-            is_output_block_format ? 1U : 0U,   // ct_arg[21]: is_output_block_format
-            is_output_bfp4_b ? 1U : 0U          // ct_arg[22]: is_output_bfp4_b
+            in_ntiles_c,                       // ct_arg[0]: in_ntiles_c
+            REDUCTION_SIZE,                    // ct_arg[1]: REDUCTION_SIZE
+            enable_split_reader,               // ct_arg[2]: enable_split_reader
+            total_interpolations,              // ct_arg[3]: total_interpolations
+            channels_per_shard,                // ct_arg[4]: channels_per_shard
+            in_nblocks_c,                      // ct_arg[5]: in_nblocks_c
+            MAX_ROWS_FOR_REDUCTION,            // ct_arg[6]: MAX_ROWS_FOR_REDUCTION
+            input_cb_index_0,                  // ct_arg[7]: input_cb_index_0
+            input_cb_index_1,                  // ct_arg[8]: input_cb_index_1
+            DUMMY_CB_ID,                       // ct_arg[9]: unused
+            DUMMY_CB_ID,                       // ct_arg[10]: unused
+            scalar_cb_index_0,                 // ct_arg[11]: scalar_cb_index_0
+            scalar_cb_index_1,                 // ct_arg[12]: scalar_cb_index_1
+            DUMMY_CB_ID,                       // ct_arg[13]: unused
+            DUMMY_CB_ID,                       // ct_arg[14]: unused
+            output_cb_index,                   // ct_arg[15]: output_cb_index
+            DUMMY_CB_ID,                       // ct_arg[16]: unused
+            ONE_SCALAR_PER_CORE,               // ct_arg[17]: ONE_SCALAR_PER_CORE
+            false,                             // ct_arg[18]: unused
+            pre_tilize_cb_id,                  // ct_arg[19]: pre_tilize_cb_id
+            is_output_tiled ? 1U : 0U,         // ct_arg[20]: is_output_tiled
+            is_output_block_format ? 1U : 0U,  // ct_arg[21]: is_output_block_format
+            is_output_bfp4_b ? 1U : 0U         // ct_arg[22]: is_output_bfp4_b
         };
 
         return tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <math.h>
 #include <cstdint>
 #include "tt-metalium/kernel_types.hpp"
 #include "tt-metalium/tensor_accessor_args.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "grid_sample_op.hpp"
 #include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
 #include "ttnn/operations/pool/pool_utils.hpp"
 
 #include <tt-metalium/host_api.hpp>
@@ -20,6 +18,67 @@
 
 namespace ttnn::operations::grid_sample {
 
+// Constants
+constexpr uint32_t MAX_TILES_PER_REDUCTION = 8, BUFFERING_FACTOR = 2, REDUCTION_SIZE = 4;
+constexpr uint32_t MAX_ROWS_FOR_REDUCTION = 16;  // Height of one face (always 16)
+constexpr bool ONE_SCALAR_PER_CORE = false;
+constexpr uint32_t DUMMY_CB_ID = 32;
+
+// Function to determine if split reader should be used
+static bool should_use_split_reader(const Tensor& input_tensor, const Tensor& grid_tensor, bool use_precomputed_grid) {
+    // Split reader is only compatible with a sharded grid tensor
+    if (!grid_tensor.is_sharded()) {
+        return false;
+    }
+
+    // In the case when the grid is not precomputed, majority of processing time goes to computing the coordinates and
+    // the weights Processing time is in most cases halved, as both NCRISC and BRISC calculate these weights and
+    // coordinates
+    if (!use_precomputed_grid) {
+        return true;
+    }
+
+    // As one of the NoCs is significantly slower than the other when it comes to DRAM reads, we avoid using split
+    // reader when input tensor is in DRAM
+    if (input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM) {
+        return false;
+    }
+
+    // Get device architecture
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    const auto arch = device->arch();
+
+    // On wormhole, the bottleneck is always the reading of the input image, so split reader is beneficial
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        return true;
+    }
+
+    // On blackhole, for a lower number of channels, the bottleneck is the reading of the input image, so split reader
+    // is benefitial On higher number of channels, the bottleneck is on the unpacker side, where using split reader also
+    // adds additional overhead, so it slows down the program
+    if (arch == tt::ARCH::BLACKHOLE) {
+        const uint32_t input_channels = input_tensor.padded_shape()[-1];
+        return input_channels <= 224;
+    }
+
+    // Default case for other architectures, currently should be unreachable
+    return false;
+}
+
+// Utility functions
+static uint32_t get_grid_batching_factor(const Tensor& grid_tensor, bool use_precomputed_grid) {
+    return grid_tensor.logical_shape()[-1] /
+           (use_precomputed_grid ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT : STANDARD_GRID_ELEMENTS_PER_POINT);
+}
+
+static uint32_t get_aligned_stick_size(const ttnn::Shape& shape, const Tensor& tensor) {
+    const uint32_t stick_nbytes = shape[-1] * tensor.element_size();
+    const uint32_t alignment = tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                   ? tt::tt_metal::hal::get_dram_alignment()
+                                   : tt::tt_metal::hal::get_l1_alignment();
+    return tt::round_up(stick_nbytes, alignment);
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const Tensor& input_tensor,
     const Tensor& grid_tensor,
@@ -28,317 +87,342 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const std::string& padding_mode,
     bool use_precomputed_grid,
     bool batch_output_channels) {
+    const bool is_sharded = grid_tensor.is_sharded();
     tt::tt_metal::Program program{};
 
-    const tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    const tt::DataFormat grid_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(grid_tensor.dtype());
-    const tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
-
+    // Data formats and device
+    const auto [input_cb_data_format, grid_cb_data_format, output_cb_data_format] = std::make_tuple(
+        tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(grid_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype()));
     tt::tt_metal::IDevice* const device = output_tensor.device();
 
-    const auto& input_shape = input_tensor.padded_shape();
-    const auto& grid_shape = grid_tensor.padded_shape();
-    const auto& output_shape = output_tensor.padded_shape();
+    // Shape and dimensions
+    const auto& [input_shape, grid_shape, output_shape] =
+        std::tie(input_tensor.padded_shape(), grid_tensor.padded_shape(), output_tensor.padded_shape());
+    const uint32_t input_height = input_shape[1], input_width = input_shape[2];
+    const uint32_t grid_height = grid_shape[1], grid_width = grid_shape[2];
+    const uint32_t grid_hw = grid_height * grid_width;
+    const uint32_t grid_batching_factor = get_grid_batching_factor(grid_tensor, use_precomputed_grid);
+    const bool enable_split_reader = should_use_split_reader(input_tensor, grid_tensor, use_precomputed_grid);
 
-    const uint32_t input_height = input_shape[1];
-    const uint32_t input_width = input_shape[2];
+    tt::tt_metal::CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores, grid_nsticks_per_core, output_nsticks_per_core = 0;
+    uint32_t num_sticks_per_core_group_1 = 0, num_sticks_per_core_group_2 = 0;
+    std::vector<CoreCoord> logical_cores;
 
-    const uint32_t output_height = grid_shape[1];
-    const uint32_t output_width = grid_shape[2];
+    if (is_sharded) {
+        const auto grid_shard_spec = grid_tensor.shard_spec().value();
+        all_cores = grid_shard_spec.grid;
+        num_cores = grid_shard_spec.num_cores();
+        grid_nsticks_per_core = grid_shard_spec.shape[0];
+        output_nsticks_per_core = output_tensor.shard_spec().value().shape[0];
+        logical_cores = corerange_to_cores(
+            all_cores, num_cores, grid_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    } else {
+        const uint32_t grid_nsticks = grid_tensor.physical_volume() / grid_shape[-1];
+        const auto compute_grid_size = device->compute_with_storage_grid_size();
+        auto [num_cores_used, all_cores_range, core_group_1_range, core_group_2_range, num_sticks_1, num_sticks_2] =
+            tt::tt_metal::split_work_to_cores(compute_grid_size, grid_nsticks);
 
-    // Calculate stick sizes (full rows in last dimension)
-    const uint32_t grid_buffer_alignment = grid_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                               ? tt::tt_metal::hal::get_dram_alignment()
-                                               : tt::tt_metal::hal::get_l1_alignment();
+        std::tie(num_cores, all_cores, core_group_1, core_group_2) =
+            std::make_tuple(num_cores_used, all_cores_range, core_group_1_range, core_group_2_range);
+        num_sticks_per_core_group_1 = num_sticks_1;
+        num_sticks_per_core_group_2 = num_sticks_2;
+        grid_nsticks_per_core = num_sticks_1;
 
-    const uint32_t src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                              ? tt::tt_metal::hal::get_dram_alignment()
-                                              : tt::tt_metal::hal::get_l1_alignment();
+        logical_cores = corerange_to_cores(all_cores, num_cores, true);
+    }
 
-    const uint32_t dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                              ? tt::tt_metal::hal::get_dram_alignment()
-                                              : tt::tt_metal::hal::get_l1_alignment();
+    uint32_t cb_idx = tt::CBIndex::c_0;
 
-    const uint32_t grid_stick_nbytes = grid_shape[-1] * grid_tensor.element_size();
-    const uint32_t aligned_grid_stick_nbytes = tt::round_up(grid_stick_nbytes, grid_buffer_alignment);
-    const uint32_t input_stick_nbytes = input_shape[-1] * input_tensor.element_size();
-    const uint32_t aligned_input_stick_nbytes = tt::round_up(input_stick_nbytes, src_buffer_alignment);
-    const uint32_t output_stick_nbytes = output_shape[-1] * output_tensor.element_size();
-    const uint32_t aligned_output_stick_nbytes = tt::round_up(output_stick_nbytes, dst_buffer_alignment);
-
-    // Calculate the number of data points batched into a single grid row
-    uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
-    const uint32_t num_of_elements_per_grid_point =
-        use_precomputed_grid ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT : STANDARD_GRID_ELEMENTS_PER_POINT;
-    const uint32_t grid_batching_factor = grid_last_dim / num_of_elements_per_grid_point;
-
-    // Calculate grid sticks and output sticks separately based on batch_output_channels
-    uint32_t grid_nsticks = grid_tensor.physical_volume() / grid_shape[-1];
-
-    // Work distribution explanation:
-    // - batch_output_channels=true: 1 grid stick → 1 output stick (C*K channels)
-    // - batch_output_channels=false: 1 grid stick → K output sticks (C channels each)
-    // Reader processes grid_nsticks, Writer processes output_nsticks
-
-    // Get device grid for multicore
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    // Work distribution - distribute grid sticks across cores (fundamental work units)
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, grid_nsticks);
-
-    uint32_t next_cb_index = tt::CBIndex::c_0;
-
-    const uint32_t buffering_factor = 2;
-
-    // CB0: Grid data buffer (holds grid coordinates for current output position)
-    const uint32_t grid_cb_num_pages = 1;
+    // Create CBs
+    const uint32_t grid_stick_size =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
     const auto [grid_cb_index, grid_cb_handle] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, aligned_grid_stick_nbytes, grid_cb_num_pages, grid_cb_data_format);
+        cb_idx++,
+        program,
+        all_cores,
+        grid_stick_size,
+        is_sharded ? grid_nsticks_per_core : 1,
+        grid_cb_data_format,
+        is_sharded ? grid_tensor.buffer() : nullptr);
 
     const uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[-1] / tt::constants::TILE_WIDTH);
     const uint32_t input_cb_page_size = in_ntiles_c * tt::constants::TILE_HW * input_tensor.element_size();
+    const auto [input_cb_index_0, input_cb_handle_0] = tt::tt_metal::create_cb(
+        cb_idx++, program, all_cores, input_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
 
-    // CB1: Input data buffer (holds 4 input sticks for bilinear interpolation)
-    uint32_t input_cb_num_pages = buffering_factor;  // 4 corner sticks for bilinear
-    const auto [input_cb_index, input_cb_handle] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, input_cb_page_size, input_cb_num_pages, input_cb_data_format);
+    uint32_t input_cb_index_1 = DUMMY_CB_ID;
+    tt::tt_metal::CBHandle input_cb_handle_1 = 0;
+    if (is_sharded && enable_split_reader) {
+        std::tie(input_cb_index_1, input_cb_handle_1) = tt::tt_metal::create_cb(
+            cb_idx++, program, all_cores, input_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
+    }
 
-    // CB2: Scalar buffer (holds 4 bilinear interpolation weights)
-    const uint32_t scalar_cb_num_pages = buffering_factor;
-    const uint32_t scalar_cb_page_size = tile_size(input_cb_data_format);  // 4 scalars, aligned
-    const auto [scalar_cb_index, scalar_cb_handle] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, scalar_cb_page_size, scalar_cb_num_pages, input_cb_data_format);
+    const uint32_t scalar_cb_page_size =
+        is_sharded ? tt::tt_metal::detail::TileSize(input_cb_data_format) : tile_size(input_cb_data_format);
+    const auto [scalar_cb_index_0, scalar_cb_handle_0] = tt::tt_metal::create_cb(
+        cb_idx++, program, all_cores, scalar_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
 
-    // CB3: Output buffer
+    uint32_t scalar_cb_index_1 = DUMMY_CB_ID;
+    tt::tt_metal::CBHandle scalar_cb_handle_1 = 0;
+    if (is_sharded && enable_split_reader) {
+        std::tie(scalar_cb_index_1, scalar_cb_handle_1) = tt::tt_metal::create_cb(
+            cb_idx++, program, all_cores, scalar_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
+    }
+
     const uint32_t out_ntiles_c = (uint32_t)std::ceil((float)output_shape[-1] / tt::constants::FACE_WIDTH);
-
     const uint32_t output_cb_page_size = tt::constants::FACE_WIDTH * output_tensor.element_size();
-    const uint32_t output_cb_num_pages = out_ntiles_c * buffering_factor;
-
+    const uint32_t output_cb_pages =
+        is_sharded ? output_nsticks_per_core * out_ntiles_c : out_ntiles_c * BUFFERING_FACTOR;
     const auto [output_cb_index, output_cb_handle] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, output_cb_page_size, output_cb_num_pages, output_cb_data_format);
+        cb_idx++,
+        program,
+        all_cores,
+        output_cb_page_size,
+        output_cb_pages,
+        output_cb_data_format,
+        is_sharded ? output_tensor.buffer() : nullptr);
 
+    // Prepare stick size arguments with proper names
+    const uint32_t input_stick_size = get_aligned_stick_size(input_shape, input_tensor);
+    const uint32_t grid_stick_size_arg =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
+
+    // Reader compile-time arguments - shared arguments first, then specific ones
     std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)input_cb_index,              // input CB index
-        (std::uint32_t)grid_cb_index,               // grid CB index
-        (std::uint32_t)scalar_cb_index,             // scalar CB index
-        (std::uint32_t)aligned_input_stick_nbytes,  // input stick size
-        (std::uint32_t)aligned_grid_stick_nbytes,   // grid stick size
-        (std::uint32_t)input_height,
-        (std::uint32_t)input_width,
-        (std::uint32_t)(output_height * output_width),  // output_hw_size at index 13
-        (std::uint32_t)grid_batching_factor,            // number of grids per spatial position
-        (std::uint32_t)grid_tensor.dtype(),             // grid data type
+        input_cb_index_0,                            // ct_arg[0]: input_cb_index_0
+        grid_cb_index,                               // ct_arg[1]: grid_cb_index
+        scalar_cb_index_0,                           // ct_arg[2]: scalar_cb_index_0
+        input_stick_size,                            // ct_arg[3]: input_stick_size
+        grid_stick_size_arg,                         // ct_arg[4]: grid_stick_size
+        input_height,                                // ct_arg[5]: input_height
+        input_width,                                 // ct_arg[6]: input_width
+        grid_batching_factor,                        // ct_arg[7]: grid_batching_factor (shared)
+        static_cast<uint32_t>(grid_tensor.dtype()),  // ct_arg[8]: grid_dtype (shared)
+        grid_hw,                                     // ct_arg[9]: grid_hw (shared)
+        use_precomputed_grid ? 1U : 0U               // ct_arg[10]: use_precomputed_grid (shared)
     };
 
+    if (is_sharded) {
+        reader_compile_time_args.push_back(enable_split_reader ? 1U : 0U);   // ct_arg[11]: enable_split_reader
+        reader_compile_time_args.push_back(0U);  // ct_arg[12]: reader_id (will be set later per reader)
+        reader_compile_time_args.push_back(grid_nsticks_per_core);  // ct_arg[13]: grid_nsticks_per_core
+    }
+
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(*grid_tensor.buffer()).append_to(reader_compile_time_args);
+    if (!is_sharded) {
+        tt::tt_metal::TensorAccessorArgs(*grid_tensor.buffer()).append_to(reader_compile_time_args);
+    }
 
-    const uint32_t MAX_TILES_PER_REDUCTION = 8;
+    const std::string reader_kernel_path =
+        is_sharded ? "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp"
+                   : "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/"
+                     "reader_grid_sample_interleaved_start_id.cpp";
 
-    // Grid sample parameters for pool compute kernel adaptation
-    const uint32_t reduction_size = 4;                    // Always 4 for bilinear interpolation
-    const bool split_reader = false;                      // No split reader for grid sample
-    const uint32_t channels_per_shard = input_shape[-1];  // All channels in one "shard"
-    const uint32_t in_nblocks_c = (uint32_t)std::ceil(
-        (float)in_ntiles_c / MAX_TILES_PER_REDUCTION);  // For now 1, will add wide reduction support later
-    const uint32_t max_rows_for_reduction = 4;          // 4 corner values
-    const bool one_scalar_per_core = false;             // Scalars change during computation
-    const uint32_t dummy_cb_id = 32;                    // Unused CB for split reader
+    // Create kernels
+    auto create_reader_config = [&](const std::vector<uint32_t>& args, auto processor, auto noc) {
+        return tt::tt_metal::DataMovementConfig{.processor = processor, .noc = noc, .compile_args = args};
+    };
 
-    // Create compute kernels for different work loads
-    // We'll create kernels for cores with same work amount together
-    tt::tt_metal::KernelHandle compute_kernel_group_1 = 0;
-    tt::tt_metal::KernelHandle compute_kernel_group_2 = 0;
+    tt::tt_metal::KernelHandle reader0_kernel_id, reader1_kernel_id = 0;
+    if (is_sharded) {
+        auto reader0_compile_time_args = reader_compile_time_args;
+        reader0_compile_time_args[12] = 0;  // ct_arg[12]: reader_id = 0
+
+        reader0_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            reader_kernel_path,
+            all_cores,
+            create_reader_config(
+                reader0_compile_time_args,
+                tt::tt_metal::DataMovementProcessor::RISCV_0,
+                tt::tt_metal::NOC::RISCV_0_default));
+
+        if (enable_split_reader) {
+            auto reader1_compile_time_args = reader_compile_time_args;
+            reader1_compile_time_args[0] = input_cb_index_1;   // ct_arg[0]: input_cb_index_1
+            reader1_compile_time_args[2] = scalar_cb_index_1;  // ct_arg[2]: scalar_cb_index_1
+            reader1_compile_time_args[12] = 1;                 // ct_arg[12]: reader_id = 1
+
+            reader1_kernel_id = tt::tt_metal::CreateKernel(
+                program,
+                reader_kernel_path,
+                all_cores,
+                create_reader_config(
+                    reader1_compile_time_args,
+                    tt::tt_metal::DataMovementProcessor::RISCV_1,
+                    tt::tt_metal::NOC::RISCV_1_default));
+        }
+    } else {
+        reader0_kernel_id = tt::tt_metal::CreateKernel(
+            program, reader_kernel_path, all_cores, tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    }
 
     const bool is_output_tiled = false;
     const bool is_output_block_format = false;
-    const bool is_output_bfp4_b = false;
     const uint32_t pre_tilize_cb_id =
         32;  // Unused CB for pool compute kernel for grid sample, we don't have tiled output in gridsample
 
-    // Kernel for core group 1
-    if (core_group_1.num_cores() > 0) {
-        std::vector<uint32_t> compute_compile_time_args_1 = {
-            in_ntiles_c,                                         // 0: Input tiles per channel
-            reduction_size,                                      // 1: Reduction size (4 for bilinear)
-            split_reader,                                        // 2: Split reader flag
-            grid_batching_factor * num_sticks_per_core_group_1,  // 3: Total grid interpolations per core for group 1
-            channels_per_shard,                                  // 4: Channels per shard
-            in_nblocks_c,                                        // 5: Channel blocks
-            max_rows_for_reduction,                              // 6: Max rows
-            input_cb_index,                                      // 7: Input CB
-            dummy_cb_id,                                         // 8: Input CB 1 (unused)
-            dummy_cb_id,                                         // 9: Index Input CB (unused)
-            dummy_cb_id,                                         // 10: Index Input CB 1 (unused)
-            scalar_cb_index,                                     // 11: Scalar CB
-            dummy_cb_id,                                         // 12: Scalar CB 1 (unused)
-            dummy_cb_id,                                         // 13: Tile Temp CB (unused)
-            dummy_cb_id,                                         // 14: Index Tile Temp CB (unused)
-            output_cb_index,                                     // 15: Output CB
-            dummy_cb_id,                                         // 16: Index Output CB (unused)
-            one_scalar_per_core,                                 // 17: Scalar mode
-            false,                                               // 18: Return Indices (unused)
-            pre_tilize_cb_id,                                    // 19: Pre-tilize CB (unused)
-            is_output_tiled,                                     // 20: is_output_tiled (unused)
-            is_output_block_format,                              // 21: is_output_block_format (unused)
-            is_output_bfp4_b                                     // 22: is_output_bfp4_b (unused)
+    const bool is_output_bfp4_b = false;
+
+    // Compute kernels
+    const uint32_t channels_per_shard = input_shape[-1];
+    const uint32_t in_nblocks_c = (uint32_t)std::ceil((float)in_ntiles_c / MAX_TILES_PER_REDUCTION);
+
+    auto create_compute_kernel = [&](tt::tt_metal::CoreRangeSet cores, uint32_t total_interpolations) {
+        // Compute kernel compile-time arguments
+        std::vector<uint32_t> compute_compile_time_args = {
+            in_ntiles_c,                        // ct_arg[0]: in_ntiles_c
+            REDUCTION_SIZE,                     // ct_arg[1]: REDUCTION_SIZE
+            enable_split_reader && is_sharded,  // ct_arg[2]: enable_split_reader
+            total_interpolations,               // ct_arg[3]: total_interpolations
+            channels_per_shard,                 // ct_arg[4]: channels_per_shard
+            in_nblocks_c,                       // ct_arg[5]: in_nblocks_c
+            MAX_ROWS_FOR_REDUCTION,             // ct_arg[6]: MAX_ROWS_FOR_REDUCTION
+            input_cb_index_0,                   // ct_arg[7]: input_cb_index_0
+            input_cb_index_1,                   // ct_arg[8]: input_cb_index_1
+            DUMMY_CB_ID,                        // ct_arg[9]: unused
+            DUMMY_CB_ID,                        // ct_arg[10]: unused
+            scalar_cb_index_0,                  // ct_arg[11]: scalar_cb_index_0
+            scalar_cb_index_1,                  // ct_arg[12]: scalar_cb_index_1
+            DUMMY_CB_ID,                        // ct_arg[13]: unused
+            DUMMY_CB_ID,                        // ct_arg[14]: unused
+            output_cb_index,                    // ct_arg[15]: output_cb_index
+            DUMMY_CB_ID,                        // ct_arg[16]: unused
+            ONE_SCALAR_PER_CORE,                // ct_arg[17]: ONE_SCALAR_PER_CORE
+            false,                              // ct_arg[18]: unused
+            pre_tilize_cb_id,                   // ct_arg[19]: pre_tilize_cb_id
+            is_output_tiled ? 1U : 0U,          // ct_arg[20]: is_output_tiled
+            is_output_block_format ? 1U : 0U,   // ct_arg[21]: is_output_block_format
+            is_output_bfp4_b ? 1U : 0U          // ct_arg[22]: is_output_bfp4_b
         };
 
-        compute_kernel_group_1 = tt::tt_metal::CreateKernel(
+        return tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp",
-            core_group_1,
+            cores,
             tt::tt_metal::ComputeConfig{
                 .math_fidelity = MathFidelity::HiFi4,
-                .fp32_dest_acc_en = false,  // Use bfloat16
+                .fp32_dest_acc_en = false,
                 .math_approx_mode = false,
-                .compile_args = compute_compile_time_args_1,
+                .compile_args = compute_compile_time_args,
                 .defines = get_defines(pool::Pool2DType::AVG_POOL2D)});
+    };
+
+    tt::tt_metal::KernelHandle compute_kernel_group_1 = 0, compute_kernel_group_2 = 0;
+    if (is_sharded || core_group_1.num_cores() > 0) {
+        compute_kernel_group_1 = create_compute_kernel(
+            is_sharded ? all_cores : core_group_1,
+            grid_batching_factor * (is_sharded ? grid_nsticks_per_core : num_sticks_per_core_group_1));
+    }
+    if (!is_sharded && core_group_2.num_cores() > 0) {
+        compute_kernel_group_2 =
+            create_compute_kernel(core_group_2, grid_batching_factor * num_sticks_per_core_group_2);
     }
 
-    // Kernel for core group 2 (if it exists)
-    if (core_group_2.num_cores() > 0) {
-        std::vector<uint32_t> compute_compile_time_args_2 = {
-            in_ntiles_c,                                         // 0: Input tiles per channel
-            reduction_size,                                      // 1: Reduction size (4 for bilinear)
-            split_reader,                                        // 2: Split reader flag
-            grid_batching_factor * num_sticks_per_core_group_2,  // 3:  Total grid interpolations per core for group 1
-            channels_per_shard,                                  // 4: Channels per shard
-            in_nblocks_c,                                        // 5: Channel blocks
-            max_rows_for_reduction,                              // 6: Max rows
-            input_cb_index,                                      // 7: Input CB
-            dummy_cb_id,                                         // 8: Input CB 1 (unused)
-            dummy_cb_id,                                         // 9: Index Input CB (unused)
-            dummy_cb_id,                                         // 10: Index Input CB 1 (unused)
-            scalar_cb_index,                                     // 11: Scalar CB
-            dummy_cb_id,                                         // 12: Scalar CB 1 (unused)
-            dummy_cb_id,                                         // 13: Tile Temp CB (unused)
-            dummy_cb_id,                                         // 14: Index Tile Temp CB (unused)
-            output_cb_index,                                     // 15: Output CB
-            dummy_cb_id,                                         // 16: Index Output CB (unused)
-            one_scalar_per_core,                                 // 17: Scalar mode
-            false,                                               // 18: Return Indices (unused)
-            pre_tilize_cb_id,                                    // 19: Pre-tilize CB (unused)
-            is_output_tiled,                                     // 20: is_output_tiled (unused)
-            is_output_block_format,                              // 21: is_output_block_format (unused)
-            is_output_bfp4_b                                     // 22: is_output_bfp4_b (unused)
+    // Writer kernel (interleaved only)
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    if (!is_sharded) {
+        // Writer compile-time arguments - expanded row by row for readability
+        std::vector<uint32_t> writer_compile_time_args = {
+            output_cb_index,                                      // ct_arg[0]: output_cb_index
+            get_aligned_stick_size(output_shape, output_tensor),  // ct_arg[1]: output_stick_size
+            out_ntiles_c                                          // ct_arg[2]: out_ntiles_c
         };
+        tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
 
-        compute_kernel_group_2 = tt::tt_metal::CreateKernel(
+        writer_kernel_id = tt::tt_metal::CreateKernel(
             program,
-            "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp",
-            core_group_2,
-            tt::tt_metal::ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
-                .fp32_dest_acc_en = false,  // Use bfloat16
-                .math_approx_mode = false,
-                .compile_args = compute_compile_time_args_2,
-                .defines = get_defines(pool::Pool2DType::AVG_POOL2D)  // Use avg pool defines
-            });
+            "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp",
+            all_cores,
+            tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
     }
 
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index,              // output CB index
-        (std::uint32_t)aligned_output_stick_nbytes,  // output stick size
-        (std::uint32_t)out_ntiles_c                  // number of tiles per channel (for ntiles_c pages per stick)
-    };
+    // Set runtime arguments
+    if (is_sharded) {
+        for (uint32_t i = 0; i < num_cores; i++) {
+            const CoreCoord& core = logical_cores[i];
 
-    tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
+            // Runtime arguments for sharded reader
+            std::vector<uint32_t> reader_runtime_args = {
+                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
+                i * grid_nsticks_per_core          // rt_arg[1]: grid_stick_offset
+            };
 
-    std::string reader_kernel_path =
-        "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp";
-    std::string writer_kernel_path =
-        "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp";
-
-    // Create reader defines for precomputed grid
-    std::map<std::string, std::string> reader_defines;
-    if (use_precomputed_grid) {
-        reader_defines["USE_PRECOMPUTED_GRID"] = "1";
-    }
-
-    auto reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        reader_kernel_path,
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
-
-    auto writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_path, all_cores, tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    std::vector<uint32_t> reader_rt_arguments{
-        input_tensor.buffer()->address(),
-        grid_tensor.buffer()->address(),
-        0,  // set in loop, num of sticks per core
-        0   // set in loop, start_stick_id
-    };
-
-    std::vector<uint32_t> writer_rt_arguments{
-        output_tensor.buffer()->address(),
-        0,  // set in loop, num of sticks per core
-        0   // set in loop, start_stick_id
-    };
-
-    for (uint32_t i = 0, grid_sticks_processed = 0, output_sticks_processed = 0; i < num_cores; i++) {
-        const CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        uint32_t grid_sticks_per_core = 0;
-
-        if (core_group_1.contains(core)) {
-            grid_sticks_per_core = num_sticks_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            grid_sticks_per_core = num_sticks_per_core_group_2;
-        } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            tt::tt_metal::SetRuntimeArgs(program, reader0_kernel_id, core, reader_runtime_args);
+            if (enable_split_reader) {
+                tt::tt_metal::SetRuntimeArgs(program, reader1_kernel_id, core, reader_runtime_args);
+            }
         }
-
-        // Calculate output sticks this core will produce
-        uint32_t output_sticks_per_core =
-            batch_output_channels ? grid_sticks_per_core :    // batch_output_channels=true: 1:1 ratio
-                grid_sticks_per_core * grid_batching_factor;  // batch_output_channels=false: 1:K ratio
-
-        reader_rt_arguments[2] = grid_sticks_per_core;   // Reader: grid sticks
-        reader_rt_arguments[3] = grid_sticks_processed;  // Reader: grid stick start id
-
-        // Compute runtime arguments - pool kernel expects no runtime args (all compile-time)
-
-        writer_rt_arguments[1] = output_sticks_per_core;   // Writer: output sticks
-        writer_rt_arguments[2] = output_sticks_processed;  // Writer: output stick start id
-
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_arguments);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_rt_arguments);
-
-        grid_sticks_processed += grid_sticks_per_core;
-        output_sticks_processed += output_sticks_per_core;
-    }
-
-    // Runtime arguments callback following upsample pattern
-    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
-                                              const void* operation,
-                                              tt::tt_metal::Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        const auto& input_tensor = input_tensors.at(0);
-        const auto& grid_tensor = input_tensors.at(1);
-        const auto& output_tensor = output_tensors.at(0);
+    } else {
+        uint32_t grid_processed = 0;
+        uint32_t output_processed = 0;
 
         for (uint32_t i = 0; i < num_cores; i++) {
-            const CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = input_tensor.buffer()->address();
-                runtime_args[1] = grid_tensor.buffer()->address();
-            }
-            {
-                auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = output_tensor.buffer()->address();
-            }
-        }
-    };
+            const CoreCoord& core = logical_cores[i];
+            const uint32_t grid_sticks =
+                core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
+            const uint32_t output_sticks = batch_output_channels ? grid_sticks : grid_sticks * grid_batching_factor;
 
-    return {std::move(program), override_runtime_args_callback};
+            // Runtime arguments for interleaved reader - expanded row by row
+            std::vector<uint32_t> reader_runtime_args = {
+                input_tensor.buffer()->address(),  // rt_arg[0]: input_buffer_address
+                grid_tensor.buffer()->address(),   // rt_arg[1]: grid_buffer_address
+                grid_sticks,                       // rt_arg[2]: grid_sticks
+                grid_processed                     // rt_arg[3]: grid_processed
+            };
+
+            // Runtime arguments for interleaved writer - expanded row by row
+            std::vector<uint32_t> writer_runtime_args = {
+                output_tensor.buffer()->address(),  // rt_arg[0]: output_buffer_address
+                output_sticks,                      // rt_arg[1]: output_sticks
+                output_processed                    // rt_arg[2]: output_processed
+            };
+
+            tt::tt_metal::SetRuntimeArgs(program, reader0_kernel_id, core, reader_runtime_args);
+            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+
+            grid_processed += grid_sticks;
+            output_processed += output_sticks;
+        }
+    }
+
+    // Runtime callback
+    return {
+        std::move(program),
+        [=](const void*,
+            tt::tt_metal::Program& prog,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& [input_tensor, grid_tensor] = std::tie(input_tensors[0], input_tensors[1]);
+            const auto& output_tensor = output_tensors[0];
+
+            if (is_sharded) {
+                tt::tt_metal::UpdateDynamicCircularBufferAddress(prog, grid_cb_handle, *grid_tensor.buffer());
+                tt::tt_metal::UpdateDynamicCircularBufferAddress(prog, output_cb_handle, *output_tensor.buffer());
+
+                for (uint32_t i = 0; i < num_cores; i++) {
+                    const CoreCoord& core = logical_cores[i];
+                    tt::tt_metal::GetRuntimeArgs(prog, reader0_kernel_id, core)[0] = input_tensor.buffer()->address();
+                    if (enable_split_reader) {
+                        tt::tt_metal::GetRuntimeArgs(prog, reader1_kernel_id, core)[0] =
+                            input_tensor.buffer()->address();
+                    }
+                }
+            } else {
+                for (uint32_t i = 0; i < num_cores; i++) {
+                    const CoreCoord& core = logical_cores[i];
+                    auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(prog, reader0_kernel_id, core);
+                    reader_runtime_args[0] = input_tensor.buffer()->address();  // rt_arg[0]: input_buffer_address
+                    reader_runtime_args[1] = grid_tensor.buffer()->address();   // rt_arg[1]: grid_buffer_address
+                    tt::tt_metal::GetRuntimeArgs(prog, writer_kernel_id, core)[0] =
+                        output_tensor.buffer()->address();  // rt_arg[0]: output_buffer_address
+                }
+            }
+        }};
 }
 
 }  // namespace ttnn::operations::grid_sample

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp"
+#include "debug/dprint.h"
 
 #define ALWI inline __attribute__((always_inline))
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -7,8 +7,13 @@
 #include "compile_time_args.h"
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp"
-#include "debug/dprint.h"
 #include "../grid_sample_reader_common.hpp"
+
+#define PRINT_AND_PROFILE 0
+#if PRINT_AND_PROFILE
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+#include "debug/dprint.h"
+#endif
 
 void kernel_main() {
     uint32_t input_addr = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -4,42 +4,11 @@
 
 #include <cmath>
 #include <stdint.h>
+#include "compile_time_args.h"
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp"
 #include "debug/dprint.h"
-
-#define ALWI inline __attribute__((always_inline))
-
-constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
-constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
-
-// Data type constants (from ttnn/api/ttnn/tensor/types.hpp DataType enum)
-constexpr uint32_t DTYPE_BFLOAT16 = 0;
-constexpr uint32_t DTYPE_FLOAT32 = 1;
-
-ALWI bool is_coordinate_valid(int32_t coord, uint32_t max_size) {
-    return (coord >= 0) && (coord < static_cast<int32_t>(max_size));
-}
-
-ALWI void fill_four_val(uint32_t begin_addr, uint16_t val, uint16_t val1, uint16_t val2, uint16_t val3) {
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
-
-    ptr[0] = (val | (val1 << 16));
-    ptr[1] = (val2 | (val3 << 16));
-}
-
-inline uint16_t float_to_bfloat16(float value) {
-    uint32_t tmp;
-    std::memcpy(&tmp, &value, sizeof(tmp));
-    return static_cast<uint16_t>(tmp >> 16);
-}
-
-inline float bfloat16_to_float(uint16_t bf16) {
-    uint32_t tmp = static_cast<uint32_t>(bf16) << 16;
-    float result;
-    std::memcpy(&result, &tmp, sizeof(result));
-    return result;
-}
+#include "../grid_sample_reader_common.hpp"
 
 void kernel_main() {
     uint32_t input_addr = get_arg_val<uint32_t>(0);
@@ -54,26 +23,18 @@ void kernel_main() {
     constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
     constexpr uint32_t input_height = get_compile_time_arg_val(5);
     constexpr uint32_t input_width = get_compile_time_arg_val(6);
-    constexpr uint32_t output_hw_size = get_compile_time_arg_val(7);
-    constexpr uint32_t grid_batches = get_compile_time_arg_val(8);
-    constexpr uint32_t grid_dtype = get_compile_time_arg_val(9);
+    constexpr uint32_t grid_batches = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(8);
+    constexpr uint32_t output_hw_size = get_compile_time_arg_val(9);
+    constexpr bool use_precomputed_grid = get_compile_time_arg_val(10);
 
-    constexpr auto src_args = TensorAccessorArgs<10>();
+    constexpr auto src_args = TensorAccessorArgs<11>();
     constexpr auto grid_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
-    const auto s0 = TensorAccessor(grid_args, grid_addr, grid_stick_nbytes);
-    const auto s1 = TensorAccessor(src_args, input_addr, input_stick_nbytes);
+    const auto grid_tensor_accessor = TensorAccessor(grid_args, grid_addr, grid_stick_nbytes);
+    const auto input_tensor_accessor = TensorAccessor(src_args, input_addr, input_stick_nbytes);
 
     const uint32_t end_id = start_page_id + num_pages;
-
-    constexpr float input_height_f = float(input_height);
-    constexpr float input_width_f = float(input_width);
-
-    constexpr float height_scale = input_height_f * 0.5f;
-    constexpr float height_offset = height_scale - 0.5f;
-
-    constexpr float width_scale = input_width_f * 0.5f;
-    constexpr float width_offset = width_scale - 0.5f;
 
     /*
     In the case of grid sampling, we need to account for the fact that the grid coordinates may fall outside the bounds
@@ -88,144 +49,42 @@ void kernel_main() {
 
     zero_out_tiles<input_cb_index>();
 
+    // Calculate starting batch from starting spatial position (avoid division in loop)
+    uint32_t curr_batch = start_page_id / output_hw_size;
+    uint32_t spatial_points_processed = start_page_id % output_hw_size;
+    uint32_t batch_offset = curr_batch * input_height * input_width;
+
     // Outer loop: iterate over spatial positions (output sticks)
     for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
         // Read the grid stick for this spatial position (contains grid_batches sets of coordinates)
         uint32_t l1_write_grid_addr = get_write_ptr(grid_cb_index);
-        uint64_t grid_noc_addr = s0.get_noc_addr(spatial_pos);
+        uint64_t grid_noc_addr = grid_tensor_accessor.get_noc_addr(spatial_pos);
 
         noc_async_read(grid_noc_addr, l1_write_grid_addr, grid_stick_nbytes);
         noc_async_read_barrier();
 
-        // Cast to appropriate pointer type based on grid data type
+        // Cast to appropriate pointer type for grid data access
         volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_grid_addr);
-        volatile tt_l1_ptr float* grid_float_ptr = reinterpret_cast<volatile tt_l1_ptr float*>(l1_write_grid_addr);
-
-        uint32_t curr_batch = spatial_pos / output_hw_size;
-        uint32_t batch_offset = curr_batch * input_height * input_width;
 
         // Inner loop: process grid_batches coordinate sets within this spatial position
         for (uint32_t grid_idx = 0; grid_idx < grid_batches; ++grid_idx) {
-            uint16_t weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf;
-            int32_t h0, h1, w0, w1;
+            // Direct template dispatch - no branching needed
+            process_grid_point<
+                grid_dtype,
+                use_precomputed_grid,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                input_cb_index,
+                scalar_cb_index>(grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
+        }
 
-#ifdef USE_PRECOMPUTED_GRID
-            // Each precomputed grid entry has 6 values: h0, w0, weight_nw, weight_ne, weight_sw, weight_se
-            uint32_t precomputed_data_offset = grid_idx * PRECOMPUTED_GRID_ELEMENTS_PER_POINT;
-            int16_t h0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 0]);
-            int16_t w0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 1]);
-
-            h0 = static_cast<int32_t>(h0_raw);
-            w0 = static_cast<int32_t>(w0_raw);
-            h1 = h0 + 1;
-            w1 = w0 + 1;
-
-            // Read precomputed weights
-            weight_nw_bf = grid_ptr[precomputed_data_offset + 2];
-            weight_ne_bf = grid_ptr[precomputed_data_offset + 3];
-            weight_sw_bf = grid_ptr[precomputed_data_offset + 4];
-            weight_se_bf = grid_ptr[precomputed_data_offset + 5];
-#else
-            // Each regular grid entry has 2 values: x, y coordinates
-            float h_coord_rel, w_coord_rel;
-            if constexpr (grid_dtype == DTYPE_FLOAT32) {
-                // For FLOAT32 grid, each coordinate is a 32-bit float
-                // Read from the base address with proper float32 offsets
-                volatile tt_l1_ptr float* float_data = reinterpret_cast<volatile tt_l1_ptr float*>(l1_write_grid_addr);
-                uint32_t float_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
-                w_coord_rel = float_data[float_offset + 0];  // x coordinate
-                h_coord_rel = float_data[float_offset + 1];  // y coordinate
-            } else {
-                // For BFLOAT16 grid, read as uint16 and convert
-                uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
-                uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
-                uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
-                h_coord_rel = bfloat16_to_float(h_coord_raw);
-                w_coord_rel = bfloat16_to_float(w_coord_raw);
-            }
-
-            float h_coord_image = h_coord_rel * height_scale + height_offset;
-            float w_coord_image = w_coord_rel * width_scale + width_offset;
-
-            h0 = static_cast<int32_t>(floor(h_coord_image));
-            h1 = h0 + 1;
-            w0 = static_cast<int32_t>(floor(w_coord_image));
-            w1 = w0 + 1;
-
-            // Calculate bilinear interpolation weights
-            float h0_f = static_cast<float>(h0);
-            float w0_f = static_cast<float>(w0);
-
-            float h_frac = h_coord_image - h0_f;
-            float w_frac = w_coord_image - w0_f;
-            float h_frac_inv = 1.0f - h_frac;
-            float w_frac_inv = 1.0f - w_frac;
-
-            // Need to declare boundary checks before using them
-            bool h0_valid = is_coordinate_valid(h0, input_height);
-            bool h1_valid = is_coordinate_valid(h1, input_height);
-            bool w0_valid = is_coordinate_valid(w0, input_width);
-            bool w1_valid = is_coordinate_valid(w1, input_width);
-
-            float weight_nw = (h0_valid && w0_valid) ? (h_frac_inv * w_frac_inv) : 0.0f;  // North-West
-            float weight_ne = (h0_valid && w1_valid) ? (h_frac_inv * w_frac) : 0.0f;      // North-East
-            float weight_sw = (h1_valid && w0_valid) ? (h_frac * w_frac_inv) : 0.0f;      // South-West
-            float weight_se = (h1_valid && w1_valid) ? (h_frac * w_frac) : 0.0f;          // South-East
-
-            weight_nw_bf = float_to_bfloat16(weight_nw);
-            weight_ne_bf = float_to_bfloat16(weight_ne);
-            weight_sw_bf = float_to_bfloat16(weight_sw);
-            weight_se_bf = float_to_bfloat16(weight_se);
-#endif
-
-            // For precomputed grid, we need to compute boundary checks here
-            // since they weren't computed in the #ifdef section above
-#ifdef USE_PRECOMPUTED_GRID
-            bool h0_valid = is_coordinate_valid(h0, input_height);
-            bool h1_valid = is_coordinate_valid(h1, input_height);
-            bool w0_valid = is_coordinate_valid(w0, input_width);
-            bool w1_valid = is_coordinate_valid(w1, input_width);
-#endif
-
-            // Reserve CB space for 4 corner input sticks for this grid
-            cb_reserve_back(input_cb_index, 1);
-            uint32_t l1_write_input_addr = get_write_ptr(input_cb_index);
-
-            // Read 4 corner input sticks
-            if (h0_valid && w0_valid) {
-                uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
-                uint64_t dram_read_addr = s1.get_noc_addr(north_west_stick_index);
-                noc_async_read(dram_read_addr, l1_write_input_addr, input_stick_nbytes);
-            }
-            l1_write_input_addr += input_stick_nbytes;
-
-            if (h0_valid && w1_valid) {
-                uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
-                uint64_t dram_read_addr = s1.get_noc_addr(north_east_stick_index);
-                noc_async_read(dram_read_addr, l1_write_input_addr, input_stick_nbytes);
-            }
-            l1_write_input_addr += input_stick_nbytes;
-
-            if (h1_valid && w0_valid) {
-                uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
-                uint64_t dram_read_addr = s1.get_noc_addr(south_west_stick_index);
-                noc_async_read(dram_read_addr, l1_write_input_addr, input_stick_nbytes);
-            }
-            l1_write_input_addr += input_stick_nbytes;
-
-            if (h1_valid && w1_valid) {
-                uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
-                uint64_t dram_read_addr = s1.get_noc_addr(south_east_stick_index);
-                noc_async_read(dram_read_addr, l1_write_input_addr, input_stick_nbytes);
-            }
-
-            // Store bilinear interpolation weights for this grid
-            cb_reserve_back(scalar_cb_index, 1);
-            fill_four_val(get_write_ptr(scalar_cb_index), weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
-            cb_push_back(scalar_cb_index, 1);
-
-            noc_async_read_barrier();
-            cb_push_back(input_cb_index, 1);
+        // Update batch tracking (avoid division in loop)
+        ++spatial_points_processed;
+        if (spatial_points_processed == output_hw_size) {
+            spatial_points_processed = 0;
+            ++curr_batch;
+            batch_offset = curr_batch * input_height * input_width;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp"
+#include "debug/dprint.h"
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+#include "../grid_sample_reader_common.hpp"
+
+ALWI void advance_grid_index(
+    uint32_t& in_grid_row_idx,
+    uint32_t& grid_stick_idx,
+    uint32_t& l1_grid_addr,
+    uint32_t& grid_points_processed,
+    uint32_t& curr_batch,
+    const uint32_t grid_batching_factor,
+    const uint32_t grid_stick_nbytes,
+    const uint32_t grid_hw,
+    const uint32_t grid_nsticks_per_core) {
+    ++in_grid_row_idx;
+    if (in_grid_row_idx == grid_batching_factor) {
+        in_grid_row_idx = 0;
+        ++grid_stick_idx;
+        l1_grid_addr += grid_stick_nbytes;
+        ++grid_points_processed;
+        if (grid_points_processed == grid_hw) {
+            grid_points_processed = 0;
+            ++curr_batch;
+        }
+    }
+}
+
+void kernel_main() {
+    // Runtime arguments
+    const uint32_t input_addr = get_arg_val<uint32_t>(0);
+    const uint32_t global_grid_stick_start = get_arg_val<uint32_t>(1);
+
+    // Compile time arguments
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t grid_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
+    constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
+    constexpr uint32_t input_height = get_compile_time_arg_val(5);
+    constexpr uint32_t input_width = get_compile_time_arg_val(6);
+    constexpr uint32_t grid_batching_factor = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_hw = get_compile_time_arg_val(9);
+    constexpr uint32_t use_precomputed_grid = get_compile_time_arg_val(10);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(11);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(12);
+    constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(13);
+
+    // Input tensor accessor for remote NOC reads (updated for new arg count)
+    constexpr auto input_tensor_args = TensorAccessorArgs<14>();
+    const auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_addr, input_stick_nbytes);
+
+    // Calculate starting batch from global grid stick position
+    // All grid points in one grid stick are in the same batch
+    const uint32_t starting_batch = global_grid_stick_start / grid_hw;
+
+    // Zero out input CB to handle invalid coordinates properly
+    zero_out_tiles<input_cb_index>();
+
+    // Get local grid data base address (already in L1)
+    const uint32_t l1_grid_base_addr = get_read_ptr(grid_cb_index);
+
+    // Process each grid stick assigned to this core
+    uint32_t grid_stick_idx = 0;
+    uint32_t l1_grid_addr = l1_grid_base_addr;
+
+    // For split reader: track grid point index starting from reader_id
+    uint32_t in_grid_row_idx = 0;
+
+    // Track current batch and grid position for batch increment logic
+    uint32_t curr_batch = starting_batch;
+    uint32_t grid_points_processed = global_grid_stick_start % grid_hw;
+
+    // Advance at start if needed
+    if constexpr (split_reader && reader_id == 1) {
+        advance_grid_index(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core);
+    }
+
+    while (grid_stick_idx < grid_nsticks_per_core) {
+        volatile tt_l1_ptr uint16_t* const grid_stick_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_grid_addr);
+
+        uint32_t batch_offset = curr_batch * input_height * input_width;
+        process_grid_point<
+            grid_dtype,
+            use_precomputed_grid,
+            input_height,
+            input_width,
+            input_stick_nbytes,
+            input_cb_index,
+            scalar_cb_index>(grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+
+        // Always advance once after processing
+        advance_grid_index(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core);
+
+        // For split reader, advance one more time to skip the coordinate that the other reader will process
+        if constexpr (split_reader) {
+            advance_grid_index(
+                in_grid_row_idx,
+                grid_stick_idx,
+                l1_grid_addr,
+                grid_points_processed,
+                curr_batch,
+                grid_batching_factor,
+                grid_stick_nbytes,
+                grid_hw,
+                grid_nsticks_per_core);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -6,9 +6,13 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp"
-#include "debug/dprint.h"
-#include "tt_metal/tools/profiler/kernel_profiler.hpp"
 #include "../grid_sample_reader_common.hpp"
+
+#define PRINT_AND_PROFILE 0
+#if PRINT_AND_PROFILE
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+#include "debug/dprint.h"
+#endif
 
 ALWI void advance_grid_index(
     uint32_t& in_grid_row_idx,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cmath>
+#include <stdint.h>
+#include "dataflow_api.h"
+
+#define ALWI inline __attribute__((always_inline))
+
+// Constants shared between interleaved and sharded kernels
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
+constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
+
+// Data type constants (from ttnn/api/ttnn/tensor/types.hpp DataType enum)
+constexpr uint32_t DTYPE_BFLOAT16 = 0;
+constexpr uint32_t DTYPE_FLOAT32 = 1;
+
+// Utility functions
+ALWI bool is_coordinate_valid(int32_t coord, uint32_t max_size) {
+    return (coord >= 0) && (coord < static_cast<int32_t>(max_size));
+}
+
+ALWI void fill_four_val(uint32_t begin_addr, uint16_t val, uint16_t val1, uint16_t val2, uint16_t val3) {
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
+    ptr[0] = (val | (val1 << 16));
+    ptr[1] = (val2 | (val3 << 16));
+}
+
+ALWI uint16_t float_to_bfloat16(float value) {
+    uint32_t tmp;
+    std::memcpy(&tmp, &value, sizeof(tmp));
+    return static_cast<uint16_t>(tmp >> 16);
+}
+
+ALWI float bfloat16_to_float(uint16_t bf16) {
+    uint32_t tmp = static_cast<uint32_t>(bf16) << 16;
+    float result;
+    std::memcpy(&result, &tmp, sizeof(result));
+    return result;
+}
+
+// Grid coordinate reading functions
+template <uint32_t grid_dtype, bool use_precomputed_grid>
+struct GridCoordinateReader {
+    // Read grid coordinates and return corner coordinates and weights
+    template <typename GridPtrType>
+    ALWI static void read_grid_point(
+        GridPtrType grid_ptr,
+        uint32_t grid_idx,
+        float height_scale,
+        float height_offset,
+        float width_scale,
+        float width_offset,
+        uint32_t input_height,
+        uint32_t input_width,
+        int32_t& h0,
+        int32_t& h1,
+        int32_t& w0,
+        int32_t& w1,
+        uint16_t& weight_nw_bf,
+        uint16_t& weight_ne_bf,
+        uint16_t& weight_sw_bf,
+        uint16_t& weight_se_bf) {
+        if constexpr (use_precomputed_grid) {
+            // Each precomputed grid entry has 6 values: h0, w0, weight_nw, weight_ne, weight_sw, weight_se
+            const uint32_t precomputed_data_offset = grid_idx * PRECOMPUTED_GRID_ELEMENTS_PER_POINT;
+            const int16_t h0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 0]);
+            const int16_t w0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 1]);
+
+            h0 = static_cast<int32_t>(h0_raw);
+            w0 = static_cast<int32_t>(w0_raw);
+            h1 = h0 + 1;
+            w1 = w0 + 1;
+
+            // Read precomputed weights
+            weight_nw_bf = grid_ptr[precomputed_data_offset + 2];
+            weight_ne_bf = grid_ptr[precomputed_data_offset + 3];
+            weight_sw_bf = grid_ptr[precomputed_data_offset + 4];
+            weight_se_bf = grid_ptr[precomputed_data_offset + 5];
+        } else {
+            // Each regular grid entry has 2 values: x, y coordinates
+            float h_coord_rel, w_coord_rel;
+            if constexpr (grid_dtype == DTYPE_FLOAT32) {
+                // For FLOAT32 grid, each coordinate is a 32-bit float
+                volatile tt_l1_ptr float* float_data = reinterpret_cast<volatile tt_l1_ptr float*>(grid_ptr);
+                const uint32_t float_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+                w_coord_rel = float_data[float_offset + 0];  // x coordinate
+                h_coord_rel = float_data[float_offset + 1];  // y coordinate
+            } else {
+                // For BFLOAT16 grid, read as uint16 and convert
+                const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+                const uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
+                const uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
+                h_coord_rel = bfloat16_to_float(h_coord_raw);
+                w_coord_rel = bfloat16_to_float(w_coord_raw);
+            }
+
+            const float h_coord_image = h_coord_rel * height_scale + height_offset;
+            const float w_coord_image = w_coord_rel * width_scale + width_offset;
+
+            h0 = static_cast<int32_t>(floor(h_coord_image));
+            h1 = h0 + 1;
+            w0 = static_cast<int32_t>(floor(w_coord_image));
+            w1 = w0 + 1;
+
+            // Calculate bilinear interpolation weights
+            const float h0_f = static_cast<float>(h0);
+            const float w0_f = static_cast<float>(w0);
+
+            const float h_frac = h_coord_image - h0_f;
+            const float w_frac = w_coord_image - w0_f;
+            const float h_frac_inv = 1.0f - h_frac;
+            const float w_frac_inv = 1.0f - w_frac;
+
+            // Boundary checks
+            const bool h0_valid = is_coordinate_valid(h0, input_height);
+            const bool h1_valid = is_coordinate_valid(h1, input_height);
+            const bool w0_valid = is_coordinate_valid(w0, input_width);
+            const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+            const float weight_nw = (h0_valid && w0_valid) ? (h_frac_inv * w_frac_inv) : 0.0f;  // North-West
+            const float weight_ne = (h0_valid && w1_valid) ? (h_frac_inv * w_frac) : 0.0f;      // North-East
+            const float weight_sw = (h1_valid && w0_valid) ? (h_frac * w_frac_inv) : 0.0f;      // South-West
+            const float weight_se = (h1_valid && w1_valid) ? (h_frac * w_frac) : 0.0f;          // South-East
+
+            weight_nw_bf = float_to_bfloat16(weight_nw);
+            weight_ne_bf = float_to_bfloat16(weight_ne);
+            weight_sw_bf = float_to_bfloat16(weight_sw);
+            weight_se_bf = float_to_bfloat16(weight_se);
+        }
+    }
+};
+
+// Input data reading template - handles both tensor accessor and direct NOC reads
+template <typename TensorAccessor>
+ALWI void read_four_corner_inputs(
+    const TensorAccessor& input_tensor_accessor,
+    uint32_t batch_offset,
+    uint32_t input_width,
+    uint32_t input_stick_nbytes,
+    int32_t h0,
+    int32_t h1,
+    int32_t w0,
+    int32_t w1,
+    uint32_t input_height,
+    uint32_t l1_write_input_addr) {
+    // Boundary checks (recompute for performance)
+    const bool h0_valid = is_coordinate_valid(h0, input_height);
+    const bool h1_valid = is_coordinate_valid(h1, input_height);
+    const bool w0_valid = is_coordinate_valid(w0, input_width);
+    const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+    uint32_t write_addr = l1_write_input_addr;
+
+    // Read 4 corner input sticks via NOC from remote input tensor
+    if (h0_valid && w0_valid) {
+        const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
+        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_west_stick_index);
+        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+    }
+    write_addr += input_stick_nbytes;
+
+    if (h0_valid && w1_valid) {
+        const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
+        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(north_east_stick_index);
+        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+    }
+    write_addr += input_stick_nbytes;
+
+    if (h1_valid && w0_valid) {
+        const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
+        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_west_stick_index);
+        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+    }
+    write_addr += input_stick_nbytes;
+
+    if (h1_valid && w1_valid) {
+        const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
+        const uint64_t remote_noc_addr = input_tensor_accessor.get_noc_addr(south_east_stick_index);
+        noc_async_read(remote_noc_addr, write_addr, input_stick_nbytes);
+    }
+}
+
+// Process single grid point - common logic for both interleaved and sharded
+template <
+    uint32_t grid_dtype,
+    bool use_precomputed_grid,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t input_stick_nbytes,
+    uint32_t input_cb_index,
+    uint32_t scalar_cb_index,
+    typename TensorAccessor,
+    typename GridPtrType>
+ALWI void process_grid_point(
+    GridPtrType grid_ptr, uint32_t grid_idx, const TensorAccessor& input_tensor_accessor, uint32_t batch_offset) {
+    // Compute scaling factors as constexpr
+    constexpr float input_height_f = float(input_height);
+    constexpr float input_width_f = float(input_width);
+    constexpr float height_scale = input_height_f * 0.5f;
+    constexpr float height_offset = height_scale - 0.5f;
+    constexpr float width_scale = input_width_f * 0.5f;
+    constexpr float width_offset = width_scale - 0.5f;
+
+    int32_t h0, h1, w0, w1;
+    uint16_t weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf;
+
+    // Read grid coordinates and compute weights
+    GridCoordinateReader<grid_dtype, use_precomputed_grid>::template read_grid_point(
+        grid_ptr,
+        grid_idx,
+        height_scale,
+        height_offset,
+        width_scale,
+        width_offset,
+        input_height,
+        input_width,
+        h0,
+        h1,
+        w0,
+        w1,
+        weight_nw_bf,
+        weight_ne_bf,
+        weight_sw_bf,
+        weight_se_bf);
+
+    // For precomputed grid, we need to compute boundary checks here
+    // since they weren't computed in the coordinate reading phase
+    if constexpr (use_precomputed_grid) {
+        const bool h0_valid = is_coordinate_valid(h0, input_height);
+        const bool h1_valid = is_coordinate_valid(h1, input_height);
+        const bool w0_valid = is_coordinate_valid(w0, input_width);
+        const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+        // Zero out weights for invalid coordinates
+        if (!(h0_valid && w0_valid)) {
+            weight_nw_bf = 0;
+        }
+        if (!(h0_valid && w1_valid)) {
+            weight_ne_bf = 0;
+        }
+        if (!(h1_valid && w0_valid)) {
+            weight_sw_bf = 0;
+        }
+        if (!(h1_valid && w1_valid)) {
+            weight_se_bf = 0;
+        }
+    }
+
+    // Reserve CB space for 4 corner input sticks for this grid point
+    cb_reserve_back(input_cb_index, 1);
+    const uint32_t l1_write_input_addr = get_write_ptr(input_cb_index);
+
+    // Read 4 corner input sticks
+    read_four_corner_inputs(
+        input_tensor_accessor,
+        batch_offset,
+        input_width,
+        input_stick_nbytes,
+        h0,
+        h1,
+        w0,
+        w1,
+        input_height,
+        l1_write_input_addr);
+
+    // Store bilinear interpolation weights for this grid point
+    cb_reserve_back(scalar_cb_index, 1);
+    const uint32_t l1_write_scalar_addr = get_write_ptr(scalar_cb_index);
+    fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
+    cb_push_back(scalar_cb_index, 1);
+
+    noc_async_read_barrier();
+    cb_push_back(input_cb_index, 1);
+}


### PR DESCRIPTION
### Ticket
#27904

### Problem description

Grid sample only supported interleaved inputs and outputs so far.

### What's changed

This PR adds support for height sharded grids, input image tensors and output tensors. It also adds a split reader functionality when the grid is sharded.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17642280942) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17642288657) CI with demo tests passes (if applicable)
- [x] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17642301510) CI passes (if applicable)