### PR TITLE
Cleaning up more IDevice API conditionals from code

### DIFF
--- a/ttnn/api/ttnn/async_runtime.hpp
+++ b/ttnn/api/ttnn/async_runtime.hpp
@@ -25,16 +25,12 @@ void read_buffer(
     size_t src_offset = 0,
     bool blocking = true);
 
-void queue_synchronize(tt::tt_metal::CommandQueue& cq);
 void queue_synchronize(tt::tt_metal::distributed::MeshCommandQueue& cq);
 
-void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event);
 void event_synchronize(const tt::tt_metal::distributed::MeshEvent& event);
 
-void wait_for_event(tt::tt_metal::CommandQueue& cq, const std::shared_ptr<tt::tt_metal::Event>& event);
 void wait_for_event(tt::tt_metal::distributed::MeshCommandQueue& cq, const tt::tt_metal::distributed::MeshEvent& event);
 
-void record_event(tt::tt_metal::CommandQueue& cq, const std::shared_ptr<tt::tt_metal::Event>& event);
 // Record an event for device to device synchronization. This event should be passed to `wait_for_event`.
 tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq);
 // Record an event for device to host synchronization. This event should be passed to `event_synchronize`.

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -15,7 +15,7 @@ namespace ttnn {
 void write_buffer(
     QueueId cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src, const std::optional<BufferRegion>& region) {
     auto mesh_device = dst.device();
-    TT_FATAL(mesh_device, "dst must be a mesh tensor");
+    TT_FATAL(mesh_device, "Tensor must be on device");
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(dst);
     for (size_t i = 0; i < device_tensors.size(); i++) {
@@ -32,7 +32,7 @@ void read_buffer(
     bool blocking) {
     TT_ASSERT(src_offset == 0, "src_offset is not supported");
     auto mesh_device = src.device();
-    TT_FATAL(mesh_device, "src must be a mesh tensor");
+    TT_FATAL(mesh_device, "Tensor must be on device");
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(src);
     for (size_t i = 0; i < device_tensors.size(); i++) {
@@ -40,32 +40,17 @@ void read_buffer(
     }
 }
 
-void queue_synchronize(CommandQueue& cq) {
-    // Wait for device CQ to finish
-    Finish(cq);
-}
 void queue_synchronize(tt::tt_metal::distributed::MeshCommandQueue& cq) { cq.finish(); }
 
-void event_synchronize(const std::shared_ptr<Event>& event) { EventSynchronize(event); }
 void event_synchronize(const tt::tt_metal::distributed::MeshEvent& event) {
     tt::tt_metal::distributed::EventSynchronize(event);
 }
 
-void wait_for_event(CommandQueue& cq, const std::shared_ptr<Event>& event) {
-    auto cq_id = cq.id();
-    auto cq_worker = cq.device();
-    EnqueueWaitForEvent(cq_worker->command_queue(cq_id), event);
-}
 void wait_for_event(
     tt::tt_metal::distributed::MeshCommandQueue& cq, const tt::tt_metal::distributed::MeshEvent& event) {
     tt::tt_metal::distributed::EnqueueWaitForEvent(cq, event);
 }
 
-void record_event(CommandQueue& cq, const std::shared_ptr<Event>& event) {
-    auto cq_id = cq.id();
-    auto cq_worker = cq.device();
-    EnqueueRecordEvent(cq_worker->command_queue(cq_id), event);
-}
 tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq) {
     return tt::tt_metal::distributed::EnqueueRecordEvent(cq);
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -638,11 +638,9 @@ void memcpy(
 
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
-    if (auto mesh_device = dst.device()) {
-        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
-    } else {
-        memcpy(dst.device()->command_queue(), dst, src, region);
-    }
+    auto mesh_device = dst.device();
+    TT_FATAL(mesh_device, "dst must be a mesh tensor");
+    memcpy(mesh_device->mesh_command_queue(), dst, src, region);
 }
 
 void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -602,11 +602,9 @@ void memcpy(
 
 void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
     ZoneScoped;
-    if (auto mesh_device = src.device()) {
-        memcpy(mesh_device->mesh_command_queue(), dst, src, region, blocking);
-    } else {
-        memcpy(src.device()->command_queue(), dst, src, region, blocking);
-    }
+    auto mesh_device = src.device();
+    TT_FATAL(mesh_device, "src must be a mesh tensor");
+    memcpy(mesh_device->mesh_command_queue(), dst, src, region, blocking);
 }
 
 void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
@@ -688,17 +686,13 @@ void memcpy(
 void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
-        if (auto mesh_device = src.device()) {
-            memcpy(mesh_device->mesh_command_queue(), dst, src, region);
-        } else {
-            memcpy(src.device()->command_queue(), dst, src, region);
-        }
+        auto mesh_device = src.device();
+        TT_FATAL(mesh_device, "src must be a mesh tensor");
+        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
-        if (auto mesh_device = dst.device()) {
-            memcpy(mesh_device->mesh_command_queue(), dst, src, region);
-        } else {
-            memcpy(dst.device()->command_queue(), dst, src, region);
-        }
+        auto mesh_device = dst.device();
+        TT_FATAL(mesh_device, "dst must be a mesh tensor");
+        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -603,7 +603,7 @@ void memcpy(
 void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
     ZoneScoped;
     auto mesh_device = src.device();
-    TT_FATAL(mesh_device, "src must be a mesh tensor");
+    TT_FATAL(mesh_device, "Tensor must be on device");
     memcpy(mesh_device->mesh_command_queue(), dst, src, region, blocking);
 }
 
@@ -639,7 +639,7 @@ void memcpy(
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     auto mesh_device = dst.device();
-    TT_FATAL(mesh_device, "dst must be a mesh tensor");
+    TT_FATAL(mesh_device, "Tensor must be on device");
     memcpy(mesh_device->mesh_command_queue(), dst, src, region);
 }
 
@@ -685,11 +685,9 @@ void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& r
     ZoneScoped;
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         auto mesh_device = src.device();
-        TT_FATAL(mesh_device, "src must be a mesh tensor");
         memcpy(mesh_device->mesh_command_queue(), dst, src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         auto mesh_device = dst.device();
-        TT_FATAL(mesh_device, "dst must be a mesh tensor");
         memcpy(mesh_device->mesh_command_queue(), dst, src, region);
     } else {
         TT_THROW("Unsupported memcpy");


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25699)

### Problem description
A part of [Issue](https://github.com/tenstorrent/tt-metal/issues/21099)

### What's changed
Some redundant conditionals checkign for MeshDevice vs IDevice has been removed

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17770621434) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17770642584) CI with demo tests passes (if applicable)
- [x] [T3K Tests](https://github.com/tenstorrent/tt-metal/actions/runs/17770669985)
- [x] [Single Card Tests](https://github.com/tenstorrent/tt-metal/actions/runs/17770693969)
