### PR TITLE
Skip closing devices in ttnn_test_fixtures if the test is skupped

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -57,7 +57,11 @@ protected:
         device_ = device_holder_.get();
     }
 
-    void TearDown() override { device_->close(); }
+    void TearDown() override {
+        if (device_holder_) {
+            device_holder_->close();
+        }
+    }
 
     TTNNFixtureWithDevice() : TTNNFixtureBase() {}
 
@@ -85,7 +89,11 @@ protected:
         device_ = device_holder_.get();
     }
 
-    void TearDown() override { device_->close(); }
+    void TearDown() override {
+        if (device_holder_) {
+            device_holder_->close();
+        }
+    }
 };
 
 class MultiCommandQueueT3KFixture : public TTNNFixtureBase {
@@ -111,8 +119,11 @@ protected:
     }
 
     void TearDown() override {
-        for (auto& [_, dev] : devs) {
-            dev->close();
+        if (!devs.empty()) {
+            for (auto& [_, dev] : devs) {
+                dev->close();
+            }
+            devs.clear();
         }
     }
 };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28419

### Problem description
- Running TTNN Unit Tests with Slow Dispatch enabled was causing a segfault even though tests were being skipped.
- This was because fixture setup early exited and didn't populate the `MeshDevice` pointers, while the teardown step tried to access an unintialized pointer to close the device

### What's changed
- Check if the `MeshDevice` pointer is populated before closing it in `TearDown`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes