### PR TITLE
[skip ci] Do not re-package Protobuf. Distros provide it.

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -15,15 +15,6 @@ set(CPACK_DEBIAN_NN-DEV_PACKAGE_SECTION "devel")
 set(CPACK_DEBIAN_NN-EXAMPLES_PACKAGE_SECTION "doc")
 set(CPACK_DEBIAN_NN-VALIDATION_PACKAGE_SECTION "utils")
 
-# Add descriptions for protobuf components
-set(CPACK_DEBIAN_LIBPROTOBUF_DESCRIPTION "Protocol Buffers - C++ runtime library")
-set(CPACK_DEBIAN_LIBPROTOBUF-LITE_DESCRIPTION "Protocol Buffers - C++ lite runtime library")
-set(CPACK_DEBIAN_LIBPROTOC_DESCRIPTION "Protocol Buffers - C++ compiler library")
-set(CPACK_DEBIAN_PROTOBUF-EXPORT_DESCRIPTION "Protocol Buffers - CMake export files")
-set(CPACK_DEBIAN_PROTOBUF-HEADERS_DESCRIPTION "Protocol Buffers - header files")
-set(CPACK_DEBIAN_PROTOBUF-PROTOS_DESCRIPTION "Protocol Buffers - protobuf files")
-set(CPACK_DEBIAN_PROTOC_DESCRIPTION "Protocol Buffers - compiler")
-
 set(CPACK_DEB_COMPONENT_INSTALL YES)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -64,6 +64,7 @@ CPMAddPackage(
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "protobuf_BUILD_TESTS OFF"
         "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-invalid-noreturn"
+        "protobuf_INSTALL OFF"
         "BUILD_TESTING OFF"
         "protobuf_BUILD_EXAMPLES OFF"
         "BUILD_SHARED_LIBS OFF"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We're re-packaging Protobuf.  We shouldn't.
We're consuming Protobuf as a static lib, so we don't even need an external (packaged) Protobuf at all.

### What's changed
Do not package Protobuf.
