### PR TITLE
Add Support for Strided Slice with Tile Conversion for Tiled Inputs

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -31,8 +31,6 @@ def _rand_shape(dim_size, choices=(8, 16, 32, 64, 128, 256)):
     return ret
 
 
-
-
 def _rand_slice_params(
     shape,
     *,

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -113,8 +113,7 @@ def offset_increment_tensor(shape, offset=0, dtype=torch.int32, step=1):
 
 @skip_for_blackhole("Fails on Blackhole. Issue #28021")
 @pytest.mark.parametrize("rank", range(1, 9))  # 1D … 8D
-# @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 def test_slice_write_nd(rank, layout, device):
     base_seed = 2005
     random.seed(base_seed)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -121,18 +121,12 @@ def test_slice_write_nd(rank, layout, device):
 
     shape = _rand_shape(rank)
     begins, ends, strides = _rand_slice_params(shape)
-    print(f"begins: {begins}")
-    print(f"ends: {ends}")
-    print(f"strides: {strides}")
-    print(f"shape: {shape}")
     # Build PyTorch reference slice
     slices = tuple(slice(b, e, s) for b, e, s in zip(begins, ends, strides))
 
     # Destination and source (match slice shape)
     torch_out_ref = torch.zeros(shape, dtype=torch.bfloat16)
-    # torch_src = offset_increment_tensor(torch_out_ref[slices].shape, dtype=torch.bfloat16)
     torch_src = torch.full(torch_out_ref[slices].shape, 1, dtype=torch.bfloat16)
-    print(f"torch_src.shape: {torch_src.shape}")
 
     # PyTorch ground truth
     torch_out_ref[slices] = torch_src

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -31,21 +31,6 @@ def _rand_shape(dim_size, choices=(8, 16, 32, 64, 128, 256)):
     return ret
 
 
-# def _rand_slice_params(shape):
-#     begins, ends, strides = [], [], []
-#     ndim = len(shape)
-#     for dim, size in enumerate(shape):
-#         # pick a random start < size
-#         b = random.randint(0, size - 1)
-#         # choose a random end > b, ≤ size
-#         e = random.randint(b + 1, size)
-#         begins.append(b)
-#         ends.append(e)
-#         slice_area = e - b
-#         possible_strides = [s for s in range(1, slice_area + 1) if slice_area % s == 0 and s <= slice_area // 2]
-#         s = 1 if len(possible_strides) == 0 else random.choice(possible_strides)
-#         strides.append(s)
-#     return begins, ends, strides
 
 
 def _rand_slice_params(

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -31,18 +31,61 @@ def _rand_shape(dim_size, choices=(8, 16, 32, 64, 128, 256)):
     return ret
 
 
-def _rand_slice_params(shape):
+# def _rand_slice_params(shape):
+#     begins, ends, strides = [], [], []
+#     ndim = len(shape)
+#     for dim, size in enumerate(shape):
+#         # pick a random start < size
+#         b = random.randint(0, size - 1)
+#         # choose a random end > b, ≤ size
+#         e = random.randint(b + 1, size)
+#         begins.append(b)
+#         ends.append(e)
+#         slice_area = e - b
+#         possible_strides = [s for s in range(1, slice_area + 1) if slice_area % s == 0 and s <= slice_area // 2]
+#         s = 1 if len(possible_strides) == 0 else random.choice(possible_strides)
+#         strides.append(s)
+#     return begins, ends, strides
+
+
+def _rand_slice_params(
+    shape,
+    *,
+    max_stride_per_dim=None,  # e.g. [8, 4, 4, 1] or None -> clamp to dim size
+    allow_last_dim_stride=True,  # keep last dim stride=1 if False
+    always_nonempty=True,  # guarantee at least one element per dim
+):
     begins, ends, strides = [], [], []
     ndim = len(shape)
+
     for dim, size in enumerate(shape):
-        s = 1  # stride always 1
-        # pick a random start < size
+        assert size > 0, "All dims must be > 0"
+
+        # ----- begin & end (positive stride case) -----
+        # choose a start < size
         b = random.randint(0, size - 1)
-        # choose a random end > b, ≤ size
-        e = random.randint(b + 1, size)
+
+        if always_nonempty:
+            # ensure at least one element: need e > b
+            e = random.randint(b + 1, size)
+        else:
+            # allow empty slices too (rare); still keep e in [0..size]
+            # bias toward non-empty
+            if random.random() < 0.9 and b + 1 <= size:
+                e = random.randint(b + 1, size)
+            else:
+                e = random.randint(0, size)
+
+        # ----- stride -----
+        if (dim == ndim - 1) and not allow_last_dim_stride:
+            s = 1
+        else:
+            s = random.randint(1, e - b)
+
         begins.append(b)
         ends.append(e)
         strides.append(s)
+
     return begins, ends, strides
 
 
@@ -70,6 +113,7 @@ def offset_increment_tensor(shape, offset=0, dtype=torch.int32, step=1):
 
 @skip_for_blackhole("Fails on Blackhole. Issue #28021")
 @pytest.mark.parametrize("rank", range(1, 9))  # 1D … 8D
+# @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 def test_slice_write_nd(rank, layout, device):
     base_seed = 2005
@@ -78,12 +122,18 @@ def test_slice_write_nd(rank, layout, device):
 
     shape = _rand_shape(rank)
     begins, ends, strides = _rand_slice_params(shape)
+    print(f"begins: {begins}")
+    print(f"ends: {ends}")
+    print(f"strides: {strides}")
+    print(f"shape: {shape}")
     # Build PyTorch reference slice
     slices = tuple(slice(b, e, s) for b, e, s in zip(begins, ends, strides))
 
     # Destination and source (match slice shape)
     torch_out_ref = torch.zeros(shape, dtype=torch.bfloat16)
-    torch_src = offset_increment_tensor(torch_out_ref[slices].shape, dtype=torch.bfloat16)
+    # torch_src = offset_increment_tensor(torch_out_ref[slices].shape, dtype=torch.bfloat16)
+    torch_src = torch.full(torch_out_ref[slices].shape, 1, dtype=torch.bfloat16)
+    print(f"torch_src.shape: {torch_src.shape}")
 
     # PyTorch ground truth
     torch_out_ref[slices] = torch_src

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -17,10 +17,6 @@ void kernel_main() {
     const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(7);
     const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(8);
 
-#ifdef UNPAD_INPUT_WIDTH
-    const uint32_t padding_width_ntiles = get_arg_val<uint32_t>(21);
-#endif
-
 #ifdef DEBUG
     DPRINT << "dst_addr: " << dst_addr << ENDL();
     DPRINT << "output_stick_size: " << output_stick_size << ENDL();
@@ -31,9 +27,6 @@ void kernel_main() {
     DPRINT << "num_sticks_per_core: " << num_sticks_per_core << ENDL();
     DPRINT << "num_sticks_per_core_read: " << num_sticks_per_core_read << ENDL();
     DPRINT << "num_read_per_barrier: " << num_read_per_barrier << ENDL();
-#ifdef UNPAD_INPUT_WIDTH
-    DPRINT << "padding_width_ntiles: " << padding_width_ntiles << ENDL();
-#endif
 
 #endif
     tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(9));

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t output_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t input_stick_size = get_arg_val<uint32_t>(2);
+    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
+    const uint32_t num_dims = get_arg_val<uint32_t>(4);
+    const uint32_t start_id = get_arg_val<uint32_t>(5);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(7);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(8);
+
+#ifdef UNPAD_INPUT_WIDTH
+    const uint32_t padding_width_ntiles = get_arg_val<uint32_t>(21);
+#endif
+
+#ifdef DEBUG
+    DPRINT << "dst_addr: " << dst_addr << ENDL();
+    DPRINT << "output_stick_size: " << output_stick_size << ENDL();
+    DPRINT << "input_stick_size: " << input_stick_size << ENDL();
+    DPRINT << "stick_size_offset: " << stick_size_offset << ENDL();
+    DPRINT << "num_dims: " << num_dims << ENDL();
+    DPRINT << "start_id: " << start_id << ENDL();
+    DPRINT << "num_sticks_per_core: " << num_sticks_per_core << ENDL();
+    DPRINT << "num_sticks_per_core_read: " << num_sticks_per_core_read << ENDL();
+    DPRINT << "num_read_per_barrier: " << num_read_per_barrier << ENDL();
+#ifdef UNPAD_INPUT_WIDTH
+    DPRINT << "padding_width_ntiles: " << padding_width_ntiles << ENDL();
+#endif
+
+#endif
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(9));
+    volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
+    volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
+    volatile tt_l1_ptr uint32_t* rev_stride = id_per_dim + num_dims;
+    DPRINT << "num_input_sticks_per_dim: ";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << num_unpadded_sticks[i] << ", ";
+    }
+    DPRINT << ENDL();
+    DPRINT << "num_output_sticks_per_dim: ";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << num_padded_sticks[i] << ", ";
+    }
+    DPRINT << ENDL();
+    DPRINT << "rev_stride: ";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << rev_stride[i] << ", ";
+    }
+    DPRINT << ENDL();
+    DPRINT << "id_per_dim: ";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << id_per_dim[i] << ", ";
+    }
+    DPRINT << ENDL();
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr uint32_t alignment_offset = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(2);
+    constexpr uint32_t page_begins_offset = get_compile_time_arg_val(3);
+    constexpr uint32_t element_size = get_compile_time_arg_val(4);
+    constexpr auto dst_args = TensorAccessorArgs<5>();
+
+    const auto s0 = TensorAccessor(dst_args, dst_addr, output_stick_size);
+    const uint32_t noc_write_size = std::min(output_stick_size, input_stick_size);
+    uint32_t dst_stick_id = start_id;
+    uint32_t src_stick_id = start_id;
+    uint32_t sticks_read = 0;
+    uint32_t sticks_written = 0;
+#ifdef DEBUG
+    uint32_t base_src_l1_addr = get_read_ptr(cb_id_in);
+#endif
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_written < num_sticks_per_core; ++iter) {
+#ifdef LAST_DIM_STRIDED
+        // read output rows in batches if striding on last dim
+        cb_reserve_back(cb_id_out, num_read_per_barrier);
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            uint32_t l1_write_addr = get_write_ptr(cb_id_out);
+            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+            noc_async_read(src_noc_addr, l1_write_addr, output_stick_size);
+            l1_write_addr += output_stick_size;
+            src_stick_id += rev_stride[1];
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    DPRINT << "dst_stick_id: " << src_stick_id << " + " << (num_padded_sticks[j]) << " = ";
+                    src_stick_id += num_padded_sticks[j];
+                    DPRINT << src_stick_id << ENDL();
+                } else {
+                    break;
+                }
+            }
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id_out, num_read_per_barrier);
+#endif
+
+        // begin writing
+        cb_wait_front(cb_id_in, num_read_per_barrier);
+#ifdef LAST_DIM_STRIDED
+        cb_wait_front(cb_id_out, num_read_per_barrier);
+        uint32_t output_l1_addr = get_read_ptr(cb_id_out);
+#endif
+        uint32_t src_buffer_l1_addr = get_read_ptr(cb_id_in);
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_written < num_sticks_per_core; ++i) {
+            sticks_written++;
+            uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
+#ifdef LAST_DIM_STRIDED
+            // fill the read output row with the input with stride
+            volatile tt_l1_ptr uint8_t* out_stick =
+                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(output_l1_addr + page_begins_offset);
+            volatile tt_l1_ptr uint8_t* in_stick =
+                reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_buffer_l1_addr + alignment_offset);
+            uint32_t out_index = 0;
+            for (uint32_t j = 0; j < input_stick_size / element_size; j++) {
+                // general writing for all data types byte by byte
+                for (uint32_t byte = 0; byte < element_size; byte++) {
+                    out_stick[out_index * element_size + byte] = in_stick[j * element_size + byte];
+                }
+                out_index += rev_stride[0];
+            }
+            noc_async_write(output_l1_addr, dst_noc_addr, output_stick_size);
+            output_l1_addr += output_stick_size;
+#else
+            noc_async_write(src_buffer_l1_addr + alignment_offset, dst_noc_addr + page_begins_offset, noc_write_size);
+#endif
+#ifdef DEBUG
+            DPRINT << "SRC L1 : " << src_buffer_l1_addr - base_src_l1_addr << " Dst Stick ID " << dst_stick_id
+                   << " sticks_written: " << sticks_written << " Coord ";
+            for (uint32_t j = 0; j < num_dims; j++) {
+                DPRINT << ", " << id_per_dim[j];
+            }
+            DPRINT << ENDL();
+#endif
+            src_buffer_l1_addr += stick_size_offset;
+            dst_stick_id += rev_stride[1];
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    DPRINT << "dst_stick_id: " << dst_stick_id << " + " << (num_padded_sticks[j]) << " = ";
+                    dst_stick_id += num_padded_sticks[j];
+                    DPRINT << dst_stick_id << ENDL();
+                } else {
+                    break;
+                }
+            }
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_in, num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved_strided.cpp
@@ -40,6 +40,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
     volatile tt_l1_ptr uint32_t* rev_stride = id_per_dim + num_dims;
