### PR TITLE
[TT-Train] Add NIGTLY_ to  some of the most slowest tests

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -193,6 +193,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      gtest_filter: "*-*NIGHTLY_*"
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
     needs: build-artifact

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {name: tt-train, cmd: ctest --no-tests=error --output-on-failure  --output-junit generated/test_reports/ctest_report.xml},
+          {name: tt-train, cmd: ctest -E NIGHTLY --no-tests=error --output-on-failure  --output-junit generated/test_reports/ctest_report.xml},
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      gtest_filter:
+        required: false
+        default: "*"
+        type: string
+        description: "Filter for gtest"
 
 jobs:
   models:

--- a/tt-train/tests/autograd/module_base_parameters_test.cpp
+++ b/tt-train/tests/autograd/module_base_parameters_test.cpp
@@ -84,7 +84,7 @@ TEST_F(ModuleBaseParametersTest, AllParametersIncluded) {
     EXPECT_EQ(model_params.size(), 4);
 };
 
-TEST_F(ModuleBaseParametersTest, UnusedParametersInModuleSGD) {
+TEST_F(ModuleBaseParametersTest, NIGHTLY_UnusedParametersInModuleSGD) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     ModelUnusedLayer model;
@@ -99,7 +99,7 @@ TEST_F(ModuleBaseParametersTest, UnusedParametersInModuleSGD) {
     optimizer.step();
 }
 
-TEST_F(ModuleBaseParametersTest, UnusedParametersInModuleAdamW) {
+TEST_F(ModuleBaseParametersTest, NIGHTLY_UnusedParametersInModuleAdamW) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     ModelUnusedLayer model;

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -348,19 +348,22 @@ If one of these tests fails, it means one (or more) of the following:
 */
 
 TEST_F(NanoLlamaTest, NIGHTLY_Default) {
-    if (should_run_nightly_tests()) {
-        train_test();
+    if (!should_run_nightly_tests()) {
+        GTEST_SKIP() << "Skipping Nightly test.";
     }
+    train_test();
 }
 
 TEST_F(NanoLlamaMultiDeviceTest, DISABLED_NIGHTLY_TensorParallel) {
-    if (should_run_multi_device_tests()) {
-        train_test(/*use_tensor_parallel=*/true, /*use_ddp=*/false);
+    if (!should_run_multi_device_tests()) {
+        GTEST_SKIP() << "Skipping test as we are running on a single device.";
     }
+    train_test(/*use_tensor_parallel=*/true, /*use_ddp=*/false);
 }
 
 TEST_F(NanoLlamaMultiDeviceTest, NIGHTLY_DDP) {
-    if (should_run_multi_device_tests()) {
-        train_test(/*use_tensor_parallel=*/false, /*use_ddp=*/true);
+    if (!should_run_multi_device_tests()) {
+        GTEST_SKIP() << "Skipping test as we are running on a single device.";
     }
+    train_test(/*use_tensor_parallel=*/false, /*use_ddp=*/true);
 }

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -256,7 +256,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Backward) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
-TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Huge_Backward) {
+TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 64, W = 128000U;

--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -260,7 +260,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Forward) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
-TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Huge_Forward) {
+TEST_F(CrossEntropyForwardTest, NIGHTLY_CrossEntropyForward_Huge_Forward) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -87,7 +87,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
     EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F));
 }
 
-TEST_F(RMSNormOpTest, RMSNorm_Forward_Batch) {
+TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -125,7 +125,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Forward_Batch) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 6e-2F, 1e-8F));
 }
 
-TEST_F(RMSNormOpTest, RMSNorm_Backward_Batch) {
+TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -162,7 +162,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Backward_Batch) {
 // and uses standard operations like power, mean, sqrt, and multiply.
 // Same test methodology as Section 1, but using rmsnorm_composite() instead.
 // ============================================================================
-TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Forward) {
+TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Forward) {
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -177,7 +177,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Forward) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 1e-2F));
 }
 
-TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Backward) {
+TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -210,7 +210,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Small_Backward) {
     EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F));
 }
 
-TEST_F(RMSNormOpTest, CompositeRMSNorm_Forward_Batch) {
+TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -248,7 +248,7 @@ TEST_F(RMSNormOpTest, CompositeRMSNorm_Forward_Batch) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 6e-2F, 1e-8F));
 }
 
-TEST_F(RMSNormOpTest, CompositeRMSNorm_Backward_Batch) {
+TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Backward_Batch) {
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -460,13 +460,13 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
 }
 
 // Test small batch and sequence dimensions (non-1 values)
-TEST_F(RMSNormOpTest, RMSNorm_Compare_SmallBatch_NonUnit) {
+TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_SmallBatch_NonUnit) {
     CompareKernelVsComposite({2U, 1U, 4U, 64U});
     CompareKernelVsComposite({32U, 1U, 64U, 128U});
 }
 
 // Test different masking patterns with larger batches
-TEST_F(RMSNormOpTest, RMSNorm_Compare_Masking_Patterns) {
+TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_Masking_Patterns) {
     CompareKernelVsComposite({32U, 1U, 1024U, 4091U});  // C % 32 = 11
     CompareKernelVsComposite({32U, 1U, 1024U, 4079U});  // C % 32 = 31
     CompareKernelVsComposite({32U, 1U, 1024U, 4097U});  // C % 32 = 1

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -115,7 +115,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
-TEST_F(SoftmaxTest, SoftmaxTest_Huge_Batch) {
+TEST_F(SoftmaxTest, NIGHLTY_SoftmaxTest_Huge_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -115,7 +115,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
-TEST_F(SoftmaxTest, NIGHLTY_SoftmaxTest_Huge_Batch) {
+TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;

--- a/tt-train/tests/optimizers/no_op_test.cpp
+++ b/tt-train/tests/optimizers/no_op_test.cpp
@@ -25,7 +25,7 @@ protected:
     }
 };
 
-TEST_F(NoOpFullTest, NoOpTest) {
+TEST_F(NoOpFullTest, NIGHTLY_NoOpTest) {
     using namespace ttml::ops;
     ttml::autograd::ctx().set_seed(123U);
     auto* device = &ttml::autograd::ctx().get_device();


### PR DESCRIPTION
### Ticket
@blozano-tt @afuller-TT 

### Problem description
<img width="578" height="680" alt="image" src="https://github.com/user-attachments/assets/ea73a4f9-138e-430f-a887-df1fe182eb52" />

### What's changed
Added NIGHLTY_ to some of the slowest tests.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes