### PR TITLE
`all_broadcast` Scatter-Write and Composite-RS Optimizations

### DIFF
--- a/tests/nightly/t3000/2d_ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/2d_ccl/test_minimal_reduce_scatter_async.py
@@ -93,9 +93,6 @@ def test_reduce_scatter_async_training_shapes(
     num_iters,
     ones_tensor,
 ):
-    if enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         mesh_device,
         mesh_device.get_num_devices(),

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -196,21 +196,21 @@ def run_all_gather_impl(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "ag_output_shape, dim, layout, ag_input_dtype, is_training_shape",
+    "ag_output_shape, dim, layout, ag_input_dtype",
     [
-        ([1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
-        ([1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),
+        ([1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 1024, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([8, 1, 512, 512], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 48, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Composite-AG tests
-        ([1, 1, 8, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
-        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        ([1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        ([1, 16, 32, 32], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 17, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 16, 32, 32], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "dit_shape",  # this one triggers the default chunks_per_sync
@@ -268,7 +268,6 @@ def test_all_gather_async(
     dim,
     num_links,
     ag_input_dtype,
-    is_training_shape,
     layout,
     mem_config_input,
     mem_config_ag,

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -250,7 +250,7 @@ def run_reduce_scatter_impl(
         ([1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Composite-RS tests
         ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        ([1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([2, 32, 2048, 64], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
         ([1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -238,21 +238,21 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
+    "rs_input_shape, dim, layout, rs_input_dtype",
     [
-        ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        ([1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Composite-RS tests
-        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        ([1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        ([1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
-        ([1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True),
+        ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 256, 128], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
+        ([1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -319,7 +319,6 @@ def test_reduce_scatter_async(
     dim,
     layout,
     rs_input_dtype,
-    is_training_shape,
     mem_config_input,
     mem_config_rs,
     enable_trace,
@@ -329,9 +328,6 @@ def test_reduce_scatter_async(
     use_persistent_buffers,
     rs_topology,
 ):
-    if is_training_shape and enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         mesh_device,
         mesh_device.get_num_devices(),
@@ -437,9 +433,6 @@ def test_reduce_scatter_async_training_shapes(
     num_iters,
     ones_tensor,
 ):
-    if enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         mesh_device,
         mesh_device.get_num_devices(),

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -252,7 +252,7 @@ def run_reduce_scatter_impl(
         ([1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([2, 32, 2048, 64], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
-        ([1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        ([1, 1, 29, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
         "padded_dim_2_test_one",

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -237,20 +237,20 @@ def run_reduce_scatter_impl(
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
+    "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
     [
-        (4, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
+        (4, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Composite-RS tests
-        (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
-        # (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True), #Issue 27619
+        (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
+        # (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16), #Issue 27619
     ],
     ids=[
         "padded_dim_2_test_one",
@@ -317,7 +317,6 @@ def test_reduce_scatter_async(
     dim,
     layout,
     rs_input_dtype,
-    is_training_shape,
     mem_config_input,
     mem_config_rs,
     enable_trace,
@@ -328,10 +327,6 @@ def test_reduce_scatter_async(
     rs_topology,
 ):
     validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-
-    if is_training_shape and enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         bh_1d_mesh_device,
         num_devices,
@@ -424,9 +419,6 @@ def test_reduce_scatter_async_training_shapes(
     ones_tensor,
 ):
     validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-    if enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         bh_1d_mesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
@@ -236,7 +236,7 @@ def run_all_broadcast_impl(
     "num_devices, num_links, output_shape, layout, input_dtype",
     [
         (2, 1, [2, 30], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
-        (2, 1, [3, 122, 2042], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (2, 1, [3, 121, 2042], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
         (4, 1, [1, 1, 32, 1024], ttnn.TILE_LAYOUT, ttnn.bfloat16),
         (4, 1, [2, 64, 512], ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
         (8, 1, [256, 3328], ttnn.TILE_LAYOUT, ttnn.bfloat8_b),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -114,8 +114,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         if (num_width_shards > 1) {
             buffer_page_size = input_tensor.memory_config().shard_spec()->shape[1] * input_tensor.element_size();
         }
-        cb_src0_config = tt::tt_metal::CircularBufferConfig(3 * buffer_page_size, {{src0_cb_index, df}})
-                             .set_page_size(src0_cb_index, buffer_page_size);
+        uint32_t num_rows_per_packet = (max_packet_size / buffer_page_size >= 2) ? 2 : 1;
+        cb_src0_config =
+            tt::tt_metal::CircularBufferConfig(3 * buffer_page_size * num_rows_per_packet, {{src0_cb_index, df}})
+                .set_page_size(src0_cb_index, buffer_page_size);
     }
     CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
@@ -142,11 +144,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
 
     if (!tilized) {
         reader_compile_args = {
-            src0_cb_index,                                        // cb0_id
-            num_width_shards > 1 ? buffer_page_size : page_size,  // page_size
-            row_size,
-            num_packets_per_row,  // num_packets_per_row
-            max_packet_size       // max_packet_size
+            src0_cb_index,                                      // cb0_id
+            buffer_page_size,                                   // page_size
+            row_size,                                           // row_size
+            (max_packet_size / buffer_page_size >= 2) ? 2 : 1,  // num_rows_per_packet
         };
     }
 
@@ -165,12 +166,13 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
             reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
             num_packet_headers_storable,      // num_packet_headers_storable
             src0_cb_index,                    // cb0_id
-            num_width_shards > 1 ? buffer_page_size : page_size,
+            buffer_page_size,
             row_size,
             max_packet_size,
-            num_packets_per_row,   // num_packets_per_row
-            num_targets_forward,   // num_targets_forward_direction
-            num_targets_backward,  // num_targets_backward_direction
+            (max_packet_size / buffer_page_size >= 2) ? 2 : 1,  // num_rows_per_packet
+            num_packets_per_row,                                // num_packets_per_row
+            num_targets_forward,                                // num_targets_forward_direction
+            num_targets_backward,                               // num_targets_backward_direction
         };
     }
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -15,7 +15,6 @@
 
 namespace ttnn::operations::experimental::ccl {
 
-// Composite always runs in row-major
 ttnn::Tensor composite_reduce_scatter(
     ttnn::Tensor input_tensor,
     const int32_t dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -36,6 +36,7 @@ ttnn::Tensor composite_reduce_scatter(
         num_devices = ttnn::ccl::get_active_physical_devices(input_tensor).size();
     }
 
+    DataType input_dtype = input_tensor.dtype();
     auto input_shape = input_tensor.logical_shape();
 
     int32_t rank = input_tensor.logical_shape().rank();
@@ -43,27 +44,13 @@ ttnn::Tensor composite_reduce_scatter(
 
     auto output_shape = input_shape;
     output_shape[scatter_dim] /= num_devices;
-
     bool is_tiled_and_not_tile_aligned = input_tensor.layout() == Layout::TILE &&
                                          (output_shape[2] % tile_height != 0 || output_shape[3] % tile_width != 0);
 
-    // If we need to convert to row-major, then if the input dtype is bfloat8_b we need to typecast before untilizing
-    // and after re-tilizing
-    DataType input_dtype = input_tensor.dtype();
-    bool convert_to_bfloat16_for_composite = is_tiled_and_not_tile_aligned && input_dtype == DataType::BFLOAT8_B;
-
-    // Convert to row major
-    if (is_tiled_and_not_tile_aligned) {
-        // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
-        if (convert_to_bfloat16_for_composite) {
-            input_tensor = ttnn::typecast(input_tensor, DataType::BFLOAT16);
-        }
-        input_tensor = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR);
-    }
-
     // Broadcast each tensor to all other devices in the mesh
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, num_links, memory_config, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+        input_tensor, num_links, input_tensor.memory_config(), ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+    input_tensor.deallocate();
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
@@ -72,17 +59,25 @@ ttnn::Tensor composite_reduce_scatter(
         broadcasted_tensors[i].deallocate();
     }
 
+    // Convert to row-major (if necessary)
+    if (is_tiled_and_not_tile_aligned) {
+        // If input is tiled bfloat8_b, cast up to bfloat16 prior to converting to row-major
+        if (input_dtype == DataType::BFLOAT8_B) {
+            all_reduced_tensor = ttnn::typecast(all_reduced_tensor, DataType::BFLOAT16);
+        }
+        all_reduced_tensor = ttnn::to_layout(all_reduced_tensor, Layout::ROW_MAJOR);
+    }
+
     // Partition the reduced tensor (scatter)
     ttnn::Tensor reduce_scatter_output_tensor = ttnn::prim::mesh_partition(
         all_reduced_tensor, scatter_dim, cluster_axis, memory_config.value_or(all_reduced_tensor.memory_config()));
 
-    // Convert back to tiled
+    // Convert back to tiled (if necessary)
     if (is_tiled_and_not_tile_aligned) {
         reduce_scatter_output_tensor = ttnn::to_layout(reduce_scatter_output_tensor, Layout::TILE);
-        // If we had to convert the input dtype in order to execute the row-major composite op, convert back to the
-        // input dtype
-        if (convert_to_bfloat16_for_composite) {
-            reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, input_dtype);
+        // If input was tiled bfloat8_b, cast back down to bfloat8_b
+        if (input_dtype == DataType::BFLOAT8_B) {
+            reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, DataType::BFLOAT8_B);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -49,7 +49,6 @@ ttnn::Tensor composite_reduce_scatter(
     // Broadcast each tensor to all other devices in the mesh
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor, num_links, input_tensor.memory_config(), ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
-    input_tensor.deallocate();
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];


### PR DESCRIPTION
### What's changed

## Composite-RS Algorithm
- Currently the algorithm is: `untilize -> all_broadcast -> add -> mesh_partition -> tilize`
  - note the untilize/tilize is skipped when possible
- However upon investigation, when the input is row-major, `add` is itself a composite: `tilize -> add -> untilize`
- So currently composite-RS is actually: `untilize -> all_broadcast -> tilize -> add -> untilize -> mesh_partition -> tilize`

---

- I've updated the algorithm to be: `all_broadcast -> add -> untilize -> mesh_partition -> tilize`, which eliminates the tilize/untilize around `add`
- Additionally, this means the `all_broadcast` now runs with tiles, instead of row-major
  - This also leads to better perf in most cases, as with the majority of training shapes the row size is really small, which meant we were wasting packet space as we were sending a single small row per packet
  - There are a couple exceptions (`[1, 1, 1, 4096]` and `[1, 1, 1, 2048]`) where it'd be better to send the packets in rows, but we can look into optimizing these specific cases later if need be

---

- Upon profiling one of the training shapes on T3K (`[2, 32, 2048, 64]`, DRAM interleaved), I saw a ~10x decrease in kernel time
- Disclaimer: the above shape has a shit-ton of tiny rows, so the perf increase seen from switching `all_broadcast` from row-major to tiled is a bit exaggerated (i.e. we won't see this huge of a perf increase for all shapes)
  - For this shape: originally 131,072 packets -> now 8,192 packets


## `all_broadcast` Scatter-Write
Added scatter-write to `all_broadcast`:
- tiled:
  - normal logic, same as what's used for minimal AG and minimal RS
  - profiling the above shape, saw a 50% perf increase (wrt kernel time) on top of the composite-RS changes already made
- row-major:
  - when 2 complete rows can fit in a single packet, use scatter-write
- didn't have time to do a whole bunch of profiling, but adding scatter-write to `all_broadcast` will boost perf for composite-RS, composite-AG, and composite-AR


### Pipelines
- APC: https://github.com/tenstorrent/tt-metal/actions/runs/17706144655
- BH APC: https://github.com/tenstorrent/tt-metal/actions/runs/17703145244
- T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17703094011


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes