### PR TITLE
Pool Fix For Bounded Core Grids and Shard Width > Stick Size

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -88,7 +88,7 @@ template <
     uint32_t window_h,
     uint32_t window_w,
     uint32_t in_w_padded,
-    uint32_t in_nbytes_leftover,  // in_aligned_nbytes_c
+    uint32_t in_nbytes_leftover,
     uint32_t in_c,
     uint32_t max_sticks_for_reduction,
     uint32_t total_elems_to_reduce,
@@ -97,6 +97,7 @@ template <
     uint32_t clear_value_cb_id,
     uint32_t in_cb_ntiles,
     uint32_t in_nbytes_c,
+    uint32_t shard_width_bytes,
     bool is_large_kernel,
     bool last_tile_is_partial,
     uint32_t dilation_h,
@@ -123,13 +124,13 @@ ALWI void read_window_with_top_left_index(
         }
     }
 #endif
-
     for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
         uint32_t read_bytes = in_nbytes_c;
         if constexpr (wide_reduction) {
             read_bytes =
                 (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
         }
+
         uint32_t in_l1_write_addr = get_write_ptr(in_cb_id);
         cb_reserve_back(in_cb_id, 1);
         uint32_t in_idx_l1_write_addr = 0;
@@ -145,7 +146,7 @@ ALWI void read_window_with_top_left_index(
             auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
                 const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
                 const uint32_t read_offset =
-                    in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
+                    in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
                 noc_async_read_one_packet(get_noc_addr(read_offset), in_l1_write_addr, read_bytes * w_multiple);
                 // if compute is using tilize_reconfig we will only untilize the needed number of tiles rather
                 // than the entire MAX_TILES_PER_REDUCTION, thus we use a different offset for the write address
@@ -156,7 +157,7 @@ ALWI void read_window_with_top_left_index(
                 }
                 if constexpr (return_indices) {
                     const uint32_t idx_read_offset =
-                        in_idx_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
+                        in_idx_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
                     noc_async_read_one_packet(
                         get_noc_addr(idx_read_offset), in_idx_l1_write_addr, read_bytes * w_multiple);
                     if constexpr (tilize_reconfig) {
@@ -265,7 +266,7 @@ void kernel_main() {
     constexpr int32_t pad_w = get_compile_time_arg_val(3);
 
     // channel size in bytes
-    constexpr uint32_t in_aligned_nbytes_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nbytes_leftover = get_compile_time_arg_val(4);
 
     // input tensor height / width / channels
     constexpr int32_t in_w = get_compile_time_arg_val(5);
@@ -297,7 +298,7 @@ void kernel_main() {
     constexpr bool one_scalar_per_core = get_compile_time_arg_val(28);
     constexpr uint32_t config_cb_id = get_compile_time_arg_val(29);
     constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(30);
-    constexpr uint32_t in_nbytes_padded_c = get_compile_time_arg_val(31);
+    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(31);
     constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(32);
     constexpr uint32_t stride_w = get_compile_time_arg_val(33);
     constexpr uint32_t dilation_h = get_compile_time_arg_val(34);
@@ -420,7 +421,7 @@ void kernel_main() {
                 window_h,
                 window_w,
                 in_w_padded,
-                in_aligned_nbytes_c,
+                in_nbytes_leftover,
                 in_c,
                 max_sticks_for_reduction,
                 total_elems_to_reduce,
@@ -428,7 +429,8 @@ void kernel_main() {
                 wide_reduction,
                 clear_value_cb_id,
                 in_cb_ntiles,
-                in_nbytes_padded_c,
+                in_nbytes_c,
+                shard_width_bytes,
                 is_large_kernel,
                 last_tile_is_partial,
                 dilation_h,
@@ -454,7 +456,7 @@ void kernel_main() {
             window_h,
             window_w,
             in_w_padded,
-            in_aligned_nbytes_c,
+            in_nbytes_leftover,
             in_c,
             max_sticks_for_reduction,
             total_elems_to_reduce,
@@ -462,7 +464,8 @@ void kernel_main() {
             wide_reduction,
             clear_value_cb_id,
             in_cb_ntiles,
-            in_nbytes_padded_c,
+            in_nbytes_c,
+            shard_width_bytes,
             is_large_kernel,
             last_tile_is_partial,
             dilation_h,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -259,17 +259,20 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
     const auto& input_shape = inputs[0].padded_shape();
-    [[maybe_unused]] const auto& output_shape = outputs[0].padded_shape();
-
-    const uint32_t in_nbytes_c = in_c / num_shards_c * params.nbytes;  // row of input (channels)
-    const uint32_t in_nbytes_padded_c = input_shape[3] / num_shards_c * params.nbytes;
+    const auto& output_shape = outputs[0].padded_shape();
+    const uint32_t shard_width = inputs[0].shard_spec()->shape[1];
+    const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
+                                             ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
+                                             : in_c / num_shards_c;
+    const uint32_t in_nbytes_c = in_c_per_shard_ceil * params.nbytes;  // row of input (channels)
+    const uint32_t shard_width_bytes = input_shape[3] / num_shards_c * params.nbytes;
 
     TT_FATAL(
         input_shape[3] % num_shards_c == 0,
         "Input channels {} should be divisible by number of shards {}",
         input_shape[3],
         num_shards_c);
-    const uint32_t in_aligned_nbytes_c =
+    const uint32_t in_nbytes_leftover =
         params.is_wide_reduction &&
                 (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH) != 0
             ? tt::round_up(
@@ -539,9 +542,9 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         kernel_h,                       // 1
         kernel_w,                       // 2
         pad_w,                          // 3
-        in_aligned_nbytes_c,            // 4
+        in_nbytes_leftover,             // 4
         in_w,                           // 5
-        in_c / num_shards_c,            // 6
+        in_c_per_shard_ceil,            // 6
         params.split_reader,            // enable split reader //7
         0,                              // split reader id //8
         bf16_scalar,                    // 9
@@ -566,7 +569,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         one_scalar_per_core,            // 28
         config_cb_id,                   // 29
         in_nbytes_c,                    // 30
-        in_nbytes_padded_c,             // 31
+        shard_width_bytes,              // 31
         params.multi_buffering_factor,  // 32
         stride_w,                       // 33
         dilation_h,                     // 34
@@ -602,7 +605,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         kernel_h * kernel_w,            // 1
         params.split_reader,            // 2
         out_nhw_per_core,               // 3
-        in_c / num_shards_c,            // 4
+        in_c_per_shard_ceil,            // 4
         in_nblocks_c,                   // 5
         params.max_rows_for_reduction,  // 6
         in_cb_id_0,                     // 7

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -220,6 +220,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t in_w,
     uint32_t out_h,
     uint32_t out_w,
+    uint32_t out_c,
     uint32_t kernel_h,
     uint32_t kernel_w,
     uint32_t stride_h,
@@ -259,7 +260,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
     const auto& input_shape = inputs[0].padded_shape();
-    const auto& output_shape = outputs[0].padded_shape();
     const uint32_t shard_width = inputs[0].shard_spec()->shape[1];
     const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
                                              ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
@@ -699,10 +699,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "pad_w: {}", pad_w);
         log_debug(tt::LogOp, "out_h: {}", out_h);
         log_debug(tt::LogOp, "out_w: {}", out_w);
-        log_debug(tt::LogOp, "out_c: {}", output_shape[3]);
+        log_debug(tt::LogOp, "out_c: {}", out_c);
         log_debug(tt::LogOp, "in_h: {}", in_h);
         log_debug(tt::LogOp, "in_w: {}", in_w);
-        log_debug(tt::LogOp, "in_c: {}", input_shape[3]);
+        log_debug(tt::LogOp, "in_c: {}", in_c);
         log_debug(tt::LogOp, "in_ntiles_c: {}", params.in_ntiles_c);
         log_debug(tt::LogOp, "out_ntiles_c: {}", params.out_ntiles_c);
         log_debug(tt::LogOp, "in_nblocks_c: {}", in_nblocks_c);
@@ -753,6 +753,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     auto output_shape = sliding_window_config.get_output_shape();
     uint32_t out_h = output_shape[1];
     uint32_t out_w = output_shape[2];
+    uint32_t out_c = output_shape[3];
 
     bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     auto in_n = sliding_window_config.batch_size;
@@ -798,6 +799,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         in_w,
         out_h,
         out_w,
+        out_c,
         kernel_h,
         kernel_w,
         stride_h,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -114,6 +114,8 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
 
     Program program = CreateProgram();
 
+    uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+
     if (this->in_place_) {
         // after untilize bfloat8 is converted to bfloat16
         const tt::tt_metal::DataType dtype = input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B
@@ -143,6 +145,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
             remote_read_,
             is_in_tiled,
             device,
+            num_cores_x,
             max_out_nsticks_per_core_,
             in_nsticks_per_core_,
             this->in_place_,
@@ -178,6 +181,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
             padding_exists,
             config_.num_cores_nhw,
             config_.num_cores_c,
+            num_cores_x,
             max_out_nsticks_per_core_,
             max_ref_size,
             in_out_shard_size_delta,
@@ -197,6 +201,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
             transpose_mcast_,
             remote_read_,
             device,
+            num_cores_x,
             is_in_tiled,
             UNTILIZE_BLOCK_SIZE);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -393,6 +393,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const bool padding_exists,
     const uint32_t ncores_nhw,
     const uint32_t ncores_c,
+    const uint32_t num_cores_x,
     const uint32_t max_out_nsticks_per_core,
     const uint32_t max_ref_size,
     const uint32_t in_out_shard_size_delta,
@@ -559,8 +560,8 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     }
 
     // noc conversion function
-    auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        auto num_cores_x = device->compute_with_storage_grid_size().x;
+    auto core_id_to_noc_coords =
+        [is_block_sharded, transpose_mcast, device, num_cores_x](uint32_t core_id) -> CoreCoord {
         auto core_coord = CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
         return device->worker_core_from_logical_core(core_coord);
     };
@@ -571,7 +572,6 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     // compute the number of noop cores
     const bool is_rm_orientation = input_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR;
     const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_orientation);
-    int32_t num_cores_x = device->compute_with_storage_grid_size().x;
     int32_t num_active_cores = cores.size();
     int32_t num_cores_rectangular = is_block_sharded ? num_active_cores : tt::round_up(num_active_cores, num_cores_x);
     int32_t num_noop_cores = is_block_sharded ? 0 : num_cores_rectangular - num_active_cores;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -33,6 +33,7 @@ tt::tt_metal::operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_c
     bool padding_exists,
     uint32_t ncores_nhw,
     uint32_t ncores_c,
+    uint32_t num_cores_x,
     uint32_t max_out_nsticks_per_core,
     uint32_t max_ref_size,
     uint32_t in_out_shard_size_delta,

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -606,10 +606,11 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     bool transpose_mcast,
     bool remote_read,
     IDevice* device,
+    uint32_t num_cores_x,
     bool is_in_tiled,
     int block_size) {
-    auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        auto num_cores_x = device->compute_with_storage_grid_size().x;
+    auto core_id_to_noc_coords =
+        [is_block_sharded, transpose_mcast, device, num_cores_x](uint32_t core_id) -> CoreCoord {
         auto core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id))
                                            : CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
         return device->worker_core_from_logical_core(core_coord);
@@ -804,12 +805,13 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
     bool remote_read,
     bool is_in_tiled,
     IDevice* device,
+    uint32_t num_cores_x,
     uint32_t max_out_nsticks_per_core,
     uint32_t in_nsticks_per_core,
     bool in_place,
     uint32_t in_out_shard_size_delta) {
-    auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        auto num_cores_x = device->compute_with_storage_grid_size().x;
+    auto core_id_to_noc_coords =
+        [is_block_sharded, transpose_mcast, device, num_cores_x](uint32_t core_id) -> CoreCoord {
         auto core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id))
                                            : CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
         return device->worker_core_from_logical_core(core_coord);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -130,6 +130,7 @@ std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_inplac
     bool remote_read,
     bool is_in_tiled,
     tt::tt_metal::IDevice* device,
+    uint32_t num_cores_x,
     uint32_t max_out_nsticks_per_core = INT_MAX,
     uint32_t in_nsticks_per_core = 0,
     bool in_place = false,
@@ -150,6 +151,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     bool transpose_mcast,
     bool remote_read,
     tt::tt_metal::IDevice* device,
+    uint32_t num_cores_x,
     bool is_in_tiled,
     int block_size);
 


### PR DESCRIPTION
### Problem description
Max Pool does not work with core grids having multiple rows spanning only some of the available columns (i.e. ({0,0},{2,2}) fails while ({0,0}{4,0}) works), this will also cause a hang for in place halo as the resulting NOC coordinates are not correct.

It also did not work on blackhole for shard widths larger than the stick size.

### What's changed
Halo's calculation of `num_cores_x` has been updated to use the core bounding box.

Pool's reader kernel has been updated to account for potential padding in the C dimension.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17741992797
Failing on main this PR hits same unrelated error
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17741995662
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17742014797
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17742010722
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17742004084
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17742006971
Failing on main this PR hits same unrelated error
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/17742019207
- [x] New/Existing tests provide coverage for changes