### PR TITLE
Enable MedGemma model to use Gemma3 path

### DIFF
--- a/models/demos/gemma3/demo/vision_demo.py
+++ b/models/demos/gemma3/demo/vision_demo.py
@@ -88,7 +88,7 @@ def create_multimodal_model(
         checkpoint = tt_model_args.load_state_dict()
     print(f"Loaded checkpoint for {tt_model_args.base_model_name} with {checkpoint.keys()} keys")
 
-    if "gemma-3" in tt_model_args.base_model_name:
+    if tt_model_args.is_gemma:
         model = TtGemmaModel(
             mesh_device=mesh_device,
             state_dict=checkpoint,

--- a/models/demos/gemma3/tt/gemma_image_attention.py
+++ b/models/demos/gemma3/tt/gemma_image_attention.py
@@ -94,6 +94,12 @@ class TtGemmaImageAttention(LightweightModule):
             torch.chunk(w, configuration.num_devices) for w in [wq_padded, wk_padded, wv_padded]
         )
 
+        self.qkv_program_config = lambda seq_len, MAX_MM_SEQ_LEN: (
+            None
+            if self.configuration.is_gemma
+            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN)
+        )
+
         # for Gemma
         self.wq = ttnn.as_tensor(
             tensor=wq_padded,
@@ -286,9 +292,7 @@ class TtGemmaImageAttention(LightweightModule):
         seq_len = x_11SH.shape[-2]
         batch_size = x_11SH.shape[0]
 
-        MAX_MM_SEQ_LEN = (
-            seq_len if "gemma-3" in self.configuration.base_model_name else self.configuration.VISION_MAX_MM_SEQ
-        )
+        MAX_MM_SEQ_LEN = seq_len if self.configuration.is_gemma else self.configuration.VISION_MAX_MM_SEQ
 
         if seq_len > MAX_MM_SEQ_LEN:
             x_11SH = ttnn.reshape(x_11SH, [batch_size, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])
@@ -300,9 +304,7 @@ class TtGemmaImageAttention(LightweightModule):
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config_hifi4,
-            program_config=None
-            if "gemma-3" in self.configuration.base_model_name
-            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            program_config=self.qkv_program_config(seq_len, MAX_MM_SEQ_LEN),
         )
 
         q_heads_1QSD = ttnn.transpose(ttnn.reshape(q_heads_1QSD, (batch_size, seq_len, self.n_local_heads, -1)), 1, 2)
@@ -314,9 +316,7 @@ class TtGemmaImageAttention(LightweightModule):
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config_hifi4,
-            program_config=None
-            if "gemma-3" in self.configuration.base_model_name
-            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            program_config=self.qkv_program_config(seq_len, MAX_MM_SEQ_LEN),
         )
 
         k_heads_1KSD = ttnn.transpose(ttnn.reshape(k_heads_1KSD, (batch_size, seq_len, self.n_local_heads, -1)), 1, 2)
@@ -328,9 +328,7 @@ class TtGemmaImageAttention(LightweightModule):
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config_hifi4,
-            program_config=None
-            if "gemma-3" in self.configuration.base_model_name
-            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            program_config=self.qkv_program_config(seq_len, MAX_MM_SEQ_LEN),
         )
         v_heads_1VSD = ttnn.transpose(ttnn.reshape(v_heads_1VSD, (batch_size, seq_len, self.n_local_heads, -1)), 1, 2)
 
@@ -389,9 +387,7 @@ class TtGemmaImageAttention(LightweightModule):
             compute_kernel_config=self.compute_kernel_config_hifi4,
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            program_config=None
-            if "gemma-3" in self.configuration.base_model_name
-            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN),
+            program_config=self.qkv_program_config(seq_len, MAX_MM_SEQ_LEN),
         )
         if seq_len > MAX_MM_SEQ_LEN:
             output_11SH = ttnn.reshape(output_11SH, [batch_size, 1, seq_len, -1])

--- a/models/demos/gemma3/tt/gemma_image_mlp.py
+++ b/models/demos/gemma3/tt/gemma_image_mlp.py
@@ -75,7 +75,7 @@ class TtGemmaImageFeedForward(LightweightModule):
         batch_size = x.shape[0]
 
         # Depends on whether we are padding or not
-        MAX_MM_SEQ_LEN = seq_len if "gemma-3" in self.args.base_model_name else self.args.VISION_MAX_MM_SEQ
+        MAX_MM_SEQ_LEN = seq_len if self.args.is_gemma else self.args.VISION_MAX_MM_SEQ
 
         x_in = x
         if seq_len >= MAX_MM_SEQ_LEN:  # Too big to compute. Set different program configs based on seqlen

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1210,9 +1210,7 @@ class ModelArgs:
             self.model_config["XATTN_KV_PREFILL_MEM_CFG"] = _get_xattn_kv_prefill_mem_cfg
 
             if self.is_vision():
-                self.VISION_MAX_MM_SEQ = (
-                    self.vision_chunk_ntok if "gemma-3" in self.base_model_name else nearest_32(self.vision_chunk_ntok)
-                )
+                self.VISION_MAX_MM_SEQ = self.vision_chunk_ntok if self.is_gemma else nearest_32(self.vision_chunk_ntok)
 
             # RMS NORM
             self.model_config["SHARDED_NORM_ATTN_PRGM_CFG"] = self.create_sharded_norm_config(attn_input_grid)
