### PR TITLE
De-virtualize functions in KernelImpl that don't need polymorphism

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -238,7 +238,7 @@ bool KernelImpl::binaries_exist_on_disk(const IDevice* device) const {
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
     std::optional<std::string> output_path = std::nullopt;
-    for (size_t i = 0; i < this->expected_num_binaries(); ++i) {
+    for (int i = 0; i < this->expected_num_binaries(); ++i) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
             device->build_id(), core_type, processor_class, this->get_kernel_processor_type(i));
         if (output_path.has_value()) {
@@ -251,6 +251,19 @@ bool KernelImpl::binaries_exist_on_disk(const IDevice* device) const {
     const std::string build_success_marker_path =
         fmt::format("{}{}{}", output_path.value(), this->get_full_kernel_name(), SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME);
     return std::filesystem::exists(build_success_marker_path);
+}
+
+std::vector<std::string> KernelImpl::file_paths(IDevice& device) const {
+    std::vector<std::string> file_paths;
+    auto& hal = MetalContext::instance().hal();
+    uint32_t core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
+    for (int i = 0; i < this->expected_num_binaries(); i++) {
+        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device.build_id(), core_type, processor_class, this->get_kernel_processor_type(i));
+        file_paths.push_back(build_state.get_target_out_path(this->kernel_full_name_));
+    }
+    return file_paths;
 }
 
 uint8_t DataMovementKernel::expected_num_binaries() const { return 1; }
@@ -544,16 +557,6 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
-std::vector<std::string> DataMovementKernel::file_paths(IDevice& device) const {
-    uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
-    int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device.build_id(), tensix_core_type, dm_class_idx, riscv_id);
-    return {build_state.get_target_out_path(this->kernel_full_name_)};
-}
-
 void EthernetKernel::read_binaries(IDevice* device) {
     // untested
     TT_ASSERT(this->binaries_exist_on_disk(device));
@@ -590,16 +593,6 @@ void EthernetKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
-std::vector<std::string> EthernetKernel::file_paths(IDevice& device) const {
-    uint32_t erisc_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
-    int erisc_id = enchantum::to_underlying(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device.build_id(), erisc_core_type, dm_class_idx, erisc_id);
-    return {build_state.get_target_out_path(this->kernel_full_name_)};
-}
-
 void ComputeKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
@@ -619,21 +612,6 @@ void ComputeKernel::read_binaries(IDevice* device) {
     }
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
-}
-
-std::vector<std::string> ComputeKernel::file_paths(IDevice& device) const {
-    std::vector<std::string> file_paths;
-    auto& hal = MetalContext::instance().hal();
-    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    uint32_t processor_types_count =
-        hal.get_processor_types_count(this->get_kernel_programmable_core_type(), compute_class_idx);
-    for (int trisc_id = 0; trisc_id < processor_types_count; trisc_id++) {
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device.build_id(), tensix_core_type, compute_class_idx, trisc_id);
-        file_paths.push_back(build_state.get_target_out_path(this->kernel_full_name_));
-    }
-    return file_paths;
 }
 
 bool DataMovementKernel::configure(

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -4,6 +4,7 @@
 
 #include <core_coord.hpp>
 #include <device.hpp>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <kernel.hpp>
 #include <kernel_types.hpp>
@@ -230,6 +231,26 @@ void KernelImpl::process_compile_time_args(
 void KernelImpl::process_named_compile_time_args(
     const std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)> callback) const {
     callback(this->named_compile_time_args());
+}
+
+bool KernelImpl::binaries_exist_on_disk(const IDevice* device) const {
+    const uint32_t core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
+    std::optional<std::string> output_path = std::nullopt;
+    for (size_t i = 0; i < this->expected_num_binaries(); ++i) {
+        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), core_type, processor_class, this->get_kernel_processor_type(i));
+        if (output_path.has_value()) {
+            TT_ASSERT(build_state.get_out_path() == output_path.value());
+        } else {
+            output_path = build_state.get_out_path();
+        }
+    }
+    // Note: this->get_full_kernel_name() already has a '/' at the end.
+    const std::string build_success_marker_path =
+        fmt::format("{}{}{}", output_path.value(), this->get_full_kernel_name(), SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME);
+    return std::filesystem::exists(build_success_marker_path);
 }
 
 uint8_t DataMovementKernel::expected_num_binaries() const { return 1; }
@@ -501,18 +522,6 @@ void KernelImpl::set_binaries(uint32_t build_key, std::vector<const ll_api::memo
     }
 }
 
-bool DataMovementKernel::binaries_exist_on_disk(const IDevice* device) const {
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
-    const int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
-    const std::string build_success_marker_path =
-        build_state.get_out_path() + this->get_full_kernel_name() + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
-    return std::filesystem::exists(build_success_marker_path);
-}
-
 void DataMovementKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<const ll_api::memory*> binaries;
@@ -543,18 +552,6 @@ std::vector<std::string> DataMovementKernel::file_paths(IDevice& device) const {
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
         device.build_id(), tensix_core_type, dm_class_idx, riscv_id);
     return {build_state.get_target_out_path(this->kernel_full_name_)};
-}
-
-bool EthernetKernel::binaries_exist_on_disk(const IDevice* device) const {
-    const uint32_t erisc_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
-    const int erisc_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
-    const std::string build_success_marker_path =
-        build_state.get_out_path() + this->get_full_kernel_name() + "/" + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
-    return std::filesystem::exists(build_success_marker_path);
 }
 
 void EthernetKernel::read_binaries(IDevice* device) {
@@ -601,23 +598,6 @@ std::vector<std::string> EthernetKernel::file_paths(IDevice& device) const {
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
         device.build_id(), erisc_core_type, dm_class_idx, erisc_id);
     return {build_state.get_target_out_path(this->kernel_full_name_)};
-}
-
-bool ComputeKernel::binaries_exist_on_disk(const IDevice* device) const {
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
-    const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    const auto build_states = BuildEnvManager::get_instance().get_kernel_build_states(
-        device->build_id(), tensix_core_type, compute_class_idx);
-
-    const std::string output_path = build_states[0].get_out_path();
-    for (auto& build : build_states) {
-        TT_ASSERT(build.get_out_path() == output_path);
-    }
-
-    const std::string build_success_marker_path =
-        output_path + this->get_full_kernel_name() + "/" + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
-    return std::filesystem::exists(build_success_marker_path);
 }
 
 void ComputeKernel::read_binaries(IDevice* device) {

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -29,10 +29,10 @@ public:
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
+    bool binaries_exist_on_disk(const IDevice* device) const;
 
     virtual void set_build_options(JitBuildOptions& build_options) const {}
     virtual void generate_binaries(IDevice* device, JitBuildOptions& build_options) const = 0;
-    virtual bool binaries_exist_on_disk(const IDevice* device) const = 0;
     virtual void read_binaries(IDevice* device) = 0;
 
     void register_kernel_elf_paths_with_watcher(IDevice& device) const;
@@ -94,7 +94,6 @@ public:
 
     uint32_t get_kernel_processor_type(int index) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
-    bool binaries_exist_on_disk(const IDevice* device) const override;
     void read_binaries(IDevice* device) override;
 
     bool configure(
@@ -138,7 +137,6 @@ public:
 
     uint32_t get_kernel_processor_type(int index) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
-    bool binaries_exist_on_disk(const IDevice* device) const override;
     void read_binaries(IDevice* device) override;
 
     bool configure(
@@ -181,7 +179,6 @@ public:
     uint32_t get_kernel_processor_type(int index) const override;
     void set_build_options(JitBuildOptions& build_options) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
-    bool binaries_exist_on_disk(const IDevice* device) const override;
     void read_binaries(IDevice* device) override;
 
     bool configure(

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -71,7 +71,7 @@ protected:
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
     std::unordered_map<chip_id_t, std::vector<const ll_api::memory*>> binaries_;
 
-    virtual std::vector<std::string> file_paths(IDevice& device) const = 0;
+    std::vector<std::string> file_paths(IDevice& device) const;
 };
 
 class DataMovementKernel : public KernelImpl {
@@ -113,8 +113,6 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-
-    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 class EthernetKernel : public KernelImpl {
@@ -156,7 +154,6 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 class ComputeKernel : public KernelImpl {
@@ -198,7 +195,6 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
n/a

### Problem description
binaries_exist_on_disk and file_paths can use generic implementation independent from kernel type.

### What's changed
De-virtualize their implementations.  This also removes the unnecessary assumptions about the number of binaries for each kernel.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17749911648) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17750337541) CI with demo tests passes (if applicable)