### PR TITLE
Remove non-existent import for gemma

### DIFF
--- a/models/demos/gemma3/demo/text_demo.py
+++ b/models/demos/gemma3/demo/text_demo.py
@@ -17,7 +17,6 @@ import ttnn
 from models.demos.gemma3.tt.model_config import determine_device_name, parse_decoder_json
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.perf.benchmarking_utils import BenchmarkProfiler
-from models.tt_transformers.tests.test_accuracy import get_accuracy_thresholds
 from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill, sample_host
 from models.tt_transformers.tt.generator import Generator, SamplingParams, create_submeshes
 from models.tt_transformers.tt.model_config import DecodersPrecision


### PR DESCRIPTION
### Ticket
Gemma tests are failing on import of `models/tt_transformers/test_accuracy.py` which was removed in a recent PR. See: https://github.com/tenstorrent/tt-metal/actions/runs/17692049855/job/50290389980#step:10:360

This PR removes the import - the function was already copied across.