### PR TITLE
Fused Doc Cleanup

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -460,7 +460,7 @@ def test_softmax_dtypes(device, shape, dim, dtype):
 
 
 @pytest.mark.parametrize(
-    "accuracy_config",
+    "fp32_acc_en, math_approx_mode, expected_ulp",
     [
         (True, False, 3),
         (False, True, 11),
@@ -469,7 +469,7 @@ def test_softmax_dtypes(device, shape, dim, dtype):
     ],
 )
 @pytest.mark.parametrize("shape", [(1, 1, 16384, 256)])
-def test_softmax_accuracy(device, shape, accuracy_config):
+def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected_ulp):
     torch.manual_seed(0)
 
     # Reference output
@@ -477,8 +477,6 @@ def test_softmax_accuracy(device, shape, accuracy_config):
     torch_output = torch.ops.aten._softmax.default(torch_tensor, dim=-1, half_to_float=False)
 
     # TTNN Softmax
-    fp32_acc_en, math_approx_mode, expected_ulp = accuracy_config
-
     compute_kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=math_approx_mode,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -18,23 +18,34 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
         module,
         ttnn::group_norm,
         R"doc(
-            Computes group_norm over :attr:`input_tensor`.
-            See `Group Normalization <https://arxiv.org/abs/1803.08494>`_ for more details.
+                Computes group_norm over :attr:`input_tensor`.
+                See `Group Normalization <https://arxiv.org/abs/1803.08494>`_ for more details.
 
-            .. math::
-                \text{group_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
+                .. math::
+                    \text{group_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
 
-            Where:
-                - :math:`\mu` and :math:`\sigma^2` are the mean and variance of the input tensor, respectively
-                - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
-                - :math:`\epsilon` is a small constant.
+                Where:
+                    - :math:`\mu` and :math:`\sigma^2` are the mean and variance of the input tensor, respectively
+                    - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
+                    - :math:`\epsilon` is a small constant.
+
+                GroupNorm traditionally operates by splitting the input tensor's channels into groups, and then computing the mean and variance of each group.
+                This implementation is slightly different, in that it forms the groups using the tensor's last dimension.
+                Concretely, the input tensor is expected to have a shape of [N, 1, H*W, C], where C is the dimension along which the groups are formed.
+
+                TTNN provides several functions to help with the preparation of the inputs to this op.
+                    - When using sharded input tensors, :func:`ttnn.determine_expected_group_norm_sharded_config_and_grid_size` can provide the appropriate memory configuration and grid size.
+                    - :func:`ttnn.create_group_norm_input_mask` creates the appropriate input mask for a given tensor dimension and group size.
+                    - :func:`ttnn.create_group_norm_weight_bias_rm` converts the weight and bias tensors into appropriately padded and tiled inputs
+
+                See the sharded example in this documentation for more details on how to properly supply the inputs for this op in conjunction with these functions.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
 
             Keyword args:
-                num_groups (int)
-                epsilon (float): 1e-12.
+                num_groups (int): Number of groups to split the tensor into.
+                epsilon (float): Defaults to 1e-12.
                 input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
                 weight (ttnn.Tensor, optional): Defaults to `None`.
                 bias (ttnn.Tensor, optional): Defaults to `None`.
@@ -88,15 +99,111 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                         - TILE, ROW_MAJOR
 
             Limitations:
-              - Inputs are 4D tensors already allocated on device.
-              - :attr:`input_tensor` is of shape [N, 1, H*W, C]
-              - :attr:`gamma` and :attr:`beta` must be provided
-              - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must be a multiple of :attr:`num_groups`.
+              - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
+              - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
+              - :attr:`gamma` and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.
               - Width-sharding is not supported (use height or block sharding)
+
+            Example (Sharded Input):
+                .. code-block:: python
+
+                    N, C, H, W = 1, 64, 32, 1
+                    num_groups = 4
+
+                    # Generate random inputs and reference output
+                    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+                    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+                    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+
+                    torch_output_tensor = torch.nn.functional.group_norm(
+                        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
+                    )
+
+                    # Permute to match the format TTNN will output the tensor in
+                    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+                    #Prepare TTNN input
+
+                    # Determine how to shard the input tensor
+                    sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
+                        device = device,
+                        num_channels = C,
+                        num_groups = num_groups,
+                        input_nhw = N * H * W,
+                        is_height_sharded = True,
+                        is_row_major = True
+                    )
+
+                    # Convert the input tensor to a sharded TTNN tensor
+                    input_tensor = ttnn.from_torch(
+                        torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C),
+                        dtype=ttnn.DataType.BFLOAT16,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        device=device,
+                        memory_config=sharded_mem_config,
+                    )
+
+                    # Input mask - this is needed for each group to be able to select the correct elements of the input tensor
+                    # Generally, it will have dimensions of [1, num_groups, 32, 32*block_wt]
+
+                    # In this example, C=64 and num_groups=2, so each group is 32 channels (i.e. one tile) wide
+                    # As a result, the input_mask_tensor is a [1, 2, 32, 32] tensor where every value is 1
+
+                    # If instead num_groups was 4, each group would be 16 channels (i.e. half a tile) wide
+                    # As a result, the input_mask_tensor would be a [1, 4, 32, 32] tensor that selects either the first or second half of the tile
+                    # e.g. The mask at [0][0][:][:] would be a 32x32 tensor where the left half is 1 and the right half is 0
+                    # While [0][1][:][:] would be a 32x32 tensor where the left half is 0 and the right half is 1
+
+                    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, 1) # Supply 1 for height sharded
+
+                    input_mask_tensor = ttnn.from_torch(
+                        input_mask_tensor,
+                        dtype=ttnn.DataType.BFLOAT8_B,
+                        layout=ttnn.TILE_LAYOUT,
+                        device=device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+
+                    # Prepare gamma and beta for TTNN. Traditionally, these are just 1D tensors of size [C], which isn't compatible with tile based processing
+                    # First they will zero padded if needed (does not apply to this example)
+                    # Then reshaped to be [1, 1, tiles_per_core_total, 32], which in this case will be [1, 1, 2, 32]
+
+                    # Note that we are height sharding the input tensor, so we set num_cores_x = 1, as explained in the Limitations
+                    gamma = ttnn.create_group_norm_weight_bias_rm(input_tensor =torch_weight, num_channels = C, num_cores_x = 1)
+                    beta = ttnn.create_group_norm_weight_bias_rm(input_tensor =torch_bias, num_channels = C, num_cores_x = 1)
+
+                    gamma_t = ttnn.from_torch(
+                        gamma,
+                        dtype=ttnn.DataType.BFLOAT16,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        device=device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+                    beta_t = ttnn.from_torch(
+                        beta,
+                        dtype=ttnn.DataType.BFLOAT16,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        device=device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+
+                    # Compute the TTNN output and compare with the reference output
+                    output_tensor = ttnn.group_norm(
+                        input_tensor,
+                        num_groups=num_groups,
+                        input_mask=input_mask_tensor,
+                        weight=gamma_t,
+                        bias=beta_t,
+                        memory_config=sharded_mem_config,
+                        core_grid=grid_size,
+                    )
+
+                    output_tensor = ttnn.to_torch(output_tensor)
+                    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
             Example:
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -112,7 +112,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                 .. code-block:: python
 
                     N, C, H, W = 1, 64, 32, 1
-                    num_groups = 4
+                    num_groups = 2
 
                     # Generate random inputs and reference output
                     torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -32,27 +32,26 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
 
-          Keyword args:
-              num_groups (int)
-              epsilon (float): 1e-12.
-              input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
-              weight (ttnn.Tensor, optional): Defaults to `None`.
-              bias (ttnn.Tensor, optional): Defaults to `None`.
-              memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-              dtype (ttnn.DataType, optional): Defaults to `None`.
-              core_grid (CoreGrid, optional): Defaults to `None`.
-              inplace (bool, optional): Defaults to `True`.
-              output_layout (ttnn.Layout, optional): Defaults to `None`.
-              num_out_blocks (int, optional): Defaults to `None`.
-              compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
-              negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
+            Keyword args:
+                num_groups (int)
+                epsilon (float): 1e-12.
+                input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
+                weight (ttnn.Tensor, optional): Defaults to `None`.
+                bias (ttnn.Tensor, optional): Defaults to `None`.
+                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                dtype (ttnn.DataType, optional): Defaults to `None`.
+                core_grid (CoreGrid, optional): Defaults to `None`.
+                inplace (bool, optional): Defaults to `True`.
+                output_layout (ttnn.Layout, optional): Defaults to `None`.
+                num_out_blocks (int, optional): Defaults to `None`.
+                compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
+                negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
 
 
             Returns:
                 ttnn.Tensor: the output tensor.
 
             Note:
-
                 The supported input data types and layouts:
 
                 .. list-table:: input_tensor
@@ -98,8 +97,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - Width-sharding is not supported (use height or block sharding)
 
-              Example:
-
+            Example:
                 .. code-block:: python
 
                     tile_size = 32

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -33,18 +33,18 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                 This implementation is slightly different, in that it forms the groups using the tensor's last dimension.
                 Concretely, the input tensor is expected to have a shape of [N, 1, H*W, C], where C is the dimension along which the groups are formed.
 
-                TTNN provides several functions to help with the preparation of the inputs to this op.
+                TTNN provides utility functions to help prepare this op's inputs.
                     - When using sharded input tensors, :func:`ttnn.determine_expected_group_norm_sharded_config_and_grid_size` can provide the appropriate memory configuration and grid size.
                     - :func:`ttnn.create_group_norm_input_mask` creates the appropriate input mask for a given tensor dimension and group size.
                     - :func:`ttnn.create_group_norm_weight_bias_rm` converts the weight and bias tensors into appropriately padded and tiled inputs
 
-                See the sharded example in this documentation for more details on how to properly supply the inputs for this op in conjunction with these functions.
+                See the sharded example in this document for more details on how to properly prepare the op's inputs using these functions.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
 
             Keyword args:
-                num_groups (int): Number of groups to split the tensor into.
+                num_groups (int): Number of groups to split the tensor's channels into.
                 epsilon (float): Defaults to 1e-12.
                 input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
                 weight (ttnn.Tensor, optional): Defaults to `None`.
@@ -111,23 +111,23 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
             Example (Sharded Input):
                 .. code-block:: python
 
-                    N, C, H, W = 1, 64, 32, 1
+                     N, C, H, W = 1, 64, 32, 1
                     num_groups = 2
 
-                    # Generate random inputs and reference output
+                    # Prepare random inputs
                     torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
                     torch_weight = torch.rand((C,), dtype=torch.bfloat16)
                     torch_bias = torch.rand((C,), dtype=torch.bfloat16)
 
+                    # Generate random inputs and prepare reference output
                     torch_output_tensor = torch.nn.functional.group_norm(
                         torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
                     )
 
-                    # Permute to match the format TTNN will output the tensor in
+                    # Permute the torch output to match the TTNN format, so they can be compared
                     torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
 
                     #Prepare TTNN input
-
                     # Determine how to shard the input tensor
                     sharded_mem_config, grid_size = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
                         device = device,
@@ -138,7 +138,6 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                         is_row_major = True
                     )
 
-                    # Convert the input tensor to a sharded TTNN tensor
                     input_tensor = ttnn.from_torch(
                         torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C),
                         dtype=ttnn.DataType.BFLOAT16,
@@ -148,7 +147,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                     )
 
                     # Input mask - this is needed for each group to be able to select the correct elements of the input tensor
-                    # Generally, it will have dimensions of [1, num_groups, 32, 32*block_wt]
+                    # In general, it will have dimensions of [1, num_groups, 32, 32*block_wt]
 
                     # In this example, C=64 and num_groups=2, so each group is 32 channels (i.e. one tile) wide
                     # As a result, the input_mask_tensor is a [1, 2, 32, 32] tensor where every value is 1
@@ -157,8 +156,11 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                     # As a result, the input_mask_tensor would be a [1, 4, 32, 32] tensor that selects either the first or second half of the tile
                     # e.g. The mask at [0][0][:][:] would be a 32x32 tensor where the left half is 1 and the right half is 0
                     # While [0][1][:][:] would be a 32x32 tensor where the left half is 0 and the right half is 1
-
-                    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, 1) # Supply 1 for height sharded
+                    input_mask_tensor = ttnn.create_group_norm_input_mask(
+                        num_channels=C,
+                        num_groups=num_groups,
+                        num_cores_across_channel=1 # As explained in the Limitations, supply 1 for height sharded input tensors
+                    )
 
                     input_mask_tensor = ttnn.from_torch(
                         input_mask_tensor,
@@ -168,11 +170,11 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                         memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     )
 
