### PR TITLE
Get device arch without opening device

### DIFF
--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -370,5 +370,12 @@ bool ReadFromDeviceL1(
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
+/**
+ * Return the name of the architecture present.
+ *
+ * Return value: std::string
+ */
+std::string get_physical_architecture_name();
+
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -12,7 +12,32 @@
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/simulation/simulation_device.hpp>
 
+#include "tracy/Tracy.hpp"
 namespace tt::tt_metal {
+
+static tt::ARCH current_arch = tt::ARCH::Invalid;
+
+inline tt::ARCH get_physical_architecture() {
+    ZoneScoped;
+    if (current_arch == tt::ARCH::Invalid) {
+        // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.
+        // This map holds PCI info for each mmio chip.
+        auto devices_info = PCIDevice::enumerate_devices_info();
+        if (devices_info.size() > 0) {
+            current_arch = devices_info.begin()->second.get_arch();
+            for (auto& [device_id, device_info] : devices_info) {
+                tt::ARCH detected_arch = device_info.get_arch();
+                TT_FATAL(
+                    current_arch == detected_arch,
+                    "Expected all devices to be {} but device {} is {}",
+                    tt::arch_to_str(current_arch),
+                    device_id,
+                    tt::arch_to_str(detected_arch));
+            }
+        }
+    }
+    return current_arch;
+}
 
 /**
  * @brief Detects the platform architecture based on the environment or hardware.
@@ -47,6 +72,7 @@ namespace tt::tt_metal {
  * @see tt::get_arch_from_string
  * @see PCIDevice::enumerate_devices_info
  */
+
 inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtoptions) {
     auto arch = tt::ARCH::Invalid;
     // If running in mock mode, derive architecture from provided cluster descriptor
@@ -61,21 +87,7 @@ inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtopti
         tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
         arch = init.get_arch_name();
     } else {
-        // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.
-        // This map holds PCI info for each mmio chip.
-        auto devices_info = PCIDevice::enumerate_devices_info();
-        if (devices_info.size() > 0) {
-            arch = devices_info.begin()->second.get_arch();
-            for (auto& [device_id, device_info] : devices_info) {
-                tt::ARCH detected_arch = device_info.get_arch();
-                TT_FATAL(
-                    arch == detected_arch,
-                    "Expected all devices to be {} but device {} is {}",
-                    tt::arch_to_str(arch),
-                    device_id,
-                    tt::arch_to_str(detected_arch));
-            }
-        }
+        arch = get_physical_architecture();
     }
 
     return arch;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -56,6 +56,7 @@
 #include "fabric/hw/inc/fabric_routing_mode.h"
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
+#include "get_platform_architecture.hpp"
 
 namespace tt {
 
@@ -352,6 +353,10 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(
         &regval, tt_cxy_pair(device->id(), worker_core), address);
     return true;
+}
+
+std::string get_physical_architecture_name() {
+    return tt::get_string_lowercase(tt::tt_metal::get_physical_architecture());
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -518,7 +518,10 @@ void device_module(py::module& m_device) {
         +------------------+----------------------------------+-----------------------+-------------+----------+
     )doc");
 
-    m_device.def("get_arch_name", &tt::tt_metal::hal::get_arch_name, "Return the name of the architecture present.");
+    m_device.def(
+        "get_arch_name",
+        &tt::tt_metal::detail::get_physical_architecture_name,
+        "Return the name of the architecture present.");
 
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);
     m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25388

### Problem description
Double opening device

Note: This problem was originally fixed in https://github.com/tenstorrent/tt-metal/pull/27805. However, ttnn users call this pybind in the thousands and the overhead of `PCIDevice::enumerate_devices_info();`  was regressing perf. The change was reverted and reintroduced with caching the architecture. 

### What's changed
Do not open device for getting arch name and directly use UMD

### Checklist

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17680709267)
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17680718166)
- [ ] [Single card demos](https://github.com/tenstorrent/tt-metal/actions/runs/17680754828) 
- [ ] [T3k demos](https://github.com/tenstorrent/tt-metal/actions/runs/17680739051)
- [ ] [ Galaxy demos ](https://github.com/tenstorrent/tt-metal/actions/runs/17680777131)
- [x] [T3K model perf](https://github.com/tenstorrent/tt-metal/actions/runs/17680773105)

The unchecked CIs are red but the fails don't suggest to be done by this branch. Most notably Flacon7B that failed last time is green on this PR.