### PR TITLE
[vLLM] Compatibility fixes for model generators after pulling Apr16-July22 upstream changes - removed legacy input processors and refactored for multi-modal models

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -9,7 +9,6 @@ from models.demos.llama3_70b_galaxy.tt.generator import Generator
 from models.demos.llama3_70b_galaxy.tt.llama_model import TtTransformer
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations, TtModelArgs
 from models.tt_transformers.tt.generator import create_submeshes
-from vllm.inputs import INPUT_REGISTRY
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransformer, tt_cache_path):
@@ -88,11 +87,6 @@ def initialize_vllm_text_transformer(
     return tt_model, model_args
 
 
-def input_processor_for_llama_text(ctx, inputs):
-    return inputs
-
-
-@INPUT_REGISTRY.register_input_processor(input_processor_for_llama_text)
 class LlamaForCausalLM(Generator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -96,7 +96,7 @@ class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
         return {"image": None, "video": 0}  # [INFO] videos are not supported yet
 
 
-# TOOD: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
+# TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(
     MultiModalProcessor, info=TT_Qwen2_5_VLProcessingInfo, dummy_inputs=DummyInputsBuilder
 )
@@ -177,7 +177,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
 
         # reconstruct the inputs that Qwen2.5-VL expects
         inputs = CustomNamespace()
-        inputs.input_ids = tokens.to(images[0].attention_mask.dtype) if images[0] else tokens
+        inputs.input_ids = tokens.to(images[0].attention_mask.dtype) if images[0] is not None else tokens
         inputs.attention_mask = torch.concat(
             [
                 torch.nn.functional.pad(im.attention_mask, (0, padded_seq_len - im.attention_mask.shape[-1]), value=0)
@@ -187,7 +187,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             ],
             dim=0,
         )
-        if images[0] and "pixel_values" in images[0]:
+        if images[0] is not None and "pixel_values" in images[0]:
             # we currently do not support mixed inputs of text-only users and text-image users; hence checking images[0] is enough
             inputs.pixel_values = torch.concat([im.pixel_values for im in images], dim=0)
             inputs.image_grid_thw = torch.concat([im.image_grid_thw for im in images], dim=0)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -93,7 +93,7 @@ class CustomNamespace(SimpleNamespace):
 
 class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
-        return {"image": None, "video": 0}  # [INFO] videos are not supported yet
+        return {"image": 1, "video": 0}  # [INFO] videos are not supported yet, only supporting 1 image for now
 
 
 # TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -3,15 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import List, Union
+from typing import List, Mapping, Optional, Sequence, Union
 
-import PIL
 import torch
 from llama_models.llama3.api.chat_format import create_vision_mask
+from PIL.Image import Image
 from tqdm import tqdm
-from vllm.inputs import EncoderDecoderInputs, InputContext, TokenInputs, token_inputs
+from transformers import BatchFeature
 from vllm.model_executor.models.interfaces import SupportsMultiModal, SupportsV0Only
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    MultiModalDataDict,
+    MultiModalEncDecInputs,
+    MultiModalFieldConfig,
+    MultiModalInputs,
+    MultiModalKwargs,
+)
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import BaseProcessingInfo, EncDecMultiModalProcessor, PromptUpdate
+from vllm.multimodal.profiling import BaseDummyInputsBuilder
 
 import ttnn
 from models.tt_transformers.tt.generator import Generator, create_submeshes
@@ -96,201 +106,158 @@ def initialize_vllm_text_transformer(
     return tt_model, model_args
 
 
-class MllamaProcessingInfo:
+class MllamaProcessingInfo(BaseProcessingInfo):
     """Processing information for Mllama multi-modal models."""
 
-    def __init__(self, ctx):
-        self.ctx = ctx
-
     def get_hf_config(self):
-        """Get the HuggingFace config for the model."""
         from transformers import MllamaConfig
 
         return self.ctx.get_hf_config(MllamaConfig)
 
-    def get_hf_processor(self, **kwargs):
-        """Get the HuggingFace processor for the model."""
+    def get_hf_processor(self, **kwargs: object):
         from transformers.models.mllama.processing_mllama import MllamaProcessor
 
         return self.ctx.get_hf_processor(MllamaProcessor, **kwargs)
 
     def get_supported_mm_limits(self):
         """Get the supported multimodal limits."""
-        return {"image": None}
-
-    def get_tokenizer(self):
-        """Get the tokenizer."""
-        return self.ctx.tokenizer
-
-    @property
-    def model_id(self):
-        return self.ctx.model_config.model
+        return {"image": 1}  # TT implementation currently only supports 1 image
 
 
-class MllamaDummyInputsBuilder:
-    """Builder for dummy inputs used in profiling."""
+class MllamaDummyInputsBuilder(BaseDummyInputsBuilder[MllamaProcessingInfo]):
+    """
+    We don't need to implement a dummy input builder since we don't do profiling in vLLM.
+    Create callable class just for processor registration.
+    """
 
-    def __init__(self, info):
-        self.info = info
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        raise NotImplementedError
 
-    def get_dummy_text(self, mm_counts):
-        """Generate dummy text with appropriate image tokens."""
-        num_images = mm_counts.get("image", 0)
-        processor = self.info.get_hf_processor()
-        image_token = processor.image_token
-        return image_token * num_images
-
-    def get_dummy_mm_data(self, seq_len, mm_counts):
-        """Generate dummy multimodal data for profiling."""
-        import numpy as np
-        from PIL import Image
-
-        num_images = mm_counts.get("image", 0)
-
-        # Create dummy images with reasonable size
-        target_width = 1120
-        target_height = 1120
-
-        images = []
-        for _ in range(num_images):
-            dummy_image_array = np.zeros((target_height, target_width, 3), dtype=np.uint8)
-            images.append(Image.fromarray(dummy_image_array, "RGB"))
-
-        return {"image": images if len(images) > 1 else (images[0] if images else None)}
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> MultiModalDataDict:
+        raise NotImplementedError
 
 
-class MllamaMultiModalProcessor:
-    """Multi-modal processor for Mllama that handles encoder-decoder inputs."""
+# TODO: This multi-modal processor currently bypasses vLLM's mm processing on the images
+# and passes the images directly to the model. In the future, the apply() function should
+# call super().apply() (similar to vllm.model_executor.models.mllama.py::MllamaMultiModalProcessor)
+# and _get_mm_fields_config / _get_prompt_updates should be implemented.
+class MllamaMultiModalProcessor(EncDecMultiModalProcessor[MllamaProcessingInfo]):
+    """Multi-modal processor for Llama3.2-Vision that handles encoder-decoder inputs."""
 
-    def __init__(self, info, dummy_inputs, **kwargs):
-        self.info = info
-        self.dummy_inputs = dummy_inputs
+    def create_encoder_prompt(
+        self,
+        prompt: Union[str, list[int]],
+        mm_data: MultiModalDataDict,
+    ) -> Union[str, list[int]]:
+        data = mm_data.get("image", [])
+        num_images = 1 if isinstance(data, Image) else len(data)
+        image_token_id = self.info.get_hf_config().image_token_index
+        return [image_token_id] * num_images
 
-    def apply(self, prompt, mm_data, hf_processor_mm_kwargs=None, tokenization_kwargs=None, return_mm_hashes=False):
-        """Apply processing to multimodal inputs."""
-        if hf_processor_mm_kwargs is None:
-            hf_processor_mm_kwargs = {}
-        if tokenization_kwargs is None:
-            tokenization_kwargs = {}
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: "BatchFeature",
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        """Unused, defined to satisfy abstract method requirement."""
+        raise NotImplementedError
 
-        # Create encoder-decoder inputs in the format expected by input_processor_for_mllama
-        encoder_decoder_inputs = EncoderDecoderInputs(
-            encoder={
-                "type": "token",
-                "prompt_token_ids": [],  # Will be filled by tokenization
-                "prompt": prompt if isinstance(prompt, str) else "",
-                "multi_modal_data": mm_data,
-            },
-            decoder={
-                "type": "token",
-                "prompt_token_ids": [],
-            },
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> Sequence[PromptUpdate]:
+        """Unused, defined to satisfy abstract method requirement."""
+        raise NotImplementedError
+
+    def apply(
+        self,
+        prompt: Union[str, list[int]],
+        mm_data: MultiModalDataDict,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Optional[Mapping[str, object]] = None,
+        return_mm_hashes: bool = False,
+    ) -> MultiModalEncDecInputs:
+        """
+        Based on vllm.model_executor.models.mllama.py::MllamaMultiModalProcessor
+        without performing processing on the images inputs or computing num_tiles (here it is fixed).
+        """
+
+        # In vLLM's mllama.py, super().apply() is called which also processes images,
+        # while here only prompts are tokenized.
+        encoder_prompt = self.create_encoder_prompt(prompt, mm_data)
+        encoder_inputs = MultiModalInputs(
+            type="multimodal",
+            prompt=prompt,
+            prompt_token_ids=encoder_prompt,
+            mm_kwargs=mm_data,  # We pass the image directly
+            mm_hashes={},
+            mm_placeholders={},
+        )
+        mm_inputs = self._get_enc_dec_inputs(
+            prompt=prompt,
+            mm_data=mm_data,
+            encoder_inputs=encoder_inputs,
         )
 
-        # For now, delegate to the existing input_processor_for_mllama function
-        processed = input_processor_for_mllama(ctx=self.info.ctx, inputs=encoder_decoder_inputs)
-
-        # Convert back to the expected format
-        return {
-            "type": "multimodal",
-            "prompt_token_ids": processed["decoder"]["prompt_token_ids"],
-            "prompt": processed["decoder"]["prompt"],
-            "multi_modal_data": processed["decoder"].get("multi_modal_data"),
-            "encoder_prompt_token_ids": processed["encoder"]["prompt_token_ids"],
-            "encoder_prompt": processed["encoder"]["prompt"],
-            "mm_kwargs": {},
-            "mm_hashes": {},
-            "mm_placeholders": {},
-        }
-
-
-# TODO: Update input processor to inherit from EncDecMultiModalProcessor as is done in vllm.model_executor.models.mllama.py
-def input_processor_for_mllama(
-    ctx: InputContext,
-    inputs: EncoderDecoderInputs,
-) -> EncoderDecoderInputs:
-    """
-    This was based on a previous version of vllm.model_executor.models.mllama.py::input_processor_for_mllama()
-    without the additional processing for computing num_tiles (here it is fixed).
-    """
-    # Example input to processor:
-    # {
-    #     'encoder': {
-    #         'type': 'token',
-    #         'prompt_token_ids': [128000, 128256, 128000, 3923, 374, 279, 2262, 315, 420, 2217, 30],  # noqa: E501
-    #         'prompt': '<|image|><|begin_of_text|>What is the content of this image?',  # noqa: E501
-    #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
-    #     },
-    #     'decoder': {
-    #         'type': 'token',
-    #         'prompt_token_ids': [128000],
-    #     },
-    # }
-
-    # Move encoder_prompt to prompt. If the user does not explicitly provide separate
-    # encoder and decoder prompts, vLLM by default will treat the prompt as the encoder prompt.
-    # For the block manager to allocate enough blocks and add them to the block table, the decoder prompt
-    # must contain the full text prompt.
-    dec_inputs = TokenInputs(**inputs["encoder"])
-
-    if os.environ.get("MESH_DEVICE") == "N300":
-        prompt_len = len(dec_inputs.get("prompt_token_ids"))
-        MAX_PROMPT_LEN = 8192
-        if prompt_len > MAX_PROMPT_LEN:
+        image_token_id = self.info.get_hf_config().image_token_index
+        # Check that the number of image tokens in the decoder prompt matches
+        # the number of images provided in mm_data
+        num_image_tokens = mm_inputs["prompt_token_ids"].count(image_token_id)
+        image_data = mm_data.get("image", [])
+        num_images = 1 if isinstance(image_data, Image) else len(image_data)
+        if num_image_tokens != num_images:
             raise ValueError(
-                f"TT-LLama11B-Vision does not support prompts longer than {MAX_PROMPT_LEN} tokens on N300 (received prompt with {prompt_len} tokens)"
+                f"The number of image tokens ({num_image_tokens}) must be"
+                f" the same as the number of images ({num_images})"
             )
 
-    multi_modal_data = dec_inputs.get("multi_modal_data")
-    if multi_modal_data is None or "image" not in multi_modal_data:
-        # text-only
-        return EncoderDecoderInputs(
-            encoder=token_inputs([]),
-            decoder=dec_inputs,
-        )
+        if os.environ.get("MESH_DEVICE") == "N300":
+            prompt_len = len(mm_inputs["prompt_token_ids"])
+            MAX_PROMPT_LEN = 8192
+            if prompt_len > MAX_PROMPT_LEN:
+                raise ValueError(
+                    f"TT-LLama11B-Vision does not support prompts longer than {MAX_PROMPT_LEN} tokens on N300 (received prompt with {prompt_len} tokens)"
+                )
 
-    # Set encoder prompt length based on the number of vision tokens so block manager allocates enough blocks (cross block tables).
-    hf_config = ctx.model_config.hf_config
-    vision_config = hf_config.vision_config
-    assert vision_config.image_size % 14 == 0, "chunk size should be multiple of 14"
-    token_per_chunk = nearest_32(
-        (vision_config.image_size // 14) ** 2 + 1
-    )  # Note: we use nearest 32 while vLLM does not by default
-    num_vision_tokens = (
-        vision_config.max_num_tiles * token_per_chunk
-    )  # Note: we use max_num_tiles while vLLM uses num_tiles by default
+        # Example input to encoder and decoder:
+        # {
+        #     'encoder': {
+        #         'type': 'token',
+        #         'prompt_token_ids': [128256, 128256, ..., 128256],
+        #         'prompt': '<|image|><|image|>...<|image|>',
+        #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
+        #     },
+        #     'decoder': {
+        #         'type': 'token',
+        #         'prompt_token_ids': [128000, 128256, 128000, 3923, 374, 279, 2262, 315, 420, 2217, 30],  # noqa: E501
+        #         'prompt': '<|image|><|begin_of_text|>What is the content of this image?',  # noqa: E501
+        #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
+        #     },
+        # }
 
-    # Example output from processor:
-    # {
-    #     'encoder': {
-    #         'type': 'token',
-    #         'prompt_token_ids': [128256, 128256, ..., 128256],
-    #         'prompt': '<|image|><|image|>...<|image|>',
-    #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
-    #     },
-    #     'decoder': {
-    #         'type': 'token',
-    #         'prompt_token_ids': [128000, 128256, 128000, 3923, 374, 279, 2262, 315, 420, 2217, 30],  # noqa: E501
-    #         'prompt': '<|image|><|begin_of_text|>What is the content of this image?',  # noqa: E501
-    #         'multi_modal_data': {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7FDE2C624880>},  # noqa: E501
-    #     },
-    # }
-    MLLAMA_IMAGE_TOKEN_ID = 128256
-    MLLAMA_IMAGE_TOKEN = "<|image|>"
+        if mm_data:
+            # Set encoder prompt length based on the number of vision tokens so block manager allocates enough blocks (cross block tables).
+            vision_config = self.info.get_hf_config().vision_config
+            assert vision_config.image_size % 14 == 0, "chunk size should be multiple of 14"
+            token_per_chunk = nearest_32(
+                (vision_config.image_size // 14) ** 2 + 1
+            )  # Note: we use nearest 32 while vLLM does not by default
+            num_vision_tokens = (
+                vision_config.max_num_tiles * token_per_chunk
+            )  # Note: we use max_num_tiles while vLLM uses num_tiles by default
 
-    # Create encoder inputs without multi_modal_data in token_inputs
-    encoder_token_inputs = token_inputs(
-        prompt_token_ids=[MLLAMA_IMAGE_TOKEN_ID] * num_vision_tokens,
-        prompt=MLLAMA_IMAGE_TOKEN * num_vision_tokens,
-    )
+            hf_processor = self.info.get_hf_processor()
+            image_token: str = hf_processor.image_token
+            mm_inputs["encoder_prompt_token_ids"] = [image_token_id] * num_vision_tokens
+            mm_inputs["encoder_prompt"] = image_token * num_vision_tokens
 
-    # Add multi_modal_data separately
-    encoder_inputs = {**encoder_token_inputs, "multi_modal_data": multi_modal_data}
-
-    return EncoderDecoderInputs(
-        encoder=encoder_inputs,
-        decoder=dec_inputs,
-    )
+        return mm_inputs
 
 
 # def input_processor_for_multimodal(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
@@ -366,7 +333,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal, SupportsV0On
     def prefill_forward(
         self,
         tokens: torch.Tensor,
-        images: Union[List[PIL.Image.Image], List[List[PIL.Image.Image]]],
+        images: Union[List[Image], List[List[Image]]],
         page_table: torch.Tensor,
         kv_cache,
         prompt_lens,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -501,7 +501,7 @@ class MultiModalProcessor(BaseMultiModalProcessor):
         return mm_inputs
 
 
-# TOOD: Eventually replace MultiModalProcessor with vllm.model_executor.models.gemma3_mm::Gemma3MultiModalProcessor
+# TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.gemma3_mm::Gemma3MultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(MultiModalProcessor, info=Gemma3ProcessingInfo, dummy_inputs=DummyInputsBuilder)
 class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
     def __init__(self, *args, **kwargs):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -487,7 +487,7 @@ class MultiModalProcessor(BaseMultiModalProcessor):
             return_tensors="pt",
         )
 
-        assert processed_inputs.input_ids.shape[0] == 1, "Only one image is processed at a time by vLLM"
+        assert processed_inputs.input_ids.shape[0] == 1, "Expected to process one input prompt at a time in processor"
         prompt_token_ids = processed_inputs.input_ids[0].tolist()
 
         mm_inputs = MultiModalInputs(


### PR DESCRIPTION
### Ticket
[N/A](https://github.com/tenstorrent/tt-metal/issues/27285)

### Problem description
- Legacy input mappers/processors were removed from vLLM V0 (https://github.com/vllm-project/vllm/pull/15686, https://github.com/vllm-project/vllm/issues/10114). These changes are required to maintain compatibility of existing integrated models after pulling upstream changes in https://github.com/tenstorrent/vllm/pull/189.

### What's changed
- Removed legacy vLLM input processors from Llama3, Gemma3, Qwen2.5-VL
- Defined new multi-modal input processor classes for Llama3.2-11B-Vision (`MllamaMultiModalProcessor`), Gemma3 / Qwen2.5-VL (`MultiModalProcessor`) and added support multi-modal limits for each
- Moved max seq len assertion for Llama8B to model initialization, `--max_model_len` must be set on vLLM side for any models which support less than default max context length
- Fixed bug where `create_multimodal_model` import was removed for Llama3.2-11B-Vision and broke the model (from https://github.com/tenstorrent/tt-metal/commit/87b758d1c51a1c90884440a50acbfc35ae0bbc58)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

vLLM nightly tests - https://github.com/tenstorrent/tt-metal/actions/runs/17680447236