### PR TITLE
[skip ci] Remove dev tags from setuptool-scm recgonition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ line-length = 120
 # Supported tag formats:
 # v1.2.3, v1.2.3-rc1, v1.2.3-dev20240101, v1.2.3-dev123
 tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-(?:rc\d+|dev(?:\d{8}|\d+)))?)$'
+#Only look for release tags for calculating distance for wheel name
 git_describe_command = [
   "git","describe","--dirty","--tags","--long",
   "--match","v[0-9]*.[0-9]*.[0-9]*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-rc\d+)?)$'
 git_describe_command = [
   "git","describe","--dirty","--tags","--long",
   "--match","v[0-9]*.[0-9]*.[0-9]*",
-  "--match","v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*"
+  "--match","v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*",
+  "--exclude","*-dev*"
 ]
 fallback_version = "0.0.0.dev0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-(?:rc\d+|dev(?:\d{8}|\d+)))?)$'
 git_describe_command = [
   "git","describe","--dirty","--tags","--long",
   "--match","v[0-9]*.[0-9]*.[0-9]*",
-  "--match","v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*",
-  "--match","v[0-9]*.[0-9]*.[0-9]*-dev????????",
-  "--match","v[0-9]*.[0-9]*.[0-9]*-dev[0-9]*"
+  "--match","v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*"
 ]
 fallback_version = "0.0.0.dev0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ line-length = 120
 
 [tool.setuptools_scm]
 # Supported tag formats:
-# v1.2.3, v1.2.3-rc1, v1.2.3-dev20240101, v1.2.3-dev123
+# v1.2.3, v1.2.3-rc1
 tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-rc\d+)?)$'
 #Only look for release tags for calculating distance for wheel name
 git_describe_command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ line-length = 120
 [tool.setuptools_scm]
 # Supported tag formats:
 # v1.2.3, v1.2.3-rc1, v1.2.3-dev20240101, v1.2.3-dev123
-tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-(?:rc\d+|dev(?:\d{8}|\d+)))?)$'
+tag_regex = '^(?:v)?(?P<version>\d+\.\d+\.\d+(?:-rc\d+)?)$'
 #Only look for release tags for calculating distance for wheel name
 git_describe_command = [
   "git","describe","--dirty","--tags","--long",


### PR DESCRIPTION
### Problem description
Dev tags are making dev build problems so we are ignoring them as they are only pointing to dev hash

### What's changed
Removed regex for dev tags