### PR TITLE
added stable_diffusion perf test for blackhole

### DIFF
--- a/models/demos/blackhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/blackhole/stable_diffusion/tests/test_perf.py
@@ -1,0 +1,1 @@
+../../../wormhole/stable_diffusion/tests/test_perf.py

--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 19616
+SD_L1_SMALL_SIZE = 20928
 # Trace Region Size Constants
-SD_TRACE_REGION_SIZE = 789835776
+SD_TRACE_REGION_SIZE = 814510080

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -251,7 +251,7 @@ def test_stable_diffusion_vae_trace(device):
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [
-        (1, 50, 3600, 6.31),  # Issue 7816 Inference time
+        (1, 50, 3600, 6.31) if is_wormhole_b0() else (1, 50, 3600, 3.50),  # Wormhole B0 vs Blackhole performance
     ],
 )
 def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected_compile_time, expected_inference_time):
@@ -408,7 +408,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((12.8),),
+    ((12.8) if is_wormhole_b0() else (20.0),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -95,7 +95,7 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 }
 
 run_python_model_tests_blackhole() {
-    pytest models/demos/blackhole/stable_diffusion/tests
+    pytest models/demos/blackhole/stable_diffusion/tests --ignore=models/demos/blackhole/stable_diffusion/tests/test_perf.py
 
     # Llama3.1-8B
     llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/


### PR DESCRIPTION
### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/28542 introduces P150 runners, stable_diffusion is skipped due to
not having blackhole perf tests, this PR fixes that

### What's changed
- added symlink for perf test
- bumped L1_Small usage and trace region size

### Checklist
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17768574528)