### PR TITLE
#18548: Add options to enable non-legacy reduce and rsqrt in layernorm

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -26,6 +26,8 @@ void MAIN {
     constexpr uint32_t do_gamma = get_compile_time_arg_val(2);
     constexpr uint32_t do_beta = get_compile_time_arg_val(3);
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(4) == 1;
+    constexpr bool FLOAT32_REDUCTION = get_compile_time_arg_val(5) == 1;
+    constexpr bool LEGACY_RSQRT = get_compile_time_arg_val(6) == 1;
 
     constexpr uint32_t onetile = 1;
     // reserve one tile for zeros on cb_in2
@@ -79,21 +81,21 @@ void MAIN {
         reconfig_data_format(cb_in, cb_scaler);
         pack_reconfig_data_format(cb_ex);
         cb_reserve_back(cb_ex, onetile);
-        reduce_init(cb_in, cb_scaler, cb_ex);
+        reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_in, blk);
             for (uint32_t j = 0; j < blk; j++) {
-                reduce_tile(cb_in, cb_scaler, j, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, j, scaler0, dst0);
             }
             cb_pop_front(cb_in, blk);
         }
 #ifdef FUSE_PRE_ADD
         reconfig_data_format_srca(cb_in, cb_inb);
-        reduce_init(cb_inb, cb_scaler, cb_ex);
+        reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_inb, cb_scaler, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_inb, blk);
             for (uint32_t j = 0; j < blk; j++) {
-                reduce_tile(cb_inb, cb_scaler, j, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_inb, cb_scaler, j, scaler0, dst0);
             }
             cb_pop_front(cb_inb, blk);
         }
@@ -167,10 +169,10 @@ void MAIN {
             }
             cb_wait_front(cb_xmm, blk);
             reconfig_data_format(cb_xmm, cb_scaler);
-            reduce_init(cb_xmm, cb_scaler, cb_ex2);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_xmm, cb_scaler, cb_ex2);
             // accumulates squared residual
             for (uint32_t j = 0; j < blk; j++) {
-                reduce_tile(cb_xmm, cb_scaler, j, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_xmm, cb_scaler, j, scaler0, dst0);
             }
             cb_pop_front(cb_xmm, blk);
             cb_reserve_back(cb_ex2, onetile);
@@ -200,8 +202,8 @@ void MAIN {
         add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
-        rsqrt_tile_init<true>();
-        rsqrt_tile<true>(dst0);
+        rsqrt_tile_init<LEGACY_RSQRT>();
+        rsqrt_tile<LEGACY_RSQRT>(dst0);
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -30,7 +30,9 @@ void MAIN {
     const bool is_allgather_worker = get_compile_time_arg_val(8) == 1;
     constexpr uint32_t num_tiles_per_block = get_compile_time_arg_val(9);
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(10) == 1;
-    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(11);
+    constexpr bool FLOAT32_REDUCTION = get_compile_time_arg_val(11) == 1;
+    constexpr bool LEGACY_RSQRT = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(13);
 
     const uint32_t num_reduce_tiles_per_block_h =
         get_arg_val<uint32_t>(0);  // This value is the same for all cores, except ones that have padding tiles in it.
@@ -142,13 +144,13 @@ void MAIN {
 #ifndef RMSNORM
     // E[x],
     index_h_offset = 0;
-    reduce_init(cb_in, cb_scaler, cb_ex_partial);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, cb_ex_partial);
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_ex_partial, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
-            reduce_tile(cb_in, cb_scaler, w + index_h_offset, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, w + index_h_offset, scaler0, dst0);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -163,7 +165,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init(cb_ex_external, cb_scaler_global, cb_ex);
+        reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_ex_external, cb_scaler_global, cb_ex);
         cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -171,7 +173,8 @@ void MAIN {
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
                 cb_wait_front(cb_ex_external, 1);
-                reduce_tile(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
+                    cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external, 1);
             }
             if (use_two_stage_reduce && !is_second_stage_reader) {
@@ -262,12 +265,13 @@ void MAIN {
     cb_wait_front(cb_scaler, 1);
 #endif
     cb_reserve_back(cb_ex_partial2, block_h);
-    reduce_init(cb_xmm2, cb_scaler, cb_ex_partial2);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_xmm2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
-            reduce_tile(cb_xmm2, cb_scaler, w + index_h_offset, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
+                cb_xmm2, cb_scaler, w + index_h_offset, scaler0, dst0);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -281,7 +285,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init(cb_ex_external2, cb_scaler_global, cb_ex2);
+        reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_ex_external2, cb_scaler_global, cb_ex2);
         cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -290,7 +294,8 @@ void MAIN {
             tile_regs_acquire();
             for (uint32_t w = 0; w < num_blocks_reduce; w++) {
                 cb_wait_front(cb_ex_external2, 1);
-                reduce_tile(cb_ex_external2, cb_scaler_global, 0, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
+                    cb_ex_external2, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external2, 1);
             }
             if (use_two_stage_reduce && !is_second_stage_reader) {
@@ -314,8 +319,8 @@ void MAIN {
                 add_tiles_init(cb_ex2, cb_eps);
                 add_tiles(cb_ex2, cb_eps, i, 0, dst0);
                 tile_regs_wait();
-                rsqrt_tile_init<true>();
-                rsqrt_tile<true>(dst0);
+                rsqrt_tile_init<LEGACY_RSQRT>();
+                rsqrt_tile<LEGACY_RSQRT>(dst0);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex2pe);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -30,7 +30,9 @@ void MAIN {
     const bool is_allgather_worker = get_compile_time_arg_val(8) == 1;
     constexpr uint32_t num_tiles_per_block = get_compile_time_arg_val(9);
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(10) == 1;
-    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(11);
+    constexpr bool FLOAT32_REDUCTION = get_compile_time_arg_val(11) == 1;
+    constexpr bool LEGACY_RSQRT = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(13);
 
     const uint32_t num_reduce_tiles_per_block_h =
         get_arg_val<uint32_t>(0);  // This value is the same for all cores, except ones that have padding tiles in it.
@@ -108,11 +110,11 @@ void MAIN {
 #endif
 
             cb_wait_front(cb_scaler_global, 1);
-            reduce_init(cb_stats, cb_scaler_global, cb_var);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_stats, cb_scaler_global, cb_var);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {
-                reduce_tile(
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(
                     cb_stats,
                     cb_scaler_global,
                     0,
@@ -183,8 +185,8 @@ void MAIN {
             tile_regs_acquire();
             add_tiles(cb_var, cb_eps, 0, 0, dst0);
             tile_regs_wait();
-            rsqrt_tile_init<true>();
-            rsqrt_tile<true>(dst0);
+            rsqrt_tile_init<LEGACY_RSQRT>();
+            rsqrt_tile<LEGACY_RSQRT>(dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_stats_reduced);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -27,7 +27,9 @@ void MAIN {
     const bool is_allgather_worker = get_compile_time_arg_val(8) == 1;
     constexpr uint32_t num_tiles_per_block = get_compile_time_arg_val(9);
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(10) == 1;
-    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(11);
+    constexpr bool FLOAT32_REDUCTION = get_compile_time_arg_val(11) == 1;
+    // LEGACY_RSQRT at index 12 is not used but needed for consistency across sharded compute kernels
+    constexpr uint32_t num_blocks_second_stage = get_compile_time_arg_val(13);
 
     const uint32_t num_reduce_tiles_per_block_h =
         get_arg_val<uint32_t>(0);  // This value is the same for all cores, except ones that have padding tiles in it.
@@ -119,13 +121,13 @@ void MAIN {
 #endif
     // E[x],
     index_h_offset = 0;
-    reduce_init(cb_in0, cb_scaler, cb_ex_partial2);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in0, cb_scaler, cb_ex_partial2);
 
     cb_reserve_back(cb_ex_partial2, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
-            reduce_tile(cb_in, cb_scaler, w + index_h_offset, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_in, cb_scaler, w + index_h_offset, scaler0, dst0);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -177,12 +179,12 @@ void MAIN {
 
     cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
-    reduce_init(cb_x2, cb_scaler, cb_ex_partial2);
+    reduce_init<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
-            reduce_tile(cb_x2, cb_scaler, w + index_h_offset, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FLOAT32_REDUCTION>(cb_x2, cb_scaler, w + index_h_offset, scaler0, dst0);
         }
 
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
@@ -23,6 +23,8 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_multi_core(
     Tensor& output,
     LayerNormType norm_type,
     float eps,
+    bool legacy_reduction,
+    bool legacy_rsqrt,
     DeviceComputeKernelConfig compute_kernel_config);
 
 tt::tt_metal::operation::ProgramWithCallbacks layernorm_multi_core_sharded(
@@ -39,6 +41,8 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     uint32_t subblock_wt,
     uint32_t block_ht,
     uint32_t block_wt,
+    bool legacy_reduction,
+    bool legacy_rsqrt,
     DeviceComputeKernelConfig compute_kernel_config);
 
 struct LayerNorm {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -14,13 +14,18 @@ enum class LayerNormType { LAYERNORM, RMSNORM };
 
 enum class DistributedLayerNormStage { NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER };
 
-struct LayerNormDefaultProgramConfig {};
+struct LayerNormDefaultProgramConfig {
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
+};
 struct LayerNormShardedMultiCoreProgramConfig {
     CoreCoord compute_with_storage_grid_size;
     std::size_t subblock_w;
     std::size_t block_h;
     std::size_t block_w;
     bool inplace;
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
 };
 
 using LayerNormProgramConfig = std::variant<LayerNormDefaultProgramConfig, LayerNormShardedMultiCoreProgramConfig>;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1186,6 +1186,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         compute_defines["RMSNORM"] = "1";
     }
     // compute kernel compile time args
+    bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
     std::vector<uint32_t> all_to_all_except_top_compute_compile_time_args = {
         0,
         gamma.has_value(),
@@ -1198,8 +1199,9 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         1,
         block_ht * block_wt,
         fp32_dest_acc_en,
+        float32_reduction,
+        legacy_rsqrt,
         num_blocks_second_stage};
-    bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
     std::vector<uint32_t> not_all_to_all_compute_compile_time_args = {
         0,
         gamma.has_value(),

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -93,6 +93,8 @@ operation::ProgramWithCallbacks layernorm_multi_core(
     Tensor& output,
     LayerNormType norm_type,
     float eps,
+    bool legacy_reduction,
+    bool legacy_rsqrt,
     DeviceComputeKernelConfig compute_kernel_config) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const uint32_t no_weights_max_size = 120;
@@ -310,7 +312,6 @@ operation::ProgramWithCallbacks layernorm_multi_core(
     if (rms_norm) {
         compute_defines["RMSNORM"] = "1";
     }
-
     auto reader_kernel_path = use_row_major_kernel
                                   ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
                                     "reader_unary_interleaved_ln_rm_gb.cpp"
@@ -333,7 +334,9 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         all_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    std::vector<uint32_t> compute_args = {Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en};
+    bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
+    std::vector<uint32_t> compute_args = {
+        Wt, block_size, gamma.has_value(), beta.has_value(), fp32_dest_acc_en, float32_reduction, legacy_rsqrt};
 
     auto compute_kernels_id = CreateKernel(
         program,
@@ -525,6 +528,8 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     uint32_t subblock_wt,
     uint32_t block_ht,
     uint32_t block_wt,
+    bool legacy_reduction,
+    bool legacy_rsqrt,
     DeviceComputeKernelConfig compute_kernel_config) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     bool rms_norm = norm_type == LayerNormType::RMSNORM;
@@ -1194,6 +1199,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         block_ht * block_wt,
         fp32_dest_acc_en,
         num_blocks_second_stage};
+    bool float32_reduction = fp32_dest_acc_en && !legacy_reduction;
     std::vector<uint32_t> not_all_to_all_compute_compile_time_args = {
         0,
         gamma.has_value(),
@@ -1206,6 +1212,8 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         0,
         block_ht * block_wt,
         fp32_dest_acc_en,
+        float32_reduction,
+        legacy_rsqrt,
         num_blocks_second_stage};
     // compute kernel
     std::string compute_kernel_file;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -13,17 +13,26 @@ namespace py = pybind11;
 void bind_normalization_layernorm_program_config(py::module& module) {
     py::class_<LayerNormProgramConfig>(module, "LayerNormProgramConfig").def(py::init<>());
 
-    py::class_<LayerNormDefaultProgramConfig>(module, "LayerNormDefaultProgramConfig").def(py::init<>());
+    py::class_<LayerNormDefaultProgramConfig>(module, "LayerNormDefaultProgramConfig")
+        .def(py::init<>())
+        .def(
+            py::init<bool, bool>(),
+            py::kw_only(),
+            py::arg("legacy_reduction").noconvert(),
+            py::arg("legacy_rsqrt").noconvert())
+        .def("__repr__", [](const LayerNormDefaultProgramConfig& config) { return fmt::format("{}", config); });
 
     py::class_<LayerNormShardedMultiCoreProgramConfig>(module, "LayerNormShardedMultiCoreProgramConfig")
         .def(
-            py::init<CoreCoord, std::size_t, std::size_t, std::size_t, bool>(),
+            py::init<CoreCoord, std::size_t, std::size_t, std::size_t, bool, bool, bool>(),
             py::kw_only(),
             py::arg("compute_with_storage_grid_size"),
             py::arg("subblock_w").noconvert(),
             py::arg("block_h").noconvert(),
             py::arg("block_w").noconvert(),
-            py::arg("inplace").noconvert())
+            py::arg("inplace").noconvert(),
+            py::arg("legacy_reduction").noconvert(),
+            py::arg("legacy_rsqrt").noconvert())
         .def(
             "__repr__", [](const LayerNormShardedMultiCoreProgramConfig& config) { return fmt::format("{}", config); });
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -14,12 +14,11 @@ void bind_normalization_layernorm_program_config(py::module& module) {
     py::class_<LayerNormProgramConfig>(module, "LayerNormProgramConfig").def(py::init<>());
 
     py::class_<LayerNormDefaultProgramConfig>(module, "LayerNormDefaultProgramConfig")
-        .def(py::init<>())
         .def(
             py::init<bool, bool>(),
             py::kw_only(),
-            py::arg("legacy_reduction").noconvert(),
-            py::arg("legacy_rsqrt").noconvert())
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true)
         .def("__repr__", [](const LayerNormDefaultProgramConfig& config) { return fmt::format("{}", config); });
 
     py::class_<LayerNormShardedMultiCoreProgramConfig>(module, "LayerNormShardedMultiCoreProgramConfig")
@@ -31,8 +30,8 @@ void bind_normalization_layernorm_program_config(py::module& module) {
             py::arg("block_h").noconvert(),
             py::arg("block_w").noconvert(),
             py::arg("inplace").noconvert(),
-            py::arg("legacy_reduction").noconvert(),
-            py::arg("legacy_rsqrt").noconvert())
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true)
         .def(
             "__repr__", [](const LayerNormShardedMultiCoreProgramConfig& config) { return fmt::format("{}", config); });
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #18548

### Problem description
Accuracy for layernorm is poor for some models. Can't make any changes because models depend on existing pcc and increasing accuracy can reduce pcc in some cases.

### What's changed
- Add flags for increased accuracy in reduce (use fp32 reduce where possible) and rsqrt (use legacy_compat=false) to layernorm configs and use the information in the kernels

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17743015630
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17743022544
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) Seems to be broken on main https://github.com/tenstorrent/tt-metal/actions/runs/17745018380/job/50428829217 this branch had something that looked like slight nd drop in perf https://github.com/tenstorrent/tt-metal/actions/runs/17743028765/job/50422753232
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17743035870
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). standard flow passed. Some perf ones failed, but that seems expected https://github.com/tenstorrent/tt-metal/actions/runs/17743039936/job/50422714827
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes