### PR TITLE
#28631: Test celu with exp21f

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
 import torch
 import pytest
 import ttnn
@@ -12,11 +15,7 @@ def test_celu_arange(device):
     input_tensor = input_tensor.to(torch.float32)
 
     # Mask NaN, special values where celu has ULP>1 (Covered in allclose test below).
-    mask = (
-        (torch.isnan(input_tensor))
-        | (input_tensor == 3.3895313892515355e38)
-        | ((input_tensor >= -0.28515625) & (input_tensor <= 1.1663108012064884e-38))
-    )
+    mask = (torch.isnan(input_tensor)) | ((input_tensor >= -0.28515625) & (input_tensor <= 1.1663108012064884e-38))
     input_tensor[mask] = 1.0
 
     tt_in = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
@@ -1,0 +1,64 @@
+import torch
+import pytest
+import ttnn
+import math
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def test_celu_arange(device):
+    # Generate all possible bit patterns for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # Mask NaN, special values where celu has ULP>1 (Covered in allclose test below).
+    mask = (
+        (torch.isnan(input_tensor))
+        | (input_tensor == 3.3895313892515355e38)
+        | ((input_tensor >= -0.28515625) & (input_tensor <= 1.1663108012064884e-38))
+    )
+    input_tensor[mask] = 1.0
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.celu)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.celu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize(
+    "low, high, expected_Atol, expected_rtol",
+    [
+        (-1.6 * 10**38, -0.28515625, 0.001, 0.004),
+        (-0.28515625, 1.1663108012064884e-38, 0.002, 0.02),
+        (1.1663108012064884e-38, 1.6 * 10**38, 1e-6, 1e-6),
+    ],
+)
+def test_celu_allclose(low, high, expected_Atol, expected_rtol, device):
+    num_elements = math.prod([1, 3, 320, 320])
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))
+
+    golden_function = ttnn.get_golden_function(ttnn.celu)
+    golden = golden_function(torch_input, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.celu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert torch.allclose(golden, result, atol=expected_Atol, rtol=expected_rtol)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_sfpu_exp.h"
+
+namespace ckernel::sfpu {
+
+// CELU: alpha * (exp(x / alpha) - 1)
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_celu(uint32_t param0, uint32_t param1) {
+    // All params are in FP16_B format
+    // param0 = alpha
+    // param1 = alpha_recip
+
+    sfpi::vFloat alpha = Converter::as_float(param0);
+    sfpi::vFloat alpha_recip = Converter::as_float(param1);
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+
+        v_if(v < sfpi::vConst0) {
+            // Compute exp(x / alpha)
+            sfpi::vFloat exp_val =
+                _sfpu_exp_21f_<true>(v * alpha_recip);  // is_fp32_dest_acc_en set to true to avoid rounding as it has
+                                                        // to be done at the end of operation
+
+            sfpi::vFloat result = alpha * (exp_val - sfpi::vConst1);
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
+        }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -8,6 +8,7 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "ckernel_sfpu_softsign.h"
 #include "ckernel_sfpu_softshrink.h"
+#include "ckernel_sfpu_celu.h"
 
 namespace ckernel {
 
@@ -40,18 +41,18 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
+// celu
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>(
-        ckernel::sfpu::_init_exponential_<APPROXIMATE, /*FAST_APPROX=*/APPROXIMATE, /*SCALE=*/p_sfpu::kCONST_1_FP16B>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>(alpha, alpha_recip);
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
         },
         dst_index,
         vector_mode,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_sfpu_exp.h"
+
+namespace ckernel::sfpu {
+
+// CELU: alpha * (exp(x / alpha) - 1)
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_celu(uint32_t param0, uint32_t param1) {
+    // All params are in FP16_B format
+    // param0 = alpha
+    // param1 = alpha_recip
+
+    sfpi::vFloat alpha = Converter::as_float(param0);
+    sfpi::vFloat alpha_recip = Converter::as_float(param1);
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+
+        v_if(v < sfpi::vConst0) {
+            // Compute exp(x / alpha)
+            sfpi::vFloat exp_val =
+                _sfpu_exp_21f_<true>(v * alpha_recip);  // is_fp32_dest_acc_en set to true to avoid rounding as it has
+                                                        // to be done at the end of operation
+
+            sfpi::vFloat result = alpha * (exp_val - sfpi::vConst1);
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
+            sfpi::dst_reg[0] = result;
+        }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -8,6 +8,7 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "ckernel_sfpu_softsign.h"
 #include "ckernel_sfpu_softshrink.h"
+#include "ckernel_sfpu_celu.h"
 
 namespace ckernel {
 
@@ -39,18 +40,18 @@ inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode
         ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
 }
 
+// celu
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_celu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>(
-        ckernel::sfpu::_init_exponential_<APPROXIMATE, /*FAST_APPROX=*/APPROXIMATE, /*SCALE=*/p_sfpu::kCONST_1_FP16B>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::celu, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>(alpha, alpha_recip);
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
         },
         dst_index,
         vector_mode,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/activations.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/activations.h
@@ -73,7 +73,7 @@ ALWI void softsign_tile_init() { MATH((llk_math_eltwise_unary_sfpu_softsign_init
 */
 // clang-format on
 ALWI void celu_tile(uint32_t idst, uint32_t alpha, uint32_t alpha_recip) {
-    MATH((llk_math_eltwise_unary_sfpu_celu<APPROX, ckernel::ActivationType::Celu>(idst, alpha, alpha_recip)));
+    MATH((llk_math_eltwise_unary_sfpu_celu<APPROX, DST_ACCUM_MODE>(idst, alpha, alpha_recip)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
#26993, #28631

### Problem description
Test celu with exp21f to see if there is improvement in accuracy

### What's changed
- Updated celu to use exp21
- **ULP Data** 
  - Tested for the entire 16-bit range of bfloat16 (0 through 2¹⁶), covering all possible values. Test passes with ULP 1 except for below mentioned cases
  - Attached ULP Graphs, TTNN vs Torch, Values causing higher ULP : [File](https://docs.google.com/document/d/1jSSbH0YpiJtgrWaiOrpEkK_lmz5TyilARTx8QhAnJFA/edit?tab=t.0#heading=h.fhq5x9wxrs1n)
  - Below listed are the failing cases with ULP>1
    - Main branch : 
        - Max ULP Delta: **128.0** (Mismatching values : [Link](https://drive.google.com/file/d/1KBL0hbw2LaARXIr8-Sb2yz9vGhm2Rk_O/view?usp=drive_link) ) 
        - Input Failing range : (**-4.46875**, 1.1663108012064884e-38 )
        - All close testing
          - (-4.46875, 1.1663108012064884e-38 ) : Max ATOL Delta: 0.01171875
          - (-0.28515625, 1.1663108012064884e-38 ) : Max ATOL Delta: 0.01171875
    - Updated branch : 
        - Max ULP Delta: **1.8775345440461937e+37** (Mismatching value : [Link](https://drive.google.com/file/d/1i_nSKk0A5X8LIPCsifwyuW7vYDbnHoRe/view?usp=drive_link))
        - Input Failing range : (**-0.28515625**, 1.1663108012064884e-38 )
        - All close testing
          - (-0.28515625, 1.1663108012064884e-38 ) : ATOL : 0.001953125
          - BF16 range (-1.6 * 10**38, 1.6 * 10**38) : ATOL : 0.0
- **Edge case behaviour**

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
**INPUT** | **TORCH RESULT** | **TT RESULT (Main)** | **TT RESULT (Updated)**
-- | -- | -- | --
inf | inf | inf | inf
-inf | -1 | -1 | -1
nan | nan | inf | inf
-0.0 | 0 | 0 | 0.0017
0 | 0 | 0 | 0

- **Performance analysis**
  - Single tile Performance : Updated kernel duration is about **22%** slower
    - Main Branch : [celu_main_perf.csv](https://github.com/user-attachments/files/22320498/celu_main_perf.csv)
    - Updated branch : [celu_updated_perf.csv](https://github.com/user-attachments/files/22320501/celu_updated_perf.csv)
    - <img width="419" height="129" alt="Image" src="https://github.com/user-attachments/assets/fc24e800-0184-41cb-a17f-f4eaebaca097" />
  - 8K tile Performance : Updated kernel duration is about **36.6%** slower
    - Main Branch : [celu_main_8K_perf.csv](https://github.com/user-attachments/files/22321047/celu_main_8K_perf.csv)
    - Updated branch : [celu_updated_8K_perf.csv](https://github.com/user-attachments/files/22321048/celu_updated_8K_perf.csv)
    - <img width="419" height="129" alt="Image" src="https://github.com/user-attachments/assets/09f4b992-8646-4ac2-aa14-f46ab4609e6a" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17896758942) - passed
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17896761383) - passed
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17896775338) - failed as in main
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17896772335) - passed 
- [ ] [BH PC Watcher enabled](https://github.com/tenstorrent/tt-metal/actions/runs/17896760470) - passes as in main
- [ ] [Single card pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17896774228) - passes as in main
- [ ] [T3K Pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17896776907) - passes as in main
- [x] New/Existing tests provide coverage for changes