### PR TITLE
Change config_override for failing test in P150 L2 nightly 

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -1862,9 +1862,7 @@ def test_unet_conv_wh(
         (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}),
         (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}),
         (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 16 * 32}),
-        # Issue #28172 fix bug with weights preparation in case conv maps to matmul
-        # and input tensor is interleaved and auto shard is used.
-        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32} if is_wormhole_b0() else None),
+        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32}),
     ),
 )
 @pytest.mark.parametrize(
@@ -1907,6 +1905,19 @@ def test_unet_conv_groups_2_wh(
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
+    # Issue #28172 fix bug with weights preparation in case conv maps to matmul
+    # and input tensor is interleaved and auto shard is used.
+    if (
+        filter_height == 1
+        and filter_width == 1
+        and stride_h == 1
+        and stride_w == 1
+        and pad_h == 0
+        and pad_w == 0
+        and is_blackhole()
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y < 130  # P100
+    ):
+        config_override = None
     run_conv(
         device,
         torch_tensor_map,


### PR DESCRIPTION
Blackhole L2 nightly conv test is failing: https://github.com/tenstorrent/tt-metal/actions/runs/17635660831
It is happening since `config_override` is changed for that test in https://github.com/tenstorrent/tt-metal/pull/28175
Change it just for P100 arch since that one has issue mentioned in that PR, not P150

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17650344865)