### PR TITLE
#20948: Migrate CCL tests to multi-host aware mesh device fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -520,7 +520,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
     import ttnn
 
     if ttnn.get_num_devices() < 8:
-        pytest.skip()
+        pytest.skip("Not enough devices to run test")
 
     request.node.pci_ids = ttnn.get_pcie_device_ids()
     updated_device_params = get_updated_device_params(device_params)

--- a/tests/nightly/t3000/2d_ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/2d_ccl/test_minimal_all_gather_async.py
@@ -10,25 +10,26 @@ from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, ag_input_dtype",
+    "ag_output_shape, dim, layout, ag_input_dtype",
     [
         # Gather on dim 0
-        (8, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Gather on dim 1
-        (8, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Gather on dim 2
-        (8, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # # Gather on dim 3
-        (8, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "tt_training_test_one",
@@ -71,8 +72,7 @@ from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather
     ids=["fabric_2d_dynamic_linear"],
 )
 def test_all_gather_async_training_shapes(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     ag_output_shape,
     dim,
     num_links,
@@ -85,8 +85,8 @@ def test_all_gather_async_training_shapes(
     num_iters,
 ):
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,

--- a/tests/nightly/t3000/2d_ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/2d_ccl/test_minimal_reduce_scatter_async.py
@@ -10,25 +10,26 @@ from models.utility_functions import skip_for_blackhole
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
+    "rs_input_shape, dim, layout, rs_input_dtype",
     [
         # Scatter on dim 0
-        (8, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 1
-        (8, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 2
-        (8, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # # Scatter on dim 3
-        (8, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "tt_training_test_one",
@@ -79,8 +80,7 @@ from models.utility_functions import skip_for_blackhole
     ids=["fabric_2d_dynamic_linear"],
 )
 def test_reduce_scatter_async_training_shapes(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     rs_input_shape,
     dim,
     num_links,
@@ -97,8 +97,8 @@ def test_reduce_scatter_async_training_shapes(
         pytest.skip("We've seen ND PCC when running the composite-RS with trace")
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,

--- a/tests/nightly/t3000/ccl/test_all_to_all.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all.py
@@ -281,11 +281,12 @@ def run_all_to_all_impl(
         assert eq, f"{i} FAILED: {output}"
 
 
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, num_links, logical_shape, in_dim, out_dim, layout",
+    "num_links, logical_shape, in_dim, out_dim, layout",
     [
-        (8, 1, [1, 1, 44544, 3072 * 3], 2, 3, ttnn.TILE_LAYOUT),  # Pre-attn all-to-all
-        (8, 1, [1, 1, 44544, 3072], 3, 2, ttnn.TILE_LAYOUT),  # Post-attn all-to-all
+        (1, [1, 1, 44544, 3072 * 3], 2, 3, ttnn.TILE_LAYOUT),  # Pre-attn all-to-all
+        (1, [1, 1, 44544, 3072], 3, 2, ttnn.TILE_LAYOUT),  # Post-attn all-to-all
     ],
     ids=["pre-attn", "post-attn"],
 )
@@ -315,8 +316,7 @@ def run_all_to_all_impl(
     "device_params", [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True
 )
 def test_all_to_all(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     logical_shape,
     in_dim,
     out_dim,
@@ -332,8 +332,8 @@ def test_all_to_all(
     is_ci_env,
 ):
     run_all_to_all_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         logical_shape,
         in_dim,
         out_dim,

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -15,14 +15,14 @@ from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 from tracy import signpost
 
 
-def create_global_semaphores(t3k_mesh_device, num_devices, cores, initial_value):
+def create_global_semaphores(mesh_device, num_devices, cores, initial_value):
     # create global semaphore handles
-    ccl_semaphore_handles = [ttnn.create_global_semaphore(t3k_mesh_device, cores, initial_value) for _ in range(2)]
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
     return ccl_semaphore_handles
 
 
 def run_all_gather_impl(
-    t3k_mesh_device,
+    mesh_device,
     num_devices,
     ag_output_shape,
     dim,
@@ -58,7 +58,7 @@ def run_all_gather_impl(
         pytest.fail("num_iters must be >= 1")
 
     ##### All gather setup #####
-    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
     )
@@ -70,17 +70,17 @@ def run_all_gather_impl(
     worker_sub_device_id = ttnn.SubDeviceId(0)
     sub_device_stall_group = [worker_sub_device_id]
 
-    sub_device_manager = t3k_mesh_device.create_sub_device_manager([worker_sub_device], 0)
-    t3k_mesh_device.load_sub_device_manager(sub_device_manager)
-    t3k_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
     ccl_semaphore_handles = [
-        create_global_semaphores(t3k_mesh_device, num_devices, ccl_sub_device_crs, 0) for _ in range(num_iters)
+        create_global_semaphores(mesh_device, num_devices, ccl_sub_device_crs, 0) for _ in range(num_iters)
     ]
 
     barrier_semaphore_handles = [
-        ttnn.create_global_semaphore(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
     ]
 
     ### Create persistent output buffers
@@ -88,11 +88,11 @@ def run_all_gather_impl(
     persistent_output_buffers = [
         ttnn.from_torch(
             torch.zeros(ag_output_shape),
-            device=t3k_mesh_device,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ag_input_dtype,
             memory_config=mem_config_ag,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(t3k_mesh_device),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         for _ in range(num_iters)
     ]
@@ -113,11 +113,11 @@ def run_all_gather_impl(
 
         input_tensor_mesh = ttnn.from_torch(
             ag_output_tensor,
-            device=t3k_mesh_device,
+            device=mesh_device,
             layout=layout,
             dtype=ag_input_dtype,
             memory_config=mem_config_input,
-            mesh_mapper=ttnn.ShardTensorToMesh(t3k_mesh_device, dim=dim),
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=dim),
         )
 
         input_tensor_mesh_list.append(input_tensor_mesh)
@@ -147,21 +147,21 @@ def run_all_gather_impl(
     if enable_trace:
         # Compile the op
         tt_all_gather_out_tensor = run_op(0)
-        ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
         logger.info(f"Done compiling Op")
 
         # Capture the trace
-        trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         tt_all_gather_out_tensor = run_op(0)
-        ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
         logger.info(f"Done capturing trace")
 
         # Execute trace
         signpost("start")
         for i in range(num_iters):
-            ttnn.execute_trace(t3k_mesh_device, trace_id, cq_id=0, blocking=False)
-            ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
             tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensor)
         logger.info(f"Done executing trace")
         signpost("stop")
@@ -171,7 +171,7 @@ def run_all_gather_impl(
             tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensor)
 
             logger.info(f"Waiting for op")
-            ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
             logger.info(f"Done op")
 
             logger.info(f"Done iteration {i}")
@@ -182,34 +182,35 @@ def run_all_gather_impl(
             torch_ag_out_tensor = ag_output_tensor_goldens_list[i if not enable_trace else 0]
 
             tt_ag_out = ttnn.from_device(tt_ag_out_tensor)
-            tt_ag_out = ttnn.to_torch(tt_ag_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+            tt_ag_out = ttnn.to_torch(tt_ag_out, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
             tt_ag_out = tt_ag_out[:, :, :, 0 : torch_ag_out_tensor.shape[3]]
             eq, output = comp_pcc(tt_ag_out, torch_ag_out_tensor, allowed_pcc)
             logger.info(f"{output}, iteration {i}")
             assert eq, f"{i} FAILED ag: {output}"
 
-    t3k_mesh_device.reset_sub_device_stall_group()
-    t3k_mesh_device.clear_loaded_sub_device_manager()
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, ag_input_dtype, is_training_shape",
+    "ag_output_shape, dim, layout, ag_input_dtype, is_training_shape",
     [
-        (8, [1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        (8, [1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
         # Composite-AG tests
-        (8, [1, 1, 8, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 16, 32, 32], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 8, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 16, 32, 32], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
     ],
     ids=[
         "dit_shape",  # this one triggers the default chunks_per_sync
@@ -262,8 +263,7 @@ def run_all_gather_impl(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     ag_output_shape,
     dim,
     num_links,
@@ -279,8 +279,8 @@ def test_all_gather_async(
     num_iters,
 ):
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,
@@ -298,25 +298,26 @@ def test_all_gather_async(
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, ag_input_dtype",
+    "ag_output_shape, dim, layout, ag_input_dtype",
     [
         # Gather on dim 0
-        (8, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Gather on dim 1
-        (8, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Gather on dim 2
-        (8, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # # Gather on dim 3
-        (8, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "tt_training_test_one",
@@ -360,8 +361,7 @@ def test_all_gather_async(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async_training_shapes(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     ag_output_shape,
     dim,
     num_links,
@@ -374,8 +374,8 @@ def test_all_gather_async_training_shapes(
     num_iters,
 ):
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,
@@ -392,10 +392,11 @@ def test_all_gather_async_training_shapes(
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, num_links, layout, ag_input_dtype",
+    "num_links, layout, ag_input_dtype",
     [
-        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -451,8 +452,7 @@ def test_all_gather_async_training_shapes(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async_sharded_to_sharded(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     num_links,
     layout,
     ag_input_dtype,
@@ -485,8 +485,8 @@ def test_all_gather_async_sharded_to_sharded(
     mem_config_ag = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
 
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,
@@ -501,10 +501,11 @@ def test_all_gather_async_sharded_to_sharded(
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, num_links, layout, ag_input_dtype",
+    "num_links, layout, ag_input_dtype",
     [
-        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -544,8 +545,7 @@ def test_all_gather_async_sharded_to_sharded(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async_sharded_to_interleaved(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     num_links,
     layout,
     ag_input_dtype,
@@ -570,8 +570,8 @@ def test_all_gather_async_sharded_to_interleaved(
     mem_config_ag = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,
@@ -587,9 +587,9 @@ def test_all_gather_async_sharded_to_interleaved(
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
-    "num_devices, num_links, layout, ag_input_dtype",
+    "num_links, layout, ag_input_dtype",
     [
-        (8, 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -629,8 +629,7 @@ def test_all_gather_async_sharded_to_interleaved(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_all_gather_async_interleaved_to_sharded(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     num_links,
     layout,
     ag_input_dtype,
@@ -653,8 +652,8 @@ def test_all_gather_async_interleaved_to_sharded(
     mem_config_ag = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
 
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         ag_output_shape,
         dim,
         num_links,

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -18,7 +18,7 @@ def create_global_semaphores(mesh_device, cores, initial_value):
 
 
 def run_reduce_scatter_impl(
-    t3k_mesh_device,
+    mesh_device,
     num_devices,
     rs_input_shape,
     dim,
@@ -48,7 +48,7 @@ def run_reduce_scatter_impl(
         mem_config_intermediate = mem_config_rs
 
     ##### Fabric setup #####
-    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
     )
@@ -60,15 +60,15 @@ def run_reduce_scatter_impl(
     worker_sub_device_id = ttnn.SubDeviceId(0)
     sub_device_stall_group = [worker_sub_device_id]
 
-    sub_device_manager = t3k_mesh_device.create_sub_device_manager([worker_sub_device], 0)
-    t3k_mesh_device.load_sub_device_manager(sub_device_manager)
-    t3k_mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [create_global_semaphores(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
+    ccl_semaphore_handles = [create_global_semaphores(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
 
     barrier_semaphore_handles = [
-        ttnn.create_global_semaphore(t3k_mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
     ]
 
     ### Create persistent output buffers
@@ -80,11 +80,11 @@ def run_reduce_scatter_impl(
     persistent_intermediate_buffers = [
         ttnn.from_torch(
             torch.zeros(intermediate_shape),
-            device=t3k_mesh_device,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=rs_input_dtype,
             memory_config=mem_config_intermediate,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(t3k_mesh_device),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         for _ in range(num_iters)
     ]
@@ -93,11 +93,11 @@ def run_reduce_scatter_impl(
     persistent_output_buffers = [
         ttnn.from_torch(
             torch.zeros(rs_output_shape),
-            device=t3k_mesh_device,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=rs_input_dtype,
             memory_config=mem_config_rs,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(t3k_mesh_device),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         for _ in range(num_iters)
     ]
@@ -127,12 +127,12 @@ def run_reduce_scatter_impl(
 
         input_tensor_mesh = ttnn.from_torch(
             rs_input_tensor,
-            device=t3k_mesh_device,
+            device=mesh_device,
             layout=layout,
             dtype=rs_input_dtype,
             memory_config=mem_config_input,
             mesh_mapper=ttnn.create_mesh_mapper(
-                t3k_mesh_device,
+                mesh_device,
                 ttnn.MeshMapperConfig(
                     [ttnn.PlacementReplicate(), ttnn.PlacementShard(dim)], ttnn.MeshShape(1, num_devices)
                 ),
@@ -181,34 +181,34 @@ def run_reduce_scatter_impl(
         logger.info(f"Done compiling Op")
 
         # Capture the trace
-        trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         for i in range(num_iters):
             tt_reduce_scatter_output_tensor = run_op(i)
             tt_reduce_scatter_output_trace_list.append(tt_reduce_scatter_output_tensor)
-        ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         logger.info(f"Done capturing trace")
 
         # Execute trace
-        ttnn.execute_trace(t3k_mesh_device, trace_id, cq_id=0, blocking=False)
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
         logger.info(f"Done executing trace")
 
         # Synchronize the devices
-        ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
         for tt_tensor in tt_reduce_scatter_output_trace_list:
             tt_rs_out = ttnn.from_device(tt_tensor)
-            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(t3k_mesh_device, dim=dim))
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=dim))
             tt_tensor.deallocate(True)
             tt_reduce_scatter_output_list.append(tt_rs_out)
     else:
         for i in range(num_iters):
             tt_reduce_scatter_output_tensor = run_op(i)
             tt_rs_out = ttnn.from_device(tt_reduce_scatter_output_tensor)
-            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(t3k_mesh_device, dim=dim))
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=dim))
             tt_reduce_scatter_output_tensor.deallocate(True)
             tt_reduce_scatter_output_list.append(tt_rs_out)
 
             logger.info(f"Waiting for op")
-            ttnn.synchronize_device(t3k_mesh_device, sub_device_ids=sub_device_stall_group)
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
             logger.info(f"Done op")
 
             logger.info(f"Done iteration {i}")
@@ -227,28 +227,29 @@ def run_reduce_scatter_impl(
         logger.info(f"{output}, iteration {i}")
         assert eq, f"{i} FAILED ag: {output}"
 
-    t3k_mesh_device.reset_sub_device_stall_group()
-    t3k_mesh_device.clear_loaded_sub_device_manager()
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
+    "rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
     [
-        (8, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (8, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
         # Composite-RS tests
-        (8, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (8, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
-        (8, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
+        ([1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -309,8 +310,7 @@ def run_reduce_scatter_impl(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     num_links,
     rs_input_shape,
     dim,
@@ -330,8 +330,8 @@ def test_reduce_scatter_async(
         pytest.skip("We've seen ND PCC when running the composite-RS with trace")
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,
@@ -350,25 +350,26 @@ def test_reduce_scatter_async(
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
+    "rs_input_shape, dim, layout, rs_input_dtype",
     [
         # Scatter on dim 0
-        (8, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 1
-        (8, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 2
-        (8, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # # Scatter on dim 3
-        (8, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (8, [16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "tt_training_test_one",
@@ -420,8 +421,7 @@ def test_reduce_scatter_async(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_training_shapes(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     rs_input_shape,
     dim,
     num_links,
@@ -438,8 +438,8 @@ def test_reduce_scatter_async_training_shapes(
         pytest.skip("We've seen ND PCC when running the composite-RS with trace")
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,
@@ -458,10 +458,11 @@ def test_reduce_scatter_async_training_shapes(
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, layout, rs_input_dtype",
+    "layout, rs_input_dtype",
     [
-        (8, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -534,9 +535,8 @@ def test_reduce_scatter_async_training_shapes(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_sharded_to_sharded(
-    t3k_mesh_device,
+    mesh_device,
     num_links,
-    num_devices,
     rs_input_dtype,
     layout,
     rs_input_shape,
@@ -584,8 +584,8 @@ def test_reduce_scatter_async_sharded_to_sharded(
     mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,
@@ -602,11 +602,12 @@ def test_reduce_scatter_async_sharded_to_sharded(
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, layout, rs_input_dtype",
+    "layout, rs_input_dtype",
     [
-        (8, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -660,9 +661,8 @@ def test_reduce_scatter_async_sharded_to_sharded(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_interleaved_to_sharded(
-    t3k_mesh_device,
+    mesh_device,
     num_links,
-    num_devices,
     rs_input_dtype,
     layout,
     rs_input_shape,
@@ -700,8 +700,8 @@ def test_reduce_scatter_async_interleaved_to_sharded(
     mem_config_rs = ttnn.MemoryConfig(output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec)
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,
@@ -718,11 +718,12 @@ def test_reduce_scatter_async_interleaved_to_sharded(
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, layout, rs_input_dtype",
+    "layout, rs_input_dtype",
     [
-        (8, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(
@@ -770,9 +771,8 @@ def test_reduce_scatter_async_interleaved_to_sharded(
     ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_sharded_to_interleaved(
-    t3k_mesh_device,
+    mesh_device,
     num_links,
-    num_devices,
     rs_input_dtype,
     layout,
     rs_input_shape,
@@ -798,8 +798,8 @@ def test_reduce_scatter_async_sharded_to_interleaved(
     mem_config_rs = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     run_reduce_scatter_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         rs_input_shape,
         dim,
         num_links,

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -445,6 +445,7 @@ def test_all_gather(
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather_sharded(
     mesh_device,
+    num_devices,
     output_shape,
     dim,
     num_links,
@@ -463,7 +464,7 @@ def test_all_gather_sharded(
 
     run_all_gather_impl(
         mesh_device,
-        mesh_device.get_num_devices(),
+        num_devices,
         output_shape,
         dim,
         num_links,

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -305,6 +305,7 @@ def run_all_gather_impl(
 
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
     "num_devices, num_links, output_shape, dim, layout",
     [
@@ -330,7 +331,7 @@ def run_all_gather_impl(
 @pytest.mark.parametrize("num_iters", [10])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather(
-    t3k_mesh_device,
+    mesh_device,
     # pcie_mesh_device,
     num_devices,
     output_shape,
@@ -343,7 +344,7 @@ def test_all_gather(
     function_level_defaults,
 ):
     run_all_gather_impl(
-        t3k_mesh_device,
+        mesh_device,
         num_devices,
         output_shape,
         dim,
@@ -360,6 +361,7 @@ def test_all_gather(
 
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
     "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
     [
@@ -442,8 +444,7 @@ def test_all_gather(
 @pytest.mark.parametrize("num_iters", [8])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather_sharded(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     output_shape,
     dim,
     num_links,
@@ -458,11 +459,11 @@ def test_all_gather_sharded(
     tensor_mem_layout,
 ):
     if num_links > 1:
-        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the mesh_device (and hence only has 1 link available for use)"
 
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         output_shape,
         dim,
         num_links,
@@ -482,11 +483,11 @@ def test_all_gather_sharded(
 
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    "output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
     [
         (
-            8,
             [1, 4, 32, 1280],
             3,
             ttnn.TILE_LAYOUT,
@@ -509,8 +510,7 @@ def test_all_gather_sharded(
 @pytest.mark.parametrize("num_iters", [8])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True)
 def test_all_gather_sharded_ring(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     output_shape,
     dim,
     num_links,
@@ -525,11 +525,11 @@ def test_all_gather_sharded_ring(
     tensor_mem_layout,
 ):
     if num_links > 1:
-        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the mesh_device (and hence only has 1 link available for use)"
 
     run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         output_shape,
         dim,
         num_links,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -29,7 +29,7 @@ def is_unsupported_case(input_shape, dim, math_op, mem_config, num_devices, num_
 
 
 def run_with_trace(
-    t3k_mesh_device,
+    mesh_device,
     input_tensor_mesh,
     dim,
     num_links,
@@ -54,11 +54,11 @@ def run_with_trace(
         topology=topology,
         subdevice_id=worker_sub_device_id,
     )
-    ttnn.synchronize_device(t3k_mesh_device)
+    ttnn.synchronize_device(mesh_device)
 
     # Capture trace
     logger.info("Capturing trace")
-    trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
     for i in range(num_iters):
         output_tensor_mesh = ttnn.experimental.reduce_scatter_async(
             input_tensor_mesh,
@@ -73,14 +73,14 @@ def run_with_trace(
             topology=topology,
             subdevice_id=worker_sub_device_id,
         )
-    ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
-    ttnn.synchronize_device(t3k_mesh_device)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
 
     # Run the op
     logger.info("Starting Trace perf test...")
-    ttnn.execute_trace(t3k_mesh_device, trace_id, blocking=False)
-    ttnn.release_trace(t3k_mesh_device, trace_id)
-    ttnn.synchronize_device(t3k_mesh_device)
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
 
     return output_tensor_mesh
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_nightly.py
@@ -12,10 +12,11 @@ from models.utility_functions import skip_for_grayskull
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.timeout(120)
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "num_devices, num_links",
+    "num_links",
     [
-        (8, 1),
+        1,
     ],
 )
 @pytest.mark.parametrize(
@@ -54,8 +55,7 @@ from models.utility_functions import skip_for_grayskull
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 def test_reduce_scatter_t3k_8chip_nightly(
-    t3k_mesh_device,
-    num_devices,
+    mesh_device,
     per_chip_output_shape,
     dim,
     num_links,
@@ -67,8 +67,8 @@ def test_reduce_scatter_t3k_8chip_nightly(
     num_iters=1,
 ):
     run_reduce_scatter_test(
-        t3k_mesh_device,
-        num_devices,
+        mesh_device,
+        mesh_device.get_num_devices(),
         per_chip_output_shape,
         dim,
         num_links,


### PR DESCRIPTION
### Ticket
#20948

### Problem description
`t3k_mesh_device` fixture is redundant in general, and doesn't support multi-host aware TT-NN.

### What's changed
Replace `t3k_mesh_device` with `mesh_device` for key CCL tests.

### Checklist
- [X] [T3K unit + nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17650420439)