### PR TITLE
Update PERF.md to include BH device results

### DIFF
--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -24,6 +24,7 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Llama-3.2-3B      | TG          | 87        | 97        | 33.5          |           |
 | Llama-3.1-8B      | N150        | 90        | 97        | 28.3          | 104       |
 | Llama-3.1-8B      | N300        | 90        | 97        | 44.2          | 67        |
+| Llama-3.1-8B      | P100        | 90        | 98        | 29.5          | 84        |
 | Llama-3.1-8B      | T3K         | 90        | 98        | 64.3          | 53        |
 | Llama-3.1-8B      | T3K  (DP=4) |           |           | 39.6          | 58        |
 | Llama-3.1-8B      | T3K  (DP=8) |           |           | 24.9          | 86        |

--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -25,6 +25,7 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Llama-3.1-8B      | N150        | 90        | 97        | 28.3          | 104       |
 | Llama-3.1-8B      | N300        | 90        | 97        | 44.2          | 67        |
 | Llama-3.1-8B      | P100        | 90        | 98        | 29.5          | 84        |
+| Llama-3.1-8B      | P150        | 90        | 98        | 33.6          | 76        |
 | Llama-3.1-8B      | T3K         | 90        | 98        | 64.3          | 53        |
 | Llama-3.1-8B      | T3K  (DP=4) |           |           | 39.6          | 58        |
 | Llama-3.1-8B      | T3K  (DP=8) |           |           | 24.9          | 86        |


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/28312#event-19637476660

### Problem description
Our recent change in https://github.com/tenstorrent/tt-metal/pull/25174 did not test for BH.

### What's changed
Add the missing target accuracy and perf values in PERF.md

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
  - testing for both P100 and P150: https://github.com/tenstorrent/tt-metal/actions/runs/17646888224