@@ -1235,9 +1233,9 @@ class ModelArgs:
             )
 
             self.model_config["LM_HEAD_OUTPUT_MEMCFG"] = (
-                ttnn.DRAM_MEMORY_CONFIG if "gemma-3" in self.model_name else ttnn.L1_MEMORY_CONFIG
+                ttnn.DRAM_MEMORY_CONFIG if self.is_gemma else ttnn.L1_MEMORY_CONFIG
             )
-            self.lm_head_dtype = ttnn.bfloat16 if "gemma-3" in self.model_name else None
+            self.lm_head_dtype = ttnn.bfloat16 if self.is_gemma else None
 
             self.set_tg_attention_config()
 
@@ -1385,8 +1383,7 @@ class ModelArgs:
 
     def _set_model_specific_params(self):
         # Gemma3 specific params
-        is_gemma3 = "gemma-3" in self.base_model_name.lower()
-        if is_gemma3:
+        if self.is_gemma:
             self.rms_norm_add_unit_offset = True
             self.embed_scale = self.dim**0.5
 
@@ -1529,6 +1526,10 @@ class ModelArgs:
         """
         return (self.vision_chunk_size // self.vision_patch_size) ** 2 + 1
 
+    @property
+    def is_gemma(self):
+        return any(x in self.base_model_name.lower() for x in ["gemma-3", "medgemma"])
+
     def _set_model_params(self, checkpoint_dir):
         if self.checkpoint_type == CheckpointType.Meta:
             self._set_params(checkpoint_dir)
@@ -1661,7 +1662,7 @@ class ModelArgs:
                 self.hf_config = AutoConfig.from_pretrained(self.CKPT_DIR).to_dict()
 
             if "text_config" in self.hf_config or "vision_config" in self.hf_config:
-                if "gemma-3" in self.base_model_name:
+                if self.is_gemma:
                     self._set_params_from_dict(self.hf_config, is_hf=True)
                     if "vision_config" in self.hf_config:
                         merged_vision_config = merge_vision_config(self.hf_config)
@@ -1704,7 +1705,7 @@ class ModelArgs:
         return self.vision_chunk_size > 0
 
     def get_state_dict_prefix(self, module_name, layer_num, is_vision=False):
-        if "gemma-3" in self.model_name:
+        if self.is_gemma:
             if is_vision:
                 text_prefix = "model.vision_tower.vision_model.encoder."
 
@@ -1797,7 +1798,7 @@ class ModelArgs:
 
         if self.checkpoint_type == CheckpointType.HuggingFace:
             if self.is_multimodal:
-                if "gemma-3" in self.model_name:
+                if self.is_gemma:
                     state_dict = convert_vision_hf_to_meta(state_dict, self.head_dim)
                 else:
                     state_dict = standardize_hf_keys_multimodal(state_dict)
@@ -2323,7 +2324,7 @@ class ModelArgs:
                 config.num_hidden_layers = self.n_layers
                 model = AutoModelForCausalLM.from_config(config)
             else:
-                if "gemma-3" in self.model_name:
+                if self.is_gemma:
                     from transformers import Gemma3ForConditionalGeneration
 
                     model = Gemma3ForConditionalGeneration.from_pretrained(self.CKPT_DIR)
@@ -2454,7 +2455,7 @@ class ModelArgs:
             layer = model.model.layers[i]
             rotary_emb = model.model.rotary_emb
 
-            if "gemma-3" in self.model_name:
+            if self.is_gemma:
                 rotary_emb_local = model.model.rotary_emb_local
                 wrapper = HfGemmaDecoderWrapper(layer, self.head_dim, rotary_emb, rotary_emb_local)
             else:
@@ -2639,17 +2640,13 @@ class HfDecoderWrapper:
 
     def forward(self, x, start_pos, freqs_cis_i, mask=None):
         position_ids = torch.tensor([list(range(start_pos, start_pos + x.shape[1]))] * x.shape[0])
-        model_name_env = os.getenv("HF_MODEL")
-        if "gemma-3" in model_name_env.lower():
-            position_embeddings = self.rotary_emb(x, position_ids)
-            position_embeddings_local = self.rotary_emb_local(x, position_ids)
-        else:
-            position_embeddings = self.rotary_emb(x, position_ids)
+        position_embeddings = self.rotary_emb(x, position_ids)
 
         if mask is not None:
             while len(mask.shape) < 4:
                 mask = mask.unsqueeze(0)
         if self.rotary_emb_local is not None:
+            position_embeddings_local = self.rotary_emb_local(x, position_ids)
             result = self.decoder.forward(
                 x,
                 position_embeddings_global=position_embeddings,


### PR DESCRIPTION
### Ticket
n/a

### Problem description
We've guarded Gemma3 code with "gemma-3" name in many places.

### What's changed
Localize name check in one place and use `model_args.is_gemma` where needed.
Add `["gemma-3", "medgemma"]` for `is_gemma` check.

### Checklist
[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ppetrovic%2Fmedgemma)](https://github.com/tenstorrent/tt-metal/actions/runs/17781079630)

[![(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml/badge.svg?branch=ppetrovic%2Fmedgemma)](https://github.com/tenstorrent/tt-metal/actions/runs/17788328513)

[![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=ppetrovic%2Fmedgemma)](https://github.com/tenstorrent/tt-metal/actions/runs/17781128701) - Gemma3 test passes ✅