### PR TITLE
[Fabric] Enable noc counters for BH

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2112,7 +2112,19 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
 
-    ncrisc_noc_fast_write<noc_mode, true /* use_trid */, update_counter>(
+#ifdef ARCH_BLACKHOLE
+    // We must do this because in BH, inline writes spoof their inline writes
+    // by first writing the value to L1 and then sending a noc write out of that
+    // L1 location to avoid a HW bug. A result of this is that those inline write
+    // calls on BH implicitly barrier. That barrier call compares against
+    // `noc_nonposted_writes_num_issued`, which will NOT be updated if `update_counter` is false.
+    // Therefore, we must override `update_counter` to true if `posted` is false.
+    constexpr bool update_counter_in_callee = update_counter || !posted;
+#else
+    constexpr bool update_counter_in_callee = update_counter;
+#endif
+
+    ncrisc_noc_fast_write<noc_mode, true /* use_trid */, update_counter_in_callee>(
         noc,
         cmd_buf,
         src_local_l1_addr,
@@ -2200,9 +2212,21 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_local_l1_addr, src_local_l1_addr, size);
 
+#ifdef ARCH_BLACKHOLE
+    // We must do this because in BH, inline writes spoof their inline writes
+    // by first writing the value to L1 and then sending a noc write out of that
+    // L1 location to avoid a HW bug. A result of this is that those inline write
+    // calls on BH implicitly barrier. That barrier call compares against
+    // `noc_nonposted_writes_num_issued`, which will NOT be updated if `update_counter` is false.
+    // Therefore, we must override `update_counter` to true if `posted` is false.
+    constexpr bool update_counter_in_callee = update_counter || !posted;
+#else
+    constexpr bool update_counter_in_callee = update_counter;
+#endif
+
     WAYPOINT("NWPW");
     ncrisc_noc_set_transaction_id(noc, cmd_buf, trid);
-    ncrisc_noc_write_with_state<noc_mode, posted, update_counter>(
+    ncrisc_noc_write_with_state<noc_mode, posted, update_counter_in_callee>(
         noc, cmd_buf, src_local_l1_addr, dst_local_l1_addr, size);
     WAYPOINT("NWPD");
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28446

### Problem description
Because of the workaround in BH for spoofing inline writes, we now need the noc counters enabled. For more details look at the attached issue.

This does not completely resolve the issues, we need fix for stream regs as well as captured in the issue.

Additional reference: https://github.com/tenstorrent/tt-metal/issues/28366#issuecomment-3293168217

### What's changed
Enabled noc counters for local writes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17773899708)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/17773905808)
- [ ] [Blackhole multi-chip] (https://github.com/tenstorrent/tt-metal/actions/runs/17773913480)