### PR TITLE
Migrate Fabric Test to Mesh API

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -40,6 +40,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -53,6 +54,7 @@
 // #include <tt-metalium/kernel_types.hpp>
 
 using namespace tt;
+using namespace tt::tt_metal;
 using namespace tt::test_utils;
 using namespace tt::test_utils::df;
 
@@ -88,7 +90,7 @@ public:
             tt::tt_metal::GetNumPCIeDevices() >= 1) {
             std::vector<chip_id_t> ids(num_devices_, 0);
             std::iota(ids.begin(), ids.end(), 0);
-            devices_ = tt::tt_metal::detail::CreateDevices(ids);
+            devices_ = distributed::MeshDevice::create_unit_meshes(ids);
 
         } else {
             TT_THROW("This suite can only be run on N300 Wormhole devices");
@@ -104,11 +106,11 @@ public:
     void TearDown() {
         device_open = false;
         for (auto [device_id, device_ptr] : devices_) {
-            tt::tt_metal::CloseDevice(device_ptr);
+            device_ptr->close();
         }
     }
 
-    std::map<chip_id_t, tt_metal::IDevice*> devices_;
+    std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devices_;
     tt::ARCH arch_;
     size_t num_devices_;
 
@@ -133,8 +135,8 @@ struct KernelXY {
 };
 
 void generate_receiver_worker_kernels(
-    tt_metal::Program& program,
-    tt_metal::IDevice* device,
+    distributed::MeshWorkload& workload,
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
     const CoreCoord& worker_core,
     const CoreCoord& edm_core,
     const ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface& edm_channel,
@@ -146,6 +148,11 @@ void generate_receiver_worker_kernels(
     uint32_t dram_output_buffer_base_addr,  // remote_output_buffers.at(i)->address();
     bool dest_is_dram,
     ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode) {
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto& program = workload.get_programs().at(device_range);
+    auto device = mesh_device->get_devices()[0];
+
     // Just want a dummy DF
     uint32_t src0_cb_index = CBIndex::c_0;
     tt::DataFormat df = page_size == 1024   ? tt::DataFormat::Bfp8
@@ -215,8 +222,8 @@ void generate_receiver_worker_kernels(
 }
 
 void generate_sender_worker_kernels(
-    tt_metal::Program& program,
-    tt_metal::IDevice* device,
+    distributed::MeshWorkload& workload,
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
     const CoreCoord& worker_core,
     const CoreCoord& edm_core,
     const ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface& edm_channel,
@@ -228,6 +235,11 @@ void generate_sender_worker_kernels(
     uint32_t dram_output_buffer_base_addr,  // remote_output_buffers.at(i)->address();
     bool src_is_dram,
     ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode) {
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto& program = workload.get_programs().at(device_range);
+    auto device = mesh_device->get_devices()[0];
+
     std::vector<uint32_t> sender_worker_reader_compile_args{
         num_pages_total,  //
         page_size,
@@ -291,8 +303,8 @@ void generate_sender_worker_kernels(
 }
 
 bool RunWriteBWTest(
-    tt_metal::IDevice* sender_device,
-    tt_metal::IDevice* receiver_device,
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> sender_mesh_device,
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> receiver_mesh_device,
 
     const CoreCoord& eth_sender_core,
     const CoreCoord& eth_receiver_core,
@@ -314,8 +326,21 @@ bool RunWriteBWTest(
     ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode) {
     std::size_t tensor_size_bytes = num_pages_total * page_size;
 
-    tt_metal::Program sender_program{};
-    tt_metal::Program receiver_program{};
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    distributed::MeshWorkload sender_workload;
+    tt_metal::Program sender_program_{};
+    distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program_), device_range);
+    auto& sender_program = sender_workload.get_programs().at(device_range);
+
+    distributed::MeshWorkload receiver_workload;
+    tt_metal::Program receiver_program_{};
+    distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program_), device_range);
+    auto& receiver_program = receiver_workload.get_programs().at(device_range);
+
+    auto& sender_cq = sender_mesh_device->mesh_command_queue();
+    auto& receiver_cq = receiver_mesh_device->mesh_command_queue();
 
     std::vector<CoreCoord> worker_cores;
     {
@@ -360,13 +385,20 @@ bool RunWriteBWTest(
         .output_buffer_type = dest_is_dram ? tt_metal::BufferType::DRAM : tt_metal::BufferType::L1,
         .l1_data_format = tt::DataFormat::Float16_b};
 
-    auto local_input_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
-        sender_device, test_config.size_bytes, test_config.page_size_bytes, test_config.input_buffer_type});
-    auto remote_input_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
-        receiver_device, test_config.size_bytes, test_config.page_size_bytes, test_config.input_buffer_type});
+    distributed::DeviceLocalBufferConfig local_input_config{
+        .page_size = test_config.page_size_bytes,
+        .buffer_type = test_config.input_buffer_type,
+    };
+    distributed::ReplicatedBufferConfig buffer_config{
+        .size = test_config.size_bytes,
+    };
+    auto local_input_buffer =
+        distributed::MeshBuffer::create(buffer_config, local_input_config, sender_mesh_device.get());
+    auto remote_input_buffer =
+        distributed::MeshBuffer::create(buffer_config, local_input_config, receiver_mesh_device.get());
 
-    tt_metal::detail::WriteToBuffer(local_input_buffer, inputs);
-    tt_metal::detail::WriteToBuffer(remote_input_buffer, inputs);
+    distributed::WriteShard(sender_cq, local_input_buffer, inputs, zero_coord);
+    distributed::WriteShard(receiver_cq, remote_input_buffer, inputs, zero_coord);
 
     std::vector<uint32_t> local_input_buffer_addresses(num_local_sender_channels, local_input_buffer->address());
     std::vector<uint32_t> remote_input_buffer_addresses(num_remote_sender_channels, remote_input_buffer->address());
@@ -378,25 +410,30 @@ bool RunWriteBWTest(
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
 
-    std::vector<std::shared_ptr<tt_metal::Buffer>> local_output_buffers;
-    std::vector<std::shared_ptr<tt_metal::Buffer>> remote_output_buffers;
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> local_output_buffers;
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> remote_output_buffers;
+
+    distributed::DeviceLocalBufferConfig local_output_config{
+        .page_size = test_config.page_size_bytes,
+        .buffer_type = test_config.output_buffer_type,
+    };
 
     for (std::size_t i = 0; i < num_local_sender_channels; i++) {
-        auto output_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
-            receiver_device, test_config.size_bytes, test_config.page_size_bytes, test_config.output_buffer_type});
+        auto output_buffer =
+            distributed::MeshBuffer::create(buffer_config, local_output_config, receiver_mesh_device.get());
         remote_output_buffers.push_back(output_buffer);
     }
     for (std::size_t i = 0; i < num_remote_sender_channels; i++) {
-        auto output_buffer = CreateBuffer(tt_metal::InterleavedBufferConfig{
-            sender_device, test_config.size_bytes, test_config.page_size_bytes, test_config.output_buffer_type});
+        auto output_buffer =
+            distributed::MeshBuffer::create(buffer_config, local_output_config, sender_mesh_device.get());
         local_output_buffers.push_back(output_buffer);
     }
 
     for (const auto& buffer_id : local_output_buffers) {
-        tt_metal::detail::WriteToBuffer(buffer_id, all_zeros);
+        distributed::WriteShard(sender_cq, buffer_id, all_zeros, zero_coord);
     }
     for (const auto& buffer_id : remote_output_buffers) {
-        tt_metal::detail::WriteToBuffer(buffer_id, all_zeros);
+        distributed::WriteShard(receiver_cq, buffer_id, all_zeros, zero_coord);
     }
 
     uint32_t erisc_handshake_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
@@ -438,12 +475,12 @@ bool RunWriteBWTest(
     std::vector<ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface> local_edm_channels;
     std::vector<ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface> remote_edm_channels;
     for (uint32_t i = 0; i < num_local_sender_channels; i++) {
-        auto const& worker_core_local_chip = ttnn::ccl::WorkerXY(
-            sender_device->worker_core_from_logical_core(worker_cores.at(i)).x,
-            sender_device->worker_core_from_logical_core(worker_cores.at(i)).y);
-        auto const& worker_core_remote_chip = ttnn::ccl::WorkerXY(
-            receiver_device->worker_core_from_logical_core(worker_cores.at(i)).x,
-            receiver_device->worker_core_from_logical_core(worker_cores.at(i)).y);
+        const auto& worker_core_local_chip = ttnn::ccl::WorkerXY(
+            sender_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).x,
+            sender_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).y);
+        const auto& worker_core_remote_chip = ttnn::ccl::WorkerXY(
+            receiver_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).x,
+            receiver_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).y);
         ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface const& local_sender_channel_buffer =
             local_chip_edm_builder.add_sender_channel(
                 local_worker_semaphore_addresses.at(i),
@@ -458,12 +495,12 @@ bool RunWriteBWTest(
         remote_edm_channels.push_back(remote_receiver_channel_buffer);
     }
     for (uint32_t i = num_local_sender_channels; i < num_local_sender_channels + num_remote_sender_channels; i++) {
-        auto const& worker_core_remote_chip = ttnn::ccl::WorkerXY(
-            receiver_device->worker_core_from_logical_core(worker_cores.at(i)).x,
-            receiver_device->worker_core_from_logical_core(worker_cores.at(i)).y);
-        auto const& worker_core_local_chip = ttnn::ccl::WorkerXY(
-            sender_device->worker_core_from_logical_core(worker_cores.at(i)).x,
-            sender_device->worker_core_from_logical_core(worker_cores.at(i)).y);
+        const auto& worker_core_remote_chip = ttnn::ccl::WorkerXY(
+            receiver_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).x,
+            receiver_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).y);
+        const auto& worker_core_local_chip = ttnn::ccl::WorkerXY(
+            sender_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).x,
+            sender_mesh_device->worker_core_from_logical_core(worker_cores.at(i)).y);
         ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface const& local_receiver_channel_buffer =
             local_chip_edm_builder.add_receiver_channel(
                 local_worker_semaphore_addresses.at(i),
@@ -486,8 +523,8 @@ bool RunWriteBWTest(
         auto const& worker_core = worker_cores.at(i);
         log_info(tt::LogTest, "Worker {}. On Core x={},y={}", i, worker_core.x, worker_core.y);
         generate_sender_worker_kernels(
-            sender_program,
-            sender_device,
+            sender_workload,
+            sender_mesh_device,
             worker_core,
             eth_sender_core,
             local_edm_channels.at(i),
@@ -500,8 +537,8 @@ bool RunWriteBWTest(
             src_is_dram,
             edm_termination_mode);
         generate_receiver_worker_kernels(
-            receiver_program,
-            receiver_device,
+            receiver_workload,
+            receiver_mesh_device,
             worker_core,
             eth_receiver_core,
             remote_edm_channels.at(i),
@@ -519,8 +556,8 @@ bool RunWriteBWTest(
         log_info(tt::LogTest, "Worker {}", i);
         auto const& worker_core = worker_cores.at(i + num_local_sender_channels);
         generate_sender_worker_kernels(
-            receiver_program,
-            receiver_device,
+            receiver_workload,
+            receiver_mesh_device,
             worker_core,
             eth_receiver_core,
             remote_edm_channels.at(i + num_local_sender_channels),
@@ -534,8 +571,8 @@ bool RunWriteBWTest(
             edm_termination_mode);
 
         generate_receiver_worker_kernels(
-            sender_program,
-            sender_device,
+            sender_workload,
+            sender_mesh_device,
             worker_core,
             eth_sender_core,
             local_edm_channels.at(i + num_local_sender_channels),
@@ -554,7 +591,7 @@ bool RunWriteBWTest(
     ////////////////////////////////////////////////////////////////////////////
     auto local_edm_kernel = ttnn::ccl::generate_edm_kernel(
         sender_program,
-        sender_device,
+        sender_mesh_device->get_devices()[0],
         local_chip_edm_builder,
         eth_sender_core,
         tt_metal::DataMovementProcessor::RISCV_0,
@@ -563,7 +600,7 @@ bool RunWriteBWTest(
 
     auto remote_edm_kernel = ttnn::ccl::generate_edm_kernel(
         receiver_program,
-        receiver_device,
+        receiver_mesh_device->get_devices()[0],
         remote_chip_edm_builder,
         eth_receiver_core,
         tt_metal::DataMovementProcessor::RISCV_0,
@@ -575,8 +612,8 @@ bool RunWriteBWTest(
     ////////////////////////////////////////////////////////////////////////////
 
     try {
-        tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
-        tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
+        distributed::EnqueueMeshWorkload(sender_cq, sender_workload, false);
+        distributed::EnqueueMeshWorkload(receiver_cq, receiver_workload, false);
     } catch (std::exception& e) {
         log_error(tt::LogTest, "Failed compile: {}", e.what());
         throw e;
@@ -585,30 +622,34 @@ bool RunWriteBWTest(
     log_info(tt::LogTest, "Running...");
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        std::thread th2 = std::thread([&] { tt_metal::detail::LaunchProgram(sender_device, sender_program); });
-        std::thread th1 = std::thread([&] { tt_metal::detail::LaunchProgram(receiver_device, receiver_program); });
+        std::thread th2 = std::thread([&] { distributed::EnqueueMeshWorkload(sender_cq, sender_workload, false); });
+        std::thread th1 = std::thread([&] { distributed::EnqueueMeshWorkload(receiver_cq, receiver_workload, false); });
 
         th2.join();
         th1.join();
     } else {
-        tt_metal::EnqueueProgram(sender_device->command_queue(), sender_program, false);
-        tt_metal::EnqueueProgram(receiver_device->command_queue(), receiver_program, false);
+        distributed::EnqueueMeshWorkload(sender_cq, sender_workload, false);
+        distributed::EnqueueMeshWorkload(receiver_cq, receiver_workload, false);
 
         log_debug(tt::LogTest, "Calling Finish");
-        tt_metal::Finish(sender_device->command_queue());
-        tt_metal::Finish(receiver_device->command_queue());
+        distributed::Finish(sender_cq);
+        distributed::Finish(receiver_cq);
     }
     // tt::tt_metal::detail::ReadDeviceProfilerResults(receiver_device);
     // tt::tt_metal::detail::ReadDeviceProfilerResults(sender_device);
     log_info(tt::LogTest, "Reading back outputs");
 
-    auto is_output_correct = [&all_zeros, &inputs](const std::shared_ptr<tt_metal::Buffer>& output_buffer) {
+    auto is_output_correct = [&all_zeros, &inputs](const std::shared_ptr<distributed::MeshBuffer>& output_buffer) {
         constexpr bool debug_mode = false;
         std::vector<uint32_t> readback_data_vec;  // init to 0 data for easier debug
         readback_data_vec.reserve(all_zeros.size());
         std::fill(readback_data_vec.begin(), readback_data_vec.end(), 0);
 
-        tt_metal::detail::ReadFromBuffer(output_buffer, readback_data_vec);
+        distributed::ReadShard(
+            output_buffer->device()->mesh_command_queue(),
+            readback_data_vec,
+            output_buffer,
+            distributed::MeshCoordinate(0, 0));
         log_info(tt::LogTest, "Checking outputs");
         if (readback_data_vec.size() != inputs.size()) {
             log_error(tt::LogTest, "Output size mismatch: expected {} got {}", inputs.size(), readback_data_vec.size());
@@ -678,7 +719,8 @@ int TestEntrypoint(
 
     N300TestDevice test_fixture;
 
-    const auto& device_0 = test_fixture.devices_.at(0);
+    const auto& mesh_device_0 = test_fixture.devices_.at(0);
+    auto device_0 = mesh_device_0->get_devices()[0];
 
     auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();
@@ -693,13 +735,13 @@ int TestEntrypoint(
         eth_sender_core_iter++;
     } while (device_id != 1);
     TT_ASSERT(device_id == 1);
-    const auto& device_1 = test_fixture.devices_.at(device_id);
+    const auto& mesh_device_1 = test_fixture.devices_.at(device_id);
 
     bool success = false;
     try {
         success = RunWriteBWTest(
-            device_0,
-            device_1,
+            mesh_device_0,
+            mesh_device_1,
 
             eth_sender_core,
             eth_receiver_core,


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22835)

### Problem description
TT-metal tests need to be migrated to Mesh API

### What's changed
- migrated test_erisc_data_mover_with_workers.cpp

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17777789779) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes