### PR TITLE
Gemma3 multi image test is not on by default

### DIFF
--- a/models/demos/gemma3/demo/vision_demo.py
+++ b/models/demos/gemma3/demo/vision_demo.py
@@ -166,15 +166,25 @@ def prepare_generator_args(
     ids=["normal"],
 )
 @pytest.mark.parametrize(
-    "warmup_iters, enable_trace, max_batch_size, include_text_only_prompts, max_gen_len, num_layers",
+    "warmup_iters, enable_trace, max_batch_size, include_text_only_prompts, multi_image, max_gen_len, num_layers",
     [
-        (0, False, 1, False, 500, None),  # batch1-notrace
-        (0, True, 1, False, 500, None),  # batch1-trace
-        (0, True, 32, False, 500, None),  # batch32-trace
-        (0, True, 4, True, 500, None),  # batch4-trace-with-text-prompts
-        (0, True, 1, False, 5, 1),  # tracy
+        (0, False, 1, False, False, 500, None),  # batch1-notrace
+        (0, True, 1, False, False, 500, None),  # batch1-trace
+        (0, True, 32, False, False, 500, None),  # batch32-trace
+        (0, True, 4, True, False, 500, None),  # batch4-trace-with-text-prompts
+        (0, False, 1, True, True, 500, None),  # batch1-multi-image-notrace
+        (0, True, 1, True, True, 500, None),  # batch1-multi-image-trace
+        (0, True, 1, False, False, 5, 1),  # tracy
     ],
-    ids=["batch1-notrace", "batch1-trace", "batch32-trace", "batch4-trace-with-text-prompts", "tracy"],
+    ids=[
+        "batch1-notrace",
+        "batch1-trace",
+        "batch32-trace",
+        "batch4-trace-with-text-prompts",
+        "batch1-multi-image-notrace",
+        "batch1-multi-image-trace",
+        "tracy",
+    ],
 )
 @pytest.mark.parametrize(
     "data_parallel",
@@ -202,6 +212,7 @@ def test_multimodal_demo_text(
     enable_trace,
     max_batch_size,
     include_text_only_prompts,
+    multi_image,
     data_parallel,
     test_type,
     max_seq_len,
@@ -267,30 +278,51 @@ def test_multimodal_demo_text(
     with open(IMG_PATH / "dog.jpg", "rb") as f:
         img = PIL_Image.open(f).convert("RGB")
 
-    cats_image_1 = PIL_Image.open(
+    bee_image = PIL_Image.open(
         BytesIO(
             requests.get(
-                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg"
             ).content
         )
     ).convert("RGB")
-    cats_image_2 = PIL_Image.open(
-        BytesIO(
-            requests.get(
-                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png"
-            ).content
-        )
-    ).convert("RGB")
-    logger.info(f"Cats images dimensions: {cats_image_1.size} and {cats_image_2.size} (width x height)")
+    logger.info(f"Bee image dimensions: {bee_image.size} (width x height)")
+
+    if multi_image:
+        cats_image_1 = PIL_Image.open(
+            BytesIO(
+                requests.get(
+                    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                ).content
+            )
+        ).convert("RGB")
+        cats_image_2 = PIL_Image.open(
+            BytesIO(
+                requests.get(
+                    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.png"
+                ).content
+            )
+        ).convert("RGB")
+        logger.info(f"Cats images dimensions: {cats_image_1.size} and {cats_image_2.size} (width x height)")
+
+        # Trace capture dialogs with random images
+        multi_image_dialogs = [
+            [
+                UserMessage(
+                    content=[ImageMedia(image=cats_image_1), ImageMedia(image=cats_image_2), "Compare these images."]
+                )
+            ],
+        ]
 
     # Trace capture dialogs with random images
     trace_dialogs = [
-        [
-            UserMessage(
-                content=[ImageMedia(image=cats_image_1), ImageMedia(image=cats_image_2), "Compare these images."]
-            )
-        ],
+        [UserMessage(content=[ImageMedia(image=trace_img_1120x560), "What do you see in this image?"])],
+        [UserMessage(content=[ImageMedia(image=img), "What do you see in this image?"])],
+        [UserMessage(content=[ImageMedia(image=ocr_image), "What is the full text of this image? Do OCR"])],
+        [UserMessage(content=[ImageMedia(image=img), "Describe this image in detail."])],
     ]
+
+    if multi_image:
+        trace_dialogs = multi_image_dialogs + trace_dialogs
 
     if len(trace_dialogs) < max_batch_size:
         trace_dialogs *= max_batch_size // len(trace_dialogs)
@@ -302,14 +334,14 @@ def test_multimodal_demo_text(
             img = PIL_Image.open(f).convert("RGB")
         logger.info(f"Dog image dimensions: {img.size} (width x height)")
 
+        with open(IMG_PATH / "pasta.jpeg", "rb") as f:
+            img2 = PIL_Image.open(f).convert("RGB")
+        logger.info(f"Pasta image dimensions: {img2.size} (width x height)")
+
         # Regular testing dialogs with original images
         dialogs = [
-            [
-                UserMessage(
-                    content=[ImageMedia(image=cats_image_1), ImageMedia(image=cats_image_2), "Compare these images."]
-                )
-            ],
             [UserMessage(content=[ImageMedia(image=img), "Write a haiku for this image."])],
+            [UserMessage(content=[ImageMedia(image=img2), "What is for dinner?"])],
             [UserMessage(content=[ImageMedia(image=ocr_image), "What is the full text of this image? Do OCR"])],
             [UserMessage(content=[ImageMedia(image=clutter), "What objects are in this image?"])],
         ]
@@ -321,6 +353,10 @@ def test_multimodal_demo_text(
             [UserMessage(content=[ImageMedia(image=ocr_image), "What is the full text of this image? Do OCR"])],
             [UserMessage(content=[ImageMedia(image=clutter), "What objects are in this image?"])],
         ]
+
+    if multi_image:
+        dialogs = multi_image_dialogs + dialogs
+
     if len(dialogs) < max_batch_size:
         dialogs *= max_batch_size // len(dialogs)
 
@@ -342,6 +378,8 @@ def test_multimodal_demo_text(
             for dialog in batch_dialogs:
                 for msg in dialog:
                     print(f"{msg.role.capitalize()}: {msg.content}\n")
+
+            logger.info(f"Starting processor for batch {batch_idx}")
             batch_model_input = [
                 prompt_encoder(dialog, processor) if HF_MODEL else prompt_encoder(dialog, tool_prompt_format=False)
                 for dialog in batch_dialogs

--- a/models/demos/gemma3/tt/gemma_e2e_model.py
+++ b/models/demos/gemma3/tt/gemma_e2e_model.py
@@ -4,6 +4,7 @@
 from typing import List
 
 import torch
+from loguru import logger
 
 import ttnn
 from models.demos.gemma3.tt.gemma_vision_model import TtGemmaTransformerVision
@@ -133,5 +134,7 @@ class TtGemmaModel(Transformer):
         return tokens_embd, tt_rot_mats_prefill_global, tt_rot_mats_prefill_local, tt_page_table, tt_chunk_page_table
 
     def compute_vision_token(self, pixel_values):
+        logger.info(f"Starting vision encoder for {pixel_values.shape[0]} images")
         vision_output = self.vision_model(pixel_values)
+        logger.info(f"Vision encoder done")
         return vision_output


### PR DESCRIPTION
### Ticket
n/a

### Problem description
Gemma3 T3K multi-image tests are causing hangs in the later prompts
https://github.com/tenstorrent/tt-metal/actions/runs/17758202932/job/50465490328

### What's changed
Remove multi-image tests from the default Gemma3 suite until the hangs are resolved.

### Checklist
[![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=ppetrovic%2Fgemma3-reduce-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/17761464905) - Gemma3 test passes, other errors are unrelated.
[![(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml/badge.svg?branch=ppetrovic%2Fgemma3-reduce-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/17763945898)