### PR TITLE
Add infra to extend fabric utils to multihost

### DIFF
--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -189,6 +189,9 @@ public:
     // Query the local intermesh link table containing the local to remote link mapping
     const IntermeshLinkTable& get_local_intermesh_link_table() const;
 
+    // Collect router port directions map from all hosts via MPI and merge into local map
+    void collect_and_merge_router_port_directions_from_all_hosts();
+
     // Get the ASIC ID for a chip (the ASIC ID is unique per chip, even in multi-host systems and is programmed
     // by SPI-ROM firmware)
     uint64_t get_asic_id(chip_id_t chip_id) const;

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(
         compressed_routing_table.cpp
         compressed_routing_path.cpp
         serialization/intermesh_link_table.cpp
+        serialization/router_port_directions.cpp
         serialization/physical_system_descriptor_serialization.cpp
         erisc_datamover_builder_helper.cpp
         ccl/ccl_common.cpp
@@ -71,6 +72,7 @@ include(protobuf)
 set(PROTO_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/mesh_graph_descriptor.proto
     ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/physical_system_descriptor.proto
+    ${CMAKE_CURRENT_SOURCE_DIR}/serialization/router_port_directions.proto
 )
 
 # Collect all generated protobuf files

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -45,6 +45,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/serialization/intermesh_link_table.hpp"
+#include "tt_metal/fabric/serialization/router_port_directions.hpp"
 #include "tt_stl/small_vector.hpp"
 
 namespace tt::tt_fabric {
@@ -698,22 +699,29 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     // Convert it to be unique per ethernet channel
 
     auto host_rank_id = this->get_local_host_rank_id_binding();
+    std::uint32_t num_ports_per_chip = 0;
     const auto& router_intra_mesh_routing_table = this->routing_table_generator_->get_intra_mesh_table();
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < router_intra_mesh_routing_table.size(); mesh_id_val++) {
         MeshId mesh_id{mesh_id_val};
         if (!this->is_local_mesh(mesh_id)) {
             continue;
         }
+        // Get the number of ports per chip from any chip in the local mesh
         const auto& local_mesh_chip_id_container =
             this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id);
         for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
             const auto src_fabric_node_id = FabricNodeId(mesh_id, src_fabric_chip_id);
             auto physical_chip_id = get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-            std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
-                                                   .get_cluster()
-                                                   .get_soc_desc(physical_chip_id)
-                                                   .get_cores(CoreType::ETH)
-                                                   .size();
+            num_ports_per_chip = tt::tt_metal::MetalContext::instance()
+                                     .get_cluster()
+                                     .get_soc_desc(physical_chip_id)
+                                     .get_cores(CoreType::ETH)
+                                     .size();
+            break;
+        }
+        const auto& global_mesh_chip_id_container = this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id);
+        for (const auto& [_, src_fabric_chip_id] : global_mesh_chip_id_container) {
+            const auto src_fabric_node_id = FabricNodeId(mesh_id, src_fabric_chip_id);
             this->intra_mesh_routing_tables_[src_fabric_node_id].resize(
                 num_ports_per_chip);  // contains more entries than needed, this size is for all eth channels on chip
             for (int i = 0; i < num_ports_per_chip; i++) {
@@ -767,17 +775,12 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
         if (!this->is_local_mesh(MeshId{src_mesh_id})) {
             continue;
         }
-        const auto& local_mesh_chip_id_container =
-            this->routing_table_generator_->mesh_graph->get_chip_ids(src_mesh_id, host_rank_id);
-        for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
+        const auto& global_mesh_chip_id_container =
+            this->routing_table_generator_->mesh_graph->get_chip_ids(src_mesh_id);
+        for (const auto& [_, src_fabric_chip_id] : global_mesh_chip_id_container) {
             const auto src_fabric_node_id = FabricNodeId(src_mesh_id, src_fabric_chip_id);
-            const auto& physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
-            std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
-                                                   .get_cluster()
-                                                   .get_soc_desc(physical_chip_id)
-                                                   .get_cores(CoreType::ETH)
-                                                   .size();
+            std::uint32_t num_ports_per_chip =
+                this->routing_table_generator_->mesh_graph->get_chip_spec().num_eth_ports_per_direction * 4;
             this->inter_mesh_routing_tables_[src_fabric_node_id].resize(
                 num_ports_per_chip);  // contains more entries than needed
             for (int i = 0; i < num_ports_per_chip; i++) {
@@ -1047,7 +1050,11 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
     // NOTE: This MUST be called after ordering ethernet channels
     this->trim_ethernet_channels_not_mapped_to_live_routing_planes();
 
+    this->collect_and_merge_router_port_directions_from_all_hosts();
+
     this->convert_fabric_routing_table_to_chip_routing_table();
+    // After this, router_port_directions_to_physical_eth_chan_map_, intra_mesh_routing_tables_,
+    // inter_mesh_routing_tables_ should be populated for all hosts in BigMesh
 }
 
 void ControlPlane::write_routing_tables_to_eth_cores(MeshId mesh_id, chip_id_t chip_id) const {
@@ -1161,21 +1168,76 @@ chip_id_t ControlPlane::get_physical_chip_id_from_fabric_node_id(const FabricNod
 std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_ids(
     FabricNodeId fabric_node_id, chan_id_t chan_id) const {
     // TODO: simplify this and maybe have this functionality in ControlPlane
-    auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
-    tt::umd::CoreCoord eth_core = tt::tt_metal::MetalContext::instance()
-                                      .get_cluster()
-                                      .get_soc_desc(physical_chip_id)
-                                      .get_eth_core_for_channel(chan_id, CoordSystem::LOGICAL);
-    auto [connected_physical_chip_id, connected_eth_core] =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
-            std::make_tuple(physical_chip_id, CoreCoord{eth_core.x, eth_core.y}));
+    const auto& intra_mesh_connectivity = this->routing_table_generator_->mesh_graph->get_intra_mesh_connectivity();
+    const auto& inter_mesh_connectivity = this->routing_table_generator_->mesh_graph->get_inter_mesh_connectivity();
+    RoutingDirection port_direction = RoutingDirection::NONE;
+    routing_plane_id_t routing_plane_id = 0;
+    for (const auto& [direction, eth_chans] :
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
+        for (const auto& eth_chan : eth_chans) {
+            if (eth_chan == chan_id) {
+                port_direction = direction;
+                routing_plane_id = this->get_routing_plane_id(eth_chan, eth_chans);
+                break;
+            }
+        }
+    }
 
-    auto connected_fabric_node_id = this->get_fabric_node_id_from_physical_chip_id(connected_physical_chip_id);
-    auto connected_chan_id = tt::tt_metal::MetalContext::instance()
-                                 .get_cluster()
-                                 .get_soc_desc(connected_physical_chip_id)
-                                 .logical_eth_core_to_chan_map.at(connected_eth_core);
-    return std::make_pair(connected_fabric_node_id, connected_chan_id);
+    // Try to find the connected mesh chip chan ids for the given port direction in intra mesh connectivity
+    const auto& intra_mesh_node = intra_mesh_connectivity[*fabric_node_id.mesh_id][fabric_node_id.chip_id];
+    for (const auto& [dst_fabric_chip_id, edge] : intra_mesh_node) {
+        if (edge.port_direction == port_direction) {
+            // Get reverse port direction
+            TT_ASSERT(
+                intra_mesh_connectivity[*fabric_node_id.mesh_id][dst_fabric_chip_id].contains(fabric_node_id.chip_id),
+                "Intra mesh connectivity from {} to {} not found",
+                dst_fabric_chip_id,
+                fabric_node_id.chip_id);
+            RoutingDirection reverse_port_direction =
+                intra_mesh_connectivity[*fabric_node_id.mesh_id][dst_fabric_chip_id]
+                    .at(fabric_node_id.chip_id)
+                    .port_direction;
+            // Find the eth chan on connected dst_fabric_chip_id based on routing_plane_id
+            const auto& dst_fabric_node = FabricNodeId(fabric_node_id.mesh_id, dst_fabric_chip_id);
+            const auto& dst_fabric_chip_eth_chans =
+                this->router_port_directions_to_physical_eth_chan_map_.at(dst_fabric_node);
+            for (const auto& [direction, eth_chans] : dst_fabric_chip_eth_chans) {
+                if (direction == reverse_port_direction) {
+                    return std::make_pair(dst_fabric_node, eth_chans[routing_plane_id]);
+                }
+            }
+        }
+    }
+
+    // Try to find the connected mesh chip chan ids for the given port direction in inter mesh connectivity
+    const auto& inter_mesh_node = inter_mesh_connectivity[*fabric_node_id.mesh_id][fabric_node_id.chip_id];
+    for (const auto& [dst_fabric_mesh_id, edge] : inter_mesh_node) {
+        if (edge.port_direction == port_direction) {
+            // Get reverse port direction
+            const auto& dst_connected_fabric_chip_id = edge.connected_chip_ids[0];
+            TT_ASSERT(
+                inter_mesh_connectivity[*dst_fabric_mesh_id][dst_connected_fabric_chip_id].contains(
+                    fabric_node_id.mesh_id),
+                "Inter mesh connectivity from {} to {} not found",
+                dst_fabric_mesh_id,
+                fabric_node_id.mesh_id);
+            RoutingDirection reverse_port_direction =
+                inter_mesh_connectivity[*dst_fabric_mesh_id][dst_connected_fabric_chip_id]
+                    .at(fabric_node_id.mesh_id)
+                    .port_direction;
+            // Find the eth chan on connected dst_fabric_mesh_id based on routing_plane_id
+            const auto& dst_fabric_node = FabricNodeId(dst_fabric_mesh_id, fabric_node_id.chip_id);
+            const auto& dst_fabric_chip_eth_chans =
+                this->router_port_directions_to_physical_eth_chan_map_.at(dst_fabric_node);
+            for (const auto& [direction, eth_chans] : dst_fabric_chip_eth_chans) {
+                if (direction == reverse_port_direction) {
+                    return std::make_pair(dst_fabric_node, eth_chans[routing_plane_id]);
+                }
+            }
+        }
+    }
+    TT_FATAL(false, "Could not find connected mesh chip chan ids for {} on chan {}", fabric_node_id, chan_id);
+    return std::make_pair(FabricNodeId(MeshId{0}, 0), 0);
 }
 
 std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
@@ -1237,9 +1299,8 @@ std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
     auto dst_mesh_coord = this->routing_table_generator_->mesh_graph->chip_to_coordinate(
         dst_fabric_node_id.mesh_id, dst_fabric_node_id.chip_id);
     // The src node is considered valid in this API if its owned by the current host. This requires the node to be in a
-    // mesh and coordinate range on this host.
-    bool valid_src =
-        this->is_local_mesh(src_fabric_node_id.mesh_id) and host_local_coord_range.contains(src_mesh_coord);
+    // mesh on this host.
+    bool valid_src = this->is_local_mesh(src_fabric_node_id.mesh_id);
     // Fabric Route will terminate at the exit node if the host does not own the destination node. i.e. dest is not on a
     // mesh or coordinate range owned by the host.
     bool end_route_at_exit_node =
@@ -1289,68 +1350,26 @@ std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
             // Chan to chan within chip
             route.push_back({src_fabric_node_id, next_chan_id});
         }
-
-        auto physical_chip_id = this->get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-        const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id);
-        auto next_eth_core = soc_desc.get_eth_core_for_channel(next_chan_id, CoordSystem::LOGICAL);
-        // Check if this link routes to a different host. If so, the connected link cannot be directly queried.
-        // The fabric route will end at the current chip, since it must be an exit node or an edge chip.
-        if (!this->is_intermesh_eth_link(physical_chip_id, CoreCoord(next_eth_core.x, next_eth_core.y))) {
             std::tie(src_fabric_node_id, src_chan_id) =
                 this->get_connected_mesh_chip_chan_ids(src_fabric_node_id, next_chan_id);
             route.push_back({src_fabric_node_id, src_chan_id});
-        } else {
-            // Verify that the remote eth link could not be queried because the current node is an exit node or
-            // edge chip of the local mesh.
-            TT_ASSERT(
-                end_route_at_exit_node or end_route_at_edge_of_local_mesh,
-                "ControlPlane: route between {} and {} should not end at exit node or try to exit local mesh",
-                src_fabric_node_id,
-                dst_fabric_node_id);
-            if (end_route_at_exit_node) {
-                std::vector<FabricNodeId> candidate_end_nodes =
-                    routing_table_generator_->get_exit_nodes_routing_to_mesh(dst_fabric_node_id.mesh_id);
-                // Check that the current node is a valid exit node
-                TT_ASSERT(
-                    std::find(candidate_end_nodes.begin(), candidate_end_nodes.end(), src_fabric_node_id) !=
-                        candidate_end_nodes.end(),
-                    "ControlPlane: src_fabric_node_id {} not found in candidate_end_nodes",
-                    src_fabric_node_id);
-            }
-            route.push_back({src_fabric_node_id, src_chan_id});
-            break;
-        }
     }
     return route;
 }
 
 std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id) const {
-    const auto& router_direction_eth_channels =
-        this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id);
     auto src_mesh_id = src_fabric_node_id.mesh_id;
     auto src_chip_id = src_fabric_node_id.chip_id;
     auto dst_mesh_id = dst_fabric_node_id.mesh_id;
     auto dst_chip_id = dst_fabric_node_id.chip_id;
-    for (const auto& [direction, eth_chans] : router_direction_eth_channels) {
-        for (const auto& src_chan_id : eth_chans) {
-            chan_id_t next_chan_id = 0;
-            if (src_mesh_id != dst_mesh_id) {
-                // Inter-mesh routing
-                next_chan_id = this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][*dst_mesh_id];
-            } else if (src_chip_id != dst_chip_id) {
-                // Intra-mesh routing
-                next_chan_id = this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id];
-            }
-            if (src_chan_id != next_chan_id) {
-                continue;
-            }
-
-            // dimension-order routing: only 1 direction should give the desired shortest path from src to dst
-            return direction;
-        }
+    if (src_mesh_id != dst_mesh_id) {
+        const auto& inter_mesh_routing_table = this->routing_table_generator_->get_inter_mesh_table();
+        return inter_mesh_routing_table[*src_mesh_id][src_chip_id][*dst_mesh_id];
+    } else if (src_chip_id != dst_chip_id) {
+        const auto& intra_mesh_routing_table = this->routing_table_generator_->get_intra_mesh_table();
+        return intra_mesh_routing_table[*src_mesh_id][src_chip_id][dst_chip_id];
     }
-
     return std::nullopt;
 }
 
@@ -1763,13 +1782,19 @@ void ControlPlane::write_routing_tables_to_all_chips() const {
     TT_ASSERT(
         this->intra_mesh_routing_tables_.size() == this->inter_mesh_routing_tables_.size(),
         "Intra mesh routing tables size mismatch with inter mesh routing tables");
-    for (const auto& [fabric_node_id, _] : this->intra_mesh_routing_tables_) {
-        TT_ASSERT(
-            this->inter_mesh_routing_tables_.contains(fabric_node_id),
-            "Intra mesh routing tables keys mismatch with inter mesh routing tables");
-        this->write_routing_tables_to_tensix_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
-        this->write_fabric_connections_to_tensix_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
-        this->write_routing_tables_to_eth_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+    auto user_meshes = this->get_user_physical_mesh_ids();
+    for (auto mesh_id : user_meshes) {
+        const auto& local_mesh_coord_range = this->get_coord_range(mesh_id, MeshScope::LOCAL);
+        for (const auto& mesh_coord : local_mesh_coord_range) {
+            auto fabric_chip_id = this->routing_table_generator_->mesh_graph->coordinate_to_chip(mesh_id, mesh_coord);
+            auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
+            TT_ASSERT(
+                this->inter_mesh_routing_tables_.contains(fabric_node_id),
+                "Intra mesh routing tables keys mismatch with inter mesh routing tables");
+            this->write_routing_tables_to_tensix_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+            this->write_fabric_connections_to_tensix_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+            this->write_routing_tables_to_eth_cores(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+        }
     }
 
     for (const auto& mesh_id : this->get_local_mesh_id_bindings()) {
@@ -2325,6 +2350,84 @@ void ControlPlane::populate_fabric_connection_info(
             risc_id);
     } else {
         dispatcher_connection_info = worker_connection_info;
+    }
+}
+
+void ControlPlane::collect_and_merge_router_port_directions_from_all_hosts() {
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+    if (*distributed_context.size() == 1) {
+        // No need to collect from other hosts when running a single process
+        return;
+    }
+
+    // Create RouterPortDirectionsData from local data
+    RouterPortDirectionsData local_data;
+    local_data.local_mesh_id = local_mesh_binding_.mesh_ids[0];
+    local_data.local_host_rank_id = this->get_local_host_rank_id_binding();
+    local_data.router_port_directions_map = router_port_directions_to_physical_eth_chan_map_;
+
+    auto serialized_data = tt::tt_fabric::serialize_router_port_directions_to_bytes(local_data);
+    std::vector<uint8_t> serialized_remote_data;
+    auto my_rank = *(distributed_context.rank());
+
+    for (std::size_t bcast_root = 0; bcast_root < *(distributed_context.size()); ++bcast_root) {
+        if (my_rank == bcast_root) {
+            // Issue the broadcast from the current process to all other processes in the world
+            int local_data_size_bytes = serialized_data.size();  // Send data size first
+            distributed_context.broadcast(
+                tt::stl::Span<std::byte>(
+                    reinterpret_cast<std::byte*>(&local_data_size_bytes), sizeof(local_data_size_bytes)),
+                distributed_context.rank());
+
+            distributed_context.broadcast(
+                tt::stl::as_writable_bytes(tt::stl::Span<uint8_t>(serialized_data.data(), serialized_data.size())),
+                distributed_context.rank());
+        } else {
+            // Acknowledge the broadcast issued by the root
+            int remote_data_size_bytes = 0;  // Receive the size of the serialized data
+            distributed_context.broadcast(
+                tt::stl::Span<std::byte>(
+                    reinterpret_cast<std::byte*>(&remote_data_size_bytes), sizeof(remote_data_size_bytes)),
+                tt::tt_metal::distributed::multihost::Rank{bcast_root});
+            serialized_remote_data.clear();
+            serialized_remote_data.resize(remote_data_size_bytes);
+            distributed_context.broadcast(
+                tt::stl::as_writable_bytes(
+                    tt::stl::Span<uint8_t>(serialized_remote_data.data(), serialized_remote_data.size())),
+                tt::tt_metal::distributed::multihost::Rank{bcast_root});
+
+            RouterPortDirectionsData deserialized_remote_data =
+                tt::tt_fabric::deserialize_router_port_directions_from_bytes(serialized_remote_data);
+
+            // Merge remote data into local router_port_directions_to_physical_eth_chan_map_
+            for (const auto& [fabric_node_id, direction_map] : deserialized_remote_data.router_port_directions_map) {
+                // Only merge if this fabric node is not already in our local map
+                if (router_port_directions_to_physical_eth_chan_map_.find(fabric_node_id) ==
+                    router_port_directions_to_physical_eth_chan_map_.end()) {
+                    router_port_directions_to_physical_eth_chan_map_[fabric_node_id] = direction_map;
+                } else {
+                    // If fabric node exists, merge direction maps
+                    for (const auto& [direction, channels] : direction_map) {
+                        auto& local_direction_map = router_port_directions_to_physical_eth_chan_map_[fabric_node_id];
+                        if (local_direction_map.find(direction) == local_direction_map.end()) {
+                            local_direction_map[direction] = channels;
+                        } else {
+                            // Merge channels, avoiding duplicates
+                            auto& local_channels = local_direction_map[direction];
+                            for (const auto& channel : channels) {
+                                if (std::find(local_channels.begin(), local_channels.end(), channel) ==
+                                    local_channels.end()) {
+                                    local_channels.push_back(channel);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Barrier here for safety - Ensure that all ranks have completed the bcast op before proceeding to the next
+        // root
+        distributed_context.barrier();
     }
 }
 

--- a/tt_metal/fabric/serialization/router_port_directions.cpp
+++ b/tt_metal/fabric/serialization/router_port_directions.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/serialization/router_port_directions.cpp
+++ b/tt_metal/fabric/serialization/router_port_directions.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+#include <stdexcept>
+#include "tt_metal/fabric/serialization/router_port_directions.hpp"
+#include "protobuf/router_port_directions.pb.h"
+
+namespace tt::tt_fabric {
+
+std::vector<uint8_t> serialize_router_port_directions_to_bytes(
+    const RouterPortDirectionsData& router_port_directions_data) {
+    tt::tt_fabric::protobuf::RouterPortDirectionsMap proto_msg;
+
+    // Set local mesh id
+    auto* mesh_id = proto_msg.mutable_local_mesh_id();
+    mesh_id->set_value(*router_port_directions_data.local_mesh_id);
+
+    // Set local host rank id
+    auto* host_rank_id = proto_msg.mutable_local_host_rank_id();
+    host_rank_id->set_value(*router_port_directions_data.local_host_rank_id);
+
+    // Process router port directions map
+    for (const auto& [fabric_node_id, direction_map] : router_port_directions_data.router_port_directions_map) {
+        auto* fabric_node_map = proto_msg.add_fabric_node_maps();
+
+        // Set fabric node id
+        auto* proto_fabric_node = fabric_node_map->mutable_fabric_node();
+        proto_fabric_node->set_mesh_id(*fabric_node_id.mesh_id);
+        proto_fabric_node->set_chip_id(fabric_node_id.chip_id);
+
+        // Process direction entries
+        for (const auto& [direction, channels] : direction_map) {
+            auto* direction_entry = fabric_node_map->add_direction_entries();
+            direction_entry->set_direction(static_cast<uint32_t>(direction));
+
+            // Add channels
+            for (const auto& channel : channels) {
+                direction_entry->add_channels(channel);
+            }
+        }
+    }
+
+    // Serialize to bytes
+    std::vector<uint8_t> serialized_data(proto_msg.ByteSizeLong());
+    if (!proto_msg.SerializeToArray(serialized_data.data(), serialized_data.size())) {
+        throw std::runtime_error("Failed to serialize RouterPortDirectionsMap to protobuf");
+    }
+
+    return serialized_data;
+}
+
+RouterPortDirectionsData deserialize_router_port_directions_from_bytes(const std::vector<uint8_t>& data) {
+    RouterPortDirectionsData result;
+
+    tt::tt_fabric::protobuf::RouterPortDirectionsMap proto_msg;
+    if (!proto_msg.ParseFromArray(data.data(), data.size())) {
+        throw std::runtime_error("Failed to parse protobuf data");
+    }
+
+    // Extract local mesh id
+    if (proto_msg.has_local_mesh_id()) {
+        result.local_mesh_id = MeshId{proto_msg.local_mesh_id().value()};
+    }
+
+    // Extract local host rank id
+    if (proto_msg.has_local_host_rank_id()) {
+        result.local_host_rank_id = MeshHostRankId{proto_msg.local_host_rank_id().value()};
+    }
+
+    // Extract router port directions map
+    for (const auto& fabric_node_map : proto_msg.fabric_node_maps()) {
+        FabricNodeId fabric_node_id(MeshId{0}, 0);
+
+        if (fabric_node_map.has_fabric_node()) {
+            fabric_node_id.mesh_id = MeshId{fabric_node_map.fabric_node().mesh_id()};
+            fabric_node_id.chip_id = fabric_node_map.fabric_node().chip_id();
+        }
+
+        std::unordered_map<RoutingDirection, std::vector<chan_id_t>> direction_map;
+
+        for (const auto& direction_entry : fabric_node_map.direction_entries()) {
+            RoutingDirection direction = static_cast<RoutingDirection>(direction_entry.direction());
+
+            std::vector<chan_id_t> channels;
+            for (const auto& channel : direction_entry.channels()) {
+                channels.push_back(channel);
+            }
+
+            direction_map[direction] = std::move(channels);
+        }
+
+        result.router_port_directions_map[fabric_node_id] = std::move(direction_map);
+    }
+
+    return result;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/serialization/router_port_directions.hpp
+++ b/tt_metal/fabric/serialization/router_port_directions.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/serialization/router_port_directions.hpp
+++ b/tt_metal/fabric/serialization/router_port_directions.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include "tt-metalium/fabric_types.hpp"
+#include "tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h"
+#include <tt-metalium/routing_table_generator.hpp>
+
+namespace tt::tt_fabric {
+
+// Structure to hold router port directions data for serialization
+struct RouterPortDirectionsData {
+    MeshId local_mesh_id = MeshId{0};
+    MeshHostRankId local_host_rank_id = MeshHostRankId{0};
+    std::map<FabricNodeId, std::unordered_map<RoutingDirection, std::vector<chan_id_t>>> router_port_directions_map;
+
+    bool operator==(const RouterPortDirectionsData& other) const {
+        return local_mesh_id == other.local_mesh_id && local_host_rank_id == other.local_host_rank_id &&
+               router_port_directions_map == other.router_port_directions_map;
+    }
+};
+
+// Serialization functions
+std::vector<uint8_t> serialize_router_port_directions_to_bytes(
+    const RouterPortDirectionsData& router_port_directions_data);
+RouterPortDirectionsData deserialize_router_port_directions_from_bytes(const std::vector<uint8_t>& data);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/serialization/router_port_directions.proto
+++ b/tt_metal/fabric/serialization/router_port_directions.proto
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/serialization/router_port_directions.proto
+++ b/tt_metal/fabric/serialization/router_port_directions.proto
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package tt.tt_fabric.protobuf;
+
+message MeshId {
+  uint32 value = 1;
+}
+
+message MeshHostRankId {
+  uint32 value = 1;
+}
+
+message FabricNodeId {
+  uint32 mesh_id = 1;
+  uint32 chip_id = 2;
+}
+
+message RoutingDirectionEntry {
+  uint32 direction = 1;  // RoutingDirection enum value
+  repeated uint32 channels = 2; // vector of chan_id_t
+}
+
+message FabricNodeDirectionsMap {
+  FabricNodeId fabric_node = 1;
+  repeated RoutingDirectionEntry direction_entries = 2;
+}
+
+message RouterPortDirectionsMap {
+  MeshId local_mesh_id = 1;
+  MeshHostRankId local_host_rank_id = 2;
+  repeated FabricNodeDirectionsMap fabric_node_maps = 3;
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26789#issuecomment-3264328562)

### Problem description
Fabric and control plane host utils:
- `control_plane.get_forwarding_direction`
- `control_plane.get_active_fabric_eth_channels_in_direction`
- `control_plane.routing_direction_to_eth_direction`
- `get_forwarding_link_indices_in_direction`
- `get_fabric_route`

Do not support querying for remote host.

### What's changed
- MPI collect `this->router_port_directions_to_physical_eth_chan_map_` across all hosts, which enables the above apis.
- `convert_fabric_routing_table_to_chip_routing_table` creates `intra/inter_mesh_routing_tables_` for all hosts
-  `get_connected_mesh_chip_chan_ids` now uses routing planes and mesh graph connectivity

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes