### PR TITLE
[skip ci] Run bh multicard demo tests on VM runners for now since the one BM runner is OOS

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -70,6 +70,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        with:
+          runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests
         timeout-minutes: 70
         run: |

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data:ro
+        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data
+        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -23,7 +23,7 @@ jobs:
         test-group:
           - name: LLMBox Demo tests
             runner-label: BH-LLMBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -49,7 +49,7 @@ jobs:
         test-group:
           - name: LLMBox Demo tests
             runner-label: BH-LLMBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox


### PR DESCRIPTION
### Ticket
None

### Problem description
qb-gh01 is OOS and is the only pipeline-perf runner

### What's changed
Switch from pipeline-perf (baremetal )to pipeline-functional (VM) label
Add missing step in non-large demo test

### Checklist
- [x] BH multicard demos: https://github.com/tenstorrent/tt-metal/actions/runs/17770623910