### PR TITLE
Implement interleaved MM layout conversion for conv weights [KhKwCi, Co]

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -360,7 +360,7 @@ def run_conv(
         if pcc_msg == 1:
             # Conv2d with randomized input and weights can't legitimately return PCC of 1
             # Edge case can happen rarely if activation function like ReLU zeros out all values
-            # in this case tensors have to match.
+            # In this case, tensors have to match.
             assert_equal(out, ref)
 
     if memory_config:

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -13,7 +13,7 @@ from models.utility_functions import (
 )
 from models.utility_functions import skip_for_blackhole, run_for_blackhole
 from tests.ttnn.unit_tests.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout, assert_equal
 import ttnn
 from ttnn.operations.conv2d import get_torch_act_func_from_string
 
@@ -357,7 +357,11 @@ def run_conv(
         passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
         logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
         assert passing, pcc_msg
-        assert pcc_msg != 1, "Conv2d with ranndomized input and wegihts can't ligitimately return PCC of 1"
+        if pcc_msg == 1:
+            # Conv2d with randomized input and weights can't legitimately return PCC of 1
+            # Edge case can happen rarely if activation function like ReLU zeros out all values
+            # in this case tensors have to match.
+            assert_equal(out, ref)
 
     if memory_config:
         output_memory_config = ttnn.get_memory_config(tt_output_tensor_on_device)
@@ -1772,7 +1776,7 @@ def test_sd14_vae_conv(
         (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 16 * 32}),
         (2, 16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 16 * 32}),
         (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 16 * 32}),
-        # (2, 1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32}, False) # Enable when issue #11490 resolved
+        (2, 1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 5 * 32}),
     ),
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -652,6 +652,7 @@ Result conv2d_L1(
         groups,
         opt_conv_op_block_config.act_block_h_ntiles,
         input_width,
+        mm_conv && auto_shard,
         bias_tensor.has_value(),
         true,  // parameters_on_device
         conv_config.enable_kernel_stride_folding,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1289,7 +1289,7 @@ static ttnn::Tensor prepare_conv_weights_internal(
     weight_tensor_ =
         ttnn::pad(weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
     // for conv op, pad the weights to block shape
-    if (params.interlaved_mm_conv) {
+    if (params.interleaved_mm_conv) {
         // Use interleaved MM layout conversion: [Co, Ci, Kh, Kw] -> [1, 1, KhKwCi, Co] and tilize
         weight_tensor_ = convert_conv_weight_tensor_to_interleaved_mm_layout(weight_tensor_, weight_tensor_.dtype());
     } else if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -245,6 +245,65 @@ Tensor to_weight_special_padding_tile_layout(
 }
 
 template <typename T>
+Tensor to_weight_interleaved_mm_layout(const Tensor& conv_weight_tensor, DataType output_dtype) {
+    auto w_shape = conv_weight_tensor.padded_shape();
+    uint32_t Co = w_shape[0];  // Output channels
+    uint32_t Ci = w_shape[1];  // Input channels
+    uint32_t Kh = w_shape[2];  // Kernel height
+    uint32_t Kw = w_shape[3];  // Kernel width
+
+    // Output shape: [1, 1, KhKwCi, Co]
+    uint32_t weight_matrix_rows = Kh * Kw * Ci;
+    uint32_t weight_matrix_cols = Co;
+
+    // Pad to tile boundaries
+    uint32_t weight_matrix_rows_padded = tt::round_up(weight_matrix_rows, constants::TILE_HEIGHT);
+    uint32_t weight_matrix_cols_padded = tt::round_up(weight_matrix_cols, constants::TILE_WIDTH);
+
+    const ttnn::Shape output_shape{1, 1, weight_matrix_rows_padded, weight_matrix_cols_padded};
+
+    auto compute = [&w_shape, weight_matrix_cols_padded, &output_shape, output_dtype](
+                       const tt::tt_metal::HostBuffer& input_host_buffer) {
+        auto input_buffer = tt::tt_metal::host_buffer::get_as<T>(input_host_buffer);
+
+        auto output_buffer = std::vector<T>(output_shape.volume(), T(0));
+
+        // Convert from [Co, Ci, Kh, Kw] to [1, 1, KhKwCi, Co]
+        WeightLayoutThreader::parallel_for_channels(
+            w_shape[0],  // Co
+            w_shape[1],  // Ci
+            16,          // Minimum work per thread
+            [&](uint32_t out_t, uint32_t in_t, uint32_t co_start, uint32_t co_end, uint32_t ci_start, uint32_t ci_end) {
+                for (auto kh = 0; kh < w_shape[2]; kh++) {
+                    for (auto kw = 0; kw < w_shape[3]; kw++) {
+                        for (auto ci = ci_start; ci < ci_end; ci++) {
+                            for (auto co = co_start; co < co_end; co++) {
+                                // Input index: [Co, Ci, Kh, Kw]
+                                auto input_idx = co * w_shape[1] * w_shape[2] * w_shape[3] +
+                                                 ci * w_shape[2] * w_shape[3] + kh * w_shape[3] + kw;
+
+                                // Output index: [1, 1, KhKwCi, Co]
+                                auto output_row = kh * w_shape[3] * w_shape[1] + kw * w_shape[1] + ci;
+                                auto output_idx = output_row * weight_matrix_cols_padded + co;
+
+                                output_buffer[output_idx] = input_buffer[input_idx];
+                            }
+                        }
+                    }
+                }
+            });
+
+        return create_host_buffer_for_conv_weight<T>(
+            tt::tt_metal::HostBuffer(std::move(output_buffer)), output_dtype, output_shape);
+    };
+
+    const TensorSpec output_spec(
+        output_shape, tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::TILE), MemoryConfig{}));
+
+    return convert_tensor<T>(conv_weight_tensor, compute, output_spec);
+}
+
+template <typename T>
 Tensor to_weight_tile_layout(
     const Tensor& conv_weight_tensor, uint32_t in1_block_h, uint32_t in1_block_w, DataType output_dtype) {
     auto w_shape = conv_weight_tensor.padded_shape();
@@ -301,6 +360,19 @@ Tensor to_weight_tile_layout(
         output_shape, tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::TILE), MemoryConfig{}));
 
     return convert_tensor<T>(conv_weight_tensor, compute, output_spec);
+}
+
+// Converts convolution weights to interleaved MM layout [1, 1, KhKwCi, Co] and tilizes
+// Returns a new tensor with layout=Tile
+Tensor convert_conv_weight_tensor_to_interleaved_mm_layout(
+    const Tensor& conv_weight_tensor, std::optional<DataType> output_dtype) {
+    const static std::unordered_map<DataType, std::function<Tensor(const Tensor&, DataType)>>
+        to_w_interleaved_mm_layout_map = {
+            {DataType::BFLOAT16, &to_weight_interleaved_mm_layout<bfloat16>},
+            {DataType::FLOAT32, &to_weight_interleaved_mm_layout<float>},
+            {DataType::UINT32, &to_weight_interleaved_mm_layout<uint32_t>}};
+
+    return convert_tensor_to_tiled_layout_common(conv_weight_tensor, output_dtype, to_w_interleaved_mm_layout_map);
 }
 
 // Converts convolution weights to tilized 2d matrix layout.
@@ -1132,6 +1204,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     ParallelConfig output_parallel_config = determine_output_parallel_config(
         parallel_config, device->compute_with_storage_grid_size(), out_channels, shard_orientation, mm_conv);
 
+    const bool auto_shard = !input_memory_config.is_sharded() && !conv_config.shard_layout.has_value();
     return Conv2dWeightsBiasPrepConfig(
         input_channels_alignment,
         conv_config.weights_dtype,
@@ -1142,6 +1215,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
         groups,
         opt_conv_op_block_config.act_block_h_ntiles,
         input_width,
+        mm_conv && auto_shard,
         has_bias,
         true,  // parameters_on_device
         conv_config.enable_kernel_stride_folding,
@@ -1215,7 +1289,10 @@ static ttnn::Tensor prepare_conv_weights_internal(
     weight_tensor_ =
         ttnn::pad(weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
     // for conv op, pad the weights to block shape
-    if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+    if (params.interlaved_mm_conv) {
+        // Use interleaved MM layout conversion: [Co, Ci, Kh, Kw] -> [1, 1, KhKwCi, Co] and tilize
+        weight_tensor_ = convert_conv_weight_tensor_to_interleaved_mm_layout(weight_tensor_, weight_tensor_.dtype());
+    } else if (params.input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
         weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
             weight_tensor_,
             params.weight_block_h_ntiles,
@@ -1344,7 +1421,7 @@ ttnn::Tensor prepare_conv_weights(
     }
 
     // Use common setup function to get configuration parameters
-    auto params = setup_conv_prep_config(
+    Conv2dWeightsBiasPrepConfig params = setup_conv_prep_config(
         input_memory_config,
         input_layout,
         in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -129,7 +129,7 @@ struct Conv2dWeightsBiasPrepConfig {
         uint32_t groups_,
         uint32_t act_block_h_ntiles_,
         uint32_t input_width_,
-        bool interlaved_mm_conv_,
+        bool interlaved_mm_conv,
         bool has_bias_ = false,
         bool parameters_on_device_ = true,
         bool enable_kernel_stride_folding_ = false,
@@ -155,7 +155,7 @@ struct Conv2dWeightsBiasPrepConfig {
         kernel_size(kernel_size_),
         stride(stride_),
         padding_n4(padding_n4_),
-        interlaved_mm_conv(interlaved_mm_conv_) {}
+        interleaved_mm_conv(interlaved_mm_conv) {}
 
     // Common parameters
     const uint32_t input_channels_alignment;
@@ -178,8 +178,8 @@ struct Conv2dWeightsBiasPrepConfig {
     const std::array<uint32_t, 2> kernel_size;
     const std::array<uint32_t, 2> stride;
     const std::array<uint32_t, 4> padding_n4;
-    // This conv will go through auto shard codepath for matmul basec convs
-    const bool interlaved_mm_conv;
+    // This conv will go through auto shard codepath for matmul based convs
+    const bool interleaved_mm_conv;
 };
 
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -29,6 +29,11 @@ bool is_valid_device_conv_weights(
 bool is_valid_device_conv_bias(
     const ttnn::Tensor& bias_tensor, uint32_t out_channels, const std::optional<DataType>& expected_dtype);
 
+// Converts convolution weights to interleaved MM layout [1, 1, KhKwCi, Co] and tilizes
+// Returns a new tensor with layout=Tile
+Tensor convert_conv_weight_tensor_to_interleaved_mm_layout(
+    const Tensor& conv_weight_tensor, std::optional<DataType> output_dtype = std::nullopt);
+
 // Converts convolution weights to tilized 2d matrix layout.
 // Returns a new tensor with layout=Tile
 Tensor convert_conv_weight_tensor_to_tiled_layout(
@@ -124,6 +129,7 @@ struct Conv2dWeightsBiasPrepConfig {
         uint32_t groups_,
         uint32_t act_block_h_ntiles_,
         uint32_t input_width_,
+        bool interlaved_mm_conv_,
         bool has_bias_ = false,
         bool parameters_on_device_ = true,
         bool enable_kernel_stride_folding_ = false,
@@ -148,7 +154,8 @@ struct Conv2dWeightsBiasPrepConfig {
         enable_activation_reuse(enable_activation_reuse_),
         kernel_size(kernel_size_),
         stride(stride_),
-        padding_n4(padding_n4_) {}
+        padding_n4(padding_n4_),
+        interlaved_mm_conv(interlaved_mm_conv_) {}
 
     // Common parameters
     const uint32_t input_channels_alignment;
@@ -171,6 +178,8 @@ struct Conv2dWeightsBiasPrepConfig {
     const std::array<uint32_t, 2> kernel_size;
     const std::array<uint32_t, 2> stride;
     const std::array<uint32_t, 4> padding_n4;
+    // This conv will go through auto shard codepath for matmul basec convs
+    const bool interlaved_mm_conv;
 };
 
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -227,6 +227,7 @@ Result conv_transpose2d(
             groups,
             opt_conv_op_block_config.act_block_h_ntiles,
             input_width,
+            mm_conv && auto_shard,
             bias_tensor.has_value());
         tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
             transform_weights_for_conv_transpose2d(weight_tensor, mirror_kernel), bias_tensor, params, device);


### PR DESCRIPTION
For conv2d operations implemented as matmul in auto_shard codepath, we don't need special padding.
We just convert weights from [Co, Ci, Kh, Kw] format to [1, 1, KhKwCi, Co] and perform tensor tilization.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28172)

### Problem description
In case we have a conv2d which maps to matmul op in case auto-shard is used weights can be prepared incorrectly.
In this mode conv will NOT shard the input as it usually does, instead it will pass through interleaved tensor strait to matmul.
Since input tensor is not sharded with any weird padding, weights preparation should be strait forward it should be tensor in format [1, 1, CiKhKw, Co] tilized nothing more then that. Conv weights preparation assumes that input tensor will be sharded and padded and it will account
for this in weights preparation. We need to a new naive path for weights preparation for this case.

### What's changed
Make special codepath for weights preparation for this case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17790499445)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17765578303) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17765563992)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17765557359)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17770291978)