+
+#ifdef DEBUG
     DPRINT << "num_input_sticks_per_dim: ";
     for (uint32_t i = 0; i < num_dims; i++) {
         DPRINT << num_unpadded_sticks[i] << ", ";
@@ -60,6 +62,7 @@ void kernel_main() {
         DPRINT << id_per_dim[i] << ", ";
     }
     DPRINT << ENDL();
+#endif
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t alignment_offset = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(2);
@@ -91,9 +94,7 @@ void kernel_main() {
                 id_per_dim[j]++;
                 if (id_per_dim[j] == num_unpadded_sticks[j]) {
                     id_per_dim[j] = 0;
-                    DPRINT << "dst_stick_id: " << src_stick_id << " + " << (num_padded_sticks[j]) << " = ";
                     src_stick_id += num_padded_sticks[j];
-                    DPRINT << src_stick_id << ENDL();
                 } else {
                     break;
                 }
@@ -146,9 +147,7 @@ void kernel_main() {
                 id_per_dim[j]++;
                 if (id_per_dim[j] == num_unpadded_sticks[j]) {
                     id_per_dim[j] = 0;
-                    DPRINT << "dst_stick_id: " << dst_stick_id << " + " << (num_padded_sticks[j]) << " = ";
                     dst_stick_id += num_padded_sticks[j];
-                    DPRINT << dst_stick_id << ENDL();
                 } else {
                     break;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -57,9 +57,6 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
     std::vector<uint32_t> rev_stride(num_dims);
-    if (num_dims == 1) {
-        rev_stride.push_back(1);
-    }
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
 
@@ -911,7 +908,6 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args_vec, reader_defines));
 
-    writer_defines["DEBUG"] = "1";
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/"

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -29,6 +29,7 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
     const Tensor& input_tensor,
     const Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& stride,
     uint32_t num_cores_total,
     uint32_t num_cores,
     uint32_t num_cores_y,
@@ -49,11 +50,16 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
 
     uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
     uint32_t input_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    bool strided = std::any_of(stride.cbegin(), stride.cend(), [](int val) { return val != 1; });
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
+    std::vector<uint32_t> rev_stride(num_dims);
+    if (num_dims == 1) {
+        rev_stride.push_back(1);
+    }
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
 
@@ -62,11 +68,21 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
     num_input_sticks_per_dim[0] = 1;
     num_output_sticks_per_dim[0] = 0;
     accumulated_total_per_dim[0] = 1;
+    rev_stride[0] = stride[num_dims - 1];
 
     for (int32_t i = 1; i < num_dims; i++) {
         uint32_t num_unpadded_dim = input_shape[-(i + 1)];
         uint32_t num_total_dim = output_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        rev_stride[i] = stride[num_dims - (i + 1)];
+        uint32_t num_padded_dim;
+        if (strided) {
+            uint32_t dims_traversed = (rev_stride[i] * (num_unpadded_dim - 1));
+            uint32_t num_dims_to_skip = (num_total_dim - dims_traversed);
+            num_padded_dim = num_dims_to_skip * accumulated_total_per_dim[i - 1];
+        } else {
+            num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        }
+
         num_input_sticks_per_dim[i] = num_unpadded_dim;
         num_output_sticks_per_dim[i] = num_padded_dim;
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
@@ -85,6 +101,11 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
         accumulated_str += std::to_string(i) + ", ";
     }
 
+    std::string rev_stride_str = "";
+    for (auto& i : rev_stride) {
+        rev_stride_str += std::to_string(i) + ", ";
+    }
+
     using namespace tt::tt_metal::experimental;
     auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                     ? hal::get_dram_alignment()
@@ -92,7 +113,8 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
     uint32_t input_row_size_bytes_offset = tt::round_up(input_row_size_bytes, src_buffer_alignment);
 
     std::vector<uint32_t> common_writer_kernel_args = {
-        output_buffer->address() + output_tensor_start[-1] * output_tensor.element_size(),
+        // output_buffer->address() + output_tensor_start[-1] * output_tensor.element_size(),
+        output_buffer->address(),
         output_row_size_bytes,
         input_row_size_bytes,
         input_row_size_bytes_offset,
@@ -106,6 +128,11 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
         common_writer_kernel_args.end(), num_input_sticks_per_dim.begin(), num_input_sticks_per_dim.end());
     common_writer_kernel_args.insert(
         common_writer_kernel_args.end(), num_output_sticks_per_dim.begin(), num_output_sticks_per_dim.end());
+
+    std::cout << "num_input_sticks_per_dim: " << unpadded_sticks_str << std::endl;
+    std::cout << "num_output_sticks_per_dim: " << padded_sticks_str << std::endl;
+    std::cout << "accumulated_total_per_dim: " << accumulated_str << std::endl;
+    std::cout << "rev_stride: " << rev_stride_str << std::endl;
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
 
@@ -131,15 +158,27 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
                 tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, input_row_size_bytes, max_read_size);
             num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
         }
-        id_per_dim[0] = num_sticks_read % num_input_sticks_per_dim[0];
-        uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];
+        id_per_dim[0] =
+            num_sticks_read %
+            num_input_sticks_per_dim[0];  // is num_input_sticks_per_dim[0] always 1? Which means this is always 0
+        // std::cout << "Core: (" << core.x << "," << core.y << ") id_per_dim[0]: " << id_per_dim[0] << std::endl;
+        // std::cout << "num_sticks_read: " << num_sticks_read << std::endl;
+        uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];  // is this always num_sticks_read?
         uint32_t start_id = id_per_dim[0] + start_offset;
 
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
             unpadded_written = unpadded_written / num_input_sticks_per_dim[j];
-            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+            // std::cout << "start_id = " << start_id;
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1] * rev_stride[j];
+            // std::cout << " + " << id_per_dim[j] << " * " << accumulated_total_per_dim[j - 1] << " = " << start_id <<
+            // std::endl;
         }
+        // std::cout << "Core: (" << core.x << "," << core.y << ") id_per_dim: " << start_id << std::endl;
+        // for(auto id : id_per_dim) {
+        //     std::cout << id << ", ";
+        // }
+        // std::cout << std::endl;
         std::vector<uint32_t> writer_kernel_args = common_writer_kernel_args;
 
         uint32_t addr_offset = 5;  // output buffer addr, output_row_size_bytes, input_row_size_bytes, num_dims
@@ -148,6 +187,7 @@ static SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
         writer_kernel_args[addr_offset++] = num_sticks_per_core_read;
         writer_kernel_args[addr_offset] = num_read_per_barrier;
         writer_kernel_args.insert(writer_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+        writer_kernel_args.insert(writer_kernel_args.end(), rev_stride.begin(), rev_stride.end());
 
         std::vector<uint32_t> reader_kernel_args = {
             input_buffer->address(),
@@ -790,7 +830,8 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
     const Tensor& input,
     const Tensor& output,
     const ttnn::Shape& output_tensor_start,
-    const ttnn::Shape& output_tensor_end) {
+    const ttnn::Shape& output_tensor_end,
+    const ttnn::Shape& stride) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = input.device();
@@ -836,7 +877,8 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
         reader_defines["LAST_DIM"] = "1";
     }
 
-    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;  // cb for reading in input
+    const uint32_t dst0_cb_index = tt::CBIndex::c_1;  // cb for reading in output pages for last dim striding
     uint32_t cb_page_size = tt::round_up(input_row_size_bytes, alignment);
 
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
@@ -854,8 +896,26 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
             .set_page_size(src0_cb_index, cb_page_size);
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
+    std::map<std::string, std::string> writer_defines;
+    if (stride[-1] != 1) {
+        writer_defines["LAST_DIM_STRIDED"] = "1";
+        uint32_t output_row_size_bytes = input_padded_shape[-1] * input.element_size();
+        cb_page_size = tt::round_up(output_row_size_bytes, alignment);
+        tt::tt_metal::CircularBufferConfig cb_dst0_config =
+            tt::tt_metal::CircularBufferConfig(
+                num_read_per_barrier * 2 * cb_page_size,
+                {{dst0_cb_index, cb_data_format}})  // input/output data_formats should be the same
+                .set_page_size(dst0_cb_index, cb_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_dst0_config);
+    }
+
     std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_cb_index, page_alignment_offset};
