### PR TITLE
[tt-train] SwiGLU forward kernel implementation

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -135,6 +135,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/rope_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/scaled_dot_product_attention.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/scaled_dot_product_attention.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/swiglu_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/swiglu_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/unary_ops.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/unary_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/sampling_op.cpp
@@ -264,6 +266,14 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.cpp
+    # SwiGLU Forward
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
 )
 
 list(APPEND SOURCES ${METAL_OPS_FILES})

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -13,6 +13,7 @@
 #include "ops/silu_bw/silu_bw.hpp"
 #include "ops/softmax/softmax.hpp"
 #include "optimizers/sgd_fused/sgd_fused.hpp"
+#include "ops/swiglu_fw/swiglu_fw.hpp"
 
 namespace ttml::metal {
 
@@ -41,6 +42,9 @@ constexpr auto silu_bw =
 
 constexpr auto sdpa_fw =
     ttnn::register_operation<"ttml::metal::sdpa_fw", ttml::metal::ops::sdpa_fw::SDPAForwardOperation>();
+    
+constexpr auto swiglu_fw =
+    ttnn::register_operation<"ttml::metal::swiglu_fw", ttml::metal::ops::swiglu_fw::SwiGLUForwardOperation>();
 
 constexpr auto sgd_fused =
     ttnn::register_operation<"ttml::metal::sgd_fused", ttml::metal::optimizers::sgd_fused::SGDFusedOptimizer>();

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -42,7 +42,7 @@ constexpr auto silu_bw =
 
 constexpr auto sdpa_fw =
     ttnn::register_operation<"ttml::metal::sdpa_fw", ttml::metal::ops::sdpa_fw::SDPAForwardOperation>();
-    
+
 constexpr auto swiglu_fw =
     ttnn::register_operation<"ttml::metal::swiglu_fw", ttml::metal::ops::swiglu_fw::SwiGLUForwardOperation>();
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <compute_kernel_api/eltwise_binary_sfpu.h>
+#include <compute_kernel_api/reconfig_data_format.h>
+#include <debug/dprint.h>
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/cb_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/copy_dest_values.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/fill.h"
+#include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/ops/common/compute_utils.hpp"
+namespace NAMESPACE {
+
+// ----------------------------------------------------------------------
+// Problem:
+//
+// Given:
+//   X   shape [R, P]
+//   W1  shape [P, K]
+//   W2  shape [K, C]
+//   W3  shape [P, K]
+// We want:
+//   Y[r, c] = sum_k( M[r, k] * W2[k, c] )
+//   where
+//       M[r, k] = sum_p( X[r, p] * W1[p, k] ) * sum_p( X[r, p] * W3[p, k] )
+//
+// We compute in 3 nested block loops over c, k, p
+//   p is split into p_blocks for streaming X, W1 and W3
+//   k is split into k_blocks for streaming M and W2
+//   c is split into c_blocks to fit Y accumulators in registers
+// ----------------------------------------------------------------------
+
+constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t Wt = get_compile_time_arg_val(2);         // total C
+constexpr uint32_t hidden_Wt = get_compile_time_arg_val(3);  // total H
+constexpr uint32_t mask_w = get_compile_time_arg_val(4);     // mask for input inner dimension
+constexpr uint32_t mask_hw = get_compile_time_arg_val(5);    // mask for hidden inner dimension
+
+// CBs with input data
+constexpr auto cb_input_idx = tt::CBIndex::c_0;  // X[r, p_block]
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
+constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
+constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
+// CBs with masks
+constexpr auto cb_mask_w_idx = tt::CBIndex::c_4;   // Mask for input inner dimension
+constexpr auto cb_mask_hw_idx = tt::CBIndex::c_5;  // Mask for hidden inner dimension
+// CBs with intermediate computations
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;        // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;        // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;          // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;  // Partial Y[r, c_block] between k_blocks
+// CB with output data
+constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
+
+constexpr uint32_t onetile = 1U;
+
+#ifdef DO_MASK_W
+constexpr bool do_mask_w = true;
+#else
+constexpr bool do_mask_w = false;
+#endif
+
+#ifdef DO_MASK_HW
+constexpr bool do_mask_hw = true;
+#else
+constexpr bool do_mask_hw = false;
+#endif
+
+// ============================================================================
+// Phase A: Compute full M[r, k] over all p_s
+//   M[r, k] = SiLU(sum_p( X[r, p] * W1[p, k] )) * sum_p( X[r, p] * W3[p, k] )
+// ============================================================================
+inline void compute_M_for_k() {
+    const uint32_t xw1_accum_reg = 0U;  // REG0 will hold the accumulated (X @ W1)[r, k]
+    const uint32_t xw3_accum_reg = 1U;  // REG1 will hold the accumulated (X @ W3)[r, k]
+    const uint32_t silu_xw1_reg = 2U;   // REG2 will hold the SiLU(X @ W1)[r, k]
+    const uint32_t m_reg = 3U;          // REG3 will hold M[r, k] = SiLU(X @ W1) * (X @ W3)
+
+    tile_regs_acquire();  // acquire working regs
+
+    reconfig_data_format(cb_input_idx, cb_w1_idx);
+    mm_init(cb_input_idx, cb_w1_idx, cb_xw1_idx);
+
+    // Accumulate XW1 and XW3 over all p_blocks
+    for (uint32_t p_block_start = 0; p_block_start < Wt; p_block_start += block_size) {
+        const uint32_t p_block_size = (p_block_start + block_size <= Wt) ? block_size : Wt - p_block_start;
+
+        cb_wait_front(cb_input_idx, block_size);
+        cb_wait_front(cb_w1_idx, block_size);
+        cb_wait_front(cb_w3_idx, block_size);
+
+        for (uint32_t block_idx = 0; block_idx < p_block_size; ++block_idx) {
+            // Compute XW1
+            matmul_tiles(cb_input_idx, cb_w1_idx, block_idx, block_idx, xw1_accum_reg, false);
+            // Compute XW3 using same X tile
+            matmul_tiles(cb_input_idx, cb_w3_idx, block_idx, block_idx, xw3_accum_reg, false);
+        }
+
+        cb_pop_front(cb_input_idx, block_size);
+        cb_pop_front(cb_w1_idx, block_size);
+        cb_pop_front(cb_w3_idx, block_size);
+    }
+    // Copy xw1_accum_reg to silu_xw1_reg
+    copy_dest_values_init();
+    copy_dest_values(silu_xw1_reg, xw1_accum_reg);
+    // Apply sigmoid activation to compute sigmoid(XW1)
+    sigmoid_tile_init();
+
+    sigmoid_tile(silu_xw1_reg);
+    // Multiply XW1 * sigmoid(XW1) to get SiLU(XW1)
+    mul_binary_tile_init();
+    mul_binary_tile(xw1_accum_reg, silu_xw1_reg, silu_xw1_reg);
+    // Final multiplication: M = SiLU(XW1) * XW3
+    mul_binary_tile(silu_xw1_reg, xw3_accum_reg, m_reg);
+
+    tile_regs_commit();
+    pack_and_push(m_reg, cb_m_idx);
+}
+
+// ============================================================================
+// Phase B: Complete Y computation and store
+//   Y[r,c] += sum_k( M[r,k] * W2[k,c] )
+//   Stores result to output_cb_idx (either Y_partial or Y_final CB)
+// ============================================================================
+inline void mul_MxW2_accumulate_Y(uint32_t k_block_size, uint32_t c_block_size, bool first_k_block, bool last_k_block) {
+    tile_regs_acquire();
+    // Initialize or load Y accumulators
+    if (!first_k_block) {
+        cb_wait_front(cb_y_partial_idx, block_size);
+        reconfig_data_format(cb_y_partial_idx, cb_y_partial_idx);
+        copy_tile_init(cb_y_partial_idx);
+        for (uint32_t c = 0; c < c_block_size; ++c) {
+            copy_tile(cb_y_partial_idx, c, c);  // CB tile -> REG
+        }
+        cb_pop_front(cb_y_partial_idx, block_size);
+    }
+    cb_wait_front(cb_m_idx, block_size);  // M[r,k] values ready
+    reconfig_data_format(cb_m_idx, cb_w2_idx);
+    // NOTE(maciek): Using mm_init_short since we do not want to zero reguisters. mm_init does zero them.
+    mm_init_short(cb_m_idx, cb_w2_idx, false);
+    // Process each column of W2 sequentially
+    for (uint32_t c = 0; c < c_block_size; ++c) {
+        // Wait for W2 data: block_size tiles per column
+        cb_wait_front(cb_w2_idx, block_size);
+
+        // Compute Y[r, c] = sum_k( M[r,k] * W2[k, c] )
+        for (uint32_t k = 0; k < k_block_size; ++k) {
+            matmul_tiles(cb_m_idx, cb_w2_idx, k, k, c, false);
+        }
+        cb_pop_front(cb_w2_idx, block_size);  // Done with all W2 data
+    }
+    // Pop all and M[r,k] values at once
+    cb_pop_front(cb_m_idx, block_size);  // Done with M[r,k] values
+
+    tile_regs_commit();
+    // Store result to appropriate CB
+    const auto output_cb_idx = last_k_block ? cb_y_idx : cb_y_partial_idx;
+    pack_and_push_block(output_cb_idx, block_size);
+}
+
+// ========================= Compute kernel structure =========================
+// for r in rows:
+//   for c_block in c_blocks:
+//     for k_block in k_blocks:
+//       for k in k_block:
+//         XW1 = sum_p( X[r,p] * W1[p,k] )
+//         XW3 = sum_p( X[r,p] * W3[p,k] )
+//         M[r,k] = SiLU(XW1) * XW3
+//       for c in c_block:
+//         Y_partial[r,c] += sum_k( M[r,k] * W2[k,c] )
+//     store final Y_partial to Y
+// ============================================================================
+inline void MAIN {
+    if constexpr (do_mask_w) {
+        // cb_wait_front(cb_mask_w_idx, onetile);
+    }
+    if constexpr (do_mask_hw) {
+        // cb_wait_front(cb_mask_hw_idx, onetile);
+    }
+
+    init_sfpu(cb_input_idx, cb_y_idx);
+    binary_op_init_common(cb_input_idx, cb_w1_idx, cb_y_idx);
+    for (uint32_t r = 0; r < num_rows_per_core; ++r) {
+        // Loop over c_blocks with tail handling
+        for (uint32_t c_block_start = 0; c_block_start < Wt; c_block_start += block_size) {
+            const uint32_t c_block_size = (c_block_start + block_size <= Wt) ? block_size : Wt - c_block_start;
+
+            // Loop over k_blocks with tail handling
+            for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
+                const uint32_t k_block_size =
+                    (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
+
+                const bool first_k_block = (k_block_start == 0);
+                const bool last_k_block = (k_block_start + block_size >= hidden_Wt);
+
+                // ---- Phase A: compute M[r,k] for all k in this k_block ----
+                // M[r,k] = sum_p( X[r,p] * W1[p,k] )
+                for (uint32_t k = 0; k < block_size; ++k) {
+                    if (k < k_block_size) {
+                        compute_M_for_k();
+                    } else {
+                        // Push empty/invalid M for k >= k_block_size
+                        tile_regs_acquire();
+                        tile_regs_commit();
+                        pack_and_push(3U, cb_m_idx);  // push empty/invalid M
+                    }
+                }
+                // ---- Phase B: accumulate into Y[r, c_block] and store ----
+                mul_MxW2_accumulate_Y(k_block_size, c_block_size, first_k_block, last_k_block);
+            }
+        }
+    }
+}
+
+}  // namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel.cpp
@@ -1,18 +1,15 @@
 // SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <compute_kernel_api/eltwise_binary_sfpu.h>
-#include <compute_kernel_api/reconfig_data_format.h>
-
-#include <cstdint>
-
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/cb_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/copy_dest_values.h"
 #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/ops/common/compute_utils.hpp"
 namespace NAMESPACE {
@@ -50,304 +47,15 @@ constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
 constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
 constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
 // CBs with intermediate computations
-constexpr auto cb_xw1_partial_idx = tt::CBIndex::c_4;  // Partial (X @ W1)[r, k_block] between p_blocks
-constexpr auto cb_xw3_partial_idx = tt::CBIndex::c_5;  // Partial (X @ W3)[r, k_block] between p_blocks
-constexpr auto cb_xw1_idx = tt::CBIndex::c_6;          // (X @ W1)[r, k_block]
-constexpr auto cb_xw3_idx = tt::CBIndex::c_7;          // (X @ W3)[r, k_block]
-constexpr auto cb_m_idx = tt::CBIndex::c_8;            // M[r, k_block]
-constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;    // Partial Y[r, c_block] between k_blocks
+// tt::CBIndex::c_4 and tt::CBIndex::c_5 are unused in this implementation.
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;        // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;        // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;          // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;  // Partial Y[r, c_block] between k_blocks
 // CB with output data
 constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
 
 constexpr uint32_t onetile = 1U;
-
-#ifdef ROW_OF_M_FITS_IN_L1
-// ============================================================================
-// Abstracted operation to compute
-// C[r, c : c + c_block_size] = A[r, k : k + ab_block_size] * B[k : k + ab_block_size, c : c + c_block_size]
-//
-//   if first_ab_block is true C := ...
-//   else C += ...
-//   if last_ab_block is true, store C to cb_c_final_idx
-//   else store C to cb_c_partial_idx
-//
-// NOTE: This function does not wait for nor pop cb A. It only waits for and pops B. The caller is responsible for
-// waiting for and popping A.
-// ============================================================================
-inline void mul_AxB_accumulate_C(
-    tt::CBIndex cb_a_idx,
-    tt::CBIndex cb_b_idx,
-    tt::CBIndex cb_c_partial_idx,
-    tt::CBIndex cb_c_final_idx,
-    uint32_t a_start_idx,
-    uint32_t ab_block_size,
-    uint32_t c_block_size,
-    bool first_ab_block,
-    bool last_ab_block) {
-    tile_regs_acquire();
-
-    // Initialize or load C accumulators
-    if (!first_ab_block) {
-        cb_wait_front(cb_c_partial_idx, block_size);
-        copy_tile_init(cb_c_partial_idx);
-        for (uint32_t c = 0; c < c_block_size; ++c) {
-            copy_tile(cb_c_partial_idx, c, c);  // CB tile -> REG
-        }
-        cb_pop_front(cb_c_partial_idx, block_size);
-    }
-
-    mm_init_short(cb_a_idx, cb_b_idx, false);
-
-    // Process each column of B sequentially
-    for (uint32_t c = 0; c < c_block_size; ++c) {
-        // Wait for B data: block_size tiles per column
-        cb_wait_front(cb_b_idx, block_size);
-
-        // Compute C[r, c] += sum_k( A[r, k] * B[k, c] )
-        for (uint32_t k = 0; k < ab_block_size; ++k) {
-            matmul_tiles(cb_a_idx, cb_b_idx, a_start_idx + k, k, c, false);
-        }
-
-        cb_pop_front(cb_b_idx, block_size);  // Done with all B data
-    }
-
-    tile_regs_commit();
-
-    // Store result to appropriate CB
-    const auto output_cb_idx = last_ab_block ? cb_c_final_idx : cb_c_partial_idx;
-    pack_and_push_block(output_cb_idx, block_size);
-}
-
-// ============================================================================
-// Flash-attention optimization: Accumulate XW results across k_block batches
-// This function accumulates X[r, p_block] * W[p_block, k_block] into partial/final buffers
-// avoiding re-reading X for each k_block
-// ============================================================================
-inline void mul_XW_accumulate_k_block(
-    tt::CBIndex cb_x_idx,        // X[r, p_block]
-    tt::CBIndex cb_w_idx,        // W[p_block, k_block] (W1 or W3)
-    tt::CBIndex cb_partial_idx,  // Partial results buffer (cb_xw1_partial or cb_xw3_partial)
-    tt::CBIndex cb_final_idx,    // Final results buffer (cb_xw1 or cb_xw3)
-    uint32_t p_block_size,
-    uint32_t k_block_size,
-    bool first_p_block,
-    bool last_p_block) {
-    tile_regs_acquire();
-
-    // Initialize or load previous partial results for this k_block
-    if (!first_p_block) {
-        cb_wait_front(cb_partial_idx, block_size);
-
-        copy_tile_init(cb_partial_idx);
-        // Only load k_block_size values (actual data), ignore padding
-        for (uint32_t k = 0; k < k_block_size; ++k) {
-            copy_tile(cb_partial_idx, k, k);  // CB tile -> REG
-        }
-
-        cb_pop_front(cb_partial_idx, block_size);
-    }
-
-    mm_init_short(cb_x_idx, cb_w_idx, false);
-
-    // Process each p in this p_block (to match reader's organization)
-    for (uint32_t p = 0; p < p_block_size; ++p) {
-        // Wait for W data: W[p, k_block] (entire row, matching reader pattern)
-        cb_wait_front(cb_w_idx, block_size);
-
-        // Accumulate: result[k] += X[p] * W[p, k] for all k in k_block
-        for (uint32_t k = 0; k < k_block_size; ++k) {
-            matmul_tiles(cb_x_idx, cb_w_idx, p, k, k, false);
-        }
-
-        cb_pop_front(cb_w_idx, block_size);
-    }
-
-    tile_regs_commit();
-
-    // Store result to appropriate CB
-    const auto output_cb_idx = last_p_block ? cb_final_idx : cb_partial_idx;
-    pack_and_push_block(output_cb_idx, block_size);
-}
-
-// ============================================================================
-// Compute XW1[r, k] and XW3[r, k] over all p_blocks using flash-attention optimization
-//   XW1[r, k] = sum_p( X[r, p] * W1[p, k] )
-//   XW3[r, k] = sum_p( X[r, p] * W3[p, k] )
-//
-// This function implements a flash-attention-like optimization where X[r, p_block] is read
-// only once per p_block and reused across all k_blocks, significantly reducing memory reads.
-// ============================================================================
-
-inline void compute_XW1_XW3_for_r() {
-    // Flash-attention optimization: Read X[r, p_block] only once per p_block
-    // Loop order: outer p_blocks, inner k_blocks (but process k_blocks one at a time due to register limits)
-    for (uint32_t p_block_start = 0; p_block_start < Wt; p_block_start += block_size) {
-        const uint32_t p_block_size = (p_block_start + block_size <= Wt) ? block_size : Wt - p_block_start;
-        const bool first_p_block = (p_block_start == 0);
-        const bool last_p_block = (p_block_start + block_size >= Wt);
-
-        // Read X[r, p_block] once for this p_block
-        cb_wait_front(cb_input_idx, block_size);
-
-        // Process each k_block separately (due to register constraints)
-        for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
-            const uint32_t k_block_size =
-                (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
-
-            // Accumulate contributions to XW1[r, k_block] and XW3[r, k_block]
-            // On last_p_block, results go directly to final CBs
-            mul_XW_accumulate_k_block(
-                /* cb_x_idx */ cb_input_idx,
-                /* cb_w_idx */ cb_w1_idx,
-                /* cb_partial_idx */ cb_xw1_partial_idx,
-                /* cb_final_idx */ cb_xw1_idx,
-                /* p_block_size */ p_block_size,
-                /* k_block_size */ k_block_size,
-                /* first_p_block */ first_p_block,
-                /* last_p_block */ last_p_block);
-
-            mul_XW_accumulate_k_block(
-                /* cb_x_idx */ cb_input_idx,
-                /* cb_w_idx */ cb_w3_idx,
-                /* cb_partial_idx */ cb_xw3_partial_idx,
-                /* cb_final_idx */ cb_xw3_idx,
-                /* p_block_size */ p_block_size,
-                /* k_block_size */ k_block_size,
-                /* first_p_block */ first_p_block,
-                /* last_p_block */ last_p_block);
-        }
-
-        // Done with X[r, p_block]
-        cb_pop_front(cb_input_idx, block_size);
-    }
-}
-
-// ============================================================================
-// Compute M[r, :] = SiLU(XW1[r, :]) * XW3[r, :]
-//   where XW1 and XW3 are precomputed and stored in cb_xw1_idx and cb_xw3_idx
-// ============================================================================
-inline void compute_M_for_r() {
-    // Wait for XW1 and XW3 to be ready
-    cb_wait_front(cb_xw1_idx, hidden_Wt_rounded_up);
-    cb_wait_front(cb_xw3_idx, hidden_Wt_rounded_up);
-
-    for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
-        const uint32_t k_block_size =
-            (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
-        // Compute M[r, k_block_start : k_block_start + k_block_size]
-        // NOTE(maciek): We process each k in the block sequentially since we need to apply SiLU activation
-        // and we have limited number of registers. Processing all k in the block in parallel would require
-        // additional temporary CBs and packing/unpacking. I don't expect this to be a performance bottleneck.
-        for (uint32_t k = 0; k < k_block_size; ++k) {
-            const uint32_t xw1_reg = 0U;   // REG0 will hold (X @ W1)[r, k]
-            const uint32_t xw3_reg = 1U;   // REG1 will hold (X @ W3)[r, k]
-            const uint32_t silu_reg = 2U;  // REG2 will hold SiLU(X @ W1)[r, k]
-            const uint32_t m_reg = 3U;     // REG3 will hold M
-
-            const uint32_t tile_offset = k_block_start + k;
-
-            tile_regs_acquire();  // acquire working regs
-            // Copy XW1 and XW3 to registers
-            copy_tile_init(cb_xw1_idx);
-            copy_tile(cb_xw1_idx, tile_offset, xw1_reg);
-            copy_tile_init(cb_xw3_idx);
-            copy_tile(cb_xw3_idx, tile_offset, xw3_reg);
-
-            // Apply SiLU activation to compute SiLU(XW1)
-            copy_dest_values_init();
-            copy_dest_values(silu_reg, xw1_reg);
-            sigmoid_tile_init();
-            sigmoid_tile(silu_reg);
-            // Multiply XW1 * sigmoid(XW1) to get SiLU(XW1)
-            mul_binary_tile_init();
-            mul_binary_tile(xw1_reg, silu_reg, silu_reg);
-            // Final multiplication: M = SiLU(XW1) * XW3
-            mul_binary_tile(silu_reg, xw3_reg, m_reg);
-
-            tile_regs_commit();
-            pack_and_push(m_reg, cb_m_idx);
-        }
-        if (k_block_size != block_size) {
-            // Push empty/invalid Ms for k >= k_block_size
-            tile_regs_acquire();
-            tile_regs_commit();
-            pack_and_push_block(cb_m_idx, block_size - k_block_size);
-        }
-    }
-
-    cb_pop_front(cb_xw1_idx, hidden_Wt_rounded_up);
-    cb_pop_front(cb_xw3_idx, hidden_Wt_rounded_up);
-}
-
-// ================= Compute kernel structure (M fits in L1) ==================
-// FLASH-ATTENTION OPTIMIZATION: Read X only once per p_block!
-// for r in rows:
-//     # Phase A: Compute XW1[r, :] and XW3[r, :] - Flash-attention trick
-//     for p_block in p_blocks:                         # OUTER LOOP - read X once per p_block
-//         read X[r, p_block]
-//         for k_block in k_blocks:                     # INNER LOOP - reuse X for all k_blocks
-//             # Process W1 first for all p in p_block
-//             XW1_partial[r, k_block] += X[r, p_block] * W1[p_block, k_block]
-//             # Process W3 second for all p in p_block
-//             XW3_partial[r, k_block] += X[r, p_block] * W3[p_block, k_block]
-//         # After last p_block: XW1_partial[r, k_block] → XW1[r, k_block]
-//
-//     # Phase B: Compute M[r,:] once
-//     for k_block in k_blocks:                         # iterate over hidden dimension
-//         for k in k_block:
-//             M[r, k] = SiLU( XW1[r, k] ) * XW3[r, k]
-//
-//     # Phase C: Use M[r, :] for all c-blocks to compute Y[r, :]
-//     for c_block in c_blocks:                         # iterate over output dimension
-//         for k_block in k_blocks:                     # iterate over hidden dimension
-//             Y_partial[r, c] += M[r, k] * W2[k, c]
-//         store Y_partial[r, c] → Y[r, c]
-// ============================================================================
-inline void MAIN {
-    init_sfpu(cb_input_idx, cb_y_idx);
-    binary_op_init_common(cb_input_idx, cb_w1_idx, cb_y_idx);
-
-    for (uint32_t r = 0; r < num_rows_per_core; ++r) {
-        // ---- Phase A: Accumulate XW1[r,:] and XW3[r,:] in tiles over p ----
-        // XW1[r,k] = sum_p( X[r,p] * W1[p,k] )
-        // XW3[r,k] = sum_p( X[r,p] * W3[p,k] )
-        compute_XW1_XW3_for_r();
-
-        // ---- Phase B: Compute M[r,:] once ----
-        compute_M_for_r();
-        cb_wait_front(cb_m_idx, hidden_Wt_rounded_up);  // M[r, :] ready
-
-        // ---- Phase C: Use M[r,:] for all c_blocks ----
-        // Y[r, :] = sum_k( M[r,k] * W2[k,c] )
-        for (uint32_t c_block_start = 0; c_block_start < Wt; c_block_start += block_size) {
-            const uint32_t c_block_size = (c_block_start + block_size <= Wt) ? block_size : Wt - c_block_start;
-            // Compute Y[r, c_block_start : c_block_start + c_block_size]
-            for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
-                const uint32_t k_block_size =
-                    (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
-                const bool first_k_block = (k_block_start == 0);
-                const bool last_k_block = (k_block_start + block_size >= hidden_Wt);
-                mul_AxB_accumulate_C(
-                    /* cb_a_idx */ cb_m_idx,
-                    /* cb_b_idx */ cb_w2_idx,
-                    /* cb_c_partial_idx */ cb_y_partial_idx,
-                    /* cb_c_final_idx */ cb_y_idx,
-                    /* a_start_idx */ k_block_start,
-                    /* ab_block_size */ k_block_size,
-                    /* c_block_size */ c_block_size,
-                    /* first_ab_block */ first_k_block,
-                    /* last_ab_block */ last_k_block);
-                // TODO(maciek): consider double buffering row of M. This would require additional space in the CB.
-                // and maybe some smarter usage of cb_m_idx.
-            }
-        }
-
-        // M[r, :] is no longer needed
-        cb_pop_front(cb_m_idx, hidden_Wt_rounded_up);
-    }
-}
-
-#else
 
 // ============================================================================
 // Compute full M[r, k] over all p_s
@@ -418,7 +126,7 @@ inline void mul_MxW2_accumulate_Y(uint32_t k_block_size, uint32_t c_block_size, 
     }
     cb_wait_front(cb_m_idx, block_size);  // M[r, k] values ready
     reconfig_data_format(cb_m_idx, cb_w2_idx);
-    // NOTE(maciek): Using mm_init_short since we do not want to zero reguisters. mm_init does zero them.
+    // NOTE(maciek): Using mm_init_short since we do not want to zero registers. mm_init does zero them.
     mm_init_short(cb_m_idx, cb_w2_idx, false);
     // Process each column of W2 sequentially
     for (uint32_t c = 0; c < c_block_size; ++c) {
@@ -488,7 +196,5 @@ inline void MAIN {
         }
     }
 }
-
-#endif  // ROW_OF_M_FITS_IN_L1
 
 }  // namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel_m_fits_l1.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel_m_fits_l1.cpp
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <compute_kernel_api/eltwise_binary_sfpu.h>
+#include <compute_kernel_api/reconfig_data_format.h>
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/cb_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/copy_dest_values.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/matmul.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/ops/common/compute_utils.hpp"
+namespace NAMESPACE {
+
+// ----------------------------------------------------------------------
+// Problem:
+//
+// Given:
+//   X   shape [R, P]
+//   W1  shape [P, K]
+//   W2  shape [K, C]
+//   W3  shape [P, K]
+// We want:
+//   Y[r, c] = sum_k( M[r, k] * W2[k, c] )
+//   where
+//       M[r, k] = sum_p( X[r, p] * W1[p, k] ) * sum_p( X[r, p] * W3[p, k] )
+//
+// We compute in 3 nested block loops over c, k, p
+//   p is split into p_blocks for streaming X, W1 and W3
+//   k is split into k_blocks for streaming M and W2
+//   c is split into c_blocks to fit Y accumulators in registers
+// ----------------------------------------------------------------------
+
+constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t Wt = get_compile_time_arg_val(2);         // total C
+constexpr uint32_t hidden_Wt = get_compile_time_arg_val(3);  // total K
+
+const uint32_t hidden_Wt_rounded_up =
+    ((hidden_Wt + block_size - 1) / block_size) * block_size;  // Round up to nearest block_size
+
+// CBs with input data
+constexpr auto cb_input_idx = tt::CBIndex::c_0;  // X[r, p_block]
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
+constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
+constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
+// CBs with intermediate computations
+constexpr auto cb_xw1_partial_idx = tt::CBIndex::c_4;  // Partial (X @ W1)[r, k_block] between p_blocks
+constexpr auto cb_xw3_partial_idx = tt::CBIndex::c_5;  // Partial (X @ W3)[r, k_block] between p_blocks
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;          // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;          // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;            // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;    // Partial Y[r, c_block] between k_blocks
+// CB with output data
+constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
+
+constexpr uint32_t onetile = 1U;
+
+// ============================================================================
+// Abstracted operation to compute
+// C[r, c : c + c_block_size] = A[r, k : k + ab_block_size] * B[k : k + ab_block_size, c : c + c_block_size]
+//
+//   if first_ab_block is true C := ...
+//   else C += ...
+//   if last_ab_block is true, store C to cb_c_final_idx
+//   else store C to cb_c_partial_idx
+//
+// NOTE: This function does not wait for nor pop cb A. It only waits for and pops B. The caller is responsible for
+// waiting for and popping A.
+// ============================================================================
+inline void mul_AxB_accumulate_C(
+    tt::CBIndex cb_a_idx,
+    tt::CBIndex cb_b_idx,
+    tt::CBIndex cb_c_partial_idx,
+    tt::CBIndex cb_c_final_idx,
+    uint32_t a_start_idx,
+    uint32_t ab_block_size,
+    uint32_t c_block_size,
+    bool first_ab_block,
+    bool last_ab_block) {
+    tile_regs_acquire();
+
+    // Initialize or load C accumulators
+    if (!first_ab_block) {
+        cb_wait_front(cb_c_partial_idx, block_size);
+        copy_tile_init(cb_c_partial_idx);
+        for (uint32_t c = 0; c < c_block_size; ++c) {
+            copy_tile(cb_c_partial_idx, c, c);  // CB tile -> REG
+        }
+        cb_pop_front(cb_c_partial_idx, block_size);
+    }
+
+    mm_init_short(cb_a_idx, cb_b_idx, false);
+
+    // Process each column of B sequentially
+    for (uint32_t c = 0; c < c_block_size; ++c) {
+        // Wait for B data: block_size tiles per column
+        cb_wait_front(cb_b_idx, block_size);
+
+        // Compute C[r, c] += sum_k( A[r, k] * B[k, c] )
+        for (uint32_t k = 0; k < ab_block_size; ++k) {
+            matmul_tiles(cb_a_idx, cb_b_idx, a_start_idx + k, k, c, false);
+        }
+
+        cb_pop_front(cb_b_idx, block_size);  // Done with all B data
+    }
+
+    tile_regs_commit();
+
+    // Store result to appropriate CB
+    const auto output_cb_idx = last_ab_block ? cb_c_final_idx : cb_c_partial_idx;
+    pack_and_push_block(output_cb_idx, block_size);
+}
+
+// ============================================================================
+// Flash-attention optimization: Accumulate XW results across k_block batches
+// This function accumulates X[r, p_block] * W[p_block, k_block] into partial/final buffers
+// avoiding re-reading X for each k_block
+// ============================================================================
+inline void mul_XW_accumulate_k_block(
+    tt::CBIndex cb_x_idx,        // X[r, p_block]
+    tt::CBIndex cb_w_idx,        // W[p_block, k_block] (W1 or W3)
+    tt::CBIndex cb_partial_idx,  // Partial results buffer (cb_xw1_partial or cb_xw3_partial)
+    tt::CBIndex cb_final_idx,    // Final results buffer (cb_xw1 or cb_xw3)
+    uint32_t p_block_size,
+    uint32_t k_block_size,
+    bool first_p_block,
+    bool last_p_block) {
+    tile_regs_acquire();
+
+    // Initialize or load previous partial results for this k_block
+    if (!first_p_block) {
+        cb_wait_front(cb_partial_idx, block_size);
+
+        copy_tile_init(cb_partial_idx);
+        // Only load k_block_size values (actual data), ignore padding
+        for (uint32_t k = 0; k < k_block_size; ++k) {
+            copy_tile(cb_partial_idx, k, k);  // CB tile -> REG
+        }
+
+        cb_pop_front(cb_partial_idx, block_size);
+    }
+
+    mm_init_short(cb_x_idx, cb_w_idx, false);
+
+    // Process each p in this p_block (to match reader's organization)
+    for (uint32_t p = 0; p < p_block_size; ++p) {
+        // Wait for W data: W[p, k_block] (entire row, matching reader pattern)
+        cb_wait_front(cb_w_idx, block_size);
+
+        // Accumulate: result[k] += X[p] * W[p, k] for all k in k_block
+        for (uint32_t k = 0; k < k_block_size; ++k) {
+            matmul_tiles(cb_x_idx, cb_w_idx, p, k, k, false);
+        }
+
+        cb_pop_front(cb_w_idx, block_size);
+    }
+
+    tile_regs_commit();
+
+    // Store result to appropriate CB
+    const auto output_cb_idx = last_p_block ? cb_final_idx : cb_partial_idx;
+    pack_and_push_block(output_cb_idx, block_size);
+}
+
+// ============================================================================
+// Compute XW1[r, k] and XW3[r, k] over all p_blocks using flash-attention optimization
+//   XW1[r, k] = sum_p( X[r, p] * W1[p, k] )
+//   XW3[r, k] = sum_p( X[r, p] * W3[p, k] )
+//
+// This function implements a flash-attention-like optimization where X[r, p_block] is read
+// only once per p_block and reused across all k_blocks, significantly reducing memory reads.
+// ============================================================================
+
+inline void compute_XW1_XW3_for_r() {
+    // Flash-attention optimization: Read X[r, p_block] only once per p_block
+    // Loop order: outer p_blocks, inner k_blocks (but process k_blocks one at a time due to register limits)
+    for (uint32_t p_block_start = 0; p_block_start < Wt; p_block_start += block_size) {
+        const uint32_t p_block_size = (p_block_start + block_size <= Wt) ? block_size : Wt - p_block_start;
+        const bool first_p_block = (p_block_start == 0);
+        const bool last_p_block = (p_block_start + block_size >= Wt);
+
+        // Read X[r, p_block] once for this p_block
+        cb_wait_front(cb_input_idx, block_size);
+
+        // Process each k_block separately (due to register constraints)
+        for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
+            const uint32_t k_block_size =
+                (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
+
+            // Accumulate contributions to XW1[r, k_block] and XW3[r, k_block]
+            // On last_p_block, results go directly to final CBs
+            mul_XW_accumulate_k_block(
+                /* cb_x_idx */ cb_input_idx,
+                /* cb_w_idx */ cb_w1_idx,
+                /* cb_partial_idx */ cb_xw1_partial_idx,
+                /* cb_final_idx */ cb_xw1_idx,
+                /* p_block_size */ p_block_size,
+                /* k_block_size */ k_block_size,
+                /* first_p_block */ first_p_block,
+                /* last_p_block */ last_p_block);
+
+            mul_XW_accumulate_k_block(
+                /* cb_x_idx */ cb_input_idx,
+                /* cb_w_idx */ cb_w3_idx,
+                /* cb_partial_idx */ cb_xw3_partial_idx,
+                /* cb_final_idx */ cb_xw3_idx,
+                /* p_block_size */ p_block_size,
+                /* k_block_size */ k_block_size,
+                /* first_p_block */ first_p_block,
+                /* last_p_block */ last_p_block);
+        }
+
+        // Done with X[r, p_block]
+        cb_pop_front(cb_input_idx, block_size);
+    }
+}
+
+// ============================================================================
+// Compute M[r, :] = SiLU(XW1[r, :]) * XW3[r, :]
+//   where XW1 and XW3 are precomputed and stored in cb_xw1_idx and cb_xw3_idx
+// ============================================================================
+inline void compute_M_for_r() {
+    // Wait for XW1 and XW3 to be ready
+    cb_wait_front(cb_xw1_idx, hidden_Wt_rounded_up);
+    cb_wait_front(cb_xw3_idx, hidden_Wt_rounded_up);
+
+    for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
+        const uint32_t k_block_size =
+            (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
+        // Compute M[r, k_block_start : k_block_start + k_block_size]
+        // NOTE(maciek): We process each k in the block sequentially since we need to apply SiLU activation
+        // and we have limited number of registers. Processing all k in the block in parallel would require
+        // additional temporary CBs and packing/unpacking. I don't expect this to be a performance bottleneck.
+        for (uint32_t k = 0; k < k_block_size; ++k) {
+            const uint32_t xw1_reg = 0U;   // REG0 will hold (X @ W1)[r, k]
+            const uint32_t xw3_reg = 1U;   // REG1 will hold (X @ W3)[r, k]
+            const uint32_t silu_reg = 2U;  // REG2 will hold SiLU(X @ W1)[r, k]
+            const uint32_t m_reg = 3U;     // REG3 will hold M
+
+            const uint32_t tile_offset = k_block_start + k;
+
+            tile_regs_acquire();  // acquire working regs
+            // Copy XW1 and XW3 to registers
+            copy_tile_init(cb_xw1_idx);
+            copy_tile(cb_xw1_idx, tile_offset, xw1_reg);
+            copy_tile_init(cb_xw3_idx);
+            copy_tile(cb_xw3_idx, tile_offset, xw3_reg);
+
+            // Apply SiLU activation to compute SiLU(XW1)
+            copy_dest_values_init();
+            copy_dest_values(silu_reg, xw1_reg);
+            sigmoid_tile_init();
+            sigmoid_tile(silu_reg);
+            // Multiply XW1 * sigmoid(XW1) to get SiLU(XW1)
+            mul_binary_tile_init();
+            mul_binary_tile(xw1_reg, silu_reg, silu_reg);
+            // Final multiplication: M = SiLU(XW1) * XW3
+            mul_binary_tile(silu_reg, xw3_reg, m_reg);
+
+            tile_regs_commit();
+            pack_and_push(m_reg, cb_m_idx);
+        }
+        if (k_block_size != block_size) {
+            // Push empty/invalid Ms for k >= k_block_size
+            tile_regs_acquire();
+            tile_regs_commit();
+            pack_and_push_block(cb_m_idx, block_size - k_block_size);
+        }
+    }
+
+    cb_pop_front(cb_xw1_idx, hidden_Wt_rounded_up);
+    cb_pop_front(cb_xw3_idx, hidden_Wt_rounded_up);
+}
+
+// ================= Compute kernel structure (M fits in L1) ==================
+// FLASH-ATTENTION OPTIMIZATION: Read X only once per p_block!
+// for r in rows:
+//     # Phase A: Compute XW1[r, :] and XW3[r, :] - Flash-attention trick
+//     for p_block in p_blocks:                         # OUTER LOOP - read X once per p_block
+//         read X[r, p_block]
+//         for k_block in k_blocks:                     # INNER LOOP - reuse X for all k_blocks
+//             # Process W1 first for all p in p_block
+//             XW1_partial[r, k_block] += X[r, p_block] * W1[p_block, k_block]
+//             # Process W3 second for all p in p_block
+//             XW3_partial[r, k_block] += X[r, p_block] * W3[p_block, k_block]
+//         # After last p_block: XW1_partial[r, k_block] → XW1[r, k_block]
+//
+//     # Phase B: Compute M[r,:] once
+//     for k_block in k_blocks:                         # iterate over hidden dimension
+//         for k in k_block:
+//             M[r, k] = SiLU( XW1[r, k] ) * XW3[r, k]
+//
+//     # Phase C: Use M[r, :] for all c-blocks to compute Y[r, :]
+//     for c_block in c_blocks:                         # iterate over output dimension
+//         for k_block in k_blocks:                     # iterate over hidden dimension
+//             Y_partial[r, c] += M[r, k] * W2[k, c]
+//         store Y_partial[r, c] → Y[r, c]
+// ============================================================================
+inline void MAIN {
+    init_sfpu(cb_input_idx, cb_y_idx);
+    binary_op_init_common(cb_input_idx, cb_w1_idx, cb_y_idx);
+
+    for (uint32_t r = 0; r < num_rows_per_core; ++r) {
+        // ---- Phase A: Accumulate XW1[r,:] and XW3[r,:] in tiles over p ----
+        // XW1[r,k] = sum_p( X[r,p] * W1[p,k] )
+        // XW3[r,k] = sum_p( X[r,p] * W3[p,k] )
+        compute_XW1_XW3_for_r();
+
+        // ---- Phase B: Compute M[r,:] once ----
+        compute_M_for_r();
+        cb_wait_front(cb_m_idx, hidden_Wt_rounded_up);  // M[r, :] ready
+
+        // ---- Phase C: Use M[r,:] for all c_blocks ----
+        // Y[r, :] = sum_k( M[r,k] * W2[k,c] )
+        for (uint32_t c_block_start = 0; c_block_start < Wt; c_block_start += block_size) {
+            const uint32_t c_block_size = (c_block_start + block_size <= Wt) ? block_size : Wt - c_block_start;
+            // Compute Y[r, c_block_start : c_block_start + c_block_size]
+            for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
+                const uint32_t k_block_size =
+                    (k_block_start + block_size <= hidden_Wt) ? block_size : hidden_Wt - k_block_start;
+                const bool first_k_block = (k_block_start == 0);
+                const bool last_k_block = (k_block_start + block_size >= hidden_Wt);
+                mul_AxB_accumulate_C(
+                    /* cb_a_idx */ cb_m_idx,
+                    /* cb_b_idx */ cb_w2_idx,
+                    /* cb_c_partial_idx */ cb_y_partial_idx,
+                    /* cb_c_final_idx */ cb_y_idx,
+                    /* a_start_idx */ k_block_start,
+                    /* ab_block_size */ k_block_size,
+                    /* c_block_size */ c_block_size,
+                    /* first_ab_block */ first_k_block,
+                    /* last_ab_block */ last_k_block);
+                // TODO(maciek): consider double buffering row of M. This would require additional space in the CB.
+                // and maybe some smarter usage of cb_m_idx.
+            }
+        }
+
+        // M[r, :] is no longer needed
+        cb_pop_front(cb_m_idx, hidden_Wt_rounded_up);
+    }
+}
+
+}  // namespace NAMESPACE

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/reader_swiglu_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/reader_swiglu_fw_interleaved_start_id.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include <debug/dprint.h>
+
+#include <ostream>
+
+#include "dataflow_api.h"
+#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
+
+// CBs with input data
+constexpr auto cb_input_idx = tt::CBIndex::c_0;  // X[r, p_block]
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
+constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
+constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
+// CBs with masks
+constexpr auto cb_mask_w_idx = tt::CBIndex::c_4;   // Mask for input inner dimension
+constexpr auto cb_mask_hw_idx = tt::CBIndex::c_5;  // Mask for hidden inner dimension
+// CBs with intermediate computations
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;        // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;        // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;          // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;  // Partial Y[r, c_block] between k_blocks
+// CB with output data
+constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);         // output width (C)
+constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);  // inner dimension (K==P)
+constexpr uint32_t mask_w = get_compile_time_arg_val(3);     // mask for input inner dimension
+constexpr uint32_t mask_hw = get_compile_time_arg_val(4);    // mask for hidden inner dimension
+
+#ifdef DO_MASK_W
+constexpr bool do_mask_w = true;
+#else
+constexpr bool do_mask_w = false;
+#endif
+
+#ifdef DO_MASK_HW
+constexpr bool do_mask_hw = true;
+#else
+constexpr bool do_mask_hw = false;
+#endif
+
+// TODO(maciek): Decide on one consistent version of whitespace in X[a, b] vs. X[a,b]
+
+// TODO(maciek): Update read_tile to allign Stas's change.
+// TODO(maciek): Move all read_tiles_by_row and read_tiles_by_col to common utils file, and reuse them in other
+// operations. Utility: read contiguous tiles in row-major from DRAM to CB. Before calling this function, make sure to
+// reserve space in the CB and after the call, push the tiles.
+inline void read_tiles_by_row(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast<true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t num_tiles,
+    const uint32_t tile_bytes) {
+    uint32_t l1_addr = get_write_ptr(cb_idx);
+    for (uint32_t t = 0; t < num_tiles; ++t) {
+        noc_async_read_tile(start_idx + t, addr_gen, l1_addr);
+        l1_addr += tile_bytes;
+    }
+}
+
+// Utility: read contiguous tiles in col-major from DRAM to CB. Before calling this function, make sure to reserve space
+// in the CB and after the call, push the tiles.
+inline void read_tiles_by_col(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast<true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t num_tiles,
+    const uint32_t tile_bytes,
+    uint32_t stride) {
+    uint32_t l1_addr = get_write_ptr(cb_idx);
+    for (uint32_t t = 0; t < num_tiles; ++t) {
+        uint32_t tile_idx = start_idx + t * stride;
+        noc_async_read_tile(tile_idx, addr_gen, l1_addr);
+        l1_addr += tile_bytes;
+    }
+}
+
+void kernel_main() {
+    uint32_t ra = 0U;
+    uint32_t input_address = get_arg_val<uint32_t>(ra++);  // DRAM base for X
+    uint32_t w1_address = get_arg_val<uint32_t>(ra++);     // DRAM base for W1
+    uint32_t w2_address = get_arg_val<uint32_t>(ra++);     // DRAM base for W2
+    uint32_t w3_address = get_arg_val<uint32_t>(ra++);     // DRAM base for W3
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(ra++);
+    uint32_t start_row = get_arg_val<uint32_t>(ra++);
+
+    constexpr uint16_t one = 0x00003F80;  // (bfloat16)1.0 -> uint16_t
+    constexpr uint16_t zero = 0x0;
+    // Generate s if needed
+    if constexpr (do_mask_w) {
+        generate_mask_tile(cb_mask_w_idx, one, zero, mask_w);
+    }
+    if constexpr (do_mask_hw) {
+        generate_mask_tile(cb_mask_hw_idx, one, zero, mask_hw);
+    }
+
+    const uint32_t tile_bytes = get_tile_size(cb_input_idx);
+    const DataFormat data_fmt = get_dataformat(cb_input_idx);
+
+    // Address generators
+    const InterleavedAddrGenFast<true> x_ag = {
+        .bank_base_address = input_address, .page_size = tile_bytes, .data_format = data_fmt};
+    const InterleavedAddrGenFast<true> w1_ag = {
+        .bank_base_address = w1_address, .page_size = tile_bytes, .data_format = data_fmt};
+    const InterleavedAddrGenFast<true> w2_ag = {
+        .bank_base_address = w2_address, .page_size = tile_bytes, .data_format = data_fmt};
+    const InterleavedAddrGenFast<true> w3_ag = {
+        .bank_base_address = w3_address, .page_size = tile_bytes, .data_format = data_fmt};
+
+    const uint32_t end_row = start_row + num_rows_to_process;
+
+    // ================== Loop structure matches compute kernel ==================
+    // for r in rows:
+    //   for c_block in c_blocks:
+    //     for k_block in k_blocks:
+    //       for k in k_block:
+    //         for p_block in p_blocks:
+    //           stream X[r, p_block] and W1[p_block, k] for all p in p_block
+    //           [compute M[r,k] = sum_p( X[r,p] * W1[p,k] )]
+    //       for c in c_block:
+    //         stream W2[k_block, c] for all k in k_block
+    //         [compute Y[r,c] += sum_k( M[r,k] * W2[k,c] )]
+    // ============================================================================
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        // Loop over c_blocks
+        for (uint32_t c_block_start = 0; c_block_start < Wt; c_block_start += block_size) {
+            const uint32_t c_block_size = (c_block_start + block_size <= Wt) ? block_size : (Wt - c_block_start);
+
+            // Loop over k_blocks
+            for (uint32_t k_block_start = 0; k_block_start < hidden_Wt; k_block_start += block_size) {
+                const uint32_t k_block_size =
+                    (k_block_start + block_size <= hidden_Wt) ? block_size : (hidden_Wt - k_block_start);
+
+                // --------------------
+                // STEP A: Stream X + W1 for all k in this k_block
+                // --------------------
+                for (uint32_t k = 0; k < k_block_size; ++k) {
+                    const uint32_t k_global = k_block_start + k;
+
+                    // Loop over p_blocks along inner dimention
+                    for (uint32_t p_block_start = 0; p_block_start < Wt; p_block_start += block_size) {
+                        const uint32_t p_block_size =
+                            (p_block_start + block_size <= Wt) ? block_size : (Wt - p_block_start);
+
+                        // --- Read p_block_size tiles of X[r, p_block]
+                        // TODO: Consider moving reserve_back and push_back to read_tiles_by_row/read_tiles_by_col
+                        cb_reserve_back(cb_input_idx, block_size);
+                        // Calculate starting tile index for X. We read X in row-major order, so the offset equals
+                        uint32_t x_tile_start = r * Wt + p_block_start;
+                        read_tiles_by_row(cb_input_idx, x_ag, x_tile_start, p_block_size, tile_bytes);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_input_idx, block_size);
+
+                        // --- Read p_block_size tiles of W1[p_block, k_global]
+                        cb_reserve_back(cb_w1_idx, block_size);
+                        // Calculate starting tile index for W1. We read W1 in col-major order, so offset equals
+                        uint32_t w1_tile_start = p_block_start * hidden_Wt + k_global;
+                        read_tiles_by_col(cb_w1_idx, w1_ag, w1_tile_start, p_block_size, tile_bytes, hidden_Wt);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_w1_idx, block_size);
+
+                        // --- Read p_block_size tiles of W3[p_block, k_global]
+                        cb_reserve_back(cb_w3_idx, block_size);
+                        // Calculate starting tile index for W3. We read W3 in col-major order, so offset equals
+                        uint32_t w3_tile_start = p_block_start * hidden_Wt + k_global;
+                        read_tiles_by_col(cb_w3_idx, w3_ag, w3_tile_start, p_block_size, tile_bytes, hidden_Wt);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_w3_idx, block_size);
+                    }
+                }
+
+                // --------------------
+                // STEP B: W2 streaming will be handled by the compute kernel synchronization
+                // --------------------
+                // Stream W2 columns one by one as compute kernel requests them
+                for (uint32_t c_local = 0; c_local < c_block_size; ++c_local) {
+                    const uint32_t c_global = c_block_start + c_local;
+
+                    // Read W2[k_block, c_global] - one column of block_size elements
+                    cb_reserve_back(cb_w2_idx, block_size);
+                    // Calculate starting tile index for W2. We read W2 in col-major order, so offset equals
+                    uint32_t w2_tile_start = k_block_start * Wt + c_global;
+                    read_tiles_by_col(cb_w2_idx, w2_ag, w2_tile_start, k_block_size, tile_bytes, Wt);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_w2_idx, block_size);
+                }
+            }
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/reader_swiglu_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/reader_swiglu_fw_interleaved_start_id.cpp
@@ -24,7 +24,7 @@ constexpr uint32_t Wt = get_compile_time_arg_val(1);         // output width (C)
 constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);  // inner dimension (K==P)
 
 // TODO(maciek): Move all read_tiles_by_row and read_tiles_by_col to common utils file, and reuse them in other
-// operations.
+// operations. See tracking issue #31125 for more details.
 
 // Utility: read contiguous tiles in row-major from DRAM to CB.
 template <typename AddrGen>

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
@@ -5,21 +5,19 @@
 #include <cmath>
 
 #include "dataflow_api.h"
-#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
 
 // CBs with input data
 constexpr auto cb_input_idx = tt::CBIndex::c_0;  // X[r, p_block]
 constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
 constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
 constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
-// CBs with masks
-constexpr auto cb_mask_w_idx = tt::CBIndex::c_4;   // Mask for input inner dimension
-constexpr auto cb_mask_hw_idx = tt::CBIndex::c_5;  // Mask for hidden inner dimension
 // CBs with intermediate computations
-constexpr auto cb_xw1_idx = tt::CBIndex::c_6;        // (X @ W1)[r, k_block]
-constexpr auto cb_xw3_idx = tt::CBIndex::c_7;        // (X @ W3)[r, k_block]
-constexpr auto cb_m_idx = tt::CBIndex::c_8;          // M[r, k_block]
-constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;  // Partial Y[r, c_block] between k_blocks
+constexpr auto cb_xw1_partial_idx = tt::CBIndex::c_4;  // Partial (X @ W1)[r, k_block] between p_blocks
+constexpr auto cb_xw3_partial_idx = tt::CBIndex::c_5;  // Partial (X @ W3)[r, k_block] between p_blocks
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;          // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;          // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;            // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;    // Partial Y[r, c_block] between k_blocks
 // CB with output data
 constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <debug/dprint.h>
+
+#include <cmath>
+
+#include "dataflow_api.h"
+#include "tt-train/sources/ttml/metal/ops/common/dataflow_utils.hpp"
+
+// CBs with input data
+constexpr auto cb_input_idx = tt::CBIndex::c_0;  // X[r, p_block]
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;     // W1[p_block, k]
+constexpr auto cb_w2_idx = tt::CBIndex::c_2;     // W2[k_block, c_block]
+constexpr auto cb_w3_idx = tt::CBIndex::c_3;     // W3[p_block, k]
+// CBs with masks
+constexpr auto cb_mask_w_idx = tt::CBIndex::c_4;   // Mask for input inner dimension
+constexpr auto cb_mask_hw_idx = tt::CBIndex::c_5;  // Mask for hidden inner dimension
+// CBs with intermediate computations
+constexpr auto cb_xw1_idx = tt::CBIndex::c_6;        // (X @ W1)[r, k_block]
+constexpr auto cb_xw3_idx = tt::CBIndex::c_7;        // (X @ W3)[r, k_block]
+constexpr auto cb_m_idx = tt::CBIndex::c_8;          // M[r, k_block]
+constexpr auto cb_y_partial_idx = tt::CBIndex::c_9;  // Partial Y[r, c_block] between k_blocks
+// CB with output data
+constexpr auto cb_y_idx = tt::CBIndex::c_10;  // Final Y[r, c_block]
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+
+// TODO(maciek): Update write_cb_block_to_dram to allign Stas's change.
+// TODO(maciek): Move all write_cb_block to common utils file, and reuse them in other
+// operations.
+// -----------------------------------------------------------------------------
+// Shared utility: DO NOT CHANGE
+inline void write_cb_block_to_dram(
+    uint32_t cb_idx,
+    const InterleavedAddrGenFast</* is dram */ true>& addr_gen,
+    uint32_t start_idx,
+    uint32_t current_block_size,
+    uint32_t tile_bytes) {
+    uint32_t l1_read_addr = get_read_ptr(cb_idx);
+
+    // Wait for a full block in CB, but only write as many as are valid in the tail
+    for (uint32_t block_idx = 0; block_idx < current_block_size; ++block_idx) {
+        noc_async_write_tile(start_idx + block_idx, addr_gen, l1_read_addr);
+        l1_read_addr += tile_bytes;
+    }
+}
+// -----------------------------------------------------------------------------
+
+void kernel_main() {
+    uint32_t ra = 0;
+    uint32_t y_addr = get_arg_val<uint32_t>(ra++);  // DRAM base for Y
+    uint32_t num_rows_to_process = get_arg_val<uint32_t>(ra++);
+    uint32_t start_row = get_arg_val<uint32_t>(ra++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_y_idx);
+    const DataFormat data_fmt = get_dataformat(cb_y_idx);
+
+    const InterleavedAddrGenFast<true> y_addr_gen = {
+        .bank_base_address = y_addr, .page_size = tile_bytes, .data_format = data_fmt};
+
+    const uint32_t end_row = start_row + num_rows_to_process;
+
+    // ================== Loop structure matches compute kernel ==================
+    // for r in rows:
+    //   for c_block in c_blocks:
+    //     [compute processes all c for this (r, c_block)]
+    //     write Y[r, c_block] to DRAM
+    // ============================================================================
+    for (uint32_t r = start_row; r < end_row; ++r) {
+        // Loop over output columns in blocks - matches compute kernel order
+        for (uint32_t c_block_start = 0; c_block_start < Wt; c_block_start += block_size) {
+            const uint32_t current_block_size = (c_block_start + block_size <= Wt) ? block_size : (Wt - c_block_start);
+
+            // Wait for and write Y[r, c_block] - this becomes available after compute kernel finishes processing all
+            // k_blocks for this (r, c_block) combination
+            cb_wait_front(cb_y_idx, block_size);
+            // Calculate starting tile index for Y. We write Y in row-major order, so the offset equals
+            const uint32_t start_tile_idx = (r * Wt) + c_block_start;
+            write_cb_block_to_dram(cb_y_idx, y_addr_gen, start_tile_idx, current_block_size, tile_bytes);
+            noc_async_write_barrier();
+            cb_pop_front(cb_y_idx, block_size);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cmath>
-
 #include "dataflow_api.h"
 
 // CBs with input data
@@ -25,7 +23,7 @@ constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
 
 // TODO(maciek): Move all write_cb_block to common utils file, and reuse them in other
-// operations.
+// operations. See tracking issue #31125 for more details.
 template <typename AddrGen>
 inline void write_cb_block_to_dram(
     uint32_t cb_idx, const AddrGen& addr_gen, uint32_t start_idx, uint32_t current_block_size, uint32_t tile_bytes) {

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_fw_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "swiglu_fw_program_factory.hpp"
+
+namespace ttml::metal::ops::swiglu_fw::device {
+
+SwiGLUForwardDeviceOperation::program_factory_t SwiGLUForwardDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return SwiGLUForwardProgramFactory{};
+}
+
+void SwiGLUForwardDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void SwiGLUForwardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
+            "SwiGLUForward operation is only supported on Wormhole. Device arch: {}. Tensor name {}",
+            enchantum::to_string(tensor.device()->arch()),
+            name);
+
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "SwiGLUForward operation requires {} to be on Device. Input storage type: {}",
+            name,
+            static_cast<int>(tensor.storage_type()));
+
+        TT_FATAL(
+            tensor.buffer() != nullptr,
+            "Operands to SwiGLUForward need to be allocated in buffers on the device. Buffer is null. Tensor name {}",
+            name);
+
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "SwiGLUForward operation requires tensor to be in Tile layout. {} tensor layout: {}",
+            name,
+            static_cast<int>(tensor.layout()));
+
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "SwiGLUForward operation requires tensor to be of BFLOAT16 data type. {} tensor data type: {}",
+            name,
+            static_cast<int>(tensor.dtype()));
+
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "SwiGLUForward operation requires Interleaved memory layout. {} "
+            "memory layout: `{}`",
+            name,
+            static_cast<int>(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& input_tensor = tensor_args.input;
+    const auto& w1 = tensor_args.w1;
+    const auto& w2 = tensor_args.w2;
+    const auto& w3 = tensor_args.w3;
+    const auto& preallocated_swiglu_tensor = tensor_args.preallocated_swiglu;
+
+    check_tensor(input_tensor, "Input");
+    check_tensor(w1, "W1");
+    check_tensor(w2, "W2");
+    check_tensor(w3, "W3");
+    if (preallocated_swiglu_tensor.has_value()) {
+        check_tensor(preallocated_swiglu_tensor.value(), "Preallocated SwiGLU");
+    }
+}
+
+spec_return_value_t SwiGLUForwardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(1U);
+
+    if (tensor_args.preallocated_swiglu.has_value()) {
+        output_specs.push_back(tensor_args.preallocated_swiglu->tensor_spec());
+    } else {
+        output_specs.emplace_back(
+            tensor_args.input.logical_shape(),
+            tt::tt_metal::TensorLayout(
+                tensor_args.input.dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
+    }
+
+    return output_specs;
+}
+
+tensor_return_value_t SwiGLUForwardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs = compute_output_specs(args, tensor_args);
+
+    if (tensor_args.preallocated_swiglu.has_value()) {
+        return tensor_args.preallocated_swiglu.value();
+    } else {
+        return create_device_tensor(output_specs[0], tensor_args.input.device());
+    }
+}
+
+ttsl::hash::hash_t SwiGLUForwardDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_logical_shape = input_tensor.logical_shape();
+    auto program_factory = select_program_factory(args, tensor_args);
+    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<SwiGLUForwardDeviceOperation>(
+        args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
+
+    return hash;
+}
+
+std::tuple<SwiGLUForwardDeviceOperation::operation_attributes_t, SwiGLUForwardDeviceOperation::tensor_args_t>
+SwiGLUForwardDeviceOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& w1,
+    const ttnn::Tensor& w2,
+    const ttnn::Tensor& w3,
+    const std::optional<ttnn::Tensor>& preallocated_swiglu) {
+    return {
+        operation_attributes_t{},
+        tensor_args_t{.input = input_tensor, .w1 = w1, .w2 = w2, .w3 = w3, .preallocated_swiglu = preallocated_swiglu}};
+}
+
+}  // namespace ttml::metal::ops::swiglu_fw::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -105,11 +105,26 @@ tensor_return_value_t SwiGLUForwardDeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t SwiGLUForwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
+    const auto& input = tensor_args.input;
+    const auto& input_logical_shape = input.logical_shape();
+    const auto& w1 = tensor_args.w1;
+    const auto& w1_logical_shape = w1.logical_shape();
+    const auto& w2 = tensor_args.w2;
+    const auto& w2_logical_shape = w2.logical_shape();
+    const auto& w3 = tensor_args.w3;
+    const auto& w3_logical_shape = w3.logical_shape();
     auto program_factory = select_program_factory(args, tensor_args);
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<SwiGLUForwardDeviceOperation>(
-        args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
+        args,
+        program_factory.index(),
+        input.dtype(),
+        input_logical_shape,
+        w1.dtype(),
+        w1_logical_shape,
+        w2.dtype(),
+        w2_logical_shape,
+        w3.dtype(),
+        w3_logical_shape);
 
     return hash;
 }

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
@@ -4,10 +4,6 @@
 
 #include "swiglu_fw_device_operation.hpp"
 
-#include <enchantum/enchantum.hpp>
-
-#include "swiglu_fw_program_factory.hpp"
-
 namespace ttml::metal::ops::swiglu_fw::device {
 
 SwiGLUForwardDeviceOperation::program_factory_t SwiGLUForwardDeviceOperation::select_program_factory(

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "metal/ttnn_all_includes.hpp"
+#include "swiglu_fw_device_operation_types.hpp"
+#include "swiglu_fw_program_factory.hpp"
+
+namespace ttml::metal::ops::swiglu_fw::device {
+
+struct SwiGLUForwardDeviceOperation {
+    using operation_attributes_t = operation_attributes_t;
+    using tensor_args_t = tensor_args_t;
+    using spec_return_value_t = spec_return_value_t;
+    using tensor_return_value_t = tensor_return_value_t;
+    using program_factory_t = std::variant<SwiGLUForwardProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& m1,
+        const ttnn::Tensor& m2,
+        const ttnn::Tensor& m3,
+        const std::optional<ttnn::Tensor>& preallocated_swiglu = std::nullopt);
+};
+
+}  // namespace ttml::metal::ops::swiglu_fw::device
+
+namespace ttnn::prim {
+constexpr auto ttml_swiglu_fw = ttnn::register_operation<
+    "ttnn::prim::ttml_swiglu_fw",
+    ttml::metal::ops::swiglu_fw::device::SwiGLUForwardDeviceOperation>();
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::swiglu_fw::device {
+
+struct operation_attributes_t {};
+
+struct tensor_args_t {
+    ttnn::Tensor input;
+    ttnn::Tensor w1;
+    ttnn::Tensor w2;
+    ttnn::Tensor w3;
+    std::optional<ttnn::Tensor> preallocated_swiglu = std::nullopt;
+};
+
+// Output tensor specs and tensors
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+using tensor_return_value_t = ttnn::Tensor;
+
+}  // namespace ttml::metal::ops::swiglu_fw::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_fw_program_factory.hpp"
+
+#include <cstdint>
+#include <enchantum/enchantum.hpp>
+#include <iostream>
+#include <tt-metalium/assert.hpp>
+
+#include "metal/ops/common/program_utils.hpp"
+
+namespace {
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/writer_swiglu_fw_interleaved_start_id.cpp";
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/dataflow/reader_swiglu_fw_interleaved_start_id.cpp";
+
+constexpr auto kComputeKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_fw/device/kernels/compute/swiglu_fw_kernel.cpp";
+
+// Reader buffer indices
+constexpr uint32_t kInputBufferIdx = 0;
+constexpr uint32_t kW1BufferIdx = 1U;
+constexpr uint32_t kW2BufferIdx = 2U;
+constexpr uint32_t kW3BufferIdx = 3U;
+
+// Writer buffer indices
+constexpr uint32_t kSwigluBufferIdx = 0;
+
+// CBs with input data
+constexpr auto kInputCbIndex = tt::CBIndex::c_0;
+constexpr auto kW1CbIndex = tt::CBIndex::c_1;
+constexpr auto kW2CbIndex = tt::CBIndex::c_2;
+constexpr auto kW3CbIndex = tt::CBIndex::c_3;
+// CBs with masks
+constexpr auto kMaskWCbIndex = tt::CBIndex::c_4;
+constexpr auto kMaskHWCbIndex = tt::CBIndex::c_5;
+// CBs with intermediate computations
+constexpr auto kXW1CbIndex = tt::CBIndex::c_6;       // keeps track of (X @ W1) [r, k]
+constexpr auto kXW3CbIndex = tt::CBIndex::c_7;       // keeps track of (X @ W3) [r, k]
+constexpr auto kMCbIndex = tt::CBIndex::c_8;         // keeps track of M[r, k]
+constexpr auto kYPartialCbIndex = tt::CBIndex::c_9;  // keeps track of partial Y[r, c]
+// CB with output data
+constexpr auto kYCbIndex = tt::CBIndex::c_10;  // keeps track of final Y[r, c]
+
+constexpr uint32_t kNumMaskWTiles = 1U;
+constexpr uint32_t kNumMaskHWTiles = 1U;
+constexpr uint32_t kNumXW1Tiles = 2U;  // Likely 1U is sufficient, but using 2U for double buffering
+constexpr uint32_t kNumXW3Tiles = 2U;
+
+const std::string kMaskWDefineKey = "DO_MASK_W";
+const std::string kMaskHWDefineKey = "DO_MASK_HW";
+
+}  // namespace
+
+namespace ttml::metal::ops::swiglu_fw::device {
+
+struct SwiGLUForwardKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+    tt::tt_metal::KernelHandle compute_group_1;
+    tt::tt_metal::KernelHandle compute_group_2;
+};
+
+// this possibly could be moved to a common utils file
+void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const SwiGLUForwardKernels& kernels,
+    const tt::tt_metal::Buffer* input_buffer,
+    const tt::tt_metal::Buffer* w1,
+    const tt::tt_metal::Buffer* w2,
+    const tt::tt_metal::Buffer* w3,
+    const tt::tt_metal::Buffer* swiglu_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_rows_per_core_group_1,
+    uint32_t num_rows_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2) {
+    for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        // Determine how many rows this core will process
+        uint32_t num_rows_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_FATAL(false, "Core not in specified core ranges");
+        }
+        // Reader kernel: (input_addr, w1_addr, w2_addr, w3_addr, num_rows, offset)
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {input_buffer->address(),
+             w1->address(),
+             w2->address(),
+             w3->address(),
+             num_rows_per_core,
+             num_rows_written});
+
+        // Writer kernel: (swiglu_addr, num_rows, offset)
+        SetRuntimeArgs(program, kernels.writer, core, {swiglu_buffer->address(), num_rows_per_core, num_rows_written});
+
+        num_rows_written += num_rows_per_core;
+    }
+}
+
+// TODO: It would be good to setup a memory check, for the big matrices that might not fit into L1
+
+SwiGLUForwardProgramFactory::cached_program_t SwiGLUForwardProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    // -------------------------------------------------------------------------
+    // 1) Setup device, data formats, tile sizes, and compute split
+    // -------------------------------------------------------------------------
+    const auto& input = tensor_args.input;
+    const auto& w1 = tensor_args.w1;
+    const auto& w2 = tensor_args.w2;
+    const auto& w3 = tensor_args.w3;
+
+    auto* device = input.device();
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.dtype());
+
+    uint32_t bfloat16_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
+    uint32_t float32_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float32);
+
+    auto padded_tensor_shape = input.padded_shape();
+    auto padded_tensor_volume = input.physical_volume();
+    TT_FATAL(
+        padded_tensor_volume % tt::constants::TILE_HW == 0, "Padded input tensor volume must be divisible by TILE_HW");
+    TT_FATAL(padded_tensor_shape.rank() == 4U, "Input tensor must be 4D");
+    uint32_t Wt = padded_tensor_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t Ht = padded_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t NC = padded_tensor_shape[0] * padded_tensor_shape[1];
+    uint32_t total_rows_to_process = NC * Ht;
+
+    // Get the num_inner and hidden_num_inner
+    uint32_t num_inner = input.logical_shape()[-1];
+    uint32_t hidden_num_inner = w1.logical_shape()[-1];
+
+    // Get the hidden dimension // 32
+    uint32_t hidden_Wt = hidden_num_inner / tt::constants::TILE_WIDTH;
+
+    // These parameters are used to determine if we need to mask tiles along input/hidden dimension, i.e. if the
+    // operation applied over input/hidden dimension might produce incorrect results due to some random data in the end
+    // of the last tile.
+    uint32_t mask_w = num_inner % tt::constants::TILE_WIDTH;
+    uint32_t mask_hw = hidden_num_inner % tt::constants::TILE_WIDTH;
+
+    // TODO(maciek): Consider to add masking. Now we assume that the N and C % 32 == 0.
+    TT_FATAL(mask_w == 0, "Input inner dimension must be multiple of TILE_WIDTH");
+    TT_FATAL(mask_hw == 0, "Hidden inner dimension must be multiple of TILE_WIDTH");
+
+    // Get number of free cores
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // Compile arguments
+    // We enforce to use block_size of 4. If num_inner % 4 != 0 or hidden_num_inner % 4 != 0, we will take care of it in
+    // the kernels.
+    const uint32_t block_size = 4U;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_rows_to_process);
+
+    // -------------------------------------------------------------------------
+    // 2) Create and configure circular buffers
+    // -------------------------------------------------------------------------
+    const uint32_t twice_block_size = 2U * block_size;
+
+    // TODO(maciek): Optimize memory access to minimize DRAM reads and redundant computation.
+    // Key optimization ideas:
+    // 1. Cache M[r,:] in L1 memory if possible—this avoids recomputing M[r,:] for each matmul with W2.
+    // 2. Cache X[r,:] in L1 memory if possible—this avoids repeatedly streaming X[r,:] from DRAM for every M[r,:]
+    // computation. Leveraging L1 caching for these tiles could significantly improve performance by reducing DRAM
+    // bandwidth pressure. Currently, all data is streamed from DRAM in blocks, and M[r,:] is recomputed each time it is
+    // needed.
+
+    auto data_format = input_data_format;  // tt::DataFormat::Float16_b
+    auto precise_data_format = tt::DataFormat::Float32;
+
+    // NOTE(maciek): It is likely that there is no way we can benefit from fp32 data type. The tricky things are:
+    // - input CBs must be bf16
+    // - output CBs must be bf16
+    // - matmul_tiles supports only one data format for both input and output CBs (otherwise produces some NaNs/infs)
+    // - matmul_tiles and accumulation is done on FPU, which supports only bfloat16
+    [[maybe_unused]] auto cb_input = create_circular_buffer(
+        program, all_cores, kInputCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_w1 = create_circular_buffer(
+        program, all_cores, kW1CbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_w2 = create_circular_buffer(
+        program, all_cores, kW2CbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_w3 = create_circular_buffer(
+        program, all_cores, kW3CbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_mask_w = create_circular_buffer(
+        program, all_cores, kMaskWCbIndex, data_format, bfloat16_single_tile_size_bytes, kNumMaskWTiles);
+    [[maybe_unused]] auto cb_mask_hw = create_circular_buffer(
+        program, all_cores, kMaskHWCbIndex, data_format, bfloat16_single_tile_size_bytes, kNumMaskHWTiles);
+    [[maybe_unused]] auto cb_x_w1 = create_circular_buffer(
+        program, all_cores, kXW1CbIndex, data_format, bfloat16_single_tile_size_bytes, kNumXW1Tiles);
+    [[maybe_unused]] auto cb_x_w3 = create_circular_buffer(
+        program, all_cores, kXW3CbIndex, data_format, bfloat16_single_tile_size_bytes, kNumXW3Tiles);
+    [[maybe_unused]] auto cb_m = create_circular_buffer(
+        program, all_cores, kMCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_y_partial = create_circular_buffer(
+        program, all_cores, kYPartialCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+    [[maybe_unused]] auto cb_y = create_circular_buffer(
+        program, all_cores, kYCbIndex, data_format, bfloat16_single_tile_size_bytes, twice_block_size);
+
+    // -------------------------------------------------------------------------
+    // 3) Create reader/writer kernels
+    // -------------------------------------------------------------------------
+    auto* input_buffer = input.buffer();
+    TT_FATAL(
+        input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "Input buffer must be in DRAM. Input buffer of type {}",
+        enchantum::to_string(input_buffer->buffer_type()));
+
+    auto* w1_buffer = w1.buffer();
+    TT_FATAL(
+        w1_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "W1 buffer must be in DRAM. w1 buffer of type {}",
+        enchantum::to_string(w1_buffer->buffer_type()));
+
+    auto* w2_buffer = w2.buffer();
+    TT_FATAL(
+        w2_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "W2 buffer must be in DRAM. w2 buffer of type {}",
+        enchantum::to_string(w2_buffer->buffer_type()));
+
+    auto* w3_buffer = w3.buffer();
+    TT_FATAL(
+        w3_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "W3 buffer must be in DRAM. w3 buffer of type {}",
+        enchantum::to_string(w3_buffer->buffer_type()));
+
+    auto* swiglu_buffer = output.buffer();
+    TT_FATAL(
+        swiglu_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM,
+        "SwiGLU buffer must be in DRAM. SwiGLU buffer of type {}",
+        enchantum::to_string(swiglu_buffer->buffer_type()));
+
+    std::map<std::string, std::string> defines;
+    if (mask_w != 0) {
+        defines[kMaskWDefineKey] = "1";
+    }
+    if (mask_hw != 0) {
+        defines[kMaskHWDefineKey] = "1";
+    }
+
+    SwiGLUForwardKernels kernels;
+    // Q: consider what kind of compiled time args should be passed
+    kernels.reader =
+        create_reader_kernel(program, all_cores, {block_size, Wt, hidden_Wt, mask_w, mask_hw}, {}, kReaderKernelPath);
+
+    kernels.writer = create_writer_kernel(program, all_cores, {block_size, Wt}, {}, kWriterKernelPath);
+
+    // -------------------------------------------------------------------------
+    // 4) Create compute kernels for swiglu_fw
+    // -------------------------------------------------------------------------
+
+    // Group 1 compile-time arguments
+    std::vector<uint32_t> compute_group_1_args = {
+        num_rows_per_core_group_1,  // per_core_block_cnt
+        block_size,                 // per_core_block_size
+        Wt,                         // num_inner / TILE_W
+        hidden_Wt,                  // hidden_num_inner / TILE_W
+        mask_w,                     // mask_w
+        mask_hw                     // mask_hw
+    };
+
+    kernels.compute_group_1 = create_compute_kernel(
+        program, core_group_1, compute_group_1_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+
+    // Group 2 (if present) compile-time arguments
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_group_2_args = {
+            num_rows_per_core_group_2,  // per_core_block_cnt
+            block_size,                 // per_core_block_size
+            Wt,                         // num_inner / TILE_W
+            hidden_Wt,                  // hidden_num_inner / TILE_W
+            mask_w,                     // mask_w
+            mask_hw                     // mask_hw
+
+        };
+
+        kernels.compute_group_2 = create_compute_kernel(
+            program, core_group_2, compute_group_2_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+    }
+    // -------------------------------------------------------------------------
+    // 5) Assign runtime args for each core
+    // -------------------------------------------------------------------------
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        input_buffer,
+        w1_buffer,
+        w2_buffer,
+        w3_buffer,
+        swiglu_buffer,
+        num_cores,
+        num_cores_y,
+        num_rows_per_core_group_1,
+        num_rows_per_core_group_2,
+        core_group_1,
+        core_group_2);
+
+    // -------------------------------------------------------------------------
+    // 6) Return the fully configured program & relevant shared variables
+    // -------------------------------------------------------------------------
+    return cached_program_t{
+        std::move(program),
+        {/* swiglu_fw_reader_kernel_id  = */ kernels.reader,
+         /* swiglu_fw_writer_kernel_id  = */ kernels.writer,
+         /* swiglu_fw_kernel_group_1_id = */ kernels.compute_group_1,
+         /* swiglu_fw_kernel_group_2_id = */ kernels.compute_group_2,
+         /* core_group_1              = */ core_group_1,
+         /* core_group_2              = */ core_group_2,
+         /* num_cores                 = */ num_cores,
+         /* num_cores_y               = */ num_cores_y}};
+}
+
+void SwiGLUForwardProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& shared_variables = cached_program.shared_variables;
+    auto& swiglu_fw_reader_kernel_id = shared_variables.swiglu_fw_reader_kernel_id;
+    auto& swiglu_fw_writer_kernel_id = shared_variables.swiglu_fw_writer_kernel_id;
+
+    uint32_t num_cores = shared_variables.num_cores;
+    uint32_t num_cores_y = shared_variables.num_cores_y;
+
+    auto* input_buffer = tensor_args.input.buffer();
+    auto* w1_buffer = tensor_args.w1.buffer();
+    auto* w2_buffer = tensor_args.w2.buffer();
+    auto* w3_buffer = tensor_args.w3.buffer();
+
+    auto* swiglu_buffer = output.buffer();
+
+    // Only address arguments need updating here; tile counts remain the same as in create().
+    auto& reader_runtime_args = GetRuntimeArgs(program, swiglu_fw_reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, swiglu_fw_writer_kernel_id);
+
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        // Update input buffers for the reader kernel
+        {
+            auto& runtime_args = reader_runtime_args[core.x][core.y];
+            runtime_args[kInputBufferIdx] = input_buffer->address();
+            runtime_args[kW1BufferIdx] = w1_buffer->address();
+            runtime_args[kW2BufferIdx] = w2_buffer->address();
+            runtime_args[kW3BufferIdx] = w3_buffer->address();
+        }
+
+        // Update output buffers for the writer kernel
+        {
+            auto& runtime_args = writer_runtime_args[core.x][core.y];
+            runtime_args[kSwigluBufferIdx] = swiglu_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::swiglu_fw::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "swiglu_fw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::swiglu_fw::device {
+
+struct SwiGLUForwardProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle swiglu_fw_reader_kernel_id;
+        tt::tt_metal::KernelHandle swiglu_fw_writer_kernel_id;
+        tt::tt_metal::KernelHandle swiglu_fw_kernel_group_1_id;
+        tt::tt_metal::KernelHandle swiglu_fw_kernel_group_2_id;
+        CoreRangeSet core_group_1;
+        CoreRangeSet core_group_2;
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::swiglu_fw::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
@@ -15,8 +15,8 @@ struct SwiGLUForwardProgramFactory {
         tt::tt_metal::KernelHandle swiglu_fw_writer_kernel_id;
         tt::tt_metal::KernelHandle swiglu_fw_kernel_group_1_id;
         tt::tt_metal::KernelHandle swiglu_fw_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_fw.hpp"
+
+#include <iostream>
+
+#include "core/compute_kernel_config.hpp"
+#include "device/swiglu_fw_device_operation.hpp"
+#include "metal/ops/swiglu_fw/swiglu_fw.hpp"
+
+namespace ttml::metal::ops::swiglu_fw {
+
+ttnn::Tensor SwiGLUForwardOperation::invoke(
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
+    return ttnn::prim::ttml_swiglu_fw(
+        input_tensor,  // [B,1,S,C]
+        w1,            // [C,H]
+        w2,            // [H,C]
+        w3             // [C,H]
+    );
+}
+
+}  // namespace ttml::metal::ops::swiglu_fw

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,10 @@ namespace ttml::metal::ops::swiglu_fw {
 ttnn::Tensor SwiGLUForwardOperation::invoke(
     const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
     return ttnn::prim::ttml_swiglu_fw(
-        input_tensor,  // [B,1,S,C]
-        w1,            // [C,H]
-        w2,            // [H,C]
-        w3             // [C,H]
+        input_tensor,  // [B, 1, S, C]
+        w1,            // [1, 1, C, H]
+        w2,            // [1, 1, H, C]
+        w3             // [1, 1, C, H]
     );
 }
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -4,9 +4,6 @@
 
 #include "swiglu_fw.hpp"
 
-#include <iostream>
-
-#include "core/compute_kernel_config.hpp"
 #include "device/swiglu_fw_device_operation.hpp"
 #include "metal/ops/swiglu_fw/swiglu_fw.hpp"
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::swiglu_fw {
+
+struct SwiGLUForwardOperation {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3);
+};
+
+}  // namespace ttml::metal::ops::swiglu_fw

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <core/ttnn_all_includes.hpp>
+#include <ttnn/operations/eltwise/binary/binary.hpp>
+#include <ttnn/operations/matmul/matmul.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/graph_utils.hpp"
+#include "autograd/tensor.hpp"
+#include "metal/operations.hpp"
+#include "ops/unary_ops.hpp"
+
+namespace ttml::ops {
+
+autograd::TensorPtr swiglu(
+    const autograd::TensorPtr& tensor,
+    const autograd::TensorPtr& w1,
+    const autograd::TensorPtr& w2,
+    const autograd::TensorPtr& w3) {
+    auto a_shape = tensor->get_value().logical_shape();
+    if (a_shape.rank() != 4) {
+        throw std::runtime_error("swiglu only supports rank-4 input tensors.");
+    }
+
+    auto device = &autograd::ctx().get_device();
+
+    auto swiglu_fw_result =
+        ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
+
+    auto out = autograd::create_tensor(swiglu_fw_result);
+
+    autograd::GradFunction grad = [tensor, w1, w2, w3, out]() {
+        auto dL_dout = out->get_grad();
+        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+        // Recompute forward intermediates for backward pass
+        auto linear1 = ttnn::matmul(tensor->get_value(), w1->get_value());  // x @ w1
+        auto gate = ttnn::matmul(tensor->get_value(), w3->get_value());     // x @ w3
+        auto sigmoid_linear1 = ttnn::sigmoid(linear1);                      // sigmoid(x @ w1)
+        auto swished = ttnn::multiply(
+            linear1, sigmoid_linear1, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // silu(x @
+                                                                                                           // w1)
+        auto gated = ttnn::multiply(
+            swished, gate, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // silu(x @ w1) * (x @
+                                                                                                // w3)
+        auto projected = ttnn::matmul(gated, w2->get_value());                                  // gated @ w2
+
+        // Backward through final matmul: dL_dgated = dL_dout @ w2^T
+        auto dL_dgated = ttnn::matmul(dL_dout, ttnn::transpose(w2->get_value(), -2, -1));
+
+        // Backward through element-wise multiply:
+        // dL_dswished = dL_dgated * gate
+        // dL_dgate = dL_dgated * swished
+        auto dL_dswished =
+            ttnn::multiply(dL_dgated, gate, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
+        auto dL_dgate =
+            ttnn::multiply(dL_dgated, swished, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
+
+        // For SiLU backward: SiLU'(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
+        auto silu_grad = ttnn::multiply(
+            sigmoid_linear1,
+            ttnn::add(
+                ttnn::ones_like(sigmoid_linear1),
+                ttnn::multiply(
+                    linear1,
+                    ttnn::subtract(
+                        ttnn::ones_like(sigmoid_linear1),
+                        sigmoid_linear1,
+                        std::nullopt,
+                        std::nullopt,
+                        std::nullopt,
+                        none,
+                        none,
+                        none,
+                        false),
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    none,
+                    none,
+                    none,
+                    false),
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                none,
+                none,
+                none,
+                false),
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            none,
+            none,
+            none,
+            false);
+
+        auto dL_dlinear1 =
+            ttnn::multiply(dL_dswished, silu_grad, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
+        auto dL_dtensor_from_w1 = ttnn::matmul(dL_dlinear1, ttnn::transpose(w1->get_value(), -2, -1));
+        auto dL_dtensor_from_w3 = ttnn::matmul(dL_dgate, ttnn::transpose(w3->get_value(), -2, -1));
+
+        // Combine gradients from both paths
+        auto dL_dtensor = ttnn::add(
+            dL_dtensor_from_w1, dL_dtensor_from_w3, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
+
+        tensor->add_grad(dL_dtensor);
+
+        // W2 grad: g^T @ dL_dout
+        auto dL_dW2 = ttnn::matmul(ttnn::transpose(gated, -2, -1), dL_dout);
+        w2->add_grad(dL_dW2);
+
+        // W1 grad: x^T @ dL_dlinear1
+        auto dL_dW1 = ttnn::matmul(ttnn::transpose(tensor->get_value(), -2, -1), dL_dlinear1);
+        w1->add_grad(dL_dW1);
+
+        // W3 grad: x^T @ dL_dgate
+        auto dL_dW3 = ttnn::matmul(ttnn::transpose(tensor->get_value(), -2, -1), dL_dgate);
+        w3->add_grad(dL_dW3);
+    };
+
+    auto links = autograd::get_links(tensor);
+    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+
+    return out;
+}
+
+}  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -9,6 +9,8 @@
 #include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/operations.hpp"
+#include "ops/binary_ops.hpp"
+#include "ops/unary_ops.hpp"
 #include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::ops {
@@ -17,7 +19,8 @@ autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& w1,
     const autograd::TensorPtr& w2,
-    const autograd::TensorPtr& w3) {
+    const autograd::TensorPtr& w3,
+    bool use_composite_fw) {
     auto a_shape = tensor->get_value().logical_shape();
     if (a_shape.rank() != 4) {
         throw std::runtime_error("swiglu only supports rank-4 input tensors.");
@@ -25,14 +28,26 @@ autograd::TensorPtr swiglu(
 
     auto device = &autograd::ctx().get_device();
 
-    auto swiglu_fw_result =
-        ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
+    ttnn::Tensor swiglu_fw_result;
+
+    if (use_composite_fw) {
+        // TODO: Remove this composite implementation once both forward and backward passes are fused
+        auto linear1 = ttnn_fixed::matmul(tensor->get_value(), w1->get_value());  // x @ w1
+        autograd::TensorPtr linear1_ptr = autograd::create_tensor(linear1);
+        auto swished = ops::silu(linear1_ptr, device);                         // silu(x @ w1)
+        auto gate = ttnn_fixed::matmul(tensor->get_value(), w3->get_value());  // x @ w3
+        autograd::TensorPtr gate_ptr = autograd::create_tensor(gate);
+        auto gated = ops::mul(swished, gate_ptr);
+        swiglu_fw_result = ttnn_fixed::matmul(gated->get_value(), w2->get_value());  // gated @ w2
+    } else {
+        swiglu_fw_result =
+            ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
+    }
 
     auto out = autograd::create_tensor(swiglu_fw_result);
 
     autograd::GradFunction grad = [tensor, w1, w2, w3, out]() {
         auto dL_dout = out->get_grad();
-        constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
         // Recompute forward intermediates for backward pass
         auto linear1 = ttnn_fixed::matmul(tensor->get_value(), w1->get_value());  // x @ w1
         auto gate = ttnn_fixed::matmul(tensor->get_value(), w3->get_value());     // x @ w3

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -4,13 +4,12 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
-#include <ttnn/operations/matmul/matmul.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/operations.hpp"
-#include "ops/unary_ops.hpp"
+#include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::ops {
 
@@ -35,89 +34,49 @@ autograd::TensorPtr swiglu(
         auto dL_dout = out->get_grad();
         constexpr auto none = ttsl::Span<const ttnn::operations::unary::UnaryWithParam>{};
         // Recompute forward intermediates for backward pass
-        auto linear1 = ttnn::matmul(tensor->get_value(), w1->get_value());  // x @ w1
-        auto gate = ttnn::matmul(tensor->get_value(), w3->get_value());     // x @ w3
-        auto sigmoid_linear1 = ttnn::sigmoid(linear1);                      // sigmoid(x @ w1)
-        auto swished = ttnn::multiply(
-            linear1, sigmoid_linear1, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // silu(x @
-                                                                                                           // w1)
-        auto gated = ttnn::multiply(
-            swished, gate, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);  // silu(x @ w1) * (x @
-                                                                                                // w3)
-        auto projected = ttnn::matmul(gated, w2->get_value());                                  // gated @ w2
+        auto linear1 = ttnn_fixed::matmul(tensor->get_value(), w1->get_value());  // x @ w1
+        auto gate = ttnn_fixed::matmul(tensor->get_value(), w3->get_value());     // x @ w3
+        auto sigmoid_linear1 = ttnn::sigmoid(linear1);                            // sigmoid(x @ w1)
+        auto swished = ttnn::multiply(linear1, sigmoid_linear1);                  // silu(x @ w1)
+        auto gated = ttnn::multiply(swished, gate);                               // silu(x @ w1) * (x @ w3)
+        auto projected = ttnn_fixed::matmul(gated, w2->get_value());              // gated @ w2
 
         // Backward through final matmul: dL_dgated = dL_dout @ w2^T
-        auto dL_dgated = ttnn::matmul(dL_dout, ttnn::transpose(w2->get_value(), -2, -1));
+        auto dL_dgated = ttnn_fixed::matmul(dL_dout, w2->get_value(), false, true);
 
         // Backward through element-wise multiply:
         // dL_dswished = dL_dgated * gate
         // dL_dgate = dL_dgated * swished
-        auto dL_dswished =
-            ttnn::multiply(dL_dgated, gate, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
-        auto dL_dgate =
-            ttnn::multiply(dL_dgated, swished, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
+        auto dL_dswished = ttnn::multiply(dL_dgated, gate);
+        auto dL_dgate = ttnn::multiply(dL_dgated, swished);
 
         // For SiLU backward: SiLU'(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
         auto silu_grad = ttnn::multiply(
             sigmoid_linear1,
             ttnn::add(
                 ttnn::ones_like(sigmoid_linear1),
-                ttnn::multiply(
-                    linear1,
-                    ttnn::subtract(
-                        ttnn::ones_like(sigmoid_linear1),
-                        sigmoid_linear1,
-                        std::nullopt,
-                        std::nullopt,
-                        std::nullopt,
-                        none,
-                        none,
-                        none,
-                        false),
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
-                    none,
-                    none,
-                    none,
-                    false),
-                std::nullopt,
-                std::nullopt,
-                std::nullopt,
-                none,
-                none,
-                none,
-                false),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            none,
-            none,
-            none,
-            false);
+                ttnn::multiply(linear1, ttnn::subtract(ttnn::ones_like(sigmoid_linear1), sigmoid_linear1))));
 
-        auto dL_dlinear1 =
-            ttnn::multiply(dL_dswished, silu_grad, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
-        auto dL_dtensor_from_w1 = ttnn::matmul(dL_dlinear1, ttnn::transpose(w1->get_value(), -2, -1));
-        auto dL_dtensor_from_w3 = ttnn::matmul(dL_dgate, ttnn::transpose(w3->get_value(), -2, -1));
+        auto dL_dlinear1 = ttnn::multiply(dL_dswished, silu_grad);
+        auto dL_dtensor_from_w1 = ttnn_fixed::matmul(dL_dlinear1, w1->get_value(), false, true);
+
+        auto dL_dtensor_from_w3 = ttnn_fixed::matmul(dL_dgate, w3->get_value(), false, true);
 
         // Combine gradients from both paths
-        auto dL_dtensor = ttnn::add(
-            dL_dtensor_from_w1, dL_dtensor_from_w3, std::nullopt, std::nullopt, std::nullopt, none, none, none, false);
-
+        auto dL_dtensor = ttnn::add(dL_dtensor_from_w1, dL_dtensor_from_w3);
         tensor->add_grad(dL_dtensor);
 
         // W2 grad: g^T @ dL_dout
-        auto dL_dW2 = ttnn::matmul(ttnn::transpose(gated, -2, -1), dL_dout);
-        w2->add_grad(dL_dW2);
+        auto dL_dW2 = ttnn_fixed::matmul(gated, dL_dout, true, false);
+        w2->add_grad(ttnn::sum(dL_dW2, 0, true));
 
         // W1 grad: x^T @ dL_dlinear1
-        auto dL_dW1 = ttnn::matmul(ttnn::transpose(tensor->get_value(), -2, -1), dL_dlinear1);
-        w1->add_grad(dL_dW1);
+        auto dL_dW1 = ttnn_fixed::matmul(tensor->get_value(), dL_dlinear1, true, false);
+        w1->add_grad(ttnn::sum(dL_dW1, 0, true));
 
         // W3 grad: x^T @ dL_dgate
-        auto dL_dW3 = ttnn::matmul(ttnn::transpose(tensor->get_value(), -2, -1), dL_dgate);
-        w3->add_grad(dL_dW3);
+        auto dL_dW3 = ttnn_fixed::matmul(tensor->get_value(), dL_dgate, true, false);
+        w3->add_grad(ttnn::sum(dL_dW3, 0, true));
     };
 
     auto links = autograd::get_links(tensor);

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -25,8 +25,6 @@ autograd::TensorPtr swiglu(
         throw std::runtime_error("swiglu only supports rank-4 input tensors.");
     }
 
-    auto device = &autograd::ctx().get_device();
-
     ttnn::Tensor swiglu_fw_result =
         ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
     auto out = autograd::create_tensor(swiglu_fw_result);

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "autograd/tensor.hpp"
+
+namespace ttml::ops {
+
+autograd::TensorPtr swiglu(
+    const autograd::TensorPtr& tensor,
+    const autograd::TensorPtr& w1,
+    const autograd::TensorPtr& w2,
+    const autograd::TensorPtr& w3);
+
+}  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -12,6 +12,7 @@ autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& w1,
     const autograd::TensorPtr& w2,
-    const autograd::TensorPtr& w3);
+    const autograd::TensorPtr& w3,
+    bool use_composite_fw = false);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -12,7 +12,6 @@ autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& w1,
     const autograd::TensorPtr& w2,
-    const autograd::TensorPtr& w3,
-    bool use_composite_fw = false);
+    const autograd::TensorPtr& w3);
 
 }  // namespace ttml::ops

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCES
     ops/softmax_test.cpp
     ops/silu_op_test.cpp
     ops/sdpa_fw_op_test.cpp
+    ops/swiglu_op_test.cpp
 )
 
 add_executable(ttml_tests ${SOURCES})

--- a/tt-train/tests/ops/swiglu_op_test.cpp
+++ b/tt-train/tests/ops/swiglu_op_test.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ops/swiglu_op.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <core/ttnn_all_includes.hpp>
+#include <iostream>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "xtensor-blas/xlinalg.hpp"
+
+class SwiGLUOpTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+// ============================================================================
+// Section 1: SwiGLU Forward Pass Test
+// ============================================================================
+// This test validates the SwiGLU forward pass implementation
+//
+// Test methodology:
+// 1. Create test tensors x, w1, w2, w3
+// 2. Compute SwiGLU forward pass
+// 3. Verify the result is finite and has expected shape
+// ============================================================================
+
+namespace {
+
+// TODO(maciek): Check and create consistent naming of variables denoting dimensions (especially hidden ones)
+
+/**
+ * Reference implementation of SwiGLU forward pass using xt library
+ * SwiGLU(x, w1, w2, w3) = (silu(x @ w1) * (x @ w3)) @ w2
+ *
+ * @param x Input tensor [B, N, S, C]
+ * @param w1 Weight matrix 1 [C, H]
+ * @param w2 Weight matrix 2 [H, C]
+ * @param w3 Weight matrix 3 [C, H]
+ * @return SwiGLU activation result
+ */
+xt::xarray<float> swiglu_forward_reference(
+    const xt::xarray<float>& x, const xt::xarray<float>& w1, const xt::xarray<float>& w2, const xt::xarray<float>& w3) {
+    // x @ w1: [B, N, S, C] @ [C, H] -> [B, N, S, H]
+    auto xw1 = xt::linalg::tensordot(x, w1, {3}, {0});
+    // x @ w3: [B, N, S, C] @ [C, H] -> [B, N, S, H]
+    auto xw3 = xt::linalg::tensordot(x, w3, {3}, {0});
+    // Apply SiLU activation: SiLU(x) = x * sigmoid(x)
+    auto silu = [](const xt::xarray<float>& t) {
+        auto sigmoid = 1.0f / (1.0f + xt::exp(-t));
+        return t * sigmoid;
+    };
+    auto gated = silu(xw1) * xw3;
+
+    return xt::linalg::tensordot(gated, w2, {3}, {0});
+}
+
+void CompareKernelVsReference(
+    const xt::xarray<float>& input_data,
+    const xt::xarray<float>& w1_data,
+    const xt::xarray<float>& w2_data,
+    const xt::xarray<float>& w3_data) {
+    using namespace ttml;
+
+    // Create input tensors for kernel implementation
+    auto input_kernel = autograd::create_tensor(core::from_xtensor(input_data, &autograd::ctx().get_device()));
+    auto w1_kernel = autograd::create_tensor(core::from_xtensor(w1_data, &autograd::ctx().get_device()));
+    auto w2_kernel = autograd::create_tensor(core::from_xtensor(w2_data, &autograd::ctx().get_device()));
+    auto w3_kernel = autograd::create_tensor(core::from_xtensor(w3_data, &autograd::ctx().get_device()));
+
+    // Forward pass - kernel implementation
+    auto result_kernel = ops::swiglu(input_kernel, w1_kernel, w2_kernel, w3_kernel);
+    result_kernel->get_value();
+    std::cout << std::endl << "SwiGLU kernel result from kernel in test: " << std::endl;
+    auto result_kernel_xtensor = core::to_xtensor(result_kernel->get_value());
+
+    // Forward pass - reference implementation
+    auto result_reference = swiglu_forward_reference(input_data, w1_data, w2_data, w3_data);
+    std::cout << std::endl << "SwiGLU reference result in test:" << std::endl;
+
+    // Verify shapes match
+    EXPECT_EQ(result_kernel_xtensor.shape(), result_reference.shape())
+        << "Shape mismatch between kernel and reference results";
+    // Verify both results are finite
+    EXPECT_TRUE(xt::all(xt::isfinite(result_kernel_xtensor))) << "SwiGLU kernel result contains NaN or Inf values";
+    EXPECT_TRUE(xt::all(xt::isfinite(result_reference))) << "SwiGLU reference result contains NaN or Inf values";
+
+    // We use dynamic tolerances because the output magnitude of SwiGLU grows with input/hidden size
+    // (due to large dot-product summations in the matmuls). A fixed absolute tolerance would either:
+    //   - fail for large tensors (legitimate numerical growth triggers abs-error check), or
+    //   - be too loose for small tensors (hiding real bugs).
+    // The kernel runs in BF16 internally, so we allow ~2% relative error vs the FP32 reference.
+    // The absolute tolerance is scaled to the magnitude of the reference output for this test case.
+    float rtol = 2e-2f;
+    float atol = rtol * static_cast<float>(xt::amax(xt::abs(result_reference))());
+    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_reference, rtol, atol))
+        << "SwiGLU kernel and reference implementations differ";
+}
+
+/**
+ * Helper function to test SwiGLU forward pass with given input shape
+ *
+ * @param input_shape Input tensor shape [B, N, S, C] where:
+ *   - B: batch size
+ *   - N: number of channels (usually 1 for transformers)
+ *   - S: sequence length (height for transformers)
+ *   - C: feature dimension (width/embedding dimension)
+ * @param hidden_dim Hidden dimension for the weight matrices
+ */
+static void CompareKernelVsReferenceWithShape(const std::vector<uint32_t>& input_shape, uint32_t hidden_dim) {
+    using namespace ttml;
+
+    // Generate random input data
+    const float bound = 1.0F;
+    xt::random::seed(42);
+    xt::xarray<float> input_data = xt::random::rand<float>(input_shape, -bound, bound);
+
+    // Create weight matrices - w1, w3 map from input_dim to hidden_dim, w2 maps hidden_dim to input_dim
+    uint32_t input_dim = input_shape.back();
+    std::vector<uint32_t> w1_w3_shape = {input_dim, hidden_dim};
+    std::vector<uint32_t> w2_shape = {hidden_dim, input_dim};
+
+    xt::xarray<float> w1_data = xt::random::rand<float>(w1_w3_shape, -bound, bound);
+    xt::xarray<float> w2_data = xt::random::rand<float>(w2_shape, -bound, bound);
+    xt::xarray<float> w3_data = xt::random::rand<float>(w1_w3_shape, -bound, bound);
+
+    CompareKernelVsReference(input_data, w1_data, w2_data, w3_data);
+}
+
+}  // namespace
+
+// ============================================================================
+// Section 2: SwiGLU Kernel vs Reference Implementation Tests
+// ============================================================================
+// These tests compare the SwiGLU kernel implementation against
+// the reference implementation to ensure correctness
+// ============================================================================
+
+// 1. Basic 1x1x32x32 test (no masking)
+TEST_F(SwiGLUOpTest, SwiGLU_Basic_1x1x32x32) {
+    CompareKernelVsReferenceWithShape({1, 1, 32, 32}, 32);
+}
+
+// 2. Medium test: 2x1x32x128, hidden_dim=128 (all divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_Medium_2x1x32x128) {
+    CompareKernelVsReferenceWithShape({2, 1, 32, 128}, 128);
+}
+
+// 3. Medium test: 2x1x32x256, hidden_dim=256 (all divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_Medium_2x1x32x256) {
+    CompareKernelVsReferenceWithShape({2, 1, 32, 256}, 256);
+}
+
+// 4. Medium test: 2x1x35x128, hidden_dim=128 (rows not divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_MaskRows_Medium) {
+    CompareKernelVsReferenceWithShape({2, 1, 35, 128}, 128);
+}
+
+// 5. Medium test: 2x1x32x100, hidden_dim=128 (C not divisible by 32, mask_w)
+TEST_F(SwiGLUOpTest, SwiGLU_MaskW_Medium) {
+    CompareKernelVsReferenceWithShape({2, 1, 32, 100}, 128);
+}
+
+// 6. Medium test: 2x1x32x128, hidden_dim=100 (hidden_dim not divisible by 32, mask_hw)
+TEST_F(SwiGLUOpTest, SwiGLU_MaskHW_Medium) {
+    CompareKernelVsReferenceWithShape({2, 1, 32, 128}, 100);
+}
+
+// 7. Larger test: 4x1x64x256, hidden_dim=256 (all divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_Large_4x1x64x256) {
+    CompareKernelVsReferenceWithShape({4, 1, 64, 256}, 256);
+}
+
+// 8. Larger test: 4x1x64x512, hidden_dim=256 (all divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_Large_4x1x64x512) {
+    CompareKernelVsReferenceWithShape({4, 1, 64, 512}, 256);
+}
+
+// 9. Larger test: 4x1x65x256, hidden_dim=256 (rows not divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_MaskRows_Large) {
+    CompareKernelVsReferenceWithShape({4, 1, 65, 256}, 256);
+}
+
+// 10. Larger test: 4x1x64x260, hidden_dim=260 (C and hidden_dim not divisible by 32)
+TEST_F(SwiGLUOpTest, SwiGLU_MaskW_MaskHW_Large) {
+    CompareKernelVsReferenceWithShape({4, 1, 64, 260}, 260);
+}

--- a/tt-train/tests/ops/swiglu_op_test.cpp
+++ b/tt-train/tests/ops/swiglu_op_test.cpp
@@ -6,14 +6,10 @@
 
 #include <gtest/gtest.h>
 
-#include <cassert>
-#include <core/ttnn_all_includes.hpp>
+#include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
-#include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "xtensor-blas/xlinalg.hpp"
-#include "xtensor/misc/xmanipulation.hpp"
 
 class SwiGLUOpTest : public ::testing::Test {
 protected:
@@ -128,6 +124,7 @@ static void CompareKernelVsReferenceWithShape(const std::vector<uint32_t>& input
     using namespace ttml;
 
     // Generate random input data
+    // TODO(maciek): Use ttml::core::parallel_generate for random data generation.
     const float bound = 1.0F;
     xt::random::seed(42);
     xt::xarray<float> input_data = xt::random::rand<float>(input_shape, -bound, bound);
@@ -186,7 +183,17 @@ TEST_F(SwiGLUOpTest, SwiGLU_Large_4x1x64x256) {
     CompareKernelVsReferenceWithShape({4, 1, 64, 256}, 256);
 }
 
-// 7. NanoGPT-like shape: 32x1x256x384, hidden_dim=1024
-TEST_F(SwiGLUOpTest, SwiGLU_NanoGPT_32x1x256x384) {
+// 7. Large test: 2x1x128x512, hidden_dim=512
+TEST_F(SwiGLUOpTest, SwiGLU_Large_2x1x128x512) {
+    CompareKernelVsReferenceWithShape({2, 1, 128, 512}, 512);
+}
+
+// 8. Very large dimensions test: 1x1x1024x1024, hidden_dim=1024
+TEST_F(SwiGLUOpTest, NIGHTLY_SwiGLU_VeryLarge_1x1x1024x1024) {
+    CompareKernelVsReferenceWithShape({1, 1, 1024, 1024}, 1024);
+}
+
+// 9. NanoGPT-like shape: 32x1x256x384, hidden_dim=1024
+TEST_F(SwiGLUOpTest, NIGHTLY_SwiGLU_NanoGPT_32x1x256x384) {
     CompareKernelVsReferenceWithShape({32, 1, 256, 384}, 1024);
 }


### PR DESCRIPTION
## Ticket
[[Feature Request] SwiGLU forward and backward functions](https://github.com/tenstorrent/tt-metal/issues/14195)

## Problem description
This PR introduces a **dual-path SwiGLU forward operation** implementation with conditional compilation based on input matrix dimensions and L1 memory capacity. Currently, models depend on non-fused implementations of SwiGLU, which can be suboptimal for performance. This implementation provides both a memory-optimized fast path and a fallback streaming approach, establishing the foundation for performant fused SwiGLU while maintaining compatibility across different input sizes.

## What's changed
- **Added L1-optimized SwiGLU forward with conditional compilation**
  - **Fast path**: Caches full rows of XW1, XW3, and M in L1 when input dimensions allow the required memory to fit within fixed L1 capacity, eliminating redundant DRAM reads and recomputation
  - **Fallback path**: Streaming approach for larger input dimensions where full rows don't fit in L1, recomputes M as needed
  - Runtime memory checking automatically selects optimal algorithm based on whether memory required by input dimensions fits within fixed L1 capacity

- **Implementation details**
  - Uses block-based compute kernel
  - Enhanced tile loading utilities with row-major and column-major read functions
  - Conditional compilation with define flag propagation
  - Assumes both `C` (input dimension) and `hidden_C` (hidden dimension) are divisible by 32
  - Masking support for non-divisible dimensions **not yet implemented**

- **Backward path**
  - Added composite implementation for SwiGLU backward for compatibility with other ops

- **Testing**
  - Added comprehensive test suite using xtensor-based reference implementation to validate correctness across various scenarios

- **Limitations and future work**
  - This version does not utilize unicast/multicast optimizations (planned for next PR)
  - Implement masking for dimensions where `C % 32 != 0` or `hidden_C % 32 != 0`

## Performance
Current benchmarking on nanoGPT (7 steps, 36 calls, skipping first step):

**Composite implementation:**
- Mean: 6.808 ms
- Std dev: 0.028 ms

**Fused implementation (fast path):**
- Mean: 6.827 ms  
- Std dev: 0.069 ms

The fused implementation currently performs roughly equivalent to the composite version. Performance optimizations including unicast/multicast will be addressed in subsequent PRs.

**Methodology:** Performance measured using profiler markers wrapped around SwiGLU operations in `llama_block.cpp`, forward pass only with gradients disabled.

## Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes