### PR TITLE
Make regex not to look for git hash

### DIFF
--- a/.github/workflows/release-verify-or-create-tag.yaml
+++ b/.github/workflows/release-verify-or-create-tag.yaml
@@ -56,7 +56,7 @@ jobs:
             elif [ "$tagType" = "dev" ]; then
               dateInt=$(date +%Y%m%d)
               gitHash=$(git rev-parse --short=8 HEAD)
-              version="$baseVersion-dev$dateInt+$gitHash"
+              version="$baseVersion-dev$dateInt"
             else
               version="$baseVersion"
             fi

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -63,7 +63,7 @@ function(ParseGitDescribe)
     set(major "([0-9]+)")
     set(segment "\\.[0-9]+")
     set(status "\\-([a-zA-Z]+[0-9]+)") # eg: alpha, beta, RC
-    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?(-[0-9a-fA-F]+)?$")
+    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?(-([0-9A-Fa-f]{7,10}))?$")
     if(NOT "${tagname}" MATCHES "${tagRegex}")
         message(WARNING "Cannot parse tag ${tagname}")
         return()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -63,7 +63,7 @@ function(ParseGitDescribe)
     set(major "([0-9]+)")
     set(segment "\\.[0-9]+")
     set(status "\\-([a-zA-Z]+[0-9]+)") # eg: alpha, beta, RC
-    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?$")
+    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?(-[0-9a-fA-F]+)?$")
     if(NOT "${tagname}" MATCHES "${tagRegex}")
         message(WARNING "Cannot parse tag ${tagname}")
         return()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -63,7 +63,7 @@ function(ParseGitDescribe)
     set(major "([0-9]+)")
     set(segment "\\.[0-9]+")
     set(status "\\-([a-zA-Z]+[0-9]+)") # eg: alpha, beta, RC
-    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?(-([0-9A-Fa-f]{7,10}))?$")
+    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?$")
     if(NOT "${tagname}" MATCHES "${tagRegex}")
         message(WARNING "Cannot parse tag ${tagname}")
         return()


### PR DESCRIPTION
### Problem description
With new release process we have added git hash to tags so now cmake versions need to be fixed

### What's changed
Fixed regex