### PR TITLE
Make ULP formula handle input == dtype.max properly

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -598,8 +598,6 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
         x = ttnn.to_torch(x)
         received_ttnn_input = True
 
-    max_value = torch.full(x.size(), torch.finfo(x.dtype).max, dtype=x.dtype)
-
     # Notes:
     # - This should be identical to the definition of ULP by Goldberg
     #   "What every computer scientist should know about floating-point arithmetic"
@@ -608,8 +606,17 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
     # - For x powers of 2, x + ULP(x) is not closest number but second closest (previous number is 2x closer)
     #   However, this avoids rounding-to-nearest-tie-to-even issues on addition (i.e. x + ULP(x) != x)
     abs_x = torch.abs(x)
-    next = torch.nextafter(abs_x, max_value)  # 1 ULP ~ Difference between two consecutive floating point numbers
+    next = torch.nextafter(
+        abs_x, torch.tensor(math.inf, dtype=x.dtype)
+    )  # 1 ULP ~ Difference between two consecutive floating point numbers
     ulp_value = next - abs_x
+
+    # Special case: if abs_x == torch.finfo(x.dtype).max, then next == math.inf, which leads to ULP(x) == inf rather than finite number
+    # We fix this problem by manually calculating ULP at max value, and masking tensor when input == max
+    max_epsilon = torch.finfo(x.dtype).max - torch.nextafter(
+        torch.tensor(torch.finfo(x.dtype).max, dtype=x.dtype), torch.tensor(-math.inf, dtype=x.dtype)
+    )
+    ulp_value = torch.where(abs_x == torch.finfo(x.dtype).max, max_epsilon, ulp_value)
 
     if received_ttnn_input:  # Ensures that type(input) == type(output)
         ulp_value = ttnn.from_torch(ulp_value)

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -613,10 +613,11 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
 
     # Special case: if abs_x == torch.finfo(x.dtype).max, then next == math.inf, which leads to ULP(x) == inf rather than finite number
     # We fix this problem by manually calculating ULP at max value, and masking tensor when input == max
-    max_epsilon = torch.finfo(x.dtype).max - torch.nextafter(
-        torch.tensor(torch.finfo(x.dtype).max, dtype=x.dtype), torch.tensor(-math.inf, dtype=x.dtype)
+    dtype_max = torch.finfo(x.dtype).max
+    max_epsilon = dtype_max - torch.nextafter(
+        torch.tensor(dtype_max, dtype=x.dtype), torch.tensor(-math.inf, dtype=x.dtype)
     )
-    ulp_value = torch.where(abs_x == torch.finfo(x.dtype).max, max_epsilon, ulp_value)
+    ulp_value = torch.where(abs_x == dtype_max, max_epsilon, ulp_value)
 
     if received_ttnn_input:  # Ensures that type(input) == type(output)
         ulp_value = ttnn.from_torch(ulp_value)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
ULP calculation relies on `torch.nextafter(x, dtype.max()) - x`. The error is then obtained by dividing absolute difference with ULP resolution.
This is fine for most inputs, except for maximum value (`dtype.max()` for a given dtype), as `torch.nextafter(dtype.max(), dtype.max()) = inf` which leads to arithmetic operations on infinite. 

This can be inconvenient for exhaustive tests / accuracy characterization. 

### What's changed
With this PR, `ulp()` explicitly handle 'dtype.max()` value. Their ULP should be the same as 'previous(dtype.max())'.  

For example:

| DType | Input | ULP Before | ULP After |
|-|-|-|-|
| bfloat16 | 3.3895e+38 |  0 | 1.329227995784916e+36 |
| float32 | 3.4028e+38 | 0 | 2.028240960365167e+31 |
| bfloat16 |-3.3895e+38 |  0 | 1.329227995784916e+36 |
| float32 | -3.4028e+38 | 0 | 2.028240960365167e+31 |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/17863858598
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/17762166677
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes