### PR TITLE
#29143: Improve sigmoid_accurate accuracy using exp21f

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def test_sigmoid_accurate_arange(device):
+    # Generate all possible bit patterns for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # Mask NaN
+    mask = torch.isnan(input_tensor)
+    input_tensor[mask] = 1.0
+
+    # Exp Working range - Overflow from 88.5(inf), Underflow till -87(<0)
+    low = -87.0
+    high = 88.5
+    # masking to working range
+    mask = (input_tensor >= low) & (input_tensor <= high)
+    input_tensor = input_tensor[mask]
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.sigmoid_accurate)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.sigmoid_accurate(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_with_ulp(golden, result, 3, allow_nonfinite=True)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -257,7 +257,7 @@ Tensor Sigmoid_accurate::invoke(
     return detail::unary_impl(
         input,
         {UnaryWithParam(UnaryOpType::NEG),
-         UnaryWithParam(UnaryOpType::EXP, 1.0f),
+         UnaryWithParam(UnaryOpType::EXP),
          UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
          UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,


### PR DESCRIPTION
### Ticket
#26993,  #29143

### Problem description
Update sigmoid accurate with exp21f and check accuracy

### What's changed
- **ULP Data** : 
  - Tested for the entire 16-bit range of bfloat16 (0 through 2¹⁶), covering all possible values. Test passes with ULP 1 except for below mentioned cases
  -  Attached ULP Graphs, TTNN vs Torch, Values causing higher ULP : [Graphs](https://docs.google.com/document/d/1jSSbH0YpiJtgrWaiOrpEkK_lmz5TyilARTx8QhAnJFA/edit?tab=t.0#heading=h.9x0mphhxqsxw)
  - Below listed are the failing cases
    - Main branch: 
      - Max ULP Delta: **8.943099975585938** (Mismatching values : [Link](https://drive.google.com/file/d/15IWZ5rHTwB3GWazn2pAqbNP_4vUSp6RZ/view?usp=drive_link))
      - Input Failing range : (-87.0, 5.53125 )
    - Updated branch
      - Max ULP Delta: **2.077178955078125** (Mismatching values : [Link](https://drive.google.com/file/d/11sNnKfxZYYtiFLtd-1EHHpwo3mP2jc-v/view?usp=drive_link))
      - Input Failing range with ULP>1 : (-86.0, 5.53125 )
- **Edge case behaviour** : 

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
**INPUT** | **TORCH RESULT** | **TT RESULT (Main)** | **TT RESULT (Updated)**
-- | -- | -- | --
inf | 1 | 1 | 1
-inf | 0 | 0 | 0
nan | nan | 1 | 1
-0.0 | 0.5 | 0.5078 | 0.5
0 | 0.5 | 0.5078 | 0.5

- Performance analysis
  - Single tile Performance analysis : Updated kernel duration is about 98.8% slower
    - Main branch : [sigmoid_accurate_main_perf.csv](https://github.com/user-attachments/files/22326643/sigmoid_accurate_main_perf.csv)
    - Updated branch : [sigmoid_accurate_updated_perf.csv](https://github.com/user-attachments/files/22327504/sigmoid_accurate_updated_perf.csv)
    - <img width="422" height="130" alt="Image" src="https://github.com/user-attachments/assets/718b2582-9e43-42ce-a484-734f714eef7c" />
  - 8K tile Performance : Updated kernel duration is about 165.7% slower
    - Main branch : [sigmoid_accurate_main_8K_perf.csv](https://github.com/user-attachments/files/22326646/sigmoid_accurate_main_8K_perf.csv)
    - Updated branch : [sigmid_accurate_updated_8K_perf.csv](https://github.com/user-attachments/files/22327508/sigmid_accurate_updated_8K_perf.csv)
    - <img width="418" height="131" alt="Image" src="https://github.com/user-attachments/assets/e2d381b5-126e-41b3-a855-fdf14d216e89" />


### Checklist
- [ ] [Blackhole post-commit tests (watcher enabled)](https://github.com/tenstorrent/tt-metal/actions/runs/17892701243) - failed as in main
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17892700324)
- [x] [Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/17892705322) - PASSED
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17892709231) - failed as in main
- [ ] [Single card pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17892707998) - failed as in main
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17892703410) 
- [ ] [T3K Pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/17892711516)
- [x] New/Existing tests provide coverage for changes