### PR TITLE
[Fabric] stuff unicast 2 commands to single byte

### DIFF
--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -76,6 +76,8 @@ void fabric_set_route(
     uint32_t local_val;
     uint32_t forward_val;
     uint32_t end_hop = start_hop + num_hops;
+
+    // Pack two 4-bit hop commands per byte: even hop -> low nibble, odd hop -> high nibble
     for (uint32_t i = start_hop; i < end_hop; i++) {
         if constexpr (mcast) {
             // If forward north or forward south is set, then it may be 2d mcast and requires east/west forwarding, in
@@ -91,7 +93,13 @@ void fabric_set_route(
             forward_val = terminate ? (i == end_hop - 1 ? 0 : forward_packet) : forward_packet;
             local_val = terminate ? (i == end_hop - 1 ? local_packet : 0) : 0;
         }
-        route_vector[i] = local_val | forward_val;
+        uint8_t cmd = static_cast<uint8_t>((local_val | forward_val) & 0x0F);
+        uint32_t byte_index = i >> 1;             // i / 2
+        bool use_high_nibble = (i & 1) != 0;      // odd hop -> high nibble
+        uint8_t prev = route_vector[byte_index];  // previous packed byte
+        uint8_t packed = use_high_nibble ? static_cast<uint8_t>((prev & 0x0F) | (cmd << 4))
+                                         : static_cast<uint8_t>((prev & 0xF0) | cmd);
+        route_vector[byte_index] = packed;
     }
     packet_header->routing_fields.hop_index = 0;
 }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1761,7 +1761,13 @@ void run_receiver_channel_step_impl(
                 packet_header, downstream_edm_interfaces_vc0, downstream_edm_interface_vc1, port_direction_table);
 #elif defined(FABRIC_2D)
             // need this ifdef since the packet header for 1D does not have router_buffer field in it.
-            hop_cmd = packet_header->route_buffer[cached_routing_fields.hop_index];
+            // Packed format: 2 hops per byte, low nibble first.
+            {
+                uint16_t hop_index = cached_routing_fields.hop_index;
+                uint8_t packed = packet_header->route_buffer[hop_index >> 1];
+                bool high = (hop_index & 1) != 0;
+                hop_cmd = high ? ((packed >> 4) & 0x0F) : (packed & 0x0F);
+            }
             can_send_to_all_local_chip_receivers = can_forward_packet_completely<receiver_channel>(
                 hop_cmd, downstream_edm_interfaces_vc0, downstream_edm_interface_vc1);
 #endif

--- a/tt_metal/tools/profiler/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/fabric_event_profiler.hpp
@@ -21,22 +21,27 @@ FORCE_INLINE void recordRoutingFields2D(
     routing_fields_2d.noc_xfer_type = KernelProfilerNocEventMetadata::NocEventType::FABRIC_ROUTING_FIELDS_2D;
 
     // dimension order routing: first we have N/S forwarding with possible branching/local writes for mcast
+    // Packed format: 2 hops per byte. Iterate nibble by nibble.
     uint8_t total_hops = 0;
-    while (route_buffer[total_hops] & tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS) {
+    auto get_nibble = [&](uint16_t hop_index) -> uint8_t {
+        uint8_t packed = route_buffer[hop_index >> 1];
+        return (hop_index & 1) ? ((packed >> 4) & 0x0F) : (packed & 0x0F);
+    };
+    while (get_nibble(total_hops) & tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS) {
         total_hops++;
     }
 
     routing_fields_2d.ns_hops = total_hops;
 
     // compute e/w hops and check for e/w line mcast
-    while (route_buffer[total_hops] != tt::tt_fabric::LowLatencyMeshRoutingFields::NOOP) {
+    while (get_nibble(total_hops) != tt::tt_fabric::LowLatencyMeshRoutingFields::NOOP) {
         total_hops++;
     }
 
     // Look at last entry in buffer to check if west branch exists
     // If west branch exists, compute west hops and east hops as remaining
     // Otherwise, we only have east hops (which is trivially to 0 if we have no e/w hops at all)
-    if (route_buffer[total_hops - 1] == tt::tt_fabric::LowLatencyMeshRoutingFields::FORWARD_EAST) {
+    if (get_nibble(total_hops - 1) == tt::tt_fabric::LowLatencyMeshRoutingFields::FORWARD_EAST) {
         routing_fields_2d.w_hops = total_hops - routing_fields.branch_west_offset;
         routing_fields_2d.e_hops = routing_fields.branch_west_offset - routing_fields_2d.ns_hops;
     } else {
@@ -48,9 +53,9 @@ FORCE_INLINE void recordRoutingFields2D(
     if (routing_fields_2d.ns_hops > 0 &&
             (route_buffer[0] & tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS) ==
                 tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_NS ||
-        routing_fields_2d.e_hops > 0 && route_buffer[routing_fields.branch_east_offset] ==
+        routing_fields_2d.e_hops > 0 && get_nibble(routing_fields.branch_east_offset) ==
                                             tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_EW ||
-        routing_fields_2d.w_hops > 0 && route_buffer[routing_fields.branch_west_offset] ==
+        routing_fields_2d.w_hops > 0 && get_nibble(routing_fields.branch_west_offset) ==
                                             tt::tt_fabric::LowLatencyMeshRoutingFields::WRITE_AND_FORWARD_EW ||
         routing_fields_2d.e_hops > 0 && routing_fields_2d.w_hops > 0) {
         routing_fields_2d.is_mcast = true;


### PR DESCRIPTION
### Ticket

### Problem description
2D routing command is 4 bits each, but it is stuffed to 8 bits region which is inefficient memory usage.
This blocks using https://github.com/tenstorrent/tt-metal/pull/27660 for production

### What's changed
Stuff 2 commands in 1 byte. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes