### PR TITLE
Adjust prefill_pcc for 6U to match improved PCC from updated reciprocal.

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo_targets.json
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo_targets.json
@@ -8,7 +8,7 @@
             "token_pos": 127
         },
         "6U": {
-            "prefill_pcc": 0.9130302621110833,
+            "prefill_pcc": 0.9180439801757613,
             "decode_pcc": 0.9526383708858326,
             "throughput": 72,
             "absolute_margin": 2.0,


### PR DESCRIPTION
Reciprocal on WH is being improved slightly, which seems to improve PCC for this 6U Galaxy test which does an exact PCC check.

### Ticket

https://github.com/tenstorrent/tt-llk/pull/648

### Problem description

This test fails if the PCC changes (up or down).  This seems strange and I don't know if it's deliberate.

### What's changed

- prefill_pcc has been updated.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
