### PR TITLE
Extend ttnn binary GE and LE int32 range

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -574,6 +574,8 @@ def test_binary_mul_int32_edge_cases(use_legacy, device):
     [
         ttnn.lt,
         ttnn.gt,
+        ttnn.ge,
+        ttnn.le,
     ],
 )
 def test_comp_ops_implicit_broadcast(device, shapes, ttnn_op):
@@ -583,9 +585,6 @@ def test_comp_ops_implicit_broadcast(device, shapes, ttnn_op):
     max_int = torch.iinfo(torch.int32).max
     torch_input_tensor_a = torch.randint(low=min_int, high=max_int, size=shapes[0], dtype=torch.int32)
     torch_input_tensor_b = torch.randint(low=min_int, high=max_int, size=shapes[1], dtype=torch.int32)
-
-    golden_function = ttnn.get_golden_function(ttnn_op)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -602,6 +601,9 @@ def test_comp_ops_implicit_broadcast(device, shapes, ttnn_op):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
     output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -613,6 +615,8 @@ def test_comp_ops_implicit_broadcast(device, shapes, ttnn_op):
     [
         ttnn.lt,
         ttnn.gt,
+        ttnn.ge,
+        ttnn.le,
     ],
 )
 def test_comp_ops_edge_cases(ttnn_op, device):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -9,7 +9,7 @@
 
 namespace ckernel::sfpu {
 
-// Relational ops use int32 subtract (whose result in also in the int32 range) + sign check.
+// Comparison ops use int32 subtract (whose result in also in the int32 range) + sign check.
 // In order to avoid overflow for inputs of opposite signs, the output is determined directly from a sign check.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -22,16 +22,16 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
         // operand B
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
 
+        // Extract sign bits of A and B
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
+
+        // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
+        TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
         if constexpr (RELATIONAL_OP == SfpuType::lt) {
-            // Extract sign bits of A and B
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
             // if (LREG_3 == 0) -> use int32 subtract + extract sign
             TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
             // (A - B) -> Use 6 or LO16 as imod to convert operand B to 2's complement
@@ -48,16 +48,8 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
 
             // LREG_1 -> dest
             TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
+
         } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
-            // Extract sign bits of A and B
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
             // if (LREG_3 == 0) -> use int32 subtract + extract sign
             TTI_SFPSETCC(0, p_sfpu::LREG3, 0, SFPSETCC_MOD1_LREG_EQ0);
             // (B - A) -> Use 6 or LO16 as imod to convert operand B to 2's complement
@@ -71,6 +63,44 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
+
+            // LREG_0 -> dest
+            TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
+
+        } else if constexpr (RELATIONAL_OP == SfpuType::ge) {
+            // Implement GE by using LT logic and then inverting the result
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
+            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x00);
+            TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+
+            // XOR with 1 to invert the result
+            TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
+
+            // LREG_1 -> dest
+            TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
+
+        } else if constexpr (RELATIONAL_OP == SfpuType::le) {
+            // Implements LE by using GT logic and then inverting the result
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
+            TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x00);
+            TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+
+            // XOR with 1 to invert the result
+            TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);
 
             // LREG_0 -> dest
             TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -9,7 +9,7 @@
 
 namespace ckernel::sfpu {
 
-// Comparison ops use int32 subtract (whose result in also in the int32 range) + sign check.
+// Comparison ops use int32 subtract (whose result is also in the int32 range) + sign check.
 // In order to avoid overflow for inputs of opposite signs, the output is determined directly from a sign check.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -44,7 +44,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
 
             // LREG_1 -> dest
             TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
@@ -62,7 +61,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
 
             // LREG_0 -> dest
             TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_7, dst_index_out * dst_tile_size);
@@ -76,7 +74,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x00);
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
 
             // XOR with 1 to invert the result
@@ -95,7 +92,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x00);
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
 
             // XOR with 1 to invert the result

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -42,4 +42,36 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
         vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::ge>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::le>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -83,6 +83,8 @@ enum SfpuType {
     mul_int32,
     lt,
     gt,
+    ge,
+    le,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -9,7 +9,7 @@
 
 namespace ckernel::sfpu {
 
-// Relational ops use int32 subtract (whose result in also in the int32 range) + sign check.
+// Comparison ops use int32 subtract (whose result in also in the int32 range) + sign check.
 // In order to avoid overflow for inputs of opposite signs, the output is determined directly from a sign check.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -22,16 +22,16 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
         // operand B
         TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
 
+        // Extract sign bits of A and B
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
+        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
+
+        // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
+        TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
         if constexpr (RELATIONAL_OP == SfpuType::lt) {
-            // Extract sign bits of A and B
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
             // if (LREG_3 == 0) -> use int32 subtract + extract sign
             TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
             // (A - B) -> Use 6 or LO16 as imod to convert operand B to 2's complement
@@ -48,16 +48,8 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
 
             // LREG_1 -> dest
             TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
+
         } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
-            // Extract sign bits of A and B
-            TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-            TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-            // LREG_3 -> 0 for inputs of same sign, 1 for inputs of different signs
-            TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
-
             // if (LREG_3 == 0) -> use int32 subtract + extract sign
             TTI_SFPSETCC(0, p_sfpu::LREG3, 0, SFPSETCC_MOD1_LREG_EQ0);
             // (B - A) -> Use 6 or LO16 as imod to convert operand B to 2's complement
@@ -71,6 +63,44 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
+
+            // LREG_0 -> dest
+            TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
+
+        } else if constexpr (RELATIONAL_OP == SfpuType::ge) {
+            // Implements GE by using LT logic and then inverting the result
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0 /*unused*/, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
+            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x00);
+            TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+
+            // XOR with 1 to invert the result
+            TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
+
+            // LREG_1 -> dest
+            TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
+
+        } else if constexpr (RELATIONAL_OP == SfpuType::le) {
+            // Implements LE by using GT logic and then inverting the result
+            TTI_SFPSETCC(0, p_sfpu::LREG3, 0, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+            TTI_SFPCOMPC(0 /*unused*/, 0 /*unused*/, 0 /*unused*/, 0 /*unused*/);
+            TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x00);
+            TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+
+            // XOR with 1 to invert the result
+            TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0x01);
+            TTI_SFPXOR(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);
 
             // LREG_0 -> dest
             TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -9,7 +9,7 @@
 
 namespace ckernel::sfpu {
 
-// Comparison ops use int32 subtract (whose result in also in the int32 range) + sign check.
+// Comparison ops use int32 subtract (whose result is also in the int32 range) + sign check.
 // In order to avoid overflow for inputs of opposite signs, the output is determined directly from a sign check.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
@@ -44,7 +44,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
 
             // LREG_1 -> dest
             TT_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
@@ -62,7 +61,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
             TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
 
             // LREG_0 -> dest
             TT_SFPSTORE(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
@@ -76,7 +74,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x00);
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_NE0);
             TTI_SFPLOADI(p_sfpu::LREG1, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
 
             // XOR with 1 to invert the result
@@ -95,7 +92,6 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x00);
             TTI_SFPSETCC(0, p_sfpu::LREG2, 0, SFPSETCC_MOD1_LREG_EQ0);
             TTI_SFPLOADI(p_sfpu::LREG0, SFPLOADI_MOD0_USHORT, 0x01);
-            TTI_SFPENCC(0, 0, 0, 0);
             TTI_SFPENCC(0, 0, 0, 0);
 
             // XOR with 1 to invert the result

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -42,4 +42,36 @@ inline void llk_math_eltwise_binary_sfpu_gt_int32(
         vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::ge>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, 8, SfpuType::le>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -84,6 +84,8 @@ enum class SfpuType {
     mul_int32,
     lt,
     gt,
+    ge,
+    le,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/include/compute_kernel_api/binary_comp.h
+++ b/tt_metal/include/compute_kernel_api/binary_comp.h
@@ -38,11 +38,23 @@ ALWI void gt_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_gt_int32<APPROX>(idst0, idst1, odst)));
 }
 
