### PR TITLE
#28046: [skip ci] Run PCIe BH bandwidth ubenchmarks on CIv2 for now, as there's no perf assertions and we just need functional checks

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -59,7 +59,9 @@ jobs:
           }, # Ata Tuzuner
           {
             arch: blackhole,
-            runs-on: ["BH", "pipeline-perf", "in-service", "P150"],
+            # No perf check for now, so let's run on something that won't block everybody
+            # https://github.com/tenstorrent/tt-metal/pull/28148#issuecomment-3275595011
+            runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
             name: "BH P150 PCIe Performance",
             cmd: build/tools/mem_bench --benchmark_filter="Device (Reading|Writing) Host"
           } # Nigel Huang
@@ -75,6 +77,7 @@ jobs:
         LOGURU_LEVEL: INFO
         # We make extensive use of device profiler
         TT_METAL_DEVICE_PROFILER: 1
+        TRACY_NO_INVARIANT_CHECK: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
… 

### Ticket

#28046 

### Problem description

- More capacity on CIv2 for a test that doesn't need perf infra yet.
- I accidentally merged other changes with previous PR.

### What's changed

NEW: I swear I can actually code and didn't pull in stupid changes

Switch over the one test along with an env var we need for this.

Thanks Nigel

### Checklist
- ubench ubench https://github.com/tenstorrent/tt-metal/actions/runs/17624552646
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes