### PR TITLE
Adjust l1 small memory on sdxl vae unt test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3500,7 +3500,7 @@ def test_conv2d_sdxl_refiner(
         (1,   4, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False,                  None, 1,     0, 0),
     ),
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 27 * 1024}], indirect=True)
 def test_conv2d_vae_sdxl(
     device,
     torch_tensor_map,


### PR DESCRIPTION
#c73b4fb "stole" some memory from each L1.
test_conv2d_vae_sdxl started failing on highly tests. Model is passing because it's using smaller l1_small allocation in practice. Set unit test to use same amount of l1 small to make it pass.
