### PR TITLE
Fix max_pool2d golden function to pass ceil_mode parameter

### DIFF
--- a/ttnn/ttnn/operations/pool.py
+++ b/ttnn/ttnn/operations/pool.py
@@ -17,6 +17,7 @@ def golden_maxpool2d(
     stride: Tuple[int, int],
     padding: Tuple[int, int],
     dilation: Tuple[int, int],
+    ceil_mode: bool = False,
     **_,
 ):
     import torch
@@ -26,7 +27,7 @@ def golden_maxpool2d(
     )  # 1, 1, NHW, C -> N, C, H, W
 
     output_tensor = torch.nn.functional.max_pool2d(
-        input_tensor, kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation
+        input_tensor, kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation, ceil_mode=ceil_mode
     )
 
     N, C, H, W = output_tensor.shape


### PR DESCRIPTION
The golden function for max_pool2d was missing the ceil_mode parameter when calling torch.nn.functional.max_pool2d, causing shape mismatches in PCC comparison mode.

With ceil_mode=True and input [1,256,56,56], kernel 3x3, stride 2x2:
- ttnn: correctly produces [1,1,784,256] (28x28 output)
- torch golden (before fix): incorrectly produces [1,1,729,256] (27x27 output)
- torch golden (after fix): correctly produces [1,1,784,256] (28x28 output)

Fixes issue where PCC comparison mode fails for max_pool2d operations with ceil_mode=True.

Resolves #27576

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes