### PR TITLE
add ntype parameterization to nightly torus tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml
@@ -17,7 +17,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -38,7 +39,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -63,7 +65,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -84,7 +87,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -109,7 +113,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -130,7 +135,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -151,7 +157,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -172,7 +179,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -193,7 +201,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -214,7 +223,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -239,7 +249,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -260,7 +271,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -281,7 +293,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -302,7 +315,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -323,7 +337,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -344,7 +359,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -369,7 +385,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -391,7 +408,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -413,7 +431,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -435,7 +454,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -457,7 +477,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -479,7 +500,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -501,7 +523,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -523,7 +546,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -545,7 +569,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -567,7 +592,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -593,7 +619,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -615,7 +642,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -637,7 +665,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -659,7 +688,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -681,7 +711,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -703,7 +734,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -725,7 +757,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -747,7 +780,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -769,7 +803,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -791,7 +826,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -817,7 +853,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -839,7 +876,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -861,7 +899,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -883,7 +922,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -905,7 +945,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -927,7 +968,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -949,7 +991,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -971,7 +1014,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -993,7 +1037,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1015,7 +1060,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1041,7 +1087,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1063,7 +1110,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1085,7 +1133,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1107,7 +1156,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1129,7 +1179,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1151,7 +1202,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1173,7 +1225,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1195,7 +1248,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1217,7 +1271,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1239,7 +1294,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1265,7 +1321,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1287,7 +1344,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1309,7 +1367,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1331,7 +1390,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1353,7 +1413,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1375,7 +1436,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1397,7 +1459,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1419,7 +1482,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1441,7 +1505,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1467,7 +1532,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1489,7 +1555,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1511,7 +1578,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1537,7 +1605,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1564,7 +1633,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1587,7 +1657,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1610,7 +1681,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1633,7 +1705,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1656,7 +1729,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1679,7 +1753,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1702,7 +1777,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1725,7 +1801,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1748,7 +1825,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1771,7 +1849,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1798,7 +1877,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1821,7 +1901,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1844,7 +1925,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1867,7 +1949,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1890,7 +1973,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1913,7 +1997,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1936,7 +2021,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1959,7 +2045,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1982,7 +2069,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2005,7 +2093,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2028,7 +2117,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2055,7 +2145,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2078,7 +2169,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2101,7 +2193,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2124,7 +2217,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2147,7 +2241,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2170,7 +2265,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2193,7 +2289,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2216,7 +2313,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2239,7 +2337,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2262,7 +2361,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2285,7 +2385,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2312,7 +2413,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2335,7 +2437,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2358,7 +2461,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2381,7 +2485,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2404,7 +2509,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2427,7 +2533,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2450,7 +2557,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2473,7 +2581,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2496,7 +2605,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2519,7 +2629,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2542,7 +2653,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2569,7 +2681,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2593,7 +2706,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2617,7 +2731,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2641,7 +2756,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2665,7 +2781,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2689,7 +2806,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2713,7 +2831,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2737,7 +2856,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2761,7 +2881,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2791,7 +2912,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2812,7 +2934,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2837,7 +2960,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2858,7 +2982,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2883,7 +3008,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2904,7 +3030,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2925,7 +3052,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2946,7 +3074,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2967,7 +3096,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2988,7 +3118,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3013,7 +3144,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3034,7 +3166,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3055,7 +3188,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3076,7 +3210,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3097,7 +3232,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3118,7 +3254,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3143,7 +3280,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3165,7 +3303,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3187,7 +3326,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3209,7 +3349,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3231,7 +3372,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3253,7 +3395,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3275,7 +3418,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3297,7 +3441,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3319,7 +3464,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3341,7 +3487,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3367,7 +3514,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3389,7 +3537,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3411,7 +3560,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3433,7 +3583,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3455,7 +3606,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3477,7 +3629,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3499,7 +3652,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3521,7 +3675,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3543,7 +3698,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3565,7 +3721,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3591,7 +3748,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3613,7 +3771,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3635,7 +3794,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3657,7 +3817,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3679,7 +3840,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3701,7 +3863,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3723,7 +3886,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3745,7 +3909,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3767,7 +3932,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3789,7 +3955,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3815,7 +3982,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3837,7 +4005,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3859,7 +4028,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3881,7 +4051,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3903,7 +4074,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3925,7 +4097,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3947,7 +4120,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3969,7 +4143,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3991,7 +4166,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4013,7 +4189,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4039,7 +4216,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4061,7 +4239,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4083,7 +4262,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4105,7 +4285,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4127,7 +4308,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4149,7 +4331,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4171,7 +4354,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4193,7 +4377,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4215,7 +4400,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4241,7 +4427,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4263,7 +4450,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4285,7 +4473,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4311,7 +4500,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4338,7 +4528,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4361,7 +4552,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4384,7 +4576,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4407,7 +4600,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4430,7 +4624,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4453,7 +4648,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4476,7 +4672,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4499,7 +4696,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4522,7 +4720,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4545,7 +4744,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4572,7 +4772,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4595,7 +4796,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4618,7 +4820,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4641,7 +4844,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4664,7 +4868,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4687,7 +4892,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4710,7 +4916,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4733,7 +4940,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4756,7 +4964,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4779,7 +4988,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4802,7 +5012,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4829,7 +5040,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4852,7 +5064,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4875,7 +5088,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4898,7 +5112,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4921,7 +5136,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4944,7 +5160,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4967,7 +5184,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4990,7 +5208,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5013,7 +5232,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5036,7 +5256,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5059,7 +5280,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5086,7 +5308,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5109,7 +5332,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5132,7 +5356,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5155,7 +5380,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5178,7 +5404,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5201,7 +5428,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5224,7 +5452,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5247,7 +5476,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5270,7 +5500,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5293,7 +5524,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5316,7 +5548,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5343,7 +5576,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5367,7 +5601,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5391,7 +5626,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5415,7 +5651,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5439,7 +5676,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5463,7 +5701,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5487,7 +5726,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5511,7 +5751,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5535,7 +5776,8 @@ Tests:
       topology: Torus
       torus_config: XY
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5562,7 +5804,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5583,7 +5826,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5604,7 +5848,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5625,7 +5870,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5646,7 +5892,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5668,7 +5915,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5690,7 +5938,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5716,7 +5965,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5737,7 +5987,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5758,7 +6009,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5779,7 +6031,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5800,7 +6053,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5821,7 +6075,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5842,7 +6097,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5863,7 +6119,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5884,7 +6141,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5905,7 +6163,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5926,7 +6185,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5947,7 +6207,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5968,7 +6229,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5990,7 +6252,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6012,7 +6275,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6034,7 +6298,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6056,7 +6321,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: LowLatency
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6080,7 +6346,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6101,7 +6368,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6122,7 +6390,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6143,7 +6412,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6164,7 +6434,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6186,7 +6457,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6208,7 +6480,8 @@ Tests:
       topology: Torus
       torus_config: X
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6233,7 +6506,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6254,7 +6528,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6275,7 +6550,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6296,7 +6572,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6317,7 +6594,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6338,7 +6616,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6359,7 +6638,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6380,7 +6660,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6401,7 +6682,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6422,7 +6704,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6443,7 +6726,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6464,7 +6748,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6485,7 +6770,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6507,7 +6793,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6529,7 +6816,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6551,7 +6839,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6573,7 +6862,8 @@ Tests:
       topology: Torus
       torus_config: Y
       routing_type: Dynamic
-
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
     defaults:
       ftype: mcast
       ntype: unicast_write

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml
@@ -18,7 +18,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -40,7 +40,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -66,7 +66,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -88,7 +88,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -114,7 +114,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -136,7 +136,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -158,7 +158,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -180,7 +180,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -202,7 +202,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -224,7 +224,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -250,7 +250,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -272,7 +272,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -294,7 +294,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -316,7 +316,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -338,7 +338,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -360,7 +360,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -386,7 +386,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -409,7 +409,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -432,7 +432,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -455,7 +455,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -478,7 +478,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -501,7 +501,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -524,7 +524,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -547,7 +547,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -570,7 +570,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -593,7 +593,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -620,7 +620,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -643,7 +643,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -666,7 +666,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -689,7 +689,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -712,7 +712,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -735,7 +735,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -758,7 +758,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -781,7 +781,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -804,7 +804,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -827,7 +827,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -854,7 +854,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -877,7 +877,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -900,7 +900,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -923,7 +923,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -946,7 +946,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -969,7 +969,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -992,7 +992,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1015,7 +1015,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1038,7 +1038,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1061,7 +1061,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1088,7 +1088,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1111,7 +1111,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1134,7 +1134,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1157,7 +1157,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1180,7 +1180,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1203,7 +1203,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1226,7 +1226,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1249,7 +1249,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1272,7 +1272,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1295,7 +1295,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1322,7 +1322,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1345,7 +1345,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1368,7 +1368,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1391,7 +1391,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1414,7 +1414,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1437,7 +1437,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1460,7 +1460,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1483,7 +1483,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1506,7 +1506,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1533,7 +1533,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1556,7 +1556,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1579,7 +1579,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1606,7 +1606,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1634,7 +1634,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1658,7 +1658,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1682,7 +1682,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1706,7 +1706,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1730,7 +1730,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1754,7 +1754,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1778,7 +1778,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1802,7 +1802,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1826,7 +1826,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1850,7 +1850,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1878,7 +1878,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1902,7 +1902,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1926,7 +1926,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1950,7 +1950,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1974,7 +1974,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -1998,7 +1998,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2022,7 +2022,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2046,7 +2046,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2070,7 +2070,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2094,7 +2094,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2118,7 +2118,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2146,7 +2146,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2170,7 +2170,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2194,7 +2194,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2218,7 +2218,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2242,7 +2242,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2266,7 +2266,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2290,7 +2290,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2314,7 +2314,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2338,7 +2338,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2362,7 +2362,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2386,7 +2386,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2414,7 +2414,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2438,7 +2438,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2462,7 +2462,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2486,7 +2486,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2510,7 +2510,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2534,7 +2534,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2558,7 +2558,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2582,7 +2582,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2606,7 +2606,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2630,7 +2630,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2654,7 +2654,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2682,7 +2682,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2707,7 +2707,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2732,7 +2732,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2757,7 +2757,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2782,7 +2782,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2807,7 +2807,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2832,7 +2832,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2857,7 +2857,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2882,7 +2882,7 @@ Tests:
       torus_config: XY
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2913,7 +2913,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2935,7 +2935,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2961,7 +2961,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -2983,7 +2983,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3009,7 +3009,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3031,7 +3031,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3053,7 +3053,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3075,7 +3075,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3097,7 +3097,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3119,7 +3119,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3145,7 +3145,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3167,7 +3167,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3189,7 +3189,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3211,7 +3211,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3233,7 +3233,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3255,7 +3255,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3281,7 +3281,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3304,7 +3304,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3327,7 +3327,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3350,7 +3350,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3373,7 +3373,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3396,7 +3396,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3419,7 +3419,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3442,7 +3442,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3465,7 +3465,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3488,7 +3488,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3515,7 +3515,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3538,7 +3538,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3561,7 +3561,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3584,7 +3584,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3607,7 +3607,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3630,7 +3630,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3653,7 +3653,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3676,7 +3676,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3699,7 +3699,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3722,7 +3722,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3749,7 +3749,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3772,7 +3772,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3795,7 +3795,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3818,7 +3818,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3841,7 +3841,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3864,7 +3864,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3887,7 +3887,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3910,7 +3910,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3933,7 +3933,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3956,7 +3956,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -3983,7 +3983,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4006,7 +4006,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4029,7 +4029,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4052,7 +4052,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4075,7 +4075,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4098,7 +4098,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4121,7 +4121,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4144,7 +4144,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4167,7 +4167,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4190,7 +4190,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4217,7 +4217,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4240,7 +4240,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4263,7 +4263,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4286,7 +4286,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4309,7 +4309,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4332,7 +4332,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4355,7 +4355,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4378,7 +4378,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4401,7 +4401,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4428,7 +4428,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4451,7 +4451,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4474,7 +4474,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4501,7 +4501,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4529,7 +4529,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4553,7 +4553,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4577,7 +4577,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4601,7 +4601,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4625,7 +4625,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4649,7 +4649,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4673,7 +4673,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4697,7 +4697,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4721,7 +4721,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4745,7 +4745,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4773,7 +4773,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4797,7 +4797,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4821,7 +4821,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4845,7 +4845,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4869,7 +4869,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4893,7 +4893,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4917,7 +4917,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4941,7 +4941,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4965,7 +4965,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -4989,7 +4989,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5013,7 +5013,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5041,7 +5041,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5065,7 +5065,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5089,7 +5089,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5113,7 +5113,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5137,7 +5137,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5161,7 +5161,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5185,7 +5185,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5209,7 +5209,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5233,7 +5233,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5257,7 +5257,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5281,7 +5281,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5309,7 +5309,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5333,7 +5333,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5357,7 +5357,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5381,7 +5381,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5405,7 +5405,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5429,7 +5429,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5453,7 +5453,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5477,7 +5477,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5501,7 +5501,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5525,7 +5525,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5549,7 +5549,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5577,7 +5577,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5602,7 +5602,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5627,7 +5627,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5652,7 +5652,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5677,7 +5677,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5702,7 +5702,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5727,7 +5727,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5752,7 +5752,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5777,7 +5777,7 @@ Tests:
       torus_config: XY
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5805,7 +5805,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5827,7 +5827,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5849,7 +5849,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5871,7 +5871,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5893,7 +5893,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5916,7 +5916,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5939,7 +5939,7 @@ Tests:
       torus_config: X
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5966,7 +5966,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -5988,7 +5988,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6010,7 +6010,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6032,7 +6032,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6054,7 +6054,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6076,7 +6076,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6098,7 +6098,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6120,7 +6120,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6142,7 +6142,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6164,7 +6164,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6186,7 +6186,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6208,7 +6208,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6230,7 +6230,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6253,7 +6253,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6276,7 +6276,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6299,7 +6299,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6322,7 +6322,7 @@ Tests:
       torus_config: Y
       routing_type: LowLatency
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6347,7 +6347,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6369,7 +6369,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6391,7 +6391,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6413,7 +6413,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6435,7 +6435,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6458,7 +6458,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6481,7 +6481,7 @@ Tests:
       torus_config: X
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6507,7 +6507,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6529,7 +6529,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6551,7 +6551,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6573,7 +6573,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6595,7 +6595,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6617,7 +6617,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6639,7 +6639,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6661,7 +6661,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6683,7 +6683,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6705,7 +6705,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6727,7 +6727,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6749,7 +6749,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6771,7 +6771,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6794,7 +6794,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6817,7 +6817,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6840,7 +6840,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write
@@ -6863,7 +6863,7 @@ Tests:
       torus_config: Y
       routing_type: Dynamic
     parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
     defaults:
       ftype: mcast
       ntype: unicast_write


### PR DESCRIPTION
Added Parameterization to all of the nightly torus tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes