### PR TITLE
#23180: Extend UnaryWithParam to support other arithmetic types

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -73,6 +73,7 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
     auto input_tensor = ttnn::random::uniform(bfloat16(low), bfloat16(high), shape).to_layout(Layout::TILE);
 
     using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     if constexpr (unary_op_type == UnaryOpType::SQRT) {
         auto host_output = host_function<::detail::sqrt>(input_tensor);
@@ -115,8 +116,8 @@ void test_operation_infrastructure() {
     using namespace tt::constants;
     log_info(tt::LogTest, "Running {}", __func__);
 
-    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -127,7 +128,7 @@ void test_operation_infrastructure() {
         ttnn::random::uniform(bfloat16(0), bfloat16(1), shape).to_layout(Layout::TILE).to_device(device);
 
     ttnn::operations::unary::operation_attributes_t op_args{
-        {EltwiseUnaryWithParam{UnaryOpType::SQRT}}, DataType::BFLOAT16, tt::tt_metal::MemoryConfig{}, false, false};
+        {UnaryWithParam{UnaryOpType::SQRT}}, DataType::BFLOAT16, tt::tt_metal::MemoryConfig{}, false, false};
     ttnn::operations::unary::tensor_args_t tensor_args{input_tensor};
     auto program_hash = ttnn::operations::unary::UnaryDeviceOperation::compute_program_hash(op_args, tensor_args);
     TT_FATAL(program_hash == 3018574135764717736ULL, "Actual value is {}", program_hash);
@@ -136,6 +137,9 @@ void test_operation_infrastructure() {
 void test_shape_padding() {
     using namespace tt::constants;
     log_info(tt::LogTest, "Running {}", __func__);
+
+    using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -174,6 +178,7 @@ void test_numerically() {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
     using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -229,6 +234,7 @@ void test_program_cache() {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
     using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -73,7 +73,6 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
     auto input_tensor = ttnn::random::uniform(bfloat16(low), bfloat16(high), shape).to_layout(Layout::TILE);
 
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     if constexpr (unary_op_type == UnaryOpType::SQRT) {
         auto host_output = host_function<::detail::sqrt>(input_tensor);
@@ -116,8 +115,8 @@ void test_operation_infrastructure() {
     using namespace tt::constants;
     log_info(tt::LogTest, "Running {}", __func__);
 
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -128,7 +127,7 @@ void test_operation_infrastructure() {
         ttnn::random::uniform(bfloat16(0), bfloat16(1), shape).to_layout(Layout::TILE).to_device(device);
 
     ttnn::operations::unary::operation_attributes_t op_args{
-        {UnaryWithParam{UnaryOpType::SQRT}}, DataType::BFLOAT16, tt::tt_metal::MemoryConfig{}, false, false};
+        {EltwiseUnaryWithParam{UnaryOpType::SQRT}}, DataType::BFLOAT16, tt::tt_metal::MemoryConfig{}, false, false};
     ttnn::operations::unary::tensor_args_t tensor_args{input_tensor};
     auto program_hash = ttnn::operations::unary::UnaryDeviceOperation::compute_program_hash(op_args, tensor_args);
     TT_FATAL(program_hash == 3018574135764717736ULL, "Actual value is {}", program_hash);
@@ -137,9 +136,6 @@ void test_operation_infrastructure() {
 void test_shape_padding() {
     using namespace tt::constants;
     log_info(tt::LogTest, "Running {}", __func__);
-
-    using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -178,7 +174,6 @@ void test_numerically() {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
@@ -234,7 +229,6 @@ void test_program_cache() {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     int device_id = 0;
     auto device_owner = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -56,8 +56,8 @@ using std::vector;
 std::map<std::string, std::map<std::string, std::string>> sfpu_op_to_hlk_op_name = {};
 
 void update_sfpu_op_to_hlk_op() {
-    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
 
     for (const std::string& sfpu_op_name : sfpu_op) {
         std::string unary_op_name{sfpu_op_name};
@@ -73,14 +73,14 @@ void update_sfpu_op_to_hlk_op() {
         if (ttnn::operations::unary::utils::is_parametrized_type(unary_op_type)) {
             if (unary_op_type == UnaryOpType::EXP) {
                 sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                    ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type, 1.0f}});
+                    ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type, 1.0}});
             } else {
                 sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                    ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type, 0.5f}});
+                    ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type, 0.5}});
             }
         } else {
             sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type}});
+                ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type}});
         }
     }
 }

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -56,8 +56,8 @@ using std::vector;
 std::map<std::string, std::map<std::string, std::string>> sfpu_op_to_hlk_op_name = {};
 
 void update_sfpu_op_to_hlk_op() {
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
 
     for (const std::string& sfpu_op_name : sfpu_op) {
         std::string unary_op_name{sfpu_op_name};
@@ -73,14 +73,14 @@ void update_sfpu_op_to_hlk_op() {
         if (ttnn::operations::unary::utils::is_parametrized_type(unary_op_type)) {
             if (unary_op_type == UnaryOpType::EXP) {
                 sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                    ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type, 1.0}});
+                    ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type, 1.0f}});
             } else {
                 sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                    ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type, 0.5}});
+                    ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type, 0.5f}});
             }
         } else {
             sfpu_op_to_hlk_op_name[sfpu_op_name] =
-                ttnn::operations::unary::utils::get_block_defines({UnaryWithParam{unary_op_type}});
+                ttnn::operations::unary::utils::get_block_defines({EltwiseUnaryWithParam{unary_op_type}});
         }
     }
 }

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -69,7 +69,7 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
             ttnn::zeros(params.b_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, *device_, params.memory_config);
 
         auto call = [&] {
-            constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+            constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
             const auto output_tensor = ttnn::add(
                 input_tensor_a, input_tensor_b, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
             return output_tensor;

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -477,7 +477,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     {
         tt::tt_metal::distributed::MeshDevice* device = device_;
         const auto& output_spec = input_spec_a;
-        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+        constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::add,
@@ -512,7 +512,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinarySubtract) {
     {
         auto* device = device_;
         const auto& output_spec = input_spec_a;
-        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+        constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::subtract,
@@ -547,7 +547,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMul) {
     {
         auto* device = device_;
         const auto& output_spec = input_spec_a;
-        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+        constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::multiply,
@@ -582,7 +582,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMax) {
     {
         auto* device = device_;
         const auto& output_spec = input_spec_a;
-        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+        constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::maximum,
@@ -617,7 +617,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryMin) {
     {
         auto* device = device_;
         const auto& output_spec = input_spec_a;
-        constexpr tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+        constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
 
         auto query = ttnn::graph::query_op_constraints(
             ttnn::minimum,

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -37,15 +37,6 @@
 #include "ttnn_test_fixtures.hpp"
 #include <umd/device/types/arch.hpp>
 
-namespace ttnn {
-namespace operations {
-namespace unary {
-enum class UnaryOpType;
-struct UnaryWithParam;
-}  // namespace unary
-}  // namespace operations
-}  // namespace ttnn
-
 using namespace tt;
 using namespace tt_metal;
 using MultiCommandQueueT3KFixture = ttnn::MultiCommandQueueT3KFixture;

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -53,7 +53,7 @@ void Tensor::add_grad(const tt::tt_metal::Tensor& grad) {
 
     // It is important to not use inline addition here
     // m_grad might share memory with other tensors
-    constexpr ttsl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+    constexpr ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
     m_grad = ttnn::add(m_grad, grad, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
 }
 

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -66,7 +66,7 @@ autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::Auto
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     auto out = autograd::create_tensor();
 
-    constexpr ttsl::Span<const ttnn::operations::unary::UnaryWithParam> none{};
+    constexpr ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
     out->set_value(
         ttnn::add(a->get_value(), b->get_value(), std::nullopt, std::nullopt, std::nullopt, none, none, none, false));
     autograd::GradFunction grad = [a, b, out]() {

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -84,7 +84,7 @@ autograd::TensorPtr rmsnorm_composite(
 
     ttnn::Tensor seq_means_of_squares = ttnn::mean(squares, /*dim_arg=*/-1, /*keep_dim=*/true);  // [B,1,S,1]
 
-    constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+    constexpr auto none = ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam>{};
 
     ttnn::Tensor seq_means_of_squares_plus_epsilon = ttnn::add(
         seq_means_of_squares,
@@ -134,7 +134,7 @@ autograd::TensorPtr rmsnorm_composite(
 
         auto dL_dout = out->get_grad();  // Grad w.r.t normalized arctivations, hence [B,1,S,C]
 
-        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+        constexpr auto none = ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam>{};
 
         auto scaled_gain = ttnn::divide(
             g,

--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -147,7 +147,7 @@ autograd::TensorPtr scaled_dot_product_attention(
     auto groups = value->get_value().logical_shape().to_array_4D()[1];
 
     const float scale = 1.0F / std::sqrt(static_cast<float>(embedding_dim));
-    constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+    constexpr auto none = ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam>{};
     auto q_scaled =
         ttnn::multiply(query->get_value(), scale, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
     auto key_tensor = key->get_value();
@@ -189,7 +189,7 @@ autograd::TensorPtr scaled_dot_product_attention(
 
     ttml::autograd::GradFunction grad =
         [scale, query, key, value, attention_weights, out, mask, batch_num, heads, seq_len, embedding_dim, groups]() {
-            constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+            constexpr auto none = ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam>{};
             auto dL_dout = out->get_grad();  // (B, H, S, embedding_dim)
             // dL_d(softmax(σQK+mask)) = dL_dout @ value^T
             ttnn::Tensor dL_dattention_weights =

--- a/ttnn/cpp/ttnn-pybind/activation.cpp
+++ b/ttnn/cpp/ttnn-pybind/activation.cpp
@@ -20,6 +20,7 @@ void py_module_types(py::module& m) {
     export_enum<UnaryOpType>(m, "UnaryOpType");
 
     py::class_<UnaryWithParam>(m, "UnaryWithParam");
+    py::class_<EltwiseUnaryWithParam>(m, "EltwiseUnaryWithParam");
 }
 
 void py_module(py::module& m) {
@@ -39,6 +40,20 @@ void py_module(py::module& m) {
     py::implicitly_convertible<std::pair<UnaryOpType, bool>, UnaryWithParam>();
 
     m.def("string_to_unary_with_param", &utils::string_to_unary_with_param);
+
+    auto eltwise_unary_with_param = static_cast<py::class_<EltwiseUnaryWithParam>>(m.attr("EltwiseUnaryWithParam"));
+    eltwise_unary_with_param.def(py::init<UnaryOpType>())
+        .def(py::init<UnaryOpType, float>())
+        .def(py::init<UnaryOpType, int>())
+        .def(py::init<>([](std::pair<UnaryOpType, float> arg) { return EltwiseUnaryWithParam{arg.first, arg.second}; }))
+        .def(py::init<>([](std::pair<UnaryOpType, int> arg) { return EltwiseUnaryWithParam{arg.first, arg.second}; }))
+        .def_property_readonly("op_type", &EltwiseUnaryWithParam::type);
+
+    // Allow implicit construction of EltwiseUnaryWithParam object without user explicitly creating it
+    // Can take in just the op type, or sequence container of op type and param value
+    py::implicitly_convertible<UnaryOpType, EltwiseUnaryWithParam>();
+    py::implicitly_convertible<std::pair<UnaryOpType, float>, EltwiseUnaryWithParam>();
+    py::implicitly_convertible<std::pair<UnaryOpType, int>, EltwiseUnaryWithParam>();
 }
 
 }  // namespace ttnn::activation

--- a/ttnn/cpp/ttnn-pybind/activation.cpp
+++ b/ttnn/cpp/ttnn-pybind/activation.cpp
@@ -45,6 +45,7 @@ void py_module(py::module& m) {
     eltwise_unary_with_param.def(py::init<UnaryOpType>())
         .def(py::init<UnaryOpType, float>())
         .def(py::init<UnaryOpType, int>())
+        .def(py::init<UnaryWithParam>())
         .def(py::init<>([](std::pair<UnaryOpType, float> arg) { return EltwiseUnaryWithParam{arg.first, arg.second}; }))
         .def(py::init<>([](std::pair<UnaryOpType, int> arg) { return EltwiseUnaryWithParam{arg.first, arg.second}; }))
         .def_property_readonly("op_type", &EltwiseUnaryWithParam::type);
@@ -54,6 +55,7 @@ void py_module(py::module& m) {
     py::implicitly_convertible<UnaryOpType, EltwiseUnaryWithParam>();
     py::implicitly_convertible<std::pair<UnaryOpType, float>, EltwiseUnaryWithParam>();
     py::implicitly_convertible<std::pair<UnaryOpType, int>, EltwiseUnaryWithParam>();
+    py::implicitly_convertible<UnaryWithParam, EltwiseUnaryWithParam>();
 }
 
 }  // namespace ttnn::activation

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -354,8 +354,8 @@ bool is_legacy_only(
     const auto& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations) {
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations) {
     const auto& output_mem_cfg = memory_config.value_or(output ? output->memory_config() : MemoryConfig{});
 
     if (detail::any_non_llk_row_broadcasted(lhs, rhs) or detail::any_sharded_block_format(lhs, rhs) or
@@ -381,24 +381,24 @@ template bool is_legacy_only<Tensor>(
     const Tensor& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template bool is_legacy_only<float>(
     const Tensor& lhs,
     const float& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template bool is_legacy_only<int32_t>(
     const Tensor& lhs,
     const int32_t& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 namespace detail {
 
@@ -410,9 +410,9 @@ inline auto invoke_binary_ng(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
@@ -512,9 +512,9 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
         queue_id,
@@ -538,9 +538,9 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
         queue_id,
@@ -564,9 +564,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     return detail::invoke_binary_ng(
         queue_id,
@@ -590,9 +590,9 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
@@ -632,9 +632,9 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
         queue_id,
@@ -654,9 +654,9 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     QueueId queue_id,
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return RelationalBinary<binary_op_type>::invoke(
         queue_id,
@@ -676,9 +676,9 @@ Tensor InplaceLogicalBinary<binary_op_type>::invoke(
     QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
         queue_id,
@@ -698,9 +698,9 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     QueueId queue_id,
     const Tensor& lhs,
     const Tensor& rhs,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
         queue_id,
@@ -720,9 +720,9 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     QueueId queue_id,
     const ttnn::Tensor& lhs,
     const float rhs,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<binary_op_type>::invoke(
         queue_id,
@@ -745,9 +745,9 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return detail::invoke_binary_ng(
         queue_id,
@@ -771,7 +771,7 @@ Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
         queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
@@ -784,7 +784,7 @@ Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
     float alpha,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    SmallVector<unary::UnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
         queue_id, lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -10,20 +10,15 @@
 #include "ttnn/operations/eltwise/binary/common/binary_op_types.hpp"
 
 namespace ttnn {
-
-namespace operations {
-namespace unary {
-struct UnaryWithParam;
-}
-namespace binary {
+namespace operations::binary {
 
 bool is_legacy_only(
     const Tensor& lhs,
     const auto& rhs,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations);
 
 template <BinaryOpType binary_op_type>
 struct BinaryOperation {
@@ -34,9 +29,9 @@ struct BinaryOperation {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -46,9 +41,9 @@ struct BinaryOperation {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 };
 
@@ -61,9 +56,9 @@ struct RelationalBinary {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -73,9 +68,9 @@ struct RelationalBinary {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 
     // rhs - tensor combination not available on Pytorch for this op
@@ -94,18 +89,18 @@ struct InplaceRelationalBinary {
         QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -115,9 +110,9 @@ struct InplaceLogicalBinary {
         QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -127,18 +122,18 @@ struct InplaceBinaryOperation {
         QueueId queue_id,
         const Tensor& lhs,
         const Tensor& rhs,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& lhs,
         float rhs,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -151,9 +146,9 @@ struct BinaryOperationSfpu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -179,8 +174,7 @@ struct BinaryOperationSubalpha {
         const std::optional<Tensor>& output = std::nullopt);
 };
 
-}  // namespace binary
-}  // namespace operations
+}  // namespace operations::binary
 
 constexpr auto add =
     ttnn::register_operation<"ttnn::add", operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -49,9 +49,9 @@ struct ExecutePower {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -61,9 +61,9 @@ struct ExecutePower {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -115,9 +115,9 @@ struct ExecuteDiv {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -129,9 +129,9 @@ struct ExecuteDiv {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> output = std::nullopt,
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt);
 };
 
@@ -144,9 +144,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
             queue_id,
@@ -168,9 +168,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt) {
         return ttnn::gelu(
             queue_id,
@@ -187,9 +187,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {}) {
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {}) {
         return BinaryOperation<binary_op_type>::invoke(
             queue_id,
             input_tensor_a,
@@ -209,9 +209,9 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {}) {
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {}) {
         return BinaryOperation<binary_op_type>::invoke(
             queue_id,
             input_tensor_a,
@@ -263,9 +263,9 @@ struct ExecuteLCM {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -277,9 +277,9 @@ struct ExecuteGCD {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -291,9 +291,9 @@ struct ExecuteMaximum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -303,9 +303,9 @@ struct ExecuteMaximum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -317,9 +317,9 @@ struct ExecuteMinimum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -329,9 +329,9 @@ struct ExecuteMinimum {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -358,9 +358,9 @@ struct ExecuteRsub {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -370,9 +370,9 @@ struct ExecuteRsub {
         const std::optional<const DataType>& output_dtype = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -383,9 +383,9 @@ struct ExecuteBitwiseAnd {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -394,9 +394,9 @@ struct ExecuteBitwiseAnd {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -407,9 +407,9 @@ struct ExecuteBitwiseOr {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -418,9 +418,9 @@ struct ExecuteBitwiseOr {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -431,9 +431,9 @@ struct ExecuteBitwiseXor {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -442,9 +442,9 @@ struct ExecuteBitwiseXor {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -455,9 +455,9 @@ struct ExecuteBitwiseLeftShift {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -466,9 +466,9 @@ struct ExecuteBitwiseLeftShift {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 
@@ -479,9 +479,9 @@ struct ExecuteBitwiseRightShift {
         const Tensor& input_tensor_b_arg,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
@@ -490,9 +490,9 @@ struct ExecuteBitwiseRightShift {
         int32_t input_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
         std::optional<bool> use_legacy = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -58,8 +58,8 @@ void bind_primitive_binary_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const std::optional<unary::FusedActivations>& activations,
-               const std::optional<unary::UnaryWithParam>& input_tensor_a_activation) -> ttnn::Tensor {
+               const std::optional<unary::EltwiseFusedActivations>& activations,
+               const std::optional<unary::EltwiseUnaryWithParam>& input_tensor_a_activation) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     input_tensor_b,
@@ -153,9 +153,9 @@ void bind_binary_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -176,9 +176,9 @@ void bind_binary_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -190,9 +190,9 @@ void bind_binary_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -213,9 +213,9 @@ void bind_binary_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -296,9 +296,9 @@ void bind_binary_gcd_lcm_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -319,9 +319,9 @@ void bind_binary_gcd_lcm_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -390,9 +390,9 @@ void bind_binary_unary_max_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -413,9 +413,9 @@ void bind_binary_unary_max_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -427,9 +427,9 @@ void bind_binary_unary_max_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -450,9 +450,9 @@ void bind_binary_unary_max_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -528,9 +528,9 @@ void bind_binary_unary_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -551,9 +551,9 @@ void bind_binary_unary_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -565,9 +565,9 @@ void bind_binary_unary_operation(
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -588,9 +588,9 @@ void bind_binary_unary_operation(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -744,9 +744,9 @@ void bind_bitwise_binary_ops_operation(
                const int32_t scalar,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -765,9 +765,9 @@ void bind_bitwise_binary_ops_operation(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -778,9 +778,9 @@ void bind_bitwise_binary_ops_operation(
                const ttnn::Tensor& input_tensor_b,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -799,9 +799,9 @@ void bind_bitwise_binary_ops_operation(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -883,9 +883,9 @@ void bind_logical_binary_ops_operation(
                     dtype,
                     memory_config,
                     output_tensor,
-                    ttnn::SmallVector<unary::UnaryWithParam>(),
-                    ttnn::SmallVector<unary::UnaryWithParam>(),
-                    ttnn::SmallVector<unary::UnaryWithParam>(),
+                    ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+                    ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+                    ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
                     use_legacy);
             },
             py::arg("input_tensor_a"),
@@ -1296,9 +1296,9 @@ void bind_div(
                const std::optional<const DataType>& dtype,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -1323,9 +1323,9 @@ void bind_div(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = ttnn::DefaultQueueId},
 
@@ -1338,9 +1338,9 @@ void bind_div(
                const std::optional<const DataType>& dtype,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -1365,9 +1365,9 @@ void bind_div(
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = ttnn::DefaultQueueId});
 }
@@ -1584,9 +1584,9 @@ void bind_inplace_operation(
             [](const binary_operation_t& self,
                const Tensor& input_tensor,
                const float scalar,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                const QueueId queue_id) {
                 return self(
@@ -1600,9 +1600,9 @@ void bind_inplace_operation(
             },
             py::arg("input_a"),
             py::arg("input_b"),
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -1611,9 +1611,9 @@ void bind_inplace_operation(
             [](const binary_operation_t& self,
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                const QueueId queue_id) {
                 return self(
@@ -1628,9 +1628,9 @@ void bind_inplace_operation(
             py::arg("input_a"),
             py::arg("input_b"),
             py::kw_only(),
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -1693,9 +1693,9 @@ void bind_logical_inplace_operation(
             [](const binary_operation_t& self,
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                const QueueId queue_id) {
                 return self(
@@ -1709,9 +1709,9 @@ void bind_logical_inplace_operation(
             },
             py::arg("input_a"),
             py::arg("input_b"),
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -1746,9 +1746,9 @@ void bind_binary_inplace_operation(
             [](const binary_operation_t& self,
                const Tensor& input_tensor,
                const float scalar,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                const QueueId queue_id) {
                 return self(
@@ -1763,9 +1763,9 @@ void bind_binary_inplace_operation(
             py::arg("input_a"),
             py::arg("input_b"),
             py::kw_only(),
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId},
 
@@ -1774,9 +1774,9 @@ void bind_binary_inplace_operation(
             [](const binary_operation_t& self,
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                const QueueId queue_id) {
                 return self(
@@ -1791,9 +1791,9 @@ void bind_binary_inplace_operation(
             py::arg("input_a"),
             py::arg("input_b"),
             py::kw_only(),
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
@@ -1889,9 +1889,9 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -1912,9 +1912,9 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = ttnn::DefaultQueueId},
 
@@ -1926,9 +1926,9 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
                const std::optional<const DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const ttnn::SmallVector<unary::UnaryWithParam>& activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_a_activations,
-               const ttnn::SmallVector<unary::UnaryWithParam>& input_tensor_b_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
+               const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
                const std::optional<bool>& use_legacy,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
@@ -1949,9 +1949,9 @@ void bind_power(py::module& module, const binary_operation_t& operation, const s
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
-            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::UnaryWithParam>(),
+            py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
+            py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
             py::arg("queue_id") = ttnn::DefaultQueueId});
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -12,8 +12,8 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::binary::utils {
 
+using ttnn::operations::unary::EltwiseUnaryWithParam;
 using ttnn::operations::unary::UnaryOpType;
-using ttnn::operations::unary::UnaryWithParam;
 
 bool is_typecast(tt::tt_metal::DataType input, tt::tt_metal::DataType output) {
     using enum tt::tt_metal::DataType;
@@ -39,8 +39,8 @@ std::map<std::string, std::string> get_defines(
     BinaryOpType op_type,
     const std::optional<tt::tt_metal::DataType> input_dtype,
     const std::optional<tt::tt_metal::DataType> output_dtype,
-    const std::optional<std::vector<UnaryWithParam>>& fused_activations,
-    const std::optional<unary::UnaryWithParam>& input_tensor_a_activation) {
+    const std::optional<std::vector<EltwiseUnaryWithParam>>& fused_activations,
+    const std::optional<EltwiseUnaryWithParam>& input_tensor_a_activation) {
     std::map<std::string, std::string> defines;
     std::string op_name = "sub_tiles";
     std::string op_binary_type = "EltwiseBinaryType::ELWSUB";
@@ -157,7 +157,7 @@ std::map<std::string, std::string> get_defines(
     defines["ELTWISE_OP_TYPE"] = op_binary_type.c_str();
     if (fused_activations.has_value()) {
         if (op_type == BinaryOpType::ADD and fused_activations->size() == 1 and
-            fused_activations->at(0).op_type == UnaryOpType::RELU and not input_tensor_a_activation.has_value()) {
+            fused_activations->at(0).type() == UnaryOpType::RELU and not input_tensor_a_activation.has_value()) {
             defines["PACK_RELU"] = "1";
         } else {
             defines.merge(ttnn::operations::unary::utils::get_block_defines(*fused_activations, "0", idst));
@@ -166,7 +166,7 @@ std::map<std::string, std::string> get_defines(
 
     if (input_tensor_a_activation.has_value()) {
         defines.merge(ttnn::operations::unary::utils::get_defines(
-            input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst, input_dtype));
+            input_tensor_a_activation.value().type(), std::nullopt, "PRE_IN0_0", idst, input_dtype));
     }
 
     return defines;
@@ -176,8 +176,8 @@ std::map<std::string, std::string> get_defines_fp32(
     BinaryOpType op_type,
     const std::optional<tt::tt_metal::DataType> input_a_dtype,
     const std::optional<tt::tt_metal::DataType> input_b_dtype,
-    const std::optional<std::vector<UnaryWithParam>>& fused_activations,
-    const std::optional<unary::UnaryWithParam>& input_tensor_a_activation) {
+    const std::optional<std::vector<EltwiseUnaryWithParam>>& fused_activations,
+    const std::optional<EltwiseUnaryWithParam>& input_tensor_a_activation) {
     std::map<std::string, std::string> new_defines;
     std::string op_name = "sub_binary_tile";
     std::string idst1 = "i*2";    // tile index for input A in dst and final output
@@ -457,7 +457,7 @@ std::map<std::string, std::string> get_defines_fp32(
 
     if (fused_activations.has_value()) {
         if (op_type == BinaryOpType::ADD and fused_activations.value().size() == 1 and
-            fused_activations.value().at(0).op_type == UnaryOpType::RELU) {
+            fused_activations.value().at(0).type() == UnaryOpType::RELU) {
             new_defines["PACK_RELU"] = "1";
         } else {
             new_defines.merge(ttnn::operations::unary::utils::get_block_defines(fused_activations.value(), "0", idst1));
@@ -466,7 +466,7 @@ std::map<std::string, std::string> get_defines_fp32(
 
     if (input_tensor_a_activation.has_value()) {
         new_defines.merge(ttnn::operations::unary::utils::get_defines(
-            input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst));
+            input_tensor_a_activation.value().type(), std::nullopt, "PRE_IN0_0", idst));
     }
 
     return new_defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.hpp
@@ -21,13 +21,14 @@ std::map<std::string, std::string> get_defines(
     BinaryOpType op_type,
     std::optional<tt::tt_metal::DataType> in_dtype = std::nullopt,
     std::optional<tt::tt_metal::DataType> out_dtype = std::nullopt,
-    const std::optional<ttnn::operations::unary::FusedActivations>& fused_activations = std::nullopt,
-    const std::optional<ttnn::operations::unary::UnaryWithParam>& input_tensor_a_activation = std::nullopt);
+    const std::optional<ttnn::operations::unary::EltwiseFusedActivations>& fused_activations = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseUnaryWithParam>& input_tensor_a_activation = std::nullopt);
 
 std::map<std::string, std::string> get_defines_fp32(
     BinaryOpType op_type,
     std::optional<tt::tt_metal::DataType> in_a_dtype = std::nullopt,
     std::optional<tt::tt_metal::DataType> in_b_dtype = std::nullopt,
-    const std::optional<ttnn::operations::unary::FusedActivations>& fused_activations = std::nullopt,
-    const std::optional<ttnn::operations::unary::UnaryWithParam>& input_tensor_a_activation = std::nullopt);
-}
+    const std::optional<ttnn::operations::unary::EltwiseFusedActivations>& fused_activations = std::nullopt,
+    const std::optional<ttnn::operations::unary::EltwiseUnaryWithParam>& input_tensor_a_activation = std::nullopt);
+
+}  // namespace ttnn::operations::binary::utils

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -81,9 +81,9 @@ Tensor ExecuteMinimum::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::MINIMUM>::invoke(
         queue_id,
@@ -105,9 +105,9 @@ Tensor ExecuteMinimum::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return std::visit(
         [&](auto input_b) {
@@ -125,9 +125,9 @@ Tensor ExecuteMaximum::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::MAXIMUM>::invoke(
         queue_id,
@@ -149,9 +149,9 @@ Tensor ExecuteMaximum::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return std::visit(
         [&](auto input_b) {
@@ -213,9 +213,9 @@ Tensor ExecuteDiv::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> output_tensor,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     const auto has_legacy_only_args = round_mode.has_value() or accurate_mode;
     if (not(use_legacy ? *use_legacy
@@ -260,9 +260,9 @@ Tensor ExecuteDiv::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> output_tensor,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     const auto has_legacy_only_args = round_mode.has_value() or accurate_mode;
     if (not(use_legacy
@@ -397,7 +397,7 @@ Tensor ExecutePrelu::invoke(
 
 Tensor run_remainder(
     const Tensor& input_a, const Tensor& input_b, float t_nan, const std::optional<MemoryConfig>& output_mem_config) {
-    using FusedActivations = tt::stl::Span<const unary::UnaryWithParam>;
+    using FusedActivations = tt::stl::Span<const unary::EltwiseUnaryWithParam>;
     // explicitly using binary_ng to avoid fallback to legacy because of row boradcast
     Tensor result = ttnn::subtract(
         input_a,
@@ -614,9 +614,9 @@ Tensor ExecuteGCD::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::GCD>::invoke(
         queue_id,
@@ -638,9 +638,9 @@ Tensor ExecuteLCM::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::LCM>::invoke(
         queue_id,
@@ -714,9 +714,9 @@ Tensor ExecutePower::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperationSfpu<operations::binary::BinaryOpType::POWER>::invoke(
         queue_id,
@@ -739,9 +739,9 @@ Tensor ExecutePower::invoke(
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     // As per binary infra, first input is always a tensor but this support needed for pytorch2 tracing
     // https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/docs/operations/aten.pow.Scalar.md
@@ -767,9 +767,9 @@ Tensor ExecuteRsub::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     return BinaryOperation<operations::binary::BinaryOpType::RSUB>::invoke(
         queue_id,
@@ -791,9 +791,9 @@ Tensor ExecuteRsub::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -827,9 +827,9 @@ Tensor ExecuteBitwiseAnd::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -871,9 +871,9 @@ Tensor ExecuteBitwiseAnd::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -908,9 +908,9 @@ Tensor ExecuteBitwiseOr::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -943,9 +943,9 @@ Tensor ExecuteBitwiseOr::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -980,9 +980,9 @@ Tensor ExecuteBitwiseXor::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1015,9 +1015,9 @@ Tensor ExecuteBitwiseXor::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1052,9 +1052,9 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1087,9 +1087,9 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1124,9 +1124,9 @@ Tensor ExecuteBitwiseRightShift::invoke(
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
@@ -1159,9 +1159,9 @@ Tensor ExecuteBitwiseRightShift::invoke(
     const int32_t input_b,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -392,8 +392,8 @@ BinaryDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
-    std::optional<unary::FusedActivations> activations,
-    std::optional<unary::UnaryWithParam> input_tensor_a_activation) {
+    std::optional<unary::EltwiseFusedActivations> activations,
+    std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation) {
     if (output_dtype.has_value() && optional_output_tensor.has_value()) {
         TT_FATAL(
             output_dtype.value() == optional_output_tensor.value().dtype(),
@@ -473,8 +473,8 @@ BinaryDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
-    std::optional<unary::FusedActivations> activations,
-    std::optional<unary::UnaryWithParam> input_tensor_a_activation) {
+    std::optional<unary::EltwiseFusedActivations> activations,
+    std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation) {
     if (output_dtype.has_value() && optional_output_tensor.has_value()) {
         TT_FATAL(
             output_dtype.value() == optional_output_tensor.value().dtype(),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -27,8 +27,8 @@ namespace ttnn::operations::binary {
 struct BinaryDeviceOperation {
     struct operation_attributes_t {
         BinaryOpType binary_op_type;
-        const std::optional<unary::FusedActivations> activations;
-        const std::optional<unary::UnaryWithParam> input_tensor_a_activation;
+        const std::optional<unary::EltwiseFusedActivations> activations;
+        const std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation;
         const std::optional<float> scalar;
         const MemoryConfig memory_config;
         const DataType dtype;
@@ -250,8 +250,8 @@ struct BinaryDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<Tensor> optional_output_tensor,
-        std::optional<unary::FusedActivations> activations,
-        std::optional<unary::UnaryWithParam> input_tensor_a_activation);
+        std::optional<unary::EltwiseFusedActivations> activations,
+        std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor_a_arg,
@@ -260,8 +260,8 @@ struct BinaryDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<Tensor> optional_output_tensor,
-        std::optional<unary::FusedActivations> activations,
-        std::optional<unary::UnaryWithParam> input_tensor_a_activation);
+        std::optional<unary::EltwiseFusedActivations> activations,
+        std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation);
 };
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -23,7 +23,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
-    using ttnn::operations::unary::UnaryWithParam;
+    using ttnn::operations::unary::EltwiseFusedActivations;
     using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
@@ -31,8 +31,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     auto& output = tensor_return_value;
     const auto& op_type = operation_attributes.binary_op_type;
 
-    std::vector<UnaryWithParam> fused_activations =
-        operation_attributes.activations.value_or(std::vector<UnaryWithParam>{});
+    auto fused_activations = operation_attributes.activations.value_or(EltwiseFusedActivations{});
 
     Program program{};
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
@@ -24,7 +24,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
-    using ttnn::operations::unary::UnaryWithParam;
+    using ttnn::operations::unary::EltwiseFusedActivations;
     using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
@@ -34,8 +34,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     auto& output = tensor_return_value;
     const auto& op_type = operation_attributes.binary_op_type;
 
-    std::vector<UnaryWithParam> fused_activations =
-        operation_attributes.activations.value_or(std::vector<UnaryWithParam>{});
+    auto fused_activations = operation_attributes.activations.value_or(EltwiseFusedActivations{});
 
     Program program{};
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -50,9 +50,10 @@ std::vector<ttnn::Tensor> ExecuteBackwardAtan2::invoke(
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {UnaryWithParam{UnaryOpType::SQUARE}, UnaryWithParam{UnaryOpType::RECIP}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE}, EltwiseUnaryWithParam{UnaryOpType::RECIP}};
     Tensor recip_mul = ttnn::multiply(
         grad,
         ttnn::unary_chain(ttnn::hypot(input, other, output_mem_config), ops_chain, output_mem_config),
@@ -214,10 +215,10 @@ std::vector<ComplexTensor> ExecuteBackwardSub::invoke(
     grad_tensor.emplace_back(grad);
     const Tensor& grad_r = grad.real();
     const Tensor& grad_i = grad.imag();
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::NEG}, UnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::NEG}, EltwiseUnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, alpha}};
     ComplexTensor grad_b = ComplexTensor(
         {ttnn::unary_chain(grad_r, ops_chain, output_mem_config),
          ttnn::unary_chain(grad_i, ops_chain, output_mem_config)});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -121,13 +121,13 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
 }
 
 tt::stl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
-    // TODO: a more generalized way to skip the hashing of an UnaryWithParam?
+    // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
     // Don't hash the quantization scale, otherwise we build the kernel for each different scale
     return tt::stl::hash::hash_objects_with_default_seed(
         binary_op_type,
         lhs_activations,
         rhs_activations,
-        is_quant_op ? ttnn::SmallVector<unary::UnaryWithParam>{} : post_activations,
+        is_quant_op ? ttnn::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
         memory_config,
         get_dtype(),
         compute_kernel_config,
@@ -464,9 +464,9 @@ BinaryNgDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations) {
     // Validate storage type for input tensors
     TT_FATAL(
         input_tensor_a.storage_type() == StorageType::DEVICE,
@@ -516,9 +516,9 @@ BinaryNgDeviceOperation::invoke(
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
-    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const unary::UnaryWithParam> post_activations) {
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations) {
     DataType dtype_a = input_tensor_a.dtype();
     bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a));
     bool is_quant_op = utils::is_quant_op(binary_op_type);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -31,9 +31,9 @@ struct BinaryNgDeviceOperation {
 
     struct operation_attributes_t {
         BinaryOpType binary_op_type;
-        ttnn::SmallVector<unary::UnaryWithParam> lhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> rhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> post_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations;
         std::optional<float> scalar;
         tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;
@@ -96,9 +96,9 @@ struct BinaryNgDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<Tensor>& optional_output_tensor,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations);
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations);
 
     // tensor-scalar invocation
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
@@ -108,9 +108,9 @@ struct BinaryNgDeviceOperation {
         const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<Tensor>& optional_output_tensor,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations);
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations);
 };
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -321,12 +321,14 @@ void set_or_update_runtime_arguments(
 
         const bool is_quant_op = operation_attributes.is_quant_op;
         TT_FATAL(
-            is_quant_op == ((operation_attributes.post_activations.size() == 1) &&
-                            (operation_attributes.post_activations[0].op_type ==
-                             ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
+            is_quant_op ==
+                ((operation_attributes.post_activations.size() == 1) &&
+                 (operation_attributes.post_activations[0].type() == ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
             "Quantization op needs to exactly one zero-point value as a post activation");
         const uint32_t quantization_zero_point =
-            is_quant_op ? std::bit_cast<uint32_t>(operation_attributes.post_activations[0].params[0]) : 0u;
+            is_quant_op ? std::bit_cast<uint32_t>(
+                              operation_attributes.post_activations[0].get_param_if<float>(0).value_or(0.0f))
+                        : 0u;
 
         if (b.has_value()) {
             if (has_sharding) {
@@ -560,9 +562,9 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
 
     {
-        ttnn::SmallVector<unary::UnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> post_activations = operation_attributes.post_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> lhs_activations = operation_attributes.lhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> rhs_activations = operation_attributes.rhs_activations;
+        ttnn::SmallVector<unary::EltwiseUnaryWithParam> post_activations = operation_attributes.post_activations;
 
         if (op_config.process_lhs.has_value()) {
             lhs_activations.push_back(*op_config.process_lhs);
@@ -588,10 +590,10 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
         if (lhs_activations.empty() and rhs_activations.empty() and post_activations.size() == 1) {
             compute_kernel_defines["PROCESS_POST_ACTIVATIONS(i)"] = "";
-            if (post_activations[0].op_type == unary::UnaryOpType::RELU) {
+            if (post_activations[0].type() == unary::UnaryOpType::RELU) {
                 compute_kernel_defines["PACK_RELU"] = "1";
                 unary::utils::update_macro_defines(unary::UnaryOpType::RELU, compute_kernel_defines);
-            } else if (post_activations[0].op_type == unary::UnaryOpType::ZERO_POINT) {
+            } else if (post_activations[0].type() == unary::UnaryOpType::ZERO_POINT) {
                 // Zero-point is passed as the 4th run-time kernel argument
                 compute_kernel_defines["QUANT_ZERO_POINT_RT_ARGS_IDX"] = "3";
                 unary::utils::update_macro_defines(unary::UnaryOpType::ZERO_POINT, compute_kernel_defines);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -461,18 +461,20 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
 
 void add_activation_defines(
     std::map<std::string, std::string>& defines,
-    tt::stl::Span<const unary::UnaryWithParam> activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> activations,
     std::string_view operand,
     std::optional<DataType> dtype) {
     defines[fmt::format("PROCESS_{}_ACTIVATIONS(i)", operand)] = std::accumulate(
         activations.begin(),
         activations.end(),
         std::string{},
-        [&](std::string&& process, const unary::UnaryWithParam& a) {
-            const auto& [op_init, op_func] = unary::utils::get_op_init_and_func(a.op_type, a.params, "i", dtype);
+        [&](std::string&& process, const unary::EltwiseUnaryWithParam& a) {
+            const auto& [op_init, op_func] = std::visit(
+                [=](const auto& op) { return unary::utils::get_op_init_and_func(op.op_type, op.params, "i", dtype); },
+                a.base);
             process += op_init;
             process += op_func;
-            unary::utils::update_macro_defines(a.op_type, defines);
+            unary::utils::update_macro_defines(a.type(), defines);
             return std::move(process);
         });
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -470,8 +470,8 @@ void add_activation_defines(
         std::string{},
         [&](std::string&& process, const unary::EltwiseUnaryWithParam& a) {
             const auto& [op_init, op_func] = std::visit(
-                [=](const auto& op) { return unary::utils::get_op_init_and_func(op.op_type, op.params, "i", dtype); },
-                a.base);
+                [&](auto params) { return unary::utils::get_op_init_and_func(a.type(), params, "i", dtype); },
+                a.get_params());
             process += op_init;
             process += op_func;
             unary::utils::update_macro_defines(a.type(), defines);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -88,7 +88,7 @@ struct OpConfig {
 
 void add_activation_defines(
     std::map<std::string, std::string>& defines,
-    tt::stl::Span<const unary::UnaryWithParam> activations,
+    tt::stl::Span<const unary::EltwiseUnaryWithParam> activations,
     std::string_view operand,
     std::optional<DataType> dtype = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
@@ -179,7 +179,7 @@ Tensor WhereOperation::invoke(
             return ttnn::operations::unary::Unary_chain::invoke(
                 queue_id,
                 predicate,
-                {unary::EltwiseUnaryWithParam{op_type, {static_cast<float>(t_true), static_cast<float>(t_false)}}},
+                {unary::UnaryWithParam{op_type, {static_cast<float>(t_true), static_cast<float>(t_false)}}},
                 memory_config,
                 output);
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where/where.cpp
@@ -31,7 +31,7 @@ Tensor where_impl(
     const auto& value_false,
     const MemoryConfig& memory_config,
     std::optional<Tensor> output) {
-    using FusedActivations = tt::stl::Span<const unary::UnaryWithParam>;
+    using FusedActivations = tt::stl::Span<const unary::EltwiseUnaryWithParam>;
     constexpr auto dtype = std::nullopt;
     const auto get_multiplied = [&](const Tensor& condition, const auto& value) -> Tensor {
         return ttnn::multiply(
@@ -179,7 +179,7 @@ Tensor WhereOperation::invoke(
             return ttnn::operations::unary::Unary_chain::invoke(
                 queue_id,
                 predicate,
-                {unary::UnaryWithParam{op_type, {static_cast<float>(t_true), static_cast<float>(t_false)}}},
+                {unary::EltwiseUnaryWithParam{op_type, {static_cast<float>(t_true), static_cast<float>(t_false)}}},
                 memory_config,
                 output);
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -149,6 +149,10 @@ struct BasicUnaryWithParam {
 
     BasicUnaryWithParam(UnaryOpType op_type) : base{std::in_place_index<0>, op_type} {}
 
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    BasicUnaryWithParam(const BasicUnaryWithParam<T>& other) : base{other} {}
+
     UnaryOpType type() const noexcept {
         constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::type)...};
         return std::visit(visitor, base);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <vector>
-#include <tt_stl/overloaded.hpp>
 #include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::unary {
@@ -154,23 +153,19 @@ struct BasicUnaryWithParam {
     BasicUnaryWithParam(const BasicUnaryWithParam<T>& other) : base{other} {}
 
     UnaryOpType type() const noexcept {
-        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::type)...};
-        return std::visit(visitor, base);
+        return std::visit([](const auto& activation) { return activation.type(); }, base);
     }
 
     bool has_parameter() const noexcept {
-        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::has_parameter)...};
-        return std::visit(visitor, base);
+        return std::visit([](const auto& activation) { return activation.has_parameter(); }, base);
     }
 
     bool empty() const noexcept {
-        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::empty)...};
-        return std::visit(visitor, base);
+        return std::visit([](const auto& activation) { return activation.empty(); }, base);
     }
 
     std::variant<std::span<const Ts>...> get_params() const noexcept {
-        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::get_params)...};
-        return std::visit<decltype(get_params())>(visitor, base);
+        return std::visit<decltype(get_params())>([](const auto& activation) { return activation.get_params(); }, base);
     }
 
     template <typename T>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <vector>
+#include <tt_stl/overloaded.hpp>
 #include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::unary {
@@ -126,32 +127,120 @@ enum class VecMode {
     Invalid = 0xFF,
 };
 
-struct UnaryWithParam {
+template <typename... Ts>
+    requires(... and (std::integral<Ts> or std::floating_point<Ts>))
+struct BasicUnaryWithParam {
+    std::variant<BasicUnaryWithParam<Ts>...> base;
+
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    BasicUnaryWithParam(UnaryOpType op_type, const std::vector<T>& params) :
+        base{std::in_place_type<BasicUnaryWithParam<T>>, op_type, params} {}
+
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    BasicUnaryWithParam(UnaryOpType op_type, std::initializer_list<T> params) :
+        base{std::in_place_type<BasicUnaryWithParam<T>>, op_type, params} {}
+
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    BasicUnaryWithParam(UnaryOpType op_type, T param) :
+        base{std::in_place_type<BasicUnaryWithParam<T>>, op_type, param} {}
+
+    BasicUnaryWithParam(UnaryOpType op_type) : base{std::in_place_index<0>, op_type} {}
+
+    UnaryOpType type() const noexcept {
+        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::type)...};
+        return std::visit(visitor, base);
+    }
+
+    bool has_parameter() const noexcept {
+        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::has_parameter)...};
+        return std::visit(visitor, base);
+    }
+
+    bool empty() const noexcept {
+        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::empty)...};
+        return std::visit(visitor, base);
+    }
+
+    std::variant<std::span<const Ts>...> get_params() const noexcept {
+        constexpr ttsl::overloaded visitor = {std::mem_fn(&BasicUnaryWithParam<Ts>::get_params)...};
+        return std::visit<decltype(get_params())>(visitor, base);
+    }
+
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    std::span<const T> get_params_if() const noexcept {
+        if (const auto ptr = std::get_if<BasicUnaryWithParam<T>>(&base)) {
+            return ptr->get_params();
+        }
+
+        return {};
+    }
+
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    std::optional<T> get_param_if(std::size_t index = 0) const noexcept {
+        if (const auto ptr = std::get_if<BasicUnaryWithParam<T>>(&base)) {
+            return ptr->get_param_if(index);
+        }
+
+        return std::nullopt;
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple("base");
+    auto attribute_values() const { return std::forward_as_tuple(this->base); }
+};
+
+template <typename T>
+struct BasicUnaryWithParam<T> {
     UnaryOpType op_type;
-    std::vector<float> params;
+    std::vector<T> params;
 
-    UnaryWithParam(UnaryOpType op_type, const std::vector<float>& params) : op_type{op_type}, params{params} {}
-    UnaryWithParam(UnaryOpType op_type, float param) : op_type{op_type}, params{param} {}
-    UnaryWithParam(UnaryOpType op_type) : op_type{op_type} {}
+    BasicUnaryWithParam(UnaryOpType op_type, const std::vector<T>& params) : op_type{op_type}, params{params} {}
+    BasicUnaryWithParam(UnaryOpType op_type, std::initializer_list<T> params) : op_type{op_type}, params{params} {}
+    BasicUnaryWithParam(UnaryOpType op_type, T param) : op_type{op_type}, params{param} {}
+    BasicUnaryWithParam(UnaryOpType op_type) : op_type{op_type} {}
 
-    bool has_parameter() const { return params.size() > 0; }
+    UnaryOpType type() const noexcept { return op_type; }
+
+    bool has_parameter() const noexcept { return params.size() > 0; }
+
+    bool empty() const noexcept { return params.empty(); }
+
+    std::span<const T> get_params() const noexcept { return params; }
+
+    std::optional<T> get_param_if(std::size_t index = 0) const noexcept {
+        if (index >= params.size()) {
+            return std::nullopt;
+        }
+
+        return params[index];
+    }
 
     static constexpr auto attribute_names = std::forward_as_tuple("op_type", "param");
     auto attribute_values() const { return std::forward_as_tuple(this->op_type, this->params); }
 };
 
+using EltwiseUnaryWithParam = BasicUnaryWithParam<float, std::int32_t, std::uint32_t>;
+
+using UnaryWithParam = BasicUnaryWithParam<float>;
+
+template <typename... Ts>
+using BasicFusedActivations = std::vector<ttnn::operations::unary::BasicUnaryWithParam<Ts...>>;
+
+using EltwiseFusedActivations = std::vector<ttnn::operations::unary::EltwiseUnaryWithParam>;
+
 using FusedActivations = std::vector<ttnn::operations::unary::UnaryWithParam>;
 
 }  // namespace ttnn::operations::unary
 
-namespace ttsl::json {
-
-template <>
-struct from_json_t<ttnn::operations::unary::UnaryWithParam> {
+template <typename T>
+struct ttsl::json::from_json_t<ttnn::operations::unary::BasicUnaryWithParam<T>> {
     auto operator()(const nlohmann::json& json_object) const {
-        return ttnn::operations::unary::UnaryWithParam{
+        return ttnn::operations::unary::BasicUnaryWithParam<T>{
             from_json<ttnn::operations::unary::UnaryOpType>(json_object["op_type"]),
-            from_json<std::vector<float>>(json_object["params"])};
+            from_json<std::vector<T>>(json_object["params"])};
     }
 };
-};  // namespace ttsl::json

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -100,7 +100,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
     UnaryOpType op_type, const std::vector<T>& params, const std::string& idst, std::optional<DataType> input_dtype) {
     std::pair<std::string, std::string> op_init_and_name;
     TT_FATAL(is_parametrized_type(op_type), "operator should support at least one parameter", "Error");
-    auto param0 = params[0];
+    std::same_as<T> auto param0 = params[0];
     switch (op_type) {
         case UnaryOpType::FILL:
             if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
@@ -426,7 +426,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             break;
         }
         case UnaryOpType::CLAMP_TSS: {
-            float param1 = params[1];
+            std::same_as<T> auto param1 = params[1];
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -880,6 +880,21 @@ std::pair<std::string, std::string> get_op_init_and_func(
                              : get_op_init_and_func_default(op_type, idst, input_dtype);
 }
 
+template std::pair<std::string, std::string> get_op_init_and_func<float>(
+    UnaryOpType op_type, std::span<const float> params, const std::string& idst, std::optional<DataType> input_dtype);
+
+template std::pair<std::string, std::string> get_op_init_and_func<std::int32_t>(
+    UnaryOpType op_type,
+    std::span<const std::int32_t> params,
+    const std::string& idst,
+    std::optional<DataType> input_dtype);
+
+template std::pair<std::string, std::string> get_op_init_and_func<std::uint32_t>(
+    UnaryOpType op_type,
+    std::span<const std::uint32_t> params,
+    const std::string& idst,
+    std::optional<DataType> input_dtype);
+
 std::map<std::string, std::string> get_block_defines(
     const std::vector<EltwiseUnaryWithParam>& op_chain,
     const std::string& block_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -18,21 +18,23 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op);
 bool get_op_approx_mode(UnaryOpType op_type);
 using DataType = tt::tt_metal::DataType;
 
+template <typename T = float>
 std::pair<std::string, std::string> get_op_init_and_func(
     UnaryOpType op_type,
-    const std::vector<float>& params = {},
+    const std::vector<T>& params = {},
     const std::string& idst = "0",
     std::optional<DataType> input_dtype = std::nullopt);
 
+template <typename T = float>
 std::map<std::string, std::string> get_defines(
     UnaryOpType op_type,
-    const std::optional<std::vector<float>>& params = std::nullopt,
+    const std::optional<std::vector<std::type_identity_t<T>>>& params = std::nullopt,
     const std::string& id = "0",
     const std::string& idst = "0",
     std::optional<DataType> input_dtype = std::nullopt);
 
 std::map<std::string, std::string> get_block_defines(
-    const std::vector<UnaryWithParam>& op_chain,
+    const std::vector<EltwiseUnaryWithParam>& op_chain,
     const std::string& block_id = "0",
     const std::string& idst = "0",
     std::optional<DataType> input_dtype = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -21,14 +21,16 @@ using DataType = tt::tt_metal::DataType;
 template <typename T = float>
 std::pair<std::string, std::string> get_op_init_and_func(
     UnaryOpType op_type,
-    const std::vector<T>& params = {},
+    std::span<const T> params = {},
     const std::string& idst = "0",
     std::optional<DataType> input_dtype = std::nullopt);
 
+// type_identity_t suppresses template argument deduction
+// this allows get_defines(...) without a template list to use the default type float
 template <typename T = float>
 std::map<std::string, std::string> get_defines(
     UnaryOpType op_type,
-    const std::optional<std::vector<std::type_identity_t<T>>>& params = std::nullopt,
+    std::optional<std::span<const std::type_identity_t<T>>> params = std::nullopt,
     const std::string& id = "0",
     const std::string& idst = "0",
     std::optional<DataType> input_dtype = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -78,7 +78,7 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(
     auto arch = input_tensor.device()->arch();
     auto input_datatype = input_tensor.dtype();
     for (const auto& unary_op : args.op_chain) {
-        validate_supported_arch_dtype(arch, input_datatype, output_datatype, unary_op.op_type);
+        validate_supported_arch_dtype(arch, input_datatype, output_datatype, unary_op.type());
     }
 
     TT_FATAL(
@@ -177,7 +177,7 @@ bool UnaryDeviceOperation::skip_launch(
 std::tuple<UnaryDeviceOperation::operation_attributes_t, UnaryDeviceOperation::tensor_args_t>
 UnaryDeviceOperation::invoke(
     const Tensor& input,
-    const std::vector<UnaryWithParam>& op_chain,
+    const std::vector<EltwiseUnaryWithParam>& op_chain,
     DataType output_dtype,
     const MemoryConfig& output_memory_config,
     bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -43,7 +43,7 @@ struct UnaryDeviceOperation {
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
-        const std::vector<UnaryWithParam>& op_chain,
+        const std::vector<EltwiseUnaryWithParam>& op_chain,
         DataType output_dtype,
         const MemoryConfig& output_memory_config,
         bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
@@ -13,7 +13,7 @@
 namespace ttnn::operations::unary {
 
 struct operation_attributes_t {
-    const std::vector<UnaryWithParam> op_chain;
+    const std::vector<EltwiseUnaryWithParam> op_chain;
     const tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
     const tt::tt_metal::MemoryConfig output_memory_config;
     const bool fp32_dest_acc_en = false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
@@ -126,7 +126,7 @@ bool TanhAccurateDeviceOperation::skip_launch(
 std::tuple<TanhAccurateDeviceOperation::operation_attributes_t, TanhAccurateDeviceOperation::tensor_args_t>
 TanhAccurateDeviceOperation::invoke(
     const Tensor& input,
-    const std::vector<UnaryWithParam>& op_chain,
+    const std::vector<EltwiseUnaryWithParam>& op_chain,
     DataType output_dtype,
     const MemoryConfig& output_memory_config,
     bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
@@ -42,7 +42,7 @@ struct TanhAccurateDeviceOperation {
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
-        const std::vector<UnaryWithParam>& op_chain,
+        const std::vector<EltwiseUnaryWithParam>& op_chain,
         DataType output_dtype,
         const MemoryConfig& output_memory_config,
         bool fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
@@ -138,7 +138,7 @@ TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
     }
 
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
-    if (ops_chain[0].op_type == UnaryOpType::TANHSHRINK) {
+    if (ops_chain[0].type() == UnaryOpType::TANHSHRINK) {
         path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp";
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
@@ -164,7 +164,7 @@ TanhAccurateShardedProgramFactory::cached_program_t TanhAccurateShardedProgramFa
         unary_defines["TANH_BF16"] = "1";
     }
     auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
-    if (ops_chain[0].op_type == UnaryOpType::TANHSHRINK) {
+    if (ops_chain[0].type() == UnaryOpType::TANHSHRINK) {
         path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp";
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
@@ -40,7 +40,7 @@ inline Tensor invoke_accurate_common(
                                     ? optional_output_tensor.value().memory_config()
                                     : memory_config.value_or(input_tensor.memory_config());
 
-    const std::vector<UnaryWithParam>& op_chain = {UnaryWithParam{op_type}};
+    const std::vector<EltwiseUnaryWithParam>& op_chain = {EltwiseUnaryWithParam{op_type}};
     return prim::tanh_accurate(
         queue_id,
         input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -8,17 +8,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/eltwise/complex/complex.hpp"
 namespace ttnn {
-
-namespace operations {
-
-namespace unary {
-
-struct UnaryWithParam;
-
-template <UnaryOpType... unary_op_types>
-struct ExecuteUnaryInvokeResult {
-    using type = ComplexTensor;
-};
+namespace operations::unary {
 
 template <UnaryOpType... unary_op_types>
 struct ExecuteUnary {
@@ -28,8 +18,7 @@ struct ExecuteUnary {
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
-    static typename ExecuteUnaryInvokeResult<unary_op_types...>::type invoke(
-        const ComplexTensor& input_tensor, const MemoryConfig& memory_config);
+    static ComplexTensor invoke(const ComplexTensor& input_tensor, const MemoryConfig& memory_config);
 };
 
 template <UnaryOpType unary_op_type>
@@ -114,7 +103,7 @@ struct Unary_chain {
     static Tensor invoke(
         QueueId queue_id,
         const Tensor& input_tensor,
-        const std::vector<UnaryWithParam>& ops_chain,
+        const std::vector<EltwiseUnaryWithParam>& ops_chain,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
@@ -364,8 +353,7 @@ struct Clamp {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
-}  // namespace unary
-}  // namespace operations
+}  // namespace operations::unary
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define REGISTER_UNARY_OPERATION(operation_name, operation_type) \

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1211,7 +1211,7 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            ops_chain (list[ttnn.UnaryWithParam]): list of unary ops to be chained.
+            ops_chain (list[ttnn.EltwiseUnaryWithParam]): list of unary ops to be chained.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
@@ -1237,7 +1237,7 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
         Example:
 
             >>> tensor = ttnn.from_torch(torch.randn([32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> ops_chain = [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False), ttnn.UnaryWithParam(ttnn.UnaryOpType.POWER, 2)]
+            >>> ops_chain = [ttnn.EltwiseUnaryWithParam(ttnn.UnaryOpType.RELU), ttnn.EltwiseUnaryWithParam(ttnn.UnaryOpType.EXP, False), ttnn.EltwiseUnaryWithParam(ttnn.UnaryOpType.POWER, 2)]
             >>> output = {1}(tensor, ops_chain)
         )doc",
         ttnn::unary_chain.base_name(),
@@ -1250,7 +1250,7 @@ void bind_unary_chain(py::module& module, const unary_operation_t& operation) {
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
-               const FusedActivations& ops_chain,
+               const EltwiseFusedActivations& ops_chain,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<Tensor>& output_tensor,
                const QueueId queue_id) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1047,7 +1047,6 @@ std::vector<Tensor> ExecuteUnaryBackwardAsin::invoke(
     std::vector<Tensor> grad_tensor;
     using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
     std::vector<EltwiseUnaryWithParam> ops_chain = {
         EltwiseUnaryWithParam{UnaryOpType::SQUARE},
         EltwiseUnaryWithParam{UnaryOpType::NEG},

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -689,12 +689,12 @@ std::vector<Tensor> ExecuteUnaryBackwardAcos::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardAtan::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::SQUARE},
-        UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::RECIP}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
+        EltwiseUnaryWithParam{UnaryOpType::RECIP}};
     Tensor grad_a =
         ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_a);
@@ -1004,13 +1004,13 @@ std::vector<Tensor> ExecuteUnaryBackwardAtanh::invoke(
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");
     float t_inf = std::numeric_limits<float>::infinity();
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::SQUARE},
-        UnaryWithParam{UnaryOpType::SUB_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::NEG},
-        UnaryWithParam{UnaryOpType::RECIP}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::SUB_UNARY_SFPU, 1.0f},
+        EltwiseUnaryWithParam{UnaryOpType::NEG},
+        EltwiseUnaryWithParam{UnaryOpType::RECIP}};
 
     Tensor grad_a =
         ttnn::multiply(grad, unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
@@ -1045,13 +1045,14 @@ std::vector<Tensor> ExecuteUnaryBackwardAtanh::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardAsin::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::SQUARE},
-        UnaryWithParam{UnaryOpType::NEG},
-        UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::RSQRT}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::NEG},
+        EltwiseUnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
+        EltwiseUnaryWithParam{UnaryOpType::RSQRT}};
 
     Tensor grad_result =
         ttnn::multiply(grad, unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
@@ -1085,12 +1086,12 @@ std::vector<Tensor> ExecuteUnaryBackwardAsin::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardAsinh::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::SQUARE},
-        UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::RSQRT}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
+        EltwiseUnaryWithParam{UnaryOpType::RSQRT}};
     Tensor grad_result =
         ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_result);
@@ -1213,13 +1214,13 @@ std::vector<Tensor> ExecuteUnaryBackwardCeil::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardSoftsign::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::ABS},
-        UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::SQUARE},
-        UnaryWithParam{UnaryOpType::RECIP}};
+    std::vector<EltwiseUnaryWithParam> ops_chain = {
+        EltwiseUnaryWithParam{UnaryOpType::ABS},
+        EltwiseUnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::RECIP}};
     grad_tensor.emplace_back(
         ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config));
     return grad_tensor;

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -19,8 +19,8 @@ namespace loss_utils {
 
 using ttnn::operations::loss::LossFunction;
 using ttnn::operations::loss::LossReductionMode;
+using ttnn::operations::unary::EltwiseUnaryWithParam;
 using ttnn::operations::unary::UnaryOpType;
-using ttnn::operations::unary::UnaryWithParam;
 
 Tensor loss_function(
     QueueId queue_id,
@@ -30,10 +30,10 @@ Tensor loss_function(
     const LossReductionMode reduce_mode,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
-    std::vector<UnaryWithParam> fused_ops;
+    std::vector<EltwiseUnaryWithParam> fused_ops;
     switch (loss_kind) {
-        case LossFunction::MAE: fused_ops.push_back(UnaryWithParam{UnaryOpType::ABS}); break;
-        case LossFunction::MSE: fused_ops.push_back(UnaryWithParam{UnaryOpType::SQUARE}); break;
+        case LossFunction::MAE: fused_ops.push_back(EltwiseUnaryWithParam{UnaryOpType::ABS}); break;
+        case LossFunction::MSE: fused_ops.push_back(EltwiseUnaryWithParam{UnaryOpType::SQUARE}); break;
         default: TT_THROW("unsupported loss function {}. Please change.", loss_kind);
     }
     Tensor result =


### PR DESCRIPTION
### Ticket
#23180

### Problem description
Eltwise infrastructure does not provide a way to pass 32-bit integer parameters for unary activations and maintain full precision, because the code within ttnn internally casts it to float and back before passing it as a kernel argument.

### What's changed
Make `UnaryWithParam` a specialization of a variadic class template `BasicUnaryWithParam<Ts...>` that allows parameters to be passed as any arithmetic type contained in `Ts`, and create another specialization `EltwiseUnaryWithParam` that supports the arithmetic types `float`, `int32_t` and `uint32_t`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17769709074) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes