### PR TITLE
Add BH Galaxy to cabling generator

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -5,7 +5,6 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <enchantum/enchantum.hpp>
-#include <iomanip>
 #include <map>
 #include <tuple>
 #include <unordered_map>
@@ -152,8 +151,9 @@ std::string get_ubb_id_str(chip_id_t chip_id) {
 std::string get_physical_slot_str(chip_id_t chip_id) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto physical_slot = cluster.get_physical_slot(chip_id);
+    auto asic_loc = cluster.get_cluster_desc()->get_asic_location(chip_id);
     if (physical_slot.has_value()) {
-        return "Physical Slot: " + std::to_string(*physical_slot);
+        return "Physical Slot: " + std::to_string(*physical_slot) + " ASIC Location: " + std::to_string(asic_loc);
     }
     return "";
 }
@@ -189,19 +189,15 @@ std::string get_connector_str(chip_id_t chip_id, CoreCoord eth_core, uint32_t ch
 
 TEST(Cluster, ReportIntermeshLinks) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-
+    auto all_intermesh_links = cluster.get_ethernet_connections_to_remote_devices();
     // Check if cluster supports intermesh links
-    if (!control_plane.system_has_intermesh_links()) {
+    if (all_intermesh_links.empty()) {
         log_info(tt::LogTest, "Cluster does not support intermesh links");
         return;
     }
 
     log_info(tt::LogTest, "Intermesh Link Configuration Report");
     log_info(tt::LogTest, "===================================");
-
-    // Get all intermesh links in the system
-    auto all_intermesh_links = control_plane.get_all_intermesh_eth_links();
 
     // Summary
     size_t total_chips = 0;
@@ -219,12 +215,13 @@ TEST(Cluster, ReportIntermeshLinks) {
 
     // Detailed information per chip
     for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
-        if (control_plane.has_intermesh_links(chip_id)) {
-            auto links = control_plane.get_intermesh_eth_links(chip_id);
+        if (all_intermesh_links.find(chip_id) != all_intermesh_links.end()) {
+            auto links = all_intermesh_links.at(chip_id);
             log_info(tt::LogTest, "Chip {}: {} inter-mesh ethernet links", chip_id, links.size());
-
-            for (const auto& [eth_core, channel] : links) {
-                log_info(tt::LogTest, "  Channel {} at {}", channel, eth_core.str());
+            for (const auto& [channel, remote_connection] : links) {
+                tt::umd::CoreCoord eth_core =
+                    cluster.get_soc_desc(chip_id).get_eth_core_for_channel(channel, CoordSystem::LOGICAL);
+                log_info(tt::LogTest, "  Channel {} at {}", channel, CoreCoord{eth_core.x, eth_core.y}.str());
             }
         }
     }

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
         umd::device
     PRIVATE
         enchantum::enchantum
+        tt-logger::tt-logger
         $<BUILD_INTERFACE:yaml-cpp::yaml-cpp>
         $<BUILD_INTERFACE:protobuf::libprotobuf>
 )

--- a/tools/scaleout/board/board.cpp
+++ b/tools/scaleout/board/board.cpp
@@ -464,6 +464,12 @@ tt::umd::BoardType get_board_type_from_string(const std::string& board_name) {
     return *board_type;
 }
 
+std::ostream& operator<<(std::ostream& os, const AsicChannel& asic_channel) {
+    os << "AsicChannel{asic_location=" << asic_channel.asic_location << ", channel_id=" << *asic_channel.channel_id
+       << "}";
+    return os;
+}
+
 }  // namespace tt::scaleout_tools
 
 // Hash function implementation for AsicChannel

--- a/tools/scaleout/board/board.cpp
+++ b/tools/scaleout/board/board.cpp
@@ -179,6 +179,31 @@ const std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>& Boar
     return internal_connections_;
 }
 
+// N150 board class
+class N150 : public Board {
+public:
+    N150() : Board(create_n150_ports(), create_n150_internal_connections(), tt::umd::BoardType::N150) {}
+
+private:
+    static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_n150_ports() {
+        std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
+
+        // QSFP_DD_400G ports
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
+
+        // WARP100 ports
+        add_sequential_port(ports, PortType::WARP100, PortId(1), 0, 14, 15);  // ASIC 0, channels 14,15
+
+        return ports;
+    }
+
+    static std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>> create_n150_internal_connections() {
+        // No internal connections for N150
+        return std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>();
+    }
+};
+
 // N300 board class
 class N300 : public Board {
 public:
@@ -196,9 +221,9 @@ private:
     static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_n300_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP ports
-        add_sequential_port(ports, PortType::QSFP, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
-        add_sequential_port(ports, PortType::QSFP, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
+        // QSFP_DD_400G ports
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
 
         // WARP100 ports
         add_sequential_port(ports, PortType::WARP100, PortId(1), 0, 14, 15);  // ASIC 0, channels 14,15
@@ -230,13 +255,13 @@ private:
     create_ubb_wormhole_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP ports
-        add_sequential_port(ports, PortType::QSFP, PortId(1), 5, 4, 7);  // ASIC 5, channels 4,5,6,7
-        add_sequential_port(ports, PortType::QSFP, PortId(2), 1, 4, 7);  // ASIC 1, channels 4,5,6,7
-        add_sequential_port(ports, PortType::QSFP, PortId(3), 1, 0, 3);  // ASIC 1, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP, PortId(4), 2, 0, 3);  // ASIC 2, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP, PortId(5), 3, 0, 3);  // ASIC 3, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP, PortId(6), 4, 0, 3);  // ASIC 4, channels 0,1,2,3
+        // QSFP_DD_400G ports
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 5, 4, 7);  // ASIC 5, channels 4,5,6,7
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 1, 4, 7);  // ASIC 1, channels 4,5,6,7
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(3), 1, 0, 3);  // ASIC 1, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(4), 2, 0, 3);  // ASIC 2, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(5), 3, 0, 3);  // ASIC 3, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(6), 4, 0, 3);  // ASIC 4, channels 0,1,2,3
 
         // LINKING_BOARD_1 ports
         add_sequential_port(ports, PortType::LINKING_BOARD_1, PortId(1), 5, 12, 15);  // ASIC 5, channels 12,13,14,15
@@ -273,6 +298,30 @@ private:
         add_sequential_port(ports, PortType::TRACE, PortId(20), 4, 12, 15);  // ASIC 4, channels 12,13,14,15
 
         return ports;
+    }
+};
+
+// P150 board class
+class P150 : public Board {
+public:
+    P150() : Board(create_p150_ports(), create_p150_internal_connections(), tt::umd::BoardType::P150) {}
+
+private:
+    static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_p150_ports() {
+        std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
+
+        // QSFP_DD_800G ports
+        add_port(ports, PortType::QSFP_DD_800G, PortId(1), {{0, ChanId(9)}, {0, ChanId(11)}});  // ASIC 0, channels 9,11
+        add_port(ports, PortType::QSFP_DD_800G, PortId(2), {{0, ChanId(8)}, {0, ChanId(10)}});  // ASIC 0, channels 8,10
+        add_port(ports, PortType::QSFP_DD_800G, PortId(3), {{0, ChanId(5)}, {0, ChanId(7)}});   // ASIC 0, channels 5,7
+        add_port(ports, PortType::QSFP_DD_800G, PortId(4), {{0, ChanId(4)}, {0, ChanId(6)}});   // ASIC 0, channels 4,6
+
+        return ports;
+    }
+
+    static std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>> create_p150_internal_connections() {
+        // No internal connections for P150
+        return std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>();
     }
 };
 
@@ -319,55 +368,6 @@ private:
     }
 };
 
-// P150 board class
-class P150 : public Board {
-public:
-    P150() : Board(create_p150_ports(), create_p150_internal_connections(), tt::umd::BoardType::P150) {}
-
-private:
-    static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_p150_ports() {
-        std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
-
-        // QSFP ports
-        add_port(ports, PortType::QSFP, PortId(1), {{0, ChanId(9)}, {0, ChanId(11)}});  // ASIC 0, channels 9,11
-        add_port(ports, PortType::QSFP, PortId(2), {{0, ChanId(8)}, {0, ChanId(10)}});  // ASIC 0, channels 8,10
-        add_port(ports, PortType::QSFP, PortId(3), {{0, ChanId(5)}, {0, ChanId(7)}});   // ASIC 0, channels 5,7
-        add_port(ports, PortType::QSFP, PortId(4), {{0, ChanId(4)}, {0, ChanId(6)}});   // ASIC 0, channels 4,6
-
-        return ports;
-    }
-
-    static std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>> create_p150_internal_connections() {
-        // No internal connections for P150
-        return std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>();
-    }
-};
-
-// N150 board class
-class N150 : public Board {
-public:
-    N150() : Board(create_n150_ports(), create_n150_internal_connections(), tt::umd::BoardType::N150) {}
-
-private:
-    static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_n150_ports() {
-        std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
-
-        // QSFP ports
-        add_sequential_port(ports, PortType::QSFP, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
-        add_sequential_port(ports, PortType::QSFP, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
-
-        // WARP100 ports
-        add_sequential_port(ports, PortType::WARP100, PortId(1), 0, 14, 15);  // ASIC 0, channels 14,15
-
-        return ports;
-    }
-
-    static std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>> create_n150_internal_connections() {
-        // No internal connections for N150
-        return std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>();
-    }
-};
-
 // UBB_BLACKHOLE board class
 class UBB_BLACKHOLE : public Board {
 public:
@@ -386,21 +386,21 @@ private:
     create_ubb_blackhole_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP ports
-        add_sequential_port(ports, PortType::QSFP, PortId(1), 5, 2, 3);                 // ASIC 5, channels 2,3
-        add_sequential_port(ports, PortType::QSFP, PortId(2), 1, 2, 3);                 // ASIC 1, channels 2,3
-        add_sequential_port(ports, PortType::QSFP, PortId(3), 1, 0, 1);                 // ASIC 1, channels 0,1
-        add_sequential_port(ports, PortType::QSFP, PortId(4), 2, 0, 1);                 // ASIC 2, channels 0,1
-        add_sequential_port(ports, PortType::QSFP, PortId(5), 3, 0, 1);                 // ASIC 3, channels 0,1
-        add_sequential_port(ports, PortType::QSFP, PortId(6), 4, 0, 1);                 // ASIC 4, channels 0,1
-        add_port(ports, PortType::QSFP, PortId(7), {{1, ChanId(8)}, {2, ChanId(8)}});   // ASIC 1,2: channel 8
-        add_port(ports, PortType::QSFP, PortId(8), {{5, ChanId(8)}, {6, ChanId(8)}});   // ASIC 5,6: channel 8
-        add_port(ports, PortType::QSFP, PortId(9), {{3, ChanId(8)}, {4, ChanId(8)}});   // ASIC 3,4: channel 8
-        add_port(ports, PortType::QSFP, PortId(10), {{7, ChanId(8)}, {8, ChanId(8)}});  // ASIC 7,8: channel 8
-        add_port(ports, PortType::QSFP, PortId(11), {{1, ChanId(9)}, {2, ChanId(9)}});  // ASIC 1,2: channel 9
-        add_port(ports, PortType::QSFP, PortId(12), {{5, ChanId(9)}, {6, ChanId(9)}});  // ASIC 5,6: channel 9
-        add_port(ports, PortType::QSFP, PortId(13), {{3, ChanId(9)}, {4, ChanId(9)}});  // ASIC 3,4: channel 9
-        add_port(ports, PortType::QSFP, PortId(14), {{7, ChanId(9)}, {8, ChanId(9)}});  // ASIC 7,8: channel 9
+        // QSFP_DD_800G ports
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(1), 5, 2, 3);                 // ASIC 5, channels 2,3
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(2), 1, 2, 3);                 // ASIC 1, channels 2,3
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(3), 1, 0, 1);                 // ASIC 1, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(4), 2, 0, 1);                 // ASIC 2, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(5), 3, 0, 1);                 // ASIC 3, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(6), 4, 0, 1);                 // ASIC 4, channels 0,1
+        add_port(ports, PortType::QSFP_DD_800G, PortId(7), {{1, ChanId(8)}, {2, ChanId(8)}});   // ASIC 1,2: channel 8
+        add_port(ports, PortType::QSFP_DD_800G, PortId(8), {{5, ChanId(8)}, {6, ChanId(8)}});   // ASIC 5,6: channel 8
+        add_port(ports, PortType::QSFP_DD_800G, PortId(9), {{3, ChanId(8)}, {4, ChanId(8)}});   // ASIC 3,4: channel 8
+        add_port(ports, PortType::QSFP_DD_800G, PortId(10), {{7, ChanId(8)}, {8, ChanId(8)}});  // ASIC 7,8: channel 8
+        add_port(ports, PortType::QSFP_DD_800G, PortId(11), {{1, ChanId(9)}, {2, ChanId(9)}});  // ASIC 1,2: channel 9
+        add_port(ports, PortType::QSFP_DD_800G, PortId(12), {{5, ChanId(9)}, {6, ChanId(9)}});  // ASIC 5,6: channel 9
+        add_port(ports, PortType::QSFP_DD_800G, PortId(13), {{3, ChanId(9)}, {4, ChanId(9)}});  // ASIC 3,4: channel 9
+        add_port(ports, PortType::QSFP_DD_800G, PortId(14), {{7, ChanId(9)}, {8, ChanId(9)}});  // ASIC 7,8: channel 9
 
         // NOTE: These Linking Board connections are not finalized yet.
         log_warning(tt::LogDistributed, "UBB_BLACKHOLE: Linking Board connections are not finalized yet.");
@@ -446,11 +446,11 @@ private:
 // Factory function to create boards by type (for backward compatibility)
 Board create_board(tt::umd::BoardType board_type) {
     switch (board_type) {
+        case BoardType::N150: return N150();
         case BoardType::N300: return N300();
         case BoardType::UBB_WORMHOLE: return UBB_WORMHOLE();
-        case BoardType::P300: return P300();
         case BoardType::P150: return P150();
-        case BoardType::N150: return N150();
+        case BoardType::P300: return P300();
         case BoardType::UBB_BLACKHOLE: return UBB_BLACKHOLE();
         default: throw std::runtime_error("Unknown board type: " + std::string(enchantum::to_string(board_type)));
     }

--- a/tools/scaleout/board/board.cpp
+++ b/tools/scaleout/board/board.cpp
@@ -95,6 +95,16 @@ Board::Board(
     const std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>& internal_connections,
     const tt::umd::BoardType& board_type) :
     ports_(ports), internal_connections_(internal_connections), board_type_(board_type), asic_locations_() {
+    switch (board_type_) {
+        case tt::umd::BoardType::N150:
+        case tt::umd::BoardType::N300:
+        case tt::umd::BoardType::UBB_WORMHOLE: arch_ = tt::ARCH::WORMHOLE_B0; break;
+        case tt::umd::BoardType::P100:
+        case tt::umd::BoardType::P150:
+        case tt::umd::BoardType::P300:
+        case tt::umd::BoardType::UBB_BLACKHOLE: arch_ = tt::ARCH::BLACKHOLE; break;
+        default: throw std::runtime_error("Invalid board type");
+    }
     // Initialize available_ports from ports
     for (const auto& [port_type, port_mapping] : ports) {
         auto& available_ports = available_port_ids_[port_type];
@@ -134,7 +144,9 @@ Board::Board(
     const tt::umd::BoardType& board_type) :
     Board(ports_and_connections.first, ports_and_connections.second, board_type) {}
 
-const tt::umd::BoardType& Board::get_board_type() const { return board_type_; }
+tt::ARCH Board::get_arch() const { return arch_; }
+
+tt::umd::BoardType Board::get_board_type() const { return board_type_; }
 
 const std::vector<PortId>& Board::get_available_port_ids(PortType port_type) const {
     auto it = available_port_ids_.find(port_type);
@@ -188,9 +200,9 @@ private:
     static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_n150_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP_DD_400G ports
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
+        // QSFP_DD ports (400G)
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
 
         // WARP100 ports
         add_sequential_port(ports, PortType::WARP100, PortId(1), 0, 14, 15);  // ASIC 0, channels 14,15
@@ -221,9 +233,9 @@ private:
     static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_n300_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP_DD_400G ports
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
+        // QSFP_DD ports (400G)
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(1), 0, 6, 7);  // ASIC 0, channels 6,7
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(2), 0, 0, 1);  // ASIC 0, channels 0,1
 
         // WARP100 ports
         add_sequential_port(ports, PortType::WARP100, PortId(1), 0, 14, 15);  // ASIC 0, channels 14,15
@@ -255,13 +267,13 @@ private:
     create_ubb_wormhole_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP_DD_400G ports
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(1), 5, 4, 7);  // ASIC 5, channels 4,5,6,7
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(2), 1, 4, 7);  // ASIC 1, channels 4,5,6,7
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(3), 1, 0, 3);  // ASIC 1, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(4), 2, 0, 3);  // ASIC 2, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(5), 3, 0, 3);  // ASIC 3, channels 0,1,2,3
-        add_sequential_port(ports, PortType::QSFP_DD_400G, PortId(6), 4, 0, 3);  // ASIC 4, channels 0,1,2,3
+        // QSFP_DD ports (400G)
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(1), 5, 4, 7);  // ASIC 5, channels 4,5,6,7
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(2), 1, 4, 7);  // ASIC 1, channels 4,5,6,7
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(3), 1, 0, 3);  // ASIC 1, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(4), 2, 0, 3);  // ASIC 2, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(5), 3, 0, 3);  // ASIC 3, channels 0,1,2,3
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(6), 4, 0, 3);  // ASIC 4, channels 0,1,2,3
 
         // LINKING_BOARD_1 ports
         add_sequential_port(ports, PortType::LINKING_BOARD_1, PortId(1), 5, 12, 15);  // ASIC 5, channels 12,13,14,15
@@ -310,11 +322,11 @@ private:
     static std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> create_p150_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP_DD_800G ports
-        add_port(ports, PortType::QSFP_DD_800G, PortId(1), {{0, ChanId(9)}, {0, ChanId(11)}});  // ASIC 0, channels 9,11
-        add_port(ports, PortType::QSFP_DD_800G, PortId(2), {{0, ChanId(8)}, {0, ChanId(10)}});  // ASIC 0, channels 8,10
-        add_port(ports, PortType::QSFP_DD_800G, PortId(3), {{0, ChanId(5)}, {0, ChanId(7)}});   // ASIC 0, channels 5,7
-        add_port(ports, PortType::QSFP_DD_800G, PortId(4), {{0, ChanId(4)}, {0, ChanId(6)}});   // ASIC 0, channels 4,6
+        // QSFP_DD ports (800G)
+        add_port(ports, PortType::QSFP_DD, PortId(1), {{0, ChanId(9)}, {0, ChanId(11)}});  // ASIC 0, channels 9,11
+        add_port(ports, PortType::QSFP_DD, PortId(2), {{0, ChanId(8)}, {0, ChanId(10)}});  // ASIC 0, channels 8,10
+        add_port(ports, PortType::QSFP_DD, PortId(3), {{0, ChanId(5)}, {0, ChanId(7)}});   // ASIC 0, channels 5,7
+        add_port(ports, PortType::QSFP_DD, PortId(4), {{0, ChanId(4)}, {0, ChanId(6)}});   // ASIC 0, channels 4,6
 
         return ports;
     }
@@ -386,21 +398,21 @@ private:
     create_ubb_blackhole_ports() {
         std::unordered_map<PortType, std::unordered_map<PortId, std::vector<AsicChannel>>> ports;
 
-        // QSFP_DD_800G ports
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(1), 5, 2, 3);                 // ASIC 5, channels 2,3
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(2), 1, 2, 3);                 // ASIC 1, channels 2,3
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(3), 1, 0, 1);                 // ASIC 1, channels 0,1
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(4), 2, 0, 1);                 // ASIC 2, channels 0,1
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(5), 3, 0, 1);                 // ASIC 3, channels 0,1
-        add_sequential_port(ports, PortType::QSFP_DD_800G, PortId(6), 4, 0, 1);                 // ASIC 4, channels 0,1
-        add_port(ports, PortType::QSFP_DD_800G, PortId(7), {{1, ChanId(8)}, {2, ChanId(8)}});   // ASIC 1,2: channel 8
-        add_port(ports, PortType::QSFP_DD_800G, PortId(8), {{5, ChanId(8)}, {6, ChanId(8)}});   // ASIC 5,6: channel 8
-        add_port(ports, PortType::QSFP_DD_800G, PortId(9), {{3, ChanId(8)}, {4, ChanId(8)}});   // ASIC 3,4: channel 8
-        add_port(ports, PortType::QSFP_DD_800G, PortId(10), {{7, ChanId(8)}, {8, ChanId(8)}});  // ASIC 7,8: channel 8
-        add_port(ports, PortType::QSFP_DD_800G, PortId(11), {{1, ChanId(9)}, {2, ChanId(9)}});  // ASIC 1,2: channel 9
-        add_port(ports, PortType::QSFP_DD_800G, PortId(12), {{5, ChanId(9)}, {6, ChanId(9)}});  // ASIC 5,6: channel 9
-        add_port(ports, PortType::QSFP_DD_800G, PortId(13), {{3, ChanId(9)}, {4, ChanId(9)}});  // ASIC 3,4: channel 9
-        add_port(ports, PortType::QSFP_DD_800G, PortId(14), {{7, ChanId(9)}, {8, ChanId(9)}});  // ASIC 7,8: channel 9
+        // QSFP_DD ports (800G)
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(1), 5, 2, 3);                 // ASIC 5, channels 2,3
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(2), 1, 2, 3);                 // ASIC 1, channels 2,3
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(3), 1, 0, 1);                 // ASIC 1, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(4), 2, 0, 1);                 // ASIC 2, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(5), 3, 0, 1);                 // ASIC 3, channels 0,1
+        add_sequential_port(ports, PortType::QSFP_DD, PortId(6), 4, 0, 1);                 // ASIC 4, channels 0,1
+        add_port(ports, PortType::QSFP_DD, PortId(7), {{1, ChanId(8)}, {2, ChanId(8)}});   // ASIC 1,2: channel 8
+        add_port(ports, PortType::QSFP_DD, PortId(8), {{5, ChanId(8)}, {6, ChanId(8)}});   // ASIC 5,6: channel 8
+        add_port(ports, PortType::QSFP_DD, PortId(9), {{3, ChanId(8)}, {4, ChanId(8)}});   // ASIC 3,4: channel 8
+        add_port(ports, PortType::QSFP_DD, PortId(10), {{7, ChanId(8)}, {8, ChanId(8)}});  // ASIC 7,8: channel 8
+        add_port(ports, PortType::QSFP_DD, PortId(11), {{1, ChanId(9)}, {2, ChanId(9)}});  // ASIC 1,2: channel 9
+        add_port(ports, PortType::QSFP_DD, PortId(12), {{5, ChanId(9)}, {6, ChanId(9)}});  // ASIC 5,6: channel 9
+        add_port(ports, PortType::QSFP_DD, PortId(13), {{3, ChanId(9)}, {4, ChanId(9)}});  // ASIC 3,4: channel 9
+        add_port(ports, PortType::QSFP_DD, PortId(14), {{7, ChanId(9)}, {8, ChanId(9)}});  // ASIC 7,8: channel 9
 
         // NOTE: These Linking Board connections are not finalized yet.
         log_warning(tt::LogDistributed, "UBB_BLACKHOLE: Linking Board connections are not finalized yet.");

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -47,6 +47,8 @@ struct AsicChannel {
     auto operator<=>(const AsicChannel& other) const = default;
 };
 
+std::ostream& operator<<(std::ostream& os, const AsicChannel& asic_channel);
+
 struct Port {
     PortType port_type = PortType::TRACE;
     PortId port_id{0};

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -31,7 +31,8 @@ using ChanId = ttsl::StrongType<uint32_t, struct ChanIdTag>;
 
 enum class PortType {
     TRACE,
-    QSFP,  // TODO: Should distinguish between QSFP types?
+    QSFP_DD_400G,
+    QSFP_DD_800G,
     WARP100,
     WARP400,
     LINKING_BOARD_1,

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/strong_type.hpp>
 
@@ -31,8 +32,7 @@ using ChanId = ttsl::StrongType<uint32_t, struct ChanIdTag>;
 
 enum class PortType {
     TRACE,
-    QSFP_DD_400G,
-    QSFP_DD_800G,
+    QSFP_DD,
     WARP100,
     WARP400,
     LINKING_BOARD_1,
@@ -69,7 +69,9 @@ public:
             std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>>>& ports_and_connections,
         const tt::umd::BoardType& board_type);
 
-    const tt::umd::BoardType& get_board_type() const;
+    tt::ARCH get_arch() const;
+
+    tt::umd::BoardType get_board_type() const;
 
     // Get available port IDs for a specific port type
     const std::vector<PortId>& get_available_port_ids(PortType port_type) const;
@@ -95,7 +97,7 @@ protected:
     // Note: Internal connections currently just use dummy trace ports
     // Could switch to just direct channel mapping in the future
     std::unordered_map<PortType, std::vector<std::pair<PortId, PortId>>> internal_connections_;
-
+    tt::ARCH arch_ = tt::ARCH::Invalid;
     std::unordered_map<AsicChannel, Port> asic_to_port_map_;
     tt::umd::BoardType board_type_ = tt::umd::BoardType::UNKNOWN;
     std::unordered_set<uint32_t> asic_locations_;

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -150,6 +150,35 @@ Node build_node(
     return node;
 }
 
+// Resolve path from proto data to HostId
+HostId resolve_path_from_proto(
+    const google::protobuf::RepeatedPtrField<std::string>& path,
+    const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
+    const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+    uint32_t index = 0) {
+    if (index == path.size() - 1) {
+        // Direct node reference - look up in child_mappings
+        const std::string& node_name = path[index];
+        const auto& child_mapping = graph_instance.child_mappings().at(node_name);
+
+        if (child_mapping.mapping_case() == tt::scaleout_tools::cabling_generator::proto::ChildMapping::kHostId) {
+            return HostId(child_mapping.host_id());
+        } else {
+            throw std::runtime_error("Node " + node_name + " is not a leaf node");
+        }
+    } else {
+        // Multi-level path - descend into subgraph
+        const std::string& subgraph_name = path[index];
+        const auto& child_mapping = graph_instance.child_mappings().at(subgraph_name);
+
+        if (child_mapping.mapping_case() == tt::scaleout_tools::cabling_generator::proto::ChildMapping::kSubInstance) {
+            return resolve_path_from_proto(path, child_mapping.sub_instance(), cluster_descriptor, index + 1);
+        } else {
+            throw std::runtime_error("Subgraph " + subgraph_name + " is not a graph instance");
+        }
+    }
+}
+
 // Build resolved graph instance from template and concrete host mappings
 std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
     const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
@@ -221,13 +250,17 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
         }
 
         for (const auto& conn : port_connections.connections()) {
-            std::vector<std::string> path_a(conn.port_a().path().begin(), conn.port_a().path().end());
+            const auto& path_a = conn.port_a().path();
+            const auto& path_b = conn.port_b().path();
             TrayId board_a_id = TrayId(conn.port_a().tray_id());
             PortId port_a_id = PortId(conn.port_a().port_id());
 
-            std::vector<std::string> path_b(conn.port_b().path().begin(), conn.port_b().path().end());
             TrayId board_b_id = TrayId(conn.port_b().tray_id());
             PortId port_b_id = PortId(conn.port_b().port_id());
+
+            // Resolve paths to HostId using proto data
+            HostId host_a_id = resolve_path_from_proto(path_a, graph_instance, cluster_descriptor);
+            HostId host_b_id = resolve_path_from_proto(path_b, graph_instance, cluster_descriptor);
 
             // Validate and mark ports as used for direct node connections
             if (path_a.size() == 1 && path_b.size() == 1 && resolved->nodes.count(path_a[0]) &&
@@ -253,38 +286,13 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
                 board_b.mark_port_used(*port_type, port_b_id);
             }
 
-            // Store connection
+            // Store connection with resolved HostId
             resolved->internal_connections[*port_type].emplace_back(
-                std::make_tuple(path_a, board_a_id, port_a_id), std::make_tuple(path_b, board_b_id, port_b_id));
+                std::make_tuple(host_a_id, board_a_id, port_a_id), std::make_tuple(host_b_id, board_b_id, port_b_id));
         }
     }
 
     return resolved;
-}
-
-// Simple path resolution for connection processing
-std::pair<Node&, HostId> resolve_node_from_path(
-    ttsl::Span<const std::string> path, const std::unique_ptr<ResolvedGraphInstance>& graph) {
-    if (!graph) {
-        throw std::runtime_error("Graph not set");
-    }
-
-    if (path.size() == 1) {
-        // Direct node reference
-        if (graph->nodes.count(path[0])) {
-            auto& node = graph->nodes.at(path[0]);
-            return {node, node.host_id};
-        }
-        throw std::runtime_error("Node not found: " + path[0]);
-    } else {
-        // Multi-level path - descend into subgraph
-        const std::string& next_level = path[0];
-        if (!graph->subgraphs.count(next_level)) {
-            throw std::runtime_error("Subgraph not found: " + next_level);
-        }
-
-        return resolve_node_from_path(path.subspan(1), graph->subgraphs.at(next_level));
-    }
 }
 
 void populate_deployment_hosts(
@@ -329,8 +337,8 @@ CablingGenerator::CablingGenerator(
     // Validate host_id uniqueness across all nodes
     validate_host_id_uniqueness();
 
-    // Populate the boards_by_host_tray_ map
-    populate_boards_by_host_tray();
+    // Populate the host_id_to_node_ map
+    populate_host_id_to_node();
 
     // Generate all logical chip connections
     generate_logical_chip_connections();
@@ -341,11 +349,6 @@ CablingGenerator::CablingGenerator(
 
 // Getters for all data
 const std::vector<Host>& CablingGenerator::get_deployment_hosts() const { return deployment_hosts_; }
-
-const std::unordered_map<std::pair<HostId, TrayId>, const Board*, HostTrayHasher>&
-CablingGenerator::get_boards_by_host_tray() const {
-    return boards_by_host_tray_;
-}
 
 const std::vector<LogicalChannelConnection>& CablingGenerator::get_chip_connections() const {
     return chip_connections_;
@@ -368,11 +371,13 @@ void CablingGenerator::emit_factory_system_descriptor(const std::string& output_
     }
 
     // Add board types
-    for (const auto& [host_tray_pair, board] : boards_by_host_tray_) {
-        auto* board_location = fsd.mutable_board_types()->add_board_locations();
-        board_location->set_host_id(*host_tray_pair.first);  // Extract HostId value
-        board_location->set_tray_id(*host_tray_pair.second);
-        board_location->set_board_type(enchantum::to_string(board->get_board_type()).data());
+    for (const auto& [host_id, node] : host_id_to_node_) {
+        for (const auto& [tray_id, board] : node->boards) {
+            auto* board_location = fsd.mutable_board_types()->add_board_locations();
+            board_location->set_host_id(*host_id);
+            board_location->set_tray_id(*tray_id);
+            board_location->set_board_type(enchantum::to_string(board.get_board_type()).data());
+        }
     }
 
     // Add ASIC connections from chip_connections_
@@ -442,7 +447,8 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
     // Vector of (Host,Tray,Port) Connection Pairs
     std::vector<std::pair<std::tuple<HostId, TrayId, PortId>, std::tuple<HostId, TrayId, PortId>>> conn_list;
 
-    CablingGenerator::get_all_connections_of_type(root_instance_, PortType::QSFP, conn_list);
+    CablingGenerator::get_all_connections_of_type(
+        root_instance_, {PortType::QSFP_DD_400G, PortType::QSFP_DD_800G}, conn_list);
     output_file.fill('0');
     if (loc_info) {
         output_file << "Source,,,,,,,Destination,,,,,,,Cable Length,Cable Type" << std::endl;
@@ -525,19 +531,20 @@ void CablingGenerator::generate_logical_chip_connections() {
     if (root_instance_) {
         generate_connections_from_resolved_graph(root_instance_);
     }
+    std::sort(chip_connections_.begin(), chip_connections_.end());
 }
 
 void CablingGenerator::generate_connections_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph) {
     // Lambda to create connections between two ports
     auto create_port_connection = [&](PortType port_type,
                                       const Board& start_board,
-                                      PortId start_port_id,
                                       const Board& end_board,
-                                      PortId end_port_id,
                                       HostId start_host_id,
                                       TrayId start_tray_id,
+                                      PortId start_port_id,
                                       HostId end_host_id,
-                                      TrayId end_tray_id) {
+                                      TrayId end_tray_id,
+                                      PortId end_port_id) {
         const auto& start_channels = start_board.get_port_channels(port_type, start_port_id);
         const auto& end_channels = end_board.get_port_channels(port_type, end_port_id);
         auto asic_channel_pairs =
@@ -557,17 +564,9 @@ void CablingGenerator::generate_connections_from_resolved_graph(const std::uniqu
         // Add internal board connections
         for (const auto& [tray_id, board] : node.boards) {
             for (const auto& [port_type, connections] : board.get_internal_connections()) {
-                for (const auto& connection : connections) {
+                for (const auto& [port_a_id, port_b_id] : connections) {
                     create_port_connection(
-                        port_type,
-                        board,
-                        PortId(connection.first),
-                        board,
-                        PortId(connection.second),
-                        host_id,
-                        tray_id,
-                        host_id,
-                        tray_id);
+                        port_type, board, board, host_id, tray_id, port_a_id, host_id, tray_id, port_b_id);
                 }
             }
         }
@@ -585,13 +584,13 @@ void CablingGenerator::generate_connections_from_resolved_graph(const std::uniqu
                 create_port_connection(
                     port_type,
                     board_a_ref,
-                    port_a_id,
                     board_b_ref,
-                    port_b_id,
                     host_id,
                     board_a_id,
+                    port_a_id,
                     host_id,
-                    board_b_id);
+                    board_b_id,
+                    port_b_id);
             }
         }
     }
@@ -599,30 +598,17 @@ void CablingGenerator::generate_connections_from_resolved_graph(const std::uniqu
     // Process internal connections within this graph
     for (const auto& [port_type, connections] : graph->internal_connections) {
         for (const auto& [conn_a, conn_b] : connections) {
-            const auto& path_a = std::get<0>(conn_a);
-            TrayId board_a_id = std::get<1>(conn_a);
-            PortId port_a_id = std::get<2>(conn_a);
+            auto [host_a_id, tray_a_id, port_a_id] = conn_a;
+            auto [host_b_id, tray_b_id, port_b_id] = conn_b;
 
-            const auto& path_b = std::get<0>(conn_b);
-            TrayId board_b_id = std::get<1>(conn_b);
-            PortId port_b_id = std::get<2>(conn_b);
+            // Look up nodes using HostId
+            const Node* node_a = host_id_to_node_.at(host_a_id);
+            const Node* node_b = host_id_to_node_.at(host_b_id);
 
-            // Resolve nodes using path-based addressing
-            auto [node_a, host_a_id] = resolve_node_from_path(path_a, graph);
-            auto [node_b, host_b_id] = resolve_node_from_path(path_b, graph);
-
-            const auto& board_a_ref = node_a.boards.at(board_a_id);
-            const auto& board_b_ref = node_b.boards.at(board_b_id);
+            const auto& board_a_ref = node_a->boards.at(tray_a_id);
+            const auto& board_b_ref = node_b->boards.at(tray_b_id);
             create_port_connection(
-                port_type,
-                board_a_ref,
-                port_a_id,
-                board_b_ref,
-                port_b_id,
-                host_a_id,
-                board_a_id,
-                host_b_id,
-                board_b_id);
+                port_type, board_a_ref, board_b_ref, host_a_id, tray_a_id, port_a_id, host_b_id, tray_b_id, port_b_id);
         }
     }
 
@@ -632,61 +618,55 @@ void CablingGenerator::generate_connections_from_resolved_graph(const std::uniqu
     }
 }
 
-void CablingGenerator::populate_boards_by_host_tray() {
-    boards_by_host_tray_.clear();
+void CablingGenerator::populate_host_id_to_node() {
+    host_id_to_node_.clear();
 
     if (root_instance_) {
-        populate_boards_from_resolved_graph(root_instance_);
+        populate_host_id_from_resolved_graph(root_instance_);
     }
 }
 
-void CablingGenerator::populate_boards_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph) {
-    // Add boards from direct nodes
-    for (auto& [node_name, node] : graph->nodes) {
-        for (auto& [tray_id, board] : node.boards) {
-            std::pair<HostId, TrayId> key = std::make_pair(node.host_id, tray_id);
-            boards_by_host_tray_.emplace(key, &board);
-        }
+void CablingGenerator::populate_host_id_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph) {
+    // Add direct nodes in this graph
+    for (const auto& [node_name, node] : graph->nodes) {
+        host_id_to_node_[node.host_id] = &node;
     }
 
-    // Recursively add boards from subgraphs
+    // Recursively process subgraphs
     for (const auto& [subgraph_name, subgraph] : graph->subgraphs) {
-        populate_boards_from_resolved_graph(subgraph);
+        populate_host_id_from_resolved_graph(subgraph);
     }
 }
 
 void CablingGenerator::get_all_connections_of_type(
     const std::unique_ptr<ResolvedGraphInstance>& instance,
-    PortType port_type,
+    const std::vector<PortType>& port_types,
     std::vector<std::pair<std::tuple<HostId, TrayId, PortId>, std::tuple<HostId, TrayId, PortId>>>& conn_list) const {
-    for (const auto& [start, end] : instance->internal_connections[port_type]) {
-        auto host_id1 = resolve_node_from_path(std::get<0>(start), instance);
-
-        std::tuple<HostId, TrayId, PortId> s_tuple =
-            std::make_tuple(host_id1.second, std::get<1>(start), std::get<2>(start));
-
-        auto host_id2 = resolve_node_from_path(std::get<0>(end), instance);
-
-        std::tuple<HostId, TrayId, PortId> e_tuple =
-            std::make_tuple(host_id2.second, std::get<1>(end), std::get<2>(end));
-        conn_list.push_back(std::make_pair(s_tuple, e_tuple));
-    }
-
-    for (const auto& [child_name, child_instance] : instance->nodes) {
-        if (child_instance.inter_board_connections.count(port_type) == 0) {
+    for (auto port_type : port_types) {
+        auto internal_connections = instance->internal_connections.find(port_type);
+        if (internal_connections == instance->internal_connections.end()) {
             continue;
         }
-        for (const auto& [start, end] : child_instance.inter_board_connections.at(port_type)) {
-            std::tuple<HostId, TrayId, PortId> s_tuple =
-                std::make_tuple(child_instance.host_id, start.first, start.second);
+        conn_list.insert(conn_list.end(), internal_connections->second.begin(), internal_connections->second.end());
 
-            std::tuple<HostId, TrayId, PortId> e_tuple = std::make_tuple(child_instance.host_id, end.first, end.second);
-            conn_list.push_back(std::make_pair(s_tuple, e_tuple));
+        for (const auto& [child_name, child_instance] : instance->nodes) {
+            auto inter_board_connections = child_instance.inter_board_connections.find(port_type);
+            if (inter_board_connections == child_instance.inter_board_connections.end()) {
+                continue;
+            }
+            conn_list.reserve(conn_list.size() + inter_board_connections->second.size());
+            for (const auto& [start, end] : inter_board_connections->second) {
+                std::tuple<HostId, TrayId, PortId> s_tuple =
+                    std::make_tuple(child_instance.host_id, start.first, start.second);
+
+                std::tuple<HostId, TrayId, PortId> e_tuple =
+                    std::make_tuple(child_instance.host_id, end.first, end.second);
+                conn_list.push_back(std::make_pair(s_tuple, e_tuple));
+            }
         }
     }
-
     for (const auto& [child_name, child_instance] : instance->subgraphs) {
-        get_all_connections_of_type(child_instance, port_type, conn_list);
+        get_all_connections_of_type(child_instance, port_types, conn_list);
     }
 }
 
@@ -728,7 +708,7 @@ CableLength calc_cable_length(const Host& host1, const Host& host2) {
 // Overload operator<< for readable test output
 std::ostream& operator<<(std::ostream& os, const PhysicalChannelEndpoint& conn) {
     os << "PhysicalChannelEndpoint{hostname='" << conn.hostname << "', tray_id=" << *conn.tray_id
-       << ", asic_location=" << conn.asic_location << ", channel_id=" << *conn.channel_id << "}";
+       << ", asic_channel=" << conn.asic_channel << "}";
     return os;
 }
 
@@ -746,16 +726,14 @@ namespace std {
 template <>
 struct hash<tt::scaleout_tools::LogicalChannelEndpoint> {
     std::size_t operator()(const tt::scaleout_tools::LogicalChannelEndpoint& conn) const {
-        return tt::stl::hash::hash_objects_with_default_seed(
-            *conn.host_id, conn.tray_id, conn.asic_channel.asic_location, conn.asic_channel.channel_id);
+        return tt::stl::hash::hash_objects_with_default_seed(conn.host_id, conn.tray_id, conn.asic_channel);
     }
 };
 
 template <>
 struct hash<tt::scaleout_tools::PhysicalChannelEndpoint> {
     std::size_t operator()(const tt::scaleout_tools::PhysicalChannelEndpoint& conn) const {
-        return tt::stl::hash::hash_objects_with_default_seed(
-            conn.hostname, *conn.tray_id, conn.asic_location, conn.channel_id);
+        return tt::stl::hash::hash_objects_with_default_seed(conn.hostname, conn.tray_id, conn.asic_channel);
     }
 };
 

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -57,7 +57,7 @@ struct PhysicalPortEndpoint {
     uint32_t rack = 0;
     uint32_t shelf_u = 0;
     TrayId tray_id{0};
-    PortType port_type = PortType::QSFP;
+    PortType port_type = PortType::TRACE;
     PortId port_id{0};
 
     auto operator<=>(const PhysicalPortEndpoint& other) const = default;

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -136,7 +136,7 @@ private:
     std::unordered_map<std::string, Node> node_templates_;  // Templates with host_id=0
 
     std::unique_ptr<ResolvedGraphInstance> root_instance_;
-    std::map<HostId, const Node*> host_id_to_node_;  // Global lookup map for HostId -> Node reference
+    std::map<HostId, Node*> host_id_to_node_;  // Global lookup map for HostId -> Node reference
     // Guaranteed to be sorted
     std::vector<LogicalChannelConnection> chip_connections_;
     std::vector<Host> deployment_hosts_;

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include <tt_stl/strong_type.hpp>
@@ -17,13 +19,6 @@ namespace tt::scaleout_tools {
 // Strong types to prevent mixing with other uint32_t values
 using HostId = ttsl::StrongType<uint32_t, struct HostIdTag>;
 using TrayId = ttsl::StrongType<uint32_t, struct TrayIdTag>;
-
-// Custom hasher for (HostId, TrayId) pairs
-struct HostTrayHasher {
-    std::size_t operator()(const std::pair<HostId, TrayId>& p) const {
-        return std::hash<uint64_t>{}((static_cast<uint64_t>(*p.first) << 32) | *p.second);
-    }
-};
 
 struct Host {
     std::string hostname;
@@ -45,8 +40,7 @@ struct LogicalChannelEndpoint {
 struct PhysicalChannelEndpoint {
     std::string hostname;
     TrayId tray_id{0};
-    uint32_t asic_location = 0;
-    ChanId channel_id{0};
+    AsicChannel asic_channel;
 
     auto operator<=>(const PhysicalChannelEndpoint& other) const = default;
 };
@@ -72,7 +66,7 @@ using PhysicalChannelConnection = std::pair<PhysicalChannelEndpoint, PhysicalCha
 
 struct Node {
     std::string motherboard;
-    std::unordered_map<TrayId, Board> boards;
+    std::map<TrayId, Board> boards;
     HostId host_id{0};
     // Board-to-board connections within this node: PortType -> [(tray_id, port_id) <-> (tray_id, port_id)]
     using PortEndpoint = std::pair<TrayId, PortId>;
@@ -84,11 +78,11 @@ struct Node {
 struct ResolvedGraphInstance {
     std::string template_name;
     std::string instance_name;
-    std::unordered_map<std::string, Node> nodes;  // Direct node children (by name)
-    std::unordered_map<std::string, std::unique_ptr<ResolvedGraphInstance>> subgraphs;  // Nested graph children
+    std::map<std::string, Node> nodes;                                        // Direct node children (by name)
+    std::map<std::string, std::unique_ptr<ResolvedGraphInstance>> subgraphs;  // Nested graph children
 
     // All connections within this graph instance
-    using PortEndpoint = std::tuple<std::vector<std::string>, TrayId, PortId>;  // Path, tray_id, port_id
+    using PortEndpoint = std::tuple<HostId, TrayId, PortId>;  // host_id, tray_id, port_id
     using PortConnection = std::pair<PortEndpoint, PortEndpoint>;
     std::unordered_map<PortType, std::vector<PortConnection>> internal_connections;
 };
@@ -104,7 +98,6 @@ public:
 
     // Getters for all data
     const std::vector<Host>& get_deployment_hosts() const;
-    const std::unordered_map<std::pair<HostId, TrayId>, const Board*, HostTrayHasher>& get_boards_by_host_tray() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;
 
     // Method to emit factory system descriptor
@@ -128,13 +121,13 @@ private:
 
     void generate_connections_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph);
 
-    void populate_boards_by_host_tray();
+    void populate_host_id_to_node();
 
-    void populate_boards_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph);
+    void populate_host_id_from_resolved_graph(const std::unique_ptr<ResolvedGraphInstance>& graph);
 
     void get_all_connections_of_type(
         const std::unique_ptr<ResolvedGraphInstance>& instance,
-        PortType port_type,
+        const std::vector<PortType>& port_types,
         std::vector<std::pair<std::tuple<HostId, TrayId, PortId>, std::tuple<HostId, TrayId, PortId>>>& conn_list)
         const;
 
@@ -143,7 +136,8 @@ private:
     std::unordered_map<std::string, Node> node_templates_;  // Templates with host_id=0
 
     std::unique_ptr<ResolvedGraphInstance> root_instance_;
-    std::unordered_map<std::pair<HostId, TrayId>, const Board*, HostTrayHasher> boards_by_host_tray_;
+    std::map<HostId, const Node*> host_id_to_node_;  // Global lookup map for HostId -> Node reference
+    // Guaranteed to be sorted
     std::vector<LogicalChannelConnection> chip_connections_;
     std::vector<Host> deployment_hosts_;
 };

--- a/tools/scaleout/connector/connector.cpp
+++ b/tools/scaleout/connector/connector.cpp
@@ -63,8 +63,7 @@ std::vector<AsicChannelConnection> get_asic_channel_connections(
             }
             return connection_mappers::cross_connect_mapping(start_channels, end_channels);
 
-        case PortType::QSFP_DD_400G:
-        case PortType::QSFP_DD_800G:
+        case PortType::QSFP_DD:
         case PortType::LINKING_BOARD_1:
         case PortType::LINKING_BOARD_2:
         case PortType::LINKING_BOARD_3:

--- a/tools/scaleout/connector/connector.cpp
+++ b/tools/scaleout/connector/connector.cpp
@@ -63,7 +63,8 @@ std::vector<AsicChannelConnection> get_asic_channel_connections(
             }
             return connection_mappers::cross_connect_mapping(start_channels, end_channels);
 
-        case PortType::QSFP:
+        case PortType::QSFP_DD_400G:
+        case PortType::QSFP_DD_800G:
         case PortType::LINKING_BOARD_1:
         case PortType::LINKING_BOARD_2:
         case PortType::LINKING_BOARD_3:

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -203,8 +203,8 @@ void validate_fsd_against_gsd(
         const std::string& hostname_1 = hosts[host_id_1].hostname();
         const std::string& hostname_2 = hosts[host_id_2].hostname();
 
-        PhysicalChannelEndpoint conn_1{hostname_1, TrayId(tray_id_1), asic_location_1, ChanId(chan_id_1)};
-        PhysicalChannelEndpoint conn_2{hostname_2, TrayId(tray_id_2), asic_location_2, ChanId(chan_id_2)};
+        PhysicalChannelEndpoint conn_1{hostname_1, TrayId(tray_id_1), AsicChannel{asic_location_1, ChanId(chan_id_1)}};
+        PhysicalChannelEndpoint conn_2{hostname_2, TrayId(tray_id_2), AsicChannel{asic_location_2, ChanId(chan_id_2)}};
 
         // Sort to ensure consistent ordering
         std::pair<PhysicalChannelEndpoint, PhysicalChannelEndpoint> connection_pair_sorted;
@@ -257,8 +257,10 @@ void validate_fsd_against_gsd(
             uint32_t tray_id_2 = second_conn["tray_id"].as<uint32_t>();
             uint32_t asic_location_2 = second_conn["asic_location"].as<uint32_t>();
 
-            PhysicalChannelEndpoint conn_1{hostname_1, TrayId(tray_id_1), asic_location_1, ChanId(chan_id_1)};
-            PhysicalChannelEndpoint conn_2{hostname_2, TrayId(tray_id_2), asic_location_2, ChanId(chan_id_2)};
+            PhysicalChannelEndpoint conn_1{
+                hostname_1, TrayId(tray_id_1), AsicChannel{asic_location_1, ChanId(chan_id_1)}};
+            PhysicalChannelEndpoint conn_2{
+                hostname_2, TrayId(tray_id_2), AsicChannel{asic_location_2, ChanId(chan_id_2)}};
 
             // Sort to ensure consistent ordering
             PhysicalChannelConnection connection_pair_sorted;
@@ -297,8 +299,10 @@ void validate_fsd_against_gsd(
             uint32_t tray_id_2 = second_conn["tray_id"].as<uint32_t>();
             uint32_t asic_location_2 = second_conn["asic_location"].as<uint32_t>();
 
-            PhysicalChannelEndpoint conn_1{hostname_1, TrayId(tray_id_1), asic_location_1, ChanId(chan_id_1)};
-            PhysicalChannelEndpoint conn_2{hostname_2, TrayId(tray_id_2), asic_location_2, ChanId(chan_id_2)};
+            PhysicalChannelEndpoint conn_1{
+                hostname_1, TrayId(tray_id_1), AsicChannel{asic_location_1, ChanId(chan_id_1)}};
+            PhysicalChannelEndpoint conn_2{
+                hostname_2, TrayId(tray_id_2), AsicChannel{asic_location_2, ChanId(chan_id_2)}};
 
             // Sort to ensure consistent ordering
             PhysicalChannelConnection connection_pair_sorted;
@@ -361,8 +365,8 @@ void validate_fsd_against_gsd(
 
             Board board_a = create_board(board_type_a);
             Board board_b = create_board(board_type_b);
-            auto port_a = board_a.get_port_for_asic_channel({conn.first.asic_location, conn.first.channel_id});
-            auto port_b = board_b.get_port_for_asic_channel({conn.second.asic_location, conn.second.channel_id});
+            auto port_a = board_a.get_port_for_asic_channel(conn.first.asic_channel);
+            auto port_b = board_b.get_port_for_asic_channel(conn.second.asic_channel);
 
             PhysicalPortEndpoint port_a_conn;
             PhysicalPortEndpoint port_b_conn;

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -59,7 +59,7 @@ protected:
         add_boards(&node, "N300", 1, 4);
 
         // Add QSFP connections
-        auto* const qsfp_connections = get_port_connections(&node, "QSFP");
+        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD_400G");
         add_connection(qsfp_connections, 1, 1, 4, 1);
         add_connection(qsfp_connections, 2, 2, 3, 2);
 
@@ -90,55 +90,11 @@ public:
     }
 };
 
-// P150 QB Global Node class
-class P150QBGlobalNode {
-public:
-    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
-        tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
-        node.set_motherboard("SIENAD8-2L2T");
-
-        // Add boards
-        add_boards(&node, "P150", 1, 4);
-
-        // Add QSFP connections
-        auto* const qsfp_connections = get_port_connections(&node, "QSFP");
-        add_connection(qsfp_connections, 1, 1, 2, 1);
-        add_connection(qsfp_connections, 1, 2, 2, 2);
-        add_connection(qsfp_connections, 1, 3, 4, 3);
-        add_connection(qsfp_connections, 1, 4, 4, 4);
-        add_connection(qsfp_connections, 2, 3, 3, 3);
-        add_connection(qsfp_connections, 2, 4, 3, 4);
-        add_connection(qsfp_connections, 3, 1, 4, 1);
-        add_connection(qsfp_connections, 3, 2, 4, 2);
-
-        return node;
-    }
-};
-
-// P300 QB America Node class
-class P300QBAmericaNode {
-public:
-    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
-        tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
-        node.set_motherboard("SIENAD8-2L2T");
-
-        // Add boards
-        add_boards(&node, "P300", 1, 2);
-
-        // Add WARP400 connections
-        auto* const warp400_connections = get_port_connections(&node, "WARP400");
-        add_connection(warp400_connections, 1, 1, 2, 1);
-        add_connection(warp400_connections, 1, 2, 2, 2);
-
-        return node;
-    }
-};
-
 class WHGalaxyNode {
 private:
     // Add X-torus QSFP connections
     static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_400G");
         add_connection(qsfp_connections, 1, 3, 2, 3);
         add_connection(qsfp_connections, 1, 4, 2, 4);
         add_connection(qsfp_connections, 1, 5, 2, 5);
@@ -151,7 +107,7 @@ private:
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_400G");
         add_connection(qsfp_connections, 1, 2, 3, 2);
         add_connection(qsfp_connections, 1, 1, 3, 1);
         add_connection(qsfp_connections, 2, 1, 4, 1);
@@ -237,11 +193,55 @@ public:
     }
 };
 
+// P150 QB Global Node class
+class P150QBGlobalNode {
+public:
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
+        tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
+        node.set_motherboard("SIENAD8-2L2T");
+
+        // Add boards
+        add_boards(&node, "P150", 1, 4);
+
+        // Add QSFP connections
+        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD_800G");
+        add_connection(qsfp_connections, 1, 1, 2, 1);
+        add_connection(qsfp_connections, 1, 2, 2, 2);
+        add_connection(qsfp_connections, 1, 3, 4, 3);
+        add_connection(qsfp_connections, 1, 4, 4, 4);
+        add_connection(qsfp_connections, 2, 3, 3, 3);
+        add_connection(qsfp_connections, 2, 4, 3, 4);
+        add_connection(qsfp_connections, 3, 1, 4, 1);
+        add_connection(qsfp_connections, 3, 2, 4, 2);
+
+        return node;
+    }
+};
+
+// P300 QB America Node class
+class P300QBAmericaNode {
+public:
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
+        tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
+        node.set_motherboard("SIENAD8-2L2T");
+
+        // Add boards
+        add_boards(&node, "P300", 1, 2);
+
+        // Add WARP400 connections
+        auto* const warp400_connections = get_port_connections(&node, "WARP400");
+        add_connection(warp400_connections, 1, 1, 2, 1);
+        add_connection(warp400_connections, 1, 2, 2, 2);
+
+        return node;
+    }
+};
+
 class BHGalaxyNode {
 private:
     // Add X-torus QSFP connections
     static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_800G");
         add_connection(qsfp_connections, 1, 3, 2, 3);
         add_connection(qsfp_connections, 1, 4, 2, 4);
         add_connection(qsfp_connections, 1, 5, 2, 5);
@@ -254,7 +254,7 @@ private:
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_800G");
         add_connection(qsfp_connections, 1, 2, 3, 2);
         add_connection(qsfp_connections, 1, 1, 3, 1);
         add_connection(qsfp_connections, 2, 1, 4, 1);
@@ -344,12 +344,12 @@ tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create_node_descrip
     switch (node_type) {
         case NodeType::N300_LB: return N300LBNode::create();
         case NodeType::N300_QB: return N300QBNode::create();
-        case NodeType::P150_QB_GLOBAL: return P150QBGlobalNode::create();
-        case NodeType::P300_QB_AMERICA: return P300QBAmericaNode::create();
         case NodeType::WH_GALAXY: return WHGalaxyNode::create();
         case NodeType::WH_GALAXY_X_TORUS: return WHGalaxyXTorusNode::create();
         case NodeType::WH_GALAXY_Y_TORUS: return WHGalaxyYTorusNode::create();
         case NodeType::WH_GALAXY_XY_TORUS: return WHGalaxyXYTorusNode::create();
+        case NodeType::P150_QB_GLOBAL: return P150QBGlobalNode::create();
+        case NodeType::P300_QB_AMERICA: return P300QBAmericaNode::create();
         case NodeType::BH_GALAXY: return BHGalaxyNode::create();
         case NodeType::BH_GALAXY_X_TORUS: return BHGalaxyXTorusNode::create();
         case NodeType::BH_GALAXY_Y_TORUS: return BHGalaxyYTorusNode::create();

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -176,7 +176,8 @@ public:
         tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
         node.set_motherboard("S7T-MB");
 
-        // Add boards
+        // TODO: Use UBB_WORMHOLE instead of UBB. Currently use UBB due enum aliasing not being supported for enum
+        // reflection Add boards
         add_boards(&node, "UBB", 1, 4);
 
         // Add LINKING_BOARD_1 connections
@@ -236,6 +237,108 @@ public:
     }
 };
 
+class BHGalaxyNode {
+private:
+    // Add X-torus QSFP connections
+    static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
+        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        add_connection(qsfp_connections, 1, 3, 2, 3);
+        add_connection(qsfp_connections, 1, 4, 2, 4);
+        add_connection(qsfp_connections, 1, 5, 2, 5);
+        add_connection(qsfp_connections, 1, 6, 2, 6);
+        add_connection(qsfp_connections, 3, 6, 4, 6);
+        add_connection(qsfp_connections, 3, 5, 4, 5);
+        add_connection(qsfp_connections, 3, 4, 4, 4);
+        add_connection(qsfp_connections, 3, 3, 4, 3);
+    }
+
+    // Add Y-torus QSFP connections
+    static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
+        auto* const qsfp_connections = get_port_connections(node, "QSFP");
+        add_connection(qsfp_connections, 1, 2, 3, 2);
+        add_connection(qsfp_connections, 1, 1, 3, 1);
+        add_connection(qsfp_connections, 2, 1, 4, 1);
+        add_connection(qsfp_connections, 2, 2, 4, 2);
+    }
+
+public:
+    // BHGalaxy topology options using one-hot encoding:
+    // MESH = 0 (00) - Mesh
+    // X_TORUS = 0b01 - X-axis torus only (bit 0)
+    // Y_TORUS = 0b10 - Y-axis torus only (bit 1)
+    // XY_TORUS = 0b11 - Both X and Y torus (bits 0+1)
+    enum class BHGalaxyTopology {
+        MESH = 0b00,                   // Mesh
+        X_TORUS = 0b01,                // X-axis torus only
+        Y_TORUS = 0b10,                // Y-axis torus only
+        XY_TORUS = X_TORUS | Y_TORUS,  // Both X and Y torus
+    };
+
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create(
+        BHGalaxyTopology topology = BHGalaxyTopology::MESH) {
+        tt::scaleout_tools::cabling_generator::proto::NodeDescriptor node;
+        node.set_motherboard("S7T-MB");
+
+        // Add boards
+        add_boards(&node, "UBB_BLACKHOLE", 1, 4);
+
+        // Add LINKING_BOARD_1 connections
+        auto* const lb1_connections = get_port_connections(&node, "LINKING_BOARD_1");
+        add_connection(lb1_connections, 1, 1, 2, 1);
+        add_connection(lb1_connections, 1, 2, 2, 2);
+        add_connection(lb1_connections, 3, 1, 4, 1);
+        add_connection(lb1_connections, 3, 2, 4, 2);
+
+        // Add LINKING_BOARD_2 connections
+        auto* const lb2_connections = get_port_connections(&node, "LINKING_BOARD_2");
+        add_connection(lb2_connections, 1, 1, 2, 1);
+        add_connection(lb2_connections, 1, 2, 2, 2);
+        add_connection(lb2_connections, 3, 1, 4, 1);
+        add_connection(lb2_connections, 3, 2, 4, 2);
+
+        // Add LINKING_BOARD_3 connections
+        auto* const lb3_connections = get_port_connections(&node, "LINKING_BOARD_3");
+        add_connection(lb3_connections, 1, 1, 3, 1);
+        add_connection(lb3_connections, 1, 2, 3, 2);
+        add_connection(lb3_connections, 2, 1, 4, 1);
+        add_connection(lb3_connections, 2, 2, 4, 2);
+
+        // Add QSFP connections based on topology (one-hot encoded)
+        if (static_cast<int>(topology) & static_cast<int>(BHGalaxyTopology::X_TORUS)) {  // X_TORUS bit
+            add_x_torus_connections(&node);
+        }
+        if (static_cast<int>(topology) & static_cast<int>(BHGalaxyTopology::Y_TORUS)) {  // Y_TORUS bit
+            add_y_torus_connections(&node);
+        }
+
+        return node;
+    }
+};
+
+// BH Galaxy X Torus Node class
+class BHGalaxyXTorusNode : public BHGalaxyNode {
+public:
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
+        return BHGalaxyNode::create(BHGalaxyTopology::X_TORUS);
+    }
+};
+
+// BH Galaxy Y Torus Node class
+class BHGalaxyYTorusNode : public BHGalaxyNode {
+public:
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
+        return BHGalaxyNode::create(BHGalaxyTopology::Y_TORUS);
+    }
+};
+
+// BH Galaxy XY Torus Node class
+class BHGalaxyXYTorusNode : public BHGalaxyNode {
+public:
+    static tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create() {
+        return BHGalaxyNode::create(BHGalaxyTopology::XY_TORUS);
+    }
+};
+
 // Factory function to create node descriptors by name
 tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create_node_descriptor(NodeType node_type) {
     switch (node_type) {
@@ -247,6 +350,10 @@ tt::scaleout_tools::cabling_generator::proto::NodeDescriptor create_node_descrip
         case NodeType::WH_GALAXY_X_TORUS: return WHGalaxyXTorusNode::create();
         case NodeType::WH_GALAXY_Y_TORUS: return WHGalaxyYTorusNode::create();
         case NodeType::WH_GALAXY_XY_TORUS: return WHGalaxyXYTorusNode::create();
+        case NodeType::BH_GALAXY: return BHGalaxyNode::create();
+        case NodeType::BH_GALAXY_X_TORUS: return BHGalaxyXTorusNode::create();
+        case NodeType::BH_GALAXY_Y_TORUS: return BHGalaxyYTorusNode::create();
+        case NodeType::BH_GALAXY_XY_TORUS: return BHGalaxyXYTorusNode::create();
     }
     throw std::runtime_error("Unknown node type: " + std::string(enchantum::to_string(node_type)));
 }

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -59,7 +59,7 @@ protected:
         add_boards(&node, "N300", 1, 4);
 
         // Add QSFP connections
-        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD_400G");
+        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 1, 4, 1);
         add_connection(qsfp_connections, 2, 2, 3, 2);
 
@@ -94,7 +94,7 @@ class WHGalaxyNode {
 private:
     // Add X-torus QSFP connections
     static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_400G");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 3, 2, 3);
         add_connection(qsfp_connections, 1, 4, 2, 4);
         add_connection(qsfp_connections, 1, 5, 2, 5);
@@ -107,7 +107,7 @@ private:
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_400G");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 2, 3, 2);
         add_connection(qsfp_connections, 1, 1, 3, 1);
         add_connection(qsfp_connections, 2, 1, 4, 1);
@@ -204,7 +204,7 @@ public:
         add_boards(&node, "P150", 1, 4);
 
         // Add QSFP connections
-        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD_800G");
+        auto* const qsfp_connections = get_port_connections(&node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 1, 2, 1);
         add_connection(qsfp_connections, 1, 2, 2, 2);
         add_connection(qsfp_connections, 1, 3, 4, 3);
@@ -241,7 +241,7 @@ class BHGalaxyNode {
 private:
     // Add X-torus QSFP connections
     static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_800G");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 3, 2, 3);
         add_connection(qsfp_connections, 1, 4, 2, 4);
         add_connection(qsfp_connections, 1, 5, 2, 5);
@@ -254,7 +254,7 @@ private:
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
-        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD_800G");
+        auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
         add_connection(qsfp_connections, 1, 2, 3, 2);
         add_connection(qsfp_connections, 1, 1, 3, 1);
         add_connection(qsfp_connections, 2, 1, 4, 1);

--- a/tools/scaleout/node/node_types.hpp
+++ b/tools/scaleout/node/node_types.hpp
@@ -17,6 +17,10 @@ enum class NodeType {
     WH_GALAXY_XY_TORUS,
     P150_QB_GLOBAL,
     P300_QB_AMERICA,
+    BH_GALAXY,
+    BH_GALAXY_X_TORUS,
+    BH_GALAXY_Y_TORUS,
+    BH_GALAXY_XY_TORUS,
 };
 
 NodeType get_node_type_from_string(const std::string& node_name);

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -8,13 +8,7 @@ set_target_properties(
 )
 
 # Add the protobuf generated headers directory for tests
-target_include_directories(
-    test_factory_system_descriptor
-    SYSTEM
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../scaleout
-        ${CMAKE_CURRENT_BINARY_DIR}/../../scaleout
-)
+target_include_directories(test_factory_system_descriptor SYSTEM PRIVATE ${CMAKE_BINARY_DIR}/tools/scaleout)
 
 target_link_libraries(
     test_factory_system_descriptor

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -7,10 +7,20 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tools/scaleout
 )
 
+# Add the protobuf generated headers directory for tests
+target_include_directories(
+    test_factory_system_descriptor
+    SYSTEM
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../scaleout
+        ${CMAKE_CURRENT_BINARY_DIR}/../../scaleout
+)
+
 target_link_libraries(
     test_factory_system_descriptor
     PRIVATE
         TT::ScaleoutTools
         gmock_main
         enchantum::enchantum
+        protobuf::libprotobuf
 )

--- a/tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto
@@ -19,7 +19,7 @@ graph_templates {
     }
     # Internal superpod connections
     internal_connections {
-      key: "QSFP_DD_400G"
+      key: "QSFP_DD"
       value {
         connections {
           port_a { path: ["node1"] tray_id: 1 port_id: 2 }
@@ -72,7 +72,7 @@ graph_templates {
     }
     # Inter-superpod connections
     internal_connections {
-      key: "QSFP_DD_400G"
+      key: "QSFP_DD"
       value {
         connections {
           port_a { path: ["superpod1", "node1"] tray_id: 2 port_id: 1 }

--- a/tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto
@@ -19,7 +19,7 @@ graph_templates {
     }
     # Internal superpod connections
     internal_connections {
-      key: "QSFP"
+      key: "QSFP_DD_400G"
       value {
         connections {
           port_a { path: ["node1"] tray_id: 1 port_id: 2 }
@@ -72,7 +72,7 @@ graph_templates {
     }
     # Inter-superpod connections
     internal_connections {
-      key: "QSFP"
+      key: "QSFP_DD_400G"
       value {
         connections {
           port_a { path: ["superpod1", "node1"] tray_id: 2 port_id: 1 }

--- a/tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto
@@ -22,7 +22,7 @@ graph_templates {
       node_ref { node_descriptor: "N300_LB" }
     }
     internal_connections {
-      key: "QSFP_DD_400G"
+      key: "QSFP_DD"
       value {
         connections {
           port_a { path: ["node1"] tray_id: 4 port_id: 2 }

--- a/tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto
@@ -22,7 +22,7 @@ graph_templates {
       node_ref { node_descriptor: "N300_LB" }
     }
     internal_connections {
-      key: "QSFP"
+      key: "QSFP_DD_400G"
       value {
         connections {
           port_a { path: ["node1"] tray_id: 4 port_id: 2 }

--- a/tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto
@@ -22,7 +22,7 @@ graph_templates {
       node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" }
     }
     internal_connections {
-      key: "QSFP"
+      key: "QSFP_DD_400G"
       value {
         connections { port_a { path: ["node3"] tray_id: 4 port_id: 3 } port_b { path: ["node2"] tray_id: 4 port_id: 3 } }
         connections { port_a { path: ["node3"] tray_id: 4 port_id: 4 } port_b { path: ["node1"] tray_id: 4 port_id: 4 } }

--- a/tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto
@@ -22,7 +22,7 @@ graph_templates {
       node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" }
     }
     internal_connections {
-      key: "QSFP_DD_400G"
+      key: "QSFP_DD"
       value {
         connections { port_a { path: ["node3"] tray_id: 4 port_id: 3 } port_b { path: ["node2"] tray_id: 4 port_id: 3 } }
         connections { port_a { path: ["node3"] tray_id: 4 port_id: 4 } port_b { path: ["node1"] tray_id: 4 port_id: 4 } }

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -6,58 +6,72 @@
 #include <enchantum/enchantum.hpp>
 #include <fstream>
 #include <filesystem>
-#include <sstream>
+#include <google/protobuf/text_format.h>
 
 #include <cabling_generator/cabling_generator.hpp>
 #include <factory_system_descriptor/utils.hpp>
 #include <node/node_types.hpp>
 
+// Include generated protobuf headers
+#include "protobuf/deployment.pb.h"
+#include "protobuf/cluster_config.pb.h"
+
 namespace tt::scaleout_tools {
 
-// Helper function to generate deployment descriptor textproto content
-std::string generate_deployment_descriptor(const std::string& node_type_string) {
-    std::ostringstream oss;
-    oss << "hosts: {\n";
-    oss << "  hall: \"0\"\n";
-    oss << "  aisle: \"0\"\n";
-    oss << "  rack: 0\n";
-    oss << "  shelf_u: 0\n";
-    oss << "  node_type: \"" << node_type_string << "\"\n";
-    oss << "  host: \"host\"\n";
-    oss << "}\n";
-    return oss.str();
+// Helper function to create deployment descriptor protobuf object
+void create_deployment_descriptor(
+    const std::string& node_type_string, tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment) {
+    deployment.set_rack_capacity(1);
+
+    auto* host = deployment.add_hosts();
+    host->set_hall("0");
+    host->set_aisle("0");
+    host->set_rack(0);
+    host->set_shelf_u(0);
+    host->set_node_type(node_type_string);
+    host->set_host("host");
 }
 
-// Helper function to generate cluster config textproto content for a single node
-std::string generate_cluster_config(const std::string& node_type_string) {
-    std::ostringstream oss;
-    oss << "graph_templates {\n";
-    oss << "  key: \"single_" << node_type_string << "\"\n";
-    oss << "  value {\n";
-    oss << "    children {\n";
-    oss << "      name: \"node1\"\n";
-    oss << "      node_ref { node_descriptor: \"" << node_type_string << "\" }\n";
-    oss << "    }\n";
-    oss << "  }\n";
-    oss << "}\n";
-    oss << "\n";
-    oss << "# Root instance with concrete host mapping\n";
-    oss << "root_instance {\n";
-    oss << "  template_name: \"single_" << node_type_string << "\"\n";
-    oss << "  child_mappings {\n";
-    oss << "    key: \"node1\"\n";
-    oss << "    value { host_id: 0 }\n";
-    oss << "  }\n";
-    oss << "}\n";
-    return oss.str();
+// Helper function to create cluster config protobuf object for a single node
+void create_cluster_config(
+    const std::string& node_type_string, tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster) {
+    // Create graph template
+    auto& graph_template = cluster.mutable_graph_templates()->operator[]("single_" + node_type_string);
+    auto* child = graph_template.add_children();
+    child->set_name("node1");
+    auto* node_ref = child->mutable_node_ref();
+    node_ref->set_node_descriptor(node_type_string);
+
+    // Create root instance
+    auto* root_instance = cluster.mutable_root_instance();
+    root_instance->set_template_name("single_" + node_type_string);
+    auto& child_mapping = root_instance->mutable_child_mappings()->operator[]("node1");
+    child_mapping.set_host_id(0);
 }
 
-// Helper function to write content to a temporary file
-std::string write_temp_file(const std::string& content, const std::string& suffix) {
+// Helper function to serialize protobuf object to a temporary file
+template <typename ProtoType>
+std::string serialize_proto_to_temp_file(const ProtoType& proto, const std::string& suffix) {
     std::string temp_path = std::filesystem::temp_directory_path() / ("temp_" + suffix);
-    std::ofstream file(temp_path);
-    file << content;
-    file.close();
+
+    std::ofstream output_file(temp_path);
+    if (!output_file.is_open()) {
+        throw std::runtime_error("Failed to open output file: " + temp_path);
+    }
+
+    std::string output_string;
+    google::protobuf::TextFormat::Printer printer;
+    printer.SetUseShortRepeatedPrimitives(true);
+    printer.SetUseUtf8StringEscaping(true);
+    printer.SetSingleLineMode(false);
+    printer.SetPrintMessageFieldsInIndexOrder(true);
+
+    if (!printer.PrintToString(proto, &output_string)) {
+        throw std::runtime_error("Failed to write textproto to file: " + temp_path);
+    }
+
+    output_file << output_string;
+    output_file.close();
     return temp_path;
 }
 
@@ -65,12 +79,17 @@ TEST(Cluster, TestFactorySystemDescriptorSingleNodeTypes) {
     for (auto node_type : enchantum::values_generator<NodeType>) {
         auto node_type_string = std::string(enchantum::to_string(node_type));
 
-        // Generate temporary file names
-        std::string deployment_file = write_temp_file(
-            generate_deployment_descriptor(node_type_string), node_type_string + "_deployment.textproto");
+        // Create protobuf objects
+        tt::scaleout_tools::deployment::proto::DeploymentDescriptor deployment;
+        tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor cluster;
 
-        std::string cluster_file =
-            write_temp_file(generate_cluster_config(node_type_string), node_type_string + "_cluster.textproto");
+        create_deployment_descriptor(node_type_string, deployment);
+        create_cluster_config(node_type_string, cluster);
+
+        // Serialize to temporary files
+        std::string deployment_file =
+            serialize_proto_to_temp_file(deployment, node_type_string + "_deployment.textproto");
+        std::string cluster_file = serialize_proto_to_temp_file(cluster, node_type_string + "_cluster.textproto");
 
         std::string fsd_file = "fsd/factory_system_descriptor_" + node_type_string + ".textproto";
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
BH galaxy wasn't supported in the cabling generator due to unknown linking board and no BoardType enum value.

### What's changed
Add support for BH galaxy in cabling generator, but output a warning about linking board information not being finalized.
Uplift tests to test BH galaxy node and use protobuf instead of manually writing a textproto.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes