### PR TITLE
Repair build on GCC 15.2 

### DIFF
--- a/tt_metal/lite_fabric/host_util.cpp
+++ b/tt_metal/lite_fabric/host_util.cpp
@@ -173,8 +173,8 @@ void LaunchLiteFabric(
             "Wrote lite fabric. Core: {}, Config: {:#x}, Binary: {:#x}, Size: {} B",
             tunnel_1x.mmio_core_logical,
             config_addr,
-            config.binary_addr,
-            config.binary_size);
+            static_cast<uint32_t>(config.binary_addr),
+            static_cast<uint32_t>(config.binary_size));
     }
 
     cluster.l1_barrier(0);


### PR DESCRIPTION
### Ticket
#28482

### Problem description
`main` fails to build on the combination of Arch Linux and GCC 15.2

### What's changed
Applies cast to remove `volatile` in logging, to avoid incompatibility with function signature

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes