### PR TITLE
[skip ci] Skip the generated .pb.cc files from linting (including ClangTidy)

### DIFF
--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -18,22 +18,6 @@ function(GENERATE_PROTO_FILES PROTO_FILE)
     endif()
     set(PROTO_GENERATED_DIR "${PROTO_GENERATED_BASE}/protobuf")
 
-    # Generate .clang-tidy configuration file in the build directory
-    file(
-        WRITE
-        ${PROTO_GENERATED_DIR}/.clang-tidy
-        "InheritParentConfig: true
-Checks: >
-  -bugprone-reserved-identifier,
-  -readability-duplicate-include,
-  -cppcoreguidelines-pro-type-static-cast-downcast,
-  -readability-redundant-access-specifiers,
-  -cppcoreguidelines-interfaces-global-init,
-  -hicpp-use-equals-default,
-  -modernize-use-equals-default,
-  -cppcoreguidelines-avoid-goto"
-    )
-
     # Generate protobuf files by invoking protoc directly. This avoids depending on
     # the CMake-provided protobuf_generate() macro, which may be unavailable when
     # using protobuf via CPM.
@@ -68,8 +52,8 @@ Checks: >
     set_source_files_properties(
         ${GENERATED_CC}
         PROPERTIES
-            CXX_CLANG_TIDY
-                ""
+            SKIP_LINTING
+                TRUE
     )
 
     # Add to all_generated_files target if it exists


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The original code was attempting to use CXX_CLANG_TIDY on a source file, but that's a target-level prop, not a source-level prop.  So that is treated as a custom prop that we could read later, not actually doing what was intended.  SKIP_LINTING is the source-level prop that does what we want and covers all linters, not limited to ClangTidy.

### What's changed
Excluded *.pb.cc files from ClangTidy scans.