-                    # Prepare gamma and beta for TTNN. Traditionally, these are just 1D tensors of size [C], which isn't compatible with tile based processing
+                    # Prepare gamma and beta for TTNN. Currently these are just 1D tensors of size [C], which isn't compatible with tile based processing
                     # First they will zero padded if needed (does not apply to this example)
                     # Then reshaped to be [1, 1, tiles_per_core_total, 32], which in this case will be [1, 1, 2, 32]
 
-                    # Note that we are height sharding the input tensor, so we set num_cores_x = 1, as explained in the Limitations
+                    # As with the input mask, we supply a core count of 1 for height sharded input tensors
                     gamma = ttnn.create_group_norm_weight_bias_rm(input_tensor =torch_weight, num_channels = C, num_cores_x = 1)
                     beta = ttnn.create_group_norm_weight_bias_rm(input_tensor =torch_bias, num_channels = C, num_cores_x = 1)
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -95,6 +95,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
+              - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.
               - Width-sharding is not supported (use height or block sharding)
 
             Example:

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -60,8 +60,8 @@ void bind_normalization_layernorm_operation(py::module& module) {
             program_config (ttnn.ProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig)
 
-            Returns:
-                ttnn.Tensor: the output tensor.
+        Returns:
+            ttnn.Tensor: the output tensor.
 
         Note:
             Supported data types and layouts by tensor:

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -112,9 +112,8 @@ void bind_normalization_layernorm_operation(py::module& module) {
             - All input tensors must be on-device.
             - Unsharded tensors must be interleaved, sharded tensors cannot be height sharded.
             - If `residual_input_tensor` is provided, it must match the input's padded shape.
-            - `weight`/`bias` tensors:
-              - If TILE: last padded dim must match input's last padded dim; padded height must equal TILE_HEIGHT (i.e. 32).
-              - If ROW_MAJOR: last padded dim must be TILE_WIDTH and the stick count must align with the input width.
+            - If TILE: `weight` and `bias` padded dim must match input's last padded dim; padded height must equal TILE_HEIGHT (i.e. 32).
+            - If ROW_MAJOR: `weight` and `bias` last padded dim must be TILE_WIDTH and the stick count must align with the input width.
             - If the input is sharded, the :attr:`output` and :attr:`residual_input_tensor` must have identical shard spec and memory config.
 
         Example:

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -41,7 +41,8 @@ void bind_normalization_layernorm_operation(py::module& module) {
                 \text{layer_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
 
             Where:
-                - :math:`\mu` and :math:`\sigma^2` are the mean and variance of the input tensor, respectively
+                - :math:`\mu` is the mean of the input tensor. This is computed over the last dimension of the input tensor (W).
+                - :math:`\sigma^2` is the variance of the input tensor. This is computed over the last dimension of the input tensor (W) and is biased.
                 - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
                 - :math:`\epsilon` is a small constant
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -106,10 +106,8 @@ void bind_normalization_layernorm_operation(py::module& module) {
                * - BFLOAT16, FLOAT32, BFLOAT8_B (typically matches input; PRE_ALL_GATHER produces BF16)
                  - TILE
 
-            Rank: input rank must be >= 1. See Limitations for additional sharding/distributed constraints.
-
         Limitations:
-            - All input tensors must be on-device.
+            - All input tensors must be on-device and have a rank >= 1.
             - Unsharded tensors must be interleaved, sharded tensors cannot be height sharded.
             - If `residual_input_tensor` is provided, it must match the input's padded shape.
             - If TILE: `weight` and `bias` padded dim must match input's last padded dim; padded height must equal TILE_HEIGHT (i.e. 32).

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -79,10 +79,8 @@ void bind_normalization_rms_norm(py::module& module) {
                * - BFLOAT16, FLOAT32, BFLOAT8_B (matching input)
                  - TILE
 
-            Rank: input rank must be >= 1.
-
         Limitations:
-            - All input tensors must be on-device.
+            - All input tensors must be on-device and have a rank >= 1.
             - Unsharded tensors must be interleaved, sharded inputs cannot be height-sharded.
             - If `residual_input_tensor` is provided, it must match the input's padded shape.
             - `weight`/`bias` tensors:

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -82,10 +82,9 @@ void bind_normalization_rms_norm(py::module& module) {
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.
             - Unsharded tensors must be interleaved, sharded inputs cannot be height-sharded.
-            - If `residual_input_tensor` is provided, it must match the input's padded shape.
-            - `weight`/`bias` tensors:
-              - If TILE: last padded dim must match input's last padded dim.
-              - If ROW_MAJOR: last padded dim must be TILE_WIDTH.
+            - If `residual_input_tensor` is provided, it must match the :attr:`input_tensor`'s padded shape.
+            - If the `weight`/`bias` tensors are TILE layout: last padded dim must match :attr:`input_tensor`'s last padded dim.
+            - If the `weight`/`bias` tensors are ROW_MAJOR layout: last padded dim must be TILE_WIDTH.
 
         Example:
             .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -22,6 +22,13 @@ void bind_normalization_rms_norm(py::module& module) {
             Computes RMS norm over :attr:`input_tensor`.
             See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
+            .. math::
+              \text{RMS_norm}(x, \gamma, \beta, \epsilon) = \frac{x}{\sqrt{\epsilon+\frac{1}{N}\sum_{i=1}^{N}x^{2}}} \cdot \gamma + \beta
+
+            Where:
+                - :math:`\gamma` and :math:`\beta` are optional scale and shift parameters
+                - :math:`\epsilon` is a small constant
+
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -67,8 +67,11 @@ void bind_reduction_topk_operation(py::module& module) {
                 The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
 
             Limitations:
-                - :attr:`input_tensor` must be 4D
-                - For :attr:`input_tensor`, N*C*H must be a multiple of 32 and W must be ≥64.
+                - The op fundamentally operates on 4D tensors with :attr:`dim` of -1. The tensor will be manipulated as needed when this is not the case, and restored afterwards.
+                - For :attr:`input_tensor`, N*C*H must be a multiple of 32
+                - W is ideally ≥64. If this is not the case the op will pad the tensor to satisfy this constraint.
+                - The width of :attr:`input_tensor` along :attr:`dim` should be a multiple of tile width, and will be padded to the nearest multiple of tile width if needed.
+                - The padding is currently only supported for bfloat16, float32, int32, and uint32.
                 - To enable multicore execution, the width of :attr:`input_tensor` along :attr:`dim` must be ≥8192 and <65536, and :attr:`k` must be ≤64.
                 - All shape validations are performed on padded shapes.
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -67,7 +67,7 @@ void bind_reduction_topk_operation(py::module& module) {
                 The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
 
             Limitations:
-                - The op fundamentally operates on 4D tensors with :attr:`dim` of -1. The tensor will be manipulated as needed when this is not the case, and restored afterwards.
+                - The op fundamentally operates on 4D tensors with shape [N, C, H, W], and with :attr:`dim` of -1. The tensor will be manipulated as needed when this is not the case, and restored afterwards.
                 - For :attr:`input_tensor`, N*C*H must be a multiple of 32
                 - W is ideally ≥64. If this is not the case the op will pad the tensor to satisfy this constraint.
                 - The width of :attr:`input_tensor` along :attr:`dim` should be a multiple of tile width, and will be padded to the nearest multiple of tile width if needed.

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -195,7 +195,7 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
 def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
     """Prepares a gamma/beta tensor in a padded [1,1,-1,32] format.
 
-    - Splits channels into num_cores_x equal chunks (C must be divisible by num_cores_x).
+    - Splits channels into num_cores_x equal chunks
     - Pads each chunk to a multiple of 32 (tile width).
     - Returns a tensor reshaped to [1, 1, tiles_per_core_total, 32].
     """

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -11,6 +11,11 @@ import math
 
 
 def find_closest_largest_divisor(num: int, start_divisor: int):
+    """Return the largest divisor of num that is <= start_divisor.
+
+    Used to choose a core count that divides a work quota. Assumes
+    1 <= start_divisor <= num. Decrements until a divisor is found.
+    """
     divisor = start_divisor
     while num % divisor != 0:
         divisor = divisor - 1
@@ -120,6 +125,16 @@ LayerNormShardedMultiCoreProgramConfig = ttnn._ttnn.operations.normalization.Lay
 def determine_expected_group_norm_sharded_config_and_grid_size(
     *, device, num_channels, num_groups, input_nhw, is_height_sharded, is_row_major=False
 ):
+    """Derive sharded memory config and grid for group norm.
+
+    - num_channels must be divisible by num_groups and 32 (tile width).
+    - input_nhw is N*H*W in logical units; padded to core multiples.
+    - If is_height_sharded: shard along NHW only; channels per core is all C.
+      Otherwise: shard across channels and NHW (BLOCK_SHARDED).
+    - is_row_major toggles shard shape orientation.
+
+    Returns: (MemoryConfig, CoreGrid)
+    """
     assert num_channels % num_groups == 0
     assert num_channels % 32 == 0  # TODO: remove this later
     group_size = num_channels // num_groups
@@ -178,6 +193,12 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
 
 
 def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
+    """Prepares a gamma/beta tensor in a padded [1,1,-1,32] format.
+
+    - Splits channels into num_cores_x equal chunks (C must be divisible by num_cores_x).
+    - Pads each chunk to a multiple of 32 (tile width).
+    - Returns a tensor reshaped to [1, 1, tiles_per_core_total, 32].
+    """
     import torch
 
     def find_ceil_divisible_by_32(n):
@@ -193,6 +214,10 @@ def create_group_norm_weight_bias_rm(input_tensor, num_channels, num_cores_x):
 
 
 def dram_group_norm_virtual_columns(core_grid, num_channels, num_groups):
+    """Choose number of virtual columns for DRAM params/mask generation.
+
+    Tries to find the largest number of virtual columns that will evenly divide the number of channels into tiles.
+    """
     num_virtual_cols = min(core_grid.x, num_groups)
     while (num_channels / num_virtual_cols) % ttnn.TILE_SIZE != 0:
         num_virtual_cols -= 1
@@ -276,6 +301,9 @@ def dram_group_norm_params_from_torch(
 
 
 def find_max_tile_span(W, group_size, tile_width):
+    """Finds the maximum (worst case) number of tiles a group of size group_size can span across.
+    This helps in setting the mask width conservatively.
+    """
     current_position = 0
     max_tile_span = 0
 
@@ -290,6 +318,11 @@ def find_max_tile_span(W, group_size, tile_width):
 
 
 def create_group_norm_mask_impl(num_channel, num_groups, num_cores_across_channel, is_negative_mask=False):
+    """Create 4D mask [1, num_groups, 32, 32*block_wt] used by group norm.
+
+    - block_wt is computed from worst-case tile span across groups.
+    - num_cores_across_channel splits groups evenly across cores (must divide num_groups).
+    """
     import torch
 
     block_wt = find_max_tile_span(num_channel, num_channel // num_groups, 32)
@@ -334,6 +367,9 @@ def create_group_norm_input_negative_mask(num_channel, num_groups, num_cores_acr
 
 
 def get_group_norm_cores_across_channel(memory_layout, core_grid):
+    """Compute effective cores that split the channel axis.
+    Used to reshape gamma/beta per-core views in the golden code.
+    """
     if memory_layout == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED:
         num_cores_across_channel = core_grid.y
     elif memory_layout == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED:


### PR DESCRIPTION
### Ticket
#11202
#26712

### Problem description
Documentation of the fused ops needed further attention

### What's changed
Fixed up the formatting of groupnorm and added clarification on how it should be used, as well as providing a much more in depth example highlighting how inputs should be formatted.
Further clarified the limitations of topk. 
Added more details to RMS norm on the computation being performed. 

Added some comments to the normalization helper functions. 

Made a small cleanup of the softmax accuracy test parameters.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17774917223)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes