### PR TITLE
update unet e2e perf and disable optimization where not needed

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -74,7 +74,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1373.0),),
+    ((1, 4, 256, 30.0, 1405.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -128,7 +128,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2646.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2724.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -7,7 +7,6 @@ import ttnn
 
 from typing import Literal
 
-from ttnn.device import is_wormhole_b0
 from ttnn.model_preprocessing import infer_ttnn_module_args
 
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -78,16 +77,13 @@ def create_unet_model_parameters(
 
     parameters.c3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3["use_activation_double_buffer"] = True
-    parameters.c3["enable_activation_reuse"] = is_wormhole_b0(device)
     parameters.c3_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3_2["use_activation_double_buffer"] = True
 
     parameters.c4["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4["use_activation_double_buffer"] = True
-    parameters.c4["enable_activation_reuse"] = is_wormhole_b0(device)
     parameters.c4_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4_2["use_activation_double_buffer"] = True
-    parameters.c4_2["enable_activation_reuse"] = is_wormhole_b0(device)
 
     parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
     parameters.bnc["use_activation_double_buffer"] = False


### PR DESCRIPTION
### Ticket
#8113

### Problem description
- Unet e2e perf target wasn't updated with the initial conv 3.0 reuse PR, only device perf target was updated. Multi device perf target probably wasn't updated with some of the past optimizations, so the diff there is bigger than with the single device test.
- Optimization was used with 3 convolutions where it actually didn't bring a visible benefit, in 2 of them it added some very slight regression.

### What's changed

- Disabled optimization where it wasn't needed
- Updated targets

### Checklist
✅   Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/17736544729
✅   Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/17732771634
✅   Blackhole post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/17732865781
