### PR TITLE
[skip ci] Comment cron job in Package and Release workflow

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -7,10 +7,10 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    # Create dev every day at EOD of PST Mon-Fri + night of Sunday to kick off
-    # dev testing and builds for beginning of work week
-    - cron: "0 0 * * *"
+  # schedule:
+  #   # Create dev every day at EOD of PST Mon-Fri + night of Sunday to kick off
+  #   # dev testing and builds for beginning of work week
+  #   - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
### Problem description
Currently package and release on main creates tags that are braking merge gate and pr gate. So we need to disable auto starting of this workflow

### What's changed
Comment cron job