+ALWI void ge_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_ge_int32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void le_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_le_int32<APPROX>(idst0, idst1, odst)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
 ALWI void lt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_int32_init<APPROX>())); }
 
 ALWI void gt_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_int32_init<APPROX>())); }
+
+ALWI void ge_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_int32_init<APPROX>())); }
+
+ALWI void le_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_int32_init<APPROX>())); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -412,19 +412,21 @@ std::map<std::string, std::string> get_defines_fp32(
             break;
         case BinaryOpType::GE:
             if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
-                op_name = "sub_int32_tile";
+                new_defines.insert({"GE_INT32_INIT", fmt::format("ge_int32_tile_init();")});
+                op_name = "ge_int32_tile";
             } else {
                 op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1, input_a_dtype));
             }
-            new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::LE:
             if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
-                op_name = "sub_int32_tile";
+                new_defines.insert({"LE_INT32_INIT", fmt::format("le_int32_tile_init();")});
+                op_name = "le_int32_tile";
             } else {
                 op_name = "sub_binary_tile";
+                new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1, input_a_dtype));
             }
-            new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::EQ:
             if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -136,6 +136,12 @@ void MAIN {
 #ifdef GT_INT32_INIT
             GT_INT32_INIT
 #endif
+#ifdef GE_INT32_INIT
+            GE_INT32_INIT
+#endif
+#ifdef LE_INT32_INIT
+            LE_INT32_INIT
+#endif
 #ifdef BITWISE_INIT
             BITWISE_INIT
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -166,8 +166,20 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
                 binary_op = SfpuBinaryOp::GT;
             }
             break;
-        case BinaryOpType::GE: postprocess = unary::UnaryOpType::GEZ; break;
-        case BinaryOpType::LE: postprocess = unary::UnaryOpType::LEZ; break;
+        case BinaryOpType::GE:
+            if (dtype != DataType::INT32) {
+                postprocess = unary::UnaryOpType::GEZ;
+            } else {
+                binary_op = SfpuBinaryOp::GE;
+            }
+            break;
+        case BinaryOpType::LE:
+            if (dtype != DataType::INT32) {
+                postprocess = unary::UnaryOpType::LEZ;
+            } else {
+                binary_op = SfpuBinaryOp::LE;
+            }
+            break;
         case BinaryOpType::EQ: postprocess = unary::UnaryOpType::EQZ; break;
         case BinaryOpType::NE: postprocess = unary::UnaryOpType::NEZ; break;
         // (a-b)**2
@@ -431,6 +443,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case LT: return {"lt_int32_tile_init();", "lt_int32_tile"};
         case GT: return {"gt_int32_tile_init();", "gt_int32_tile"};
+        case GE: return {"ge_int32_tile_init();", "ge_int32_tile"};
+        case LE: return {"le_int32_tile_init();", "le_int32_tile"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -67,6 +67,8 @@ struct OpConfig {
         XLOGY,
         LT,
         GT,
+        GE,
+        LE,
     };
 
     template <class EnumT>


### PR DESCRIPTION
### Ticket
#25112 

### Problem description
Binary Less-than-or-equal-to (ttnn.le) and Greater-than-or-equal-to (ttnn.ge) ops does not support the entire int32 range due to their dependence on int32 subtract tile. Integer overflow occurs when the subtraction result of inputs of opposite signs goes beyond the int32 range causing the value to wrap around, thereby affecting the outputs of lez/gez checks.

### What's changed
Provided kernel implementation that uses less-than and greater-than logic and simply flips the results.

### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17860964794 - same as main
Latest Run: https://github.com/tenstorrent/tt-metal/actions/runs/18032988452 - same as main
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/17860982972 - same as main
Latest Run: https://github.com/tenstorrent/tt-metal/actions/runs/18032994640 (pipeline disabled for timeout re-run)
- [x] (Blackhole) Blackhole nightly tests - https://github.com/tenstorrent/tt-metal/actions/runs/17935990841 - same as main
- [x] New/Existing tests provide coverage for changes