### PR TITLE
Print more debugging info about event ordering issues

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -188,6 +188,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
     for (auto device : mesh_device_->get_devices()) {
         event_dispatch::issue_record_event_commands(
             mesh_device_,
+            device->id(),
             event.id(),
             id_,
             mesh_device_->num_hw_cqs(),
@@ -653,6 +654,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
     auto dispatch_lambda = [this, &event, &sub_device_ids, notify_host](const MeshCoordinate& coord) {
         event_dispatch::issue_record_event_commands(
             mesh_device_,
+            mesh_device_->get_device(coord)->id(),
             event.id(),
             id_,
             mesh_device_->num_hw_cqs(),
@@ -827,7 +829,12 @@ void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& re
         device->sysmem_manager().completion_queue_wait_front(id_, exit_condition_);
 
         event_dispatch::read_events_from_completion_queue(
-            read_event_descriptor.single_device_descriptor, mmio_device_id, channel, id_, device->sysmem_manager());
+            read_event_descriptor.single_device_descriptor,
+            mmio_device_id,
+            device->id(),
+            channel,
+            id_,
+            device->sysmem_manager());
     });
 }
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -847,7 +847,7 @@ void issue_read_buffer_dispatch_command_sequence(
 
     bool flush_prefetch = false;
     command_sequence.add_dispatch_write_host(
-        flush_prefetch, (DeviceAddr)dispatch_params.pages_per_txn * dispatch_params.padded_page_size, false);
+        flush_prefetch, (DeviceAddr)dispatch_params.pages_per_txn * dispatch_params.padded_page_size, false, 0);
 
     // Buffer layout specific logic
     if constexpr (std::is_same_v<T, ShardedBufferReadDispatchParams>) {

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -159,7 +159,7 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
         tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
         dispatch_params.expected_num_workers_completed[offset_index]);
 
-    command_sequence.add_dispatch_write_host(false, dispatch_params.size_bytes, false);
+    command_sequence.add_dispatch_write_host(false, dispatch_params.size_bytes, false, 0);
 
     command_sequence.add_prefetch_relay_linear(
         dispatch_params.device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_params.virtual_core),

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -459,7 +459,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged(
 template <bool hugepage_write>
 template <bool inline_data>
 void DeviceCommand<hugepage_write>::add_dispatch_write_host(
-    bool flush_prefetch, uint64_t data_sizeB, bool is_event, const void* data) {
+    bool flush_prefetch, uint64_t data_sizeB, bool is_event, uint16_t pad1, const void* data) {
     uint32_t payload_sizeB = sizeof(CQDispatchCmd) + (flush_prefetch ? data_sizeB : 0);
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
@@ -467,6 +467,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_host(
         write_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
         write_cmd->write_linear_host.is_event = is_event;
         // This padding value is checked on the host side for eveent commands.
+        write_cmd->write_linear_host.pad1 = pad1;
         write_cmd->write_linear_host.pad2 = DeviceCommand::random_padding_value();
         write_cmd->write_linear_host.length =
             sizeof(CQDispatchCmd) +
@@ -1010,10 +1011,10 @@ template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePack
 template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
 template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
 
-template void DeviceCommand<true>::add_dispatch_write_host<false>(bool, uint64_t, bool, const void*);
-template void DeviceCommand<true>::add_dispatch_write_host<true>(bool, uint64_t, bool, const void*);
-template void DeviceCommand<false>::add_dispatch_write_host<false>(bool, uint64_t, bool, const void*);
-template void DeviceCommand<false>::add_dispatch_write_host<true>(bool, uint64_t, bool, const void*);
+template void DeviceCommand<true>::add_dispatch_write_host<false>(bool, uint64_t, bool, uint16_t, const void*);
+template void DeviceCommand<true>::add_dispatch_write_host<true>(bool, uint64_t, bool, uint16_t, const void*);
+template void DeviceCommand<false>::add_dispatch_write_host<false>(bool, uint64_t, bool, uint16_t, const void*);
+template void DeviceCommand<false>::add_dispatch_write_host<true>(bool, uint64_t, bool, uint16_t, const void*);
 
 template void DeviceCommand<true>::add_dispatch_write_paged<false>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
 template void DeviceCommand<true>::add_dispatch_write_paged<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -466,7 +466,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_host(
     auto initialize_write_cmd = [&](CQDispatchCmd* write_cmd) {
         write_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
         write_cmd->write_linear_host.is_event = is_event;
-        // This padding value is checked on the host side for eveent commands.
+        // This padding value is checked on the host side for event commands.
         write_cmd->write_linear_host.pad1 = pad1;
         write_cmd->write_linear_host.pad2 = DeviceCommand::random_padding_value();
         write_cmd->write_linear_host.length =

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -198,6 +198,10 @@ public:
         return cmd;
     }
 
+    // This value is random, but stable for the lifetime of the program. It is used to pad the command for event
+    // commands, so we can check the value on the host side.
+    static uint32_t random_padding_value();
+
 private:
     static bool zero_init_enable;
 

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -111,7 +111,8 @@ public:
         const void* data = nullptr);
 
     template <bool inline_data = false>
-    void add_dispatch_write_host(bool flush_prefetch, uint64_t data_sizeB, bool is_event, const void* data = nullptr);
+    void add_dispatch_write_host(
+        bool flush_prefetch, uint64_t data_sizeB, bool is_event, uint16_t pad1, const void* data = nullptr);
 
     void add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_size, uint32_t pages);
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -572,6 +572,7 @@ void HWCommandQueue::enqueue_record_event(
     sub_device_ids = buffer_dispatch::select_sub_device_ids(this->device_, sub_device_ids);
     event_dispatch::issue_record_event_commands(
         device_,
+        device_->id(),
         event->event_id,
         id_,
         device_->num_hw_cqs(),
@@ -639,7 +640,7 @@ void HWCommandQueue::read_completion_queue() {
                         [&, this](ReadEventDescriptor& read_descriptor) {
                             ZoneScopedN("CompletionQueueReadEvent");
                             event_dispatch::read_events_from_completion_queue(
-                                read_descriptor, mmio_device_id, channel, id_, manager_);
+                                read_descriptor, mmio_device_id, this->device_->id(), channel, id_, manager_);
                         },
                         [&, this](const ReadCoreDataDescriptor& read_descriptor) {
                             ZoneScopedN("CompletionQueueReadCoreData");

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -181,6 +181,20 @@ void read_events_from_completion_queue(
         read_ptr,
         mmio_device_id,
         channel);
+
+    CQDispatchCmd* dispatch_cmd = reinterpret_cast<CQDispatchCmd*>(dispatch_cmd_and_event.data());
+    uint32_t expected_padding_value = HugepageDeviceCommand::random_padding_value();
+
+    TT_FATAL(
+        dispatch_cmd->base.cmd_id == CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST && dispatch_cmd->write_linear_host.is_event &&
+            dispatch_cmd->write_linear_host.length == sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE &&
+            dispatch_cmd->write_linear_host.pad2 == expected_padding_value,
+        "Unexpected values for event in completion queue, got cmd id {}, is event {}, length {}, pad2 {} (expected {})",
+        dispatch_cmd->base.cmd_id,
+        dispatch_cmd->write_linear_host.is_event,
+        dispatch_cmd->write_linear_host.length,
+        dispatch_cmd->write_linear_host.pad2,
+        expected_padding_value);
     uint32_t event_completed = dispatch_cmd_and_event[sizeof(CQDispatchCmd) / sizeof(uint32_t)];
 
     TT_FATAL(

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -39,6 +39,7 @@ uint32_t get_packed_write_max_unicast_sub_cmds(IDevice* device) {
 
 void issue_record_event_commands(
     IDevice* device,
+    chip_id_t device_id,
     uint32_t event_id,
     uint8_t cq_id,
     uint32_t num_command_queues,
@@ -129,8 +130,9 @@ void issue_record_event_commands(
 
     if (notify_host) {
         bool flush_prefetch = true;
+        uint16_t pad1 = (device_id << 8) | cq_id;
         command_sequence.add_dispatch_write_host<true>(
-            flush_prefetch, DispatchSettings::EVENT_PADDED_SIZE, true, event_payload.data());
+            flush_prefetch, DispatchSettings::EVENT_PADDED_SIZE, true, pad1, event_payload.data());
     }
 
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
@@ -169,6 +171,7 @@ void issue_wait_for_event_commands(
 void read_events_from_completion_queue(
     ReadEventDescriptor& event_descriptor,
     chip_id_t mmio_device_id,
+    chip_id_t device_id,
     uint16_t channel,
     uint8_t cq_id,
     SystemMemoryManager& sysmem_manager) {
@@ -184,15 +187,20 @@ void read_events_from_completion_queue(
 
     CQDispatchCmd* dispatch_cmd = reinterpret_cast<CQDispatchCmd*>(dispatch_cmd_and_event.data());
     uint32_t expected_padding_value = HugepageDeviceCommand::random_padding_value();
+    uint16_t expected_pad1 = (device_id << 8) | cq_id;
 
     TT_FATAL(
         dispatch_cmd->base.cmd_id == CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST && dispatch_cmd->write_linear_host.is_event &&
             dispatch_cmd->write_linear_host.length == sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE &&
+            dispatch_cmd->write_linear_host.pad1 == expected_pad1 &&
             dispatch_cmd->write_linear_host.pad2 == expected_padding_value,
-        "Unexpected values for event in completion queue, got cmd id {}, is event {}, length {}, pad2 {} (expected {})",
+        "Unexpected values for event in completion queue, got cmd id {}, is event {}, length {}, pad1 {} (expected "
+        "{}), pad2 {} (expected {})",
         dispatch_cmd->base.cmd_id,
         dispatch_cmd->write_linear_host.is_event,
         dispatch_cmd->write_linear_host.length,
+        dispatch_cmd->write_linear_host.pad1,
+        expected_pad1,
         dispatch_cmd->write_linear_host.pad2,
         expected_padding_value);
     uint32_t event_completed = dispatch_cmd_and_event[sizeof(CQDispatchCmd) / sizeof(uint32_t)];

--- a/tt_metal/impl/event/dispatch.hpp
+++ b/tt_metal/impl/event/dispatch.hpp
@@ -35,6 +35,7 @@ namespace event_dispatch {
 
 void issue_record_event_commands(
     IDevice* device,
+    chip_id_t device_id,
     uint32_t event_id,
     uint8_t cq_id,
     uint32_t num_command_queues,
@@ -50,6 +51,7 @@ void issue_wait_for_event_commands(
 void read_events_from_completion_queue(
     ReadEventDescriptor& event_descriptor,
     chip_id_t mmio_device_id,
+    chip_id_t device_id,
     uint16_t channel,
     uint8_t cq_id,
     SystemMemoryManager& sysmem_manager);


### PR DESCRIPTION
### Problem description
We're occasionally seeing event ordering issues, but are unclear what's happening - is it actually a correctly-written event but with an unexpected value, or is it some sort of garbage.

### What's changed
Validate a lot more data in the event. This includes setting a per-process random value in the padding, to ensure the event was created in this process.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes