### PR TITLE
Fix regression from #f0b68dd

### DIFF
--- a/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
+++ b/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
@@ -68,7 +68,6 @@ def ttnn_conv1d(
 
     conv_config = ttnn.Conv1dConfig(
         weights_dtype=ttnn.bfloat8_b,
-        activation=activation,
         deallocate_activation=deallocate_activation,
         reallocate_halo_output=reallocate_halo,
         act_block_h_override=32,


### PR DESCRIPTION
Remove missing argument in sentese bert test
One of the reasons why models pipeline is red