-    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, page_alignment_offset};
+    std::vector<uint32_t> writer_compile_time_args_vec = {
+        (std::uint32_t)src0_cb_index,
+        page_alignment_offset,
+        (std::uint32_t)dst0_cb_index,
+        begins_bytes,
+        output.element_size()};
     tt::tt_metal::TensorAccessorArgs(src0_buffer).append_to(reader_compile_time_args_vec);
     tt::tt_metal::TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args_vec);
 
@@ -866,17 +926,19 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args_vec, reader_defines));
 
+    writer_defines["DEBUG"] = "1";
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/"
-        "slice_write_writer_interleaved.cpp",
+        "slice_write_writer_interleaved_strided.cpp",
         total_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec, writer_defines));
 
     auto all_runtime_args = get_slice_write_runtime_args_rm(
         input,
         output,
         output_tensor_start,
+        stride,
         num_cores_total,
         num_cores,
         num_cores_y,
@@ -916,10 +978,13 @@ static operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
 
             const auto tensor_start =
                 static_cast<const ttnn::operations::experimental::SliceWriteDeviceOperation*>(operation)->slice_start;
+            const auto stride =
+                static_cast<const ttnn::operations::experimental::SliceWriteDeviceOperation*>(operation)->step;
             auto all_runtime_args = get_slice_write_runtime_args_rm(
                 src_tensor,
                 dst_tensor,
                 tensor_start,
+                stride,
                 num_cores_total,
                 num_cores,
                 num_cores_y,
@@ -953,8 +1018,8 @@ operation::ProgramWithCallbacks slice_write_multi_core(
         }
     }
     TT_FATAL(!output.is_sharded(), "Sharded output is not supported for slice_write operation");
-    TT_FATAL(!has_step, "Step is not supported for slice_write operation");
     if (a.is_sharded()) {  // Supports Height & Block Sharding
+        TT_FATAL(!has_step, "Step is not supported for sharded slice_write operation");
         if (a.layout() == Layout::ROW_MAJOR) {
             return slice_write_rm_sharded_input_multi_core(a, output, output_tensor_start, output_tensor_end);
         } else if (a.layout() == Layout::TILE) {
@@ -963,7 +1028,7 @@ operation::ProgramWithCallbacks slice_write_multi_core(
             TT_THROW("Unsupported output memory layout for slice_write operation");
         }
     } else if (!a.is_sharded()) {
-        return slice_write_rm_interleaved_multi_core(a, output, output_tensor_start, output_tensor_end);
+        return slice_write_rm_interleaved_multi_core(a, output, output_tensor_start, output_tensor_end, step);
     }
     TT_THROW("Unsupport input memory layout for slice_write operation");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -20,6 +20,7 @@ namespace ttnn::operations::experimental {
 ttnn::Tensor SliceWriteOperation::invoke(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& output_tensor,
+    // ttnn::Tensor& output_tensor,
     const ttnn::SmallVector<uint32_t>& begins,
     const ttnn::SmallVector<uint32_t>& ends,
     const ttnn::SmallVector<uint32_t>& step) {
@@ -29,7 +30,15 @@ ttnn::Tensor SliceWriteOperation::invoke(
 
     bool no_step = std::all_of(step.begin(), step.end(), [](uint32_t s) { return s == 1; });
 
-    TT_FATAL(no_step, "Slice Write does not support strides");
+    // TT_FATAL(no_step, "Slice Write does not support strides");
+
+    // bool rm_only_not_sharded = (input_tensor.layout() == Layout::TILE || output_tensor.layout() == Layout::TILE)
+    //                             && !(input_tensor.is_sharded() || output_tensor.is_sharded());
+    // std::cout << "rm_only_not_sharded: " << rm_only_not_sharded << std::endl; // --- IGNORE ---
+    // ttnn::Tensor input = input_tensor;
+    // if (rm_only_not_sharded) {
+    //     input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
+    // }
 
     bool rm_only = !no_step && input_tensor.layout() == Layout::TILE;
     ttnn::Tensor input = input_tensor;
@@ -126,6 +135,10 @@ ttnn::Tensor SliceWriteOperation::invoke(
         }
         log_debug(tt::LogOp, "Invoking SliceWriteDeviceOperation");
 
+        // If the operation has stride and output is tiled, convert output to RM
+        // if (rm_only_not_sharded) {
+        //     output_tensor = ttnn::to_layout(output_tensor, Layout::ROW_MAJOR);
+        // }
         (void)tt::tt_metal::operation::run(
             SliceWriteDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step)},
             {input},

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -19,7 +19,6 @@ namespace ttnn::operations::experimental {
 
 ttnn::Tensor SliceWriteOperation::invoke(
     const ttnn::Tensor& input_tensor,
-    // const ttnn::Tensor& output_tensor,
     ttnn::Tensor& output_tensor,
     const ttnn::SmallVector<uint32_t>& begins,
     const ttnn::SmallVector<uint32_t>& ends,
@@ -32,17 +31,10 @@ ttnn::Tensor SliceWriteOperation::invoke(
 
     bool rm_only_not_sharded = (input_tensor.layout() == Layout::TILE || output_tensor.layout() == Layout::TILE) &&
                                !(input_tensor.is_sharded() || output_tensor.is_sharded());
-    std::cout << "rm_only_not_sharded: " << rm_only_not_sharded << std::endl;  // --- IGNORE ---
     ttnn::Tensor input = input_tensor;
     if (rm_only_not_sharded) {
         input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
     }
-
-    // bool rm_only = !no_step && input_tensor.layout() == Layout::TILE;
-    // ttnn::Tensor input = input_tensor;
-    // if (rm_only) {
-    //     input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
-    // }
 
     TT_FATAL(!output_tensor.is_sharded(), "Slice Write currently doesn't support sharded output tensors.");
     const bool tiled = input.layout() == Layout::TILE;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -126,6 +126,7 @@ ttnn::Tensor SliceWriteOperation::invoke(
         log_debug(tt::LogOp, "Invoking SliceWriteDeviceOperation");
 
         // If the operation has stride and output is tiled, convert output to RM
+        auto original_output_layout = output_tensor.layout();
         if (rm_only_not_sharded) {
             output_tensor = ttnn::to_layout(output_tensor, Layout::ROW_MAJOR);
         }
@@ -135,7 +136,7 @@ ttnn::Tensor SliceWriteOperation::invoke(
             {},
             {output_tensor})[0];
         if (rm_only_not_sharded) {
-            output_tensor = ttnn::to_layout(output_tensor, output_tensor.layout());
+            output_tensor = ttnn::to_layout(output_tensor, original_output_layout);
         }
         return output_tensor;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -30,7 +30,7 @@ ttnn::Tensor SliceWriteOperation::invoke(
     bool no_step = std::all_of(step.begin(), step.end(), [](uint32_t s) { return s == 1; });
 
     bool rm_only_not_sharded = (input_tensor.layout() == Layout::TILE || output_tensor.layout() == Layout::TILE) &&
-                               !(input_tensor.is_sharded() || output_tensor.is_sharded());
+                               !(input_tensor.is_sharded() || output_tensor.is_sharded() && !no_step);
     ttnn::Tensor input = input_tensor;
     if (rm_only_not_sharded) {
         input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -13,8 +13,8 @@ namespace experimental {
 struct SliceWriteOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& output_tensor,
-        // ttnn::Tensor& output_tensor,
+        // const ttnn::Tensor& output_tensor,
+        ttnn::Tensor& output_tensor,
         const ttnn::SmallVector<uint32_t>& output_tensor_start,
         const ttnn::SmallVector<uint32_t>& output_tensor_end,
         const ttnn::SmallVector<uint32_t>& step);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -13,7 +13,6 @@ namespace experimental {
 struct SliceWriteOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        // const ttnn::Tensor& output_tensor,
         ttnn::Tensor& output_tensor,
         const ttnn::SmallVector<uint32_t>& output_tensor_start,
         const ttnn::SmallVector<uint32_t>& output_tensor_end,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -14,6 +14,7 @@ struct SliceWriteOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& output_tensor,
+        // ttnn::Tensor& output_tensor,
         const ttnn::SmallVector<uint32_t>& output_tensor_start,
         const ttnn::SmallVector<uint32_t>& output_tensor_end,
         const ttnn::SmallVector<uint32_t>& step);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
@@ -58,6 +58,7 @@ void bind_slice_write(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& output_tensor,
+               //    ttnn::Tensor& output_tensor,
                const ttnn::SmallVector<uint32_t>& start,
                const ttnn::SmallVector<uint32_t>& end,
                const ttnn::SmallVector<uint32_t>& step) { return self(input_tensor, output_tensor, start, end, step); },

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
@@ -57,7 +57,6 @@ void bind_slice_write(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               //    const ttnn::Tensor& output_tensor,
                ttnn::Tensor& output_tensor,
                const ttnn::SmallVector<uint32_t>& start,
                const ttnn::SmallVector<uint32_t>& end,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
@@ -57,8 +57,8 @@ void bind_slice_write(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const ttnn::Tensor& output_tensor,
-               //    ttnn::Tensor& output_tensor,
+               //    const ttnn::Tensor& output_tensor,
+               ttnn::Tensor& output_tensor,
                const ttnn::SmallVector<uint32_t>& start,
                const ttnn::SmallVector<uint32_t>& end,
                const ttnn::SmallVector<uint32_t>& step) { return self(input_tensor, output_tensor, start, end, step); },


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13723)

### Problem description
Allow strided slice write and ensure tiled inputs are supported

### What's changed
Added stride calculations to program factory and kernel.
When strided on the last dim, load in the output row, fill it with the input with stride, and then write it back to the output.
If input/output is tilized and not sharded, untilize, perform op, then retilize. Had to remove const for the output tensor to do this. This makes sense anyway as this is an in-place operation.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17682574557) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17657986401) CI with demo tests passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17657989228) CI passes (if applicable)