### PR TITLE
Enable fast_tilize for bfp4_b output in pool

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -55,7 +55,6 @@ void MAIN {
     constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(19);
     constexpr bool is_output_tiled = get_compile_time_arg_val(20);  // 1 = TILED, 0 = ROW_MAJOR
     constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(21);
-    constexpr bool is_output_bfp4_b = (bool)get_compile_time_arg_val(22);
 
     constexpr uint32_t topk_output_tiles = 1;
     constexpr uint32_t topk_cb_tile_idx = 0;
@@ -228,16 +227,10 @@ void MAIN {
                         unary_op_init_common(pre_tilize_cb_id, out_cb_id);
                         tensix_sync();
 
-                        // Skip fast_tilize path for bfp4_b output until #28380 is closed
-                        if constexpr (is_output_bfp4_b) {
-                            tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                            tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                            tilize_uninit(pre_tilize_cb_id, out_cb_id);
-                        } else {
-                            fast_tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                            fast_tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                            fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
-                        }
+                        fast_tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                        fast_tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                        fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
+
                         cb_push_back(out_cb_id, in_ntiles_c);
 
                         if constexpr (is_output_block_format) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -418,7 +418,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     const bool is_output_tiled = output_layout == Layout::TILE;
     const bool is_output_block_format = is_block_float(outputs[0].dtype());
-    const bool is_output_bfp4_b = outputs[0].dtype() == DataType::BFLOAT4_B;
 
     // Conditionally allocate temporary CB - only needed for TILED output
     uint32_t pre_tilize_cb_id = 32;  // default invalid CB ID
@@ -619,8 +618,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         (uint32_t)return_indices,       // 18
         pre_tilize_cb_id,               // 19
         is_output_tiled,                // 20
-        is_output_block_format,         // 21
-        is_output_bfp4_b};              // 22
+        is_output_block_format};        // 21
 
     auto compute_config = tt::tt_metal::ComputeConfig{
         .math_fidelity = MathFidelity::HiFi4,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -265,8 +265,6 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
     const uint32_t pre_tilize_cb_id =
         32;  // Unused CB for pool compute kernel for grid sample, we don't have tiled output in gridsample
 
-    const bool is_output_bfp4_b = false;
-
     // Compute kernels
     const uint32_t channels_per_shard = input_shape[-1];
     const uint32_t in_nblocks_c = (uint32_t)std::ceil((float)in_ntiles_c / MAX_TILES_PER_REDUCTION);
@@ -296,7 +294,6 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             pre_tilize_cb_id,                  // ct_arg[19]: pre_tilize_cb_id
             is_output_tiled ? 1U : 0U,         // ct_arg[20]: is_output_tiled
             is_output_block_format ? 1U : 0U,  // ct_arg[21]: is_output_block_format
-            is_output_bfp4_b ? 1U : 0U         // ct_arg[22]: is_output_bfp4_b
         };
 
         return tt::tt_metal::CreateKernel(


### PR DESCRIPTION
### What's changed
After https://github.com/tenstorrent/tt-metal/pull/28560 is merged, fast tilize can be enabled for bfp4_b case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17772413804)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17764270169)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17764293130)