### PR TITLE
Add qwq3 tests to CI 

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -46,7 +46,8 @@ jobs:
           # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
           # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
           { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_qwq3_tests", arch: wormhole_b0, cmd: run_t3000_qwq3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 60, owner_id: U07RY6B5FLJ},  #Gongyu Wang
           { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
           { name: "t3k_wan2.2_tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y},  #Colman Glagovich
           { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -156,6 +156,29 @@ run_t3000_qwen3_tests() {
   fi
 }
 
+run_t3000_qwq3_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Warning: updating transformers version. Make sure this is the last-run test."
+  echo "LOG_METAL: Remove this when https://github.com/tenstorrent/tt-metal/pull/22608 merges."
+  pip install -r models/tt_transformers/requirements.txt
+
+  echo "LOG_METAL: Running run_t3000_qwq3_tests"
+  qwq32b=/mnt/MLPerf/tt_dnn-models/qwen/QwQ-32B
+
+  HF_MODEL=$qwq32b pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1800 || fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_qwq3_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_llama3_vision_tests() {
   # Record the start time
   fail=0
@@ -441,6 +464,9 @@ run_t3000_tests() {
 
   # Run qwen3 tests
   run_t3000_qwen3_tests
+
+  # Run qwq tests
+  run_t3000_qwq3_tests
 
   # Run sd35_large tests
   run_t3000_sd35large_tests

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -163,7 +163,6 @@ run_t3000_qwq3_tests() {
 
   echo "LOG_METAL: Warning: updating transformers version. Make sure this is the last-run test."
   echo "LOG_METAL: Remove this when https://github.com/tenstorrent/tt-metal/pull/22608 merges."
-  pip install -r models/tt_transformers/requirements.txt
 
   echo "LOG_METAL: Running run_t3000_qwq3_tests"
   qwq32b=/mnt/MLPerf/tt_dnn-models/qwen/QwQ-32B


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28490)
This PR adds QwQ3 model tests to the T3000 CI pipeline by implementing a new test function and integrating it into the existing test suite.

Adds run_t3000_qwq3_tests() function to execute QwQ3 model tests
Integrates the new QwQ3 tests into the main run_t3000_tests() function
Follows the established pattern of other model test functions in the CI

t3k demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/17758202932