### PR TITLE
Fix lite fabric build

### DIFF
--- a/tt_metal/lite_fabric/build.cpp
+++ b/tt_metal/lite_fabric/build.cpp
@@ -13,6 +13,9 @@
 #include <fmt/format.h>
 #include "tt_cluster.hpp"
 
+// TODO: Cleanup this file
+// https://github.com/tenstorrent/tt-metal/issues/28324
+
 namespace {
 std::string GetToolchainPath(const std::string& root_dir) {
     const std::array<std::string, 2> sfpi_roots = {
@@ -111,6 +114,8 @@ int CompileFabricLite(
         // We do not access the PCIe cores
         "PCIE_NOC_X=0",
         "PCIE_NOC_Y=0",
+        // Lite Fabric is intended to run on risc1
+        "PROCESSOR_INDEX=1",
     };
 
     defines.insert(defines.end(), extra_defines.begin(), extra_defines.end());


### PR DESCRIPTION
### Ticket
N/A

### Problem description
BH Multi card test failing due to a missing Define

### What's changed
- Add missing define
- Created follow up ticket for streamlining the lite fabric build: https://github.com/tenstorrent/tt-metal/issues/28324

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes