### PR TITLE
Add noc type used for transfers from router to local chip in a fabric event

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -280,29 +280,48 @@ bool doAllDispatchCoresComeAfterNonDispatchCores(const IDevice* device, const st
     return true;
 }
 
-CoreCoord getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) {
+// The input coordinates are from noc tracing and therefore
+// will be in whatever coord system is used by the noc for that core type on that arch
+// so translation to the NOC 0 coordinate system must be done accordingly
+// For wormhole, tensix and ethernet coords are TRANSLATED and dram are NOC_0/NOC_1
+// For blackhole, tensix, ethernet, and dram are all TRANSLATED
+tt::umd::CoreCoord translateNocCoordinatesToNoc0(
+    chip_id_t device_id, const CoreCoord& c, KernelProfilerNocEventMetadata::NocType noc_used_for_transfer) {
     bool coord_is_translated = MetalContext::instance().get_cluster().arch() != tt::ARCH::WORMHOLE_B0 ||
                                c.x >= tt::umd::wormhole::tensix_translated_coordinate_start_x ||
                                c.y >= tt::umd::wormhole::tensix_translated_coordinate_start_y ||
                                c.x >= tt::umd::wormhole::eth_translated_coordinate_start_x ||
                                c.y >= tt::umd::wormhole::eth_translated_coordinate_start_y;
-
     try {
+        const metal_SocDescriptor& soc_desc =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
         if (MetalContext::instance().hal().is_coordinate_virtualization_enabled() && coord_is_translated) {
-            const metal_SocDescriptor& soc_desc =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
-            // disable linting here; slicing is __intended__
-            // NOLINTBEGIN
             return soc_desc.translate_coord_to(c, CoordSystem::TRANSLATED, CoordSystem::NOC0);
-            // NOLINTEND
         } else {
-            return c;
+            if (noc_used_for_transfer == KernelProfilerNocEventMetadata::NocType::NOC_0) {
+                // Check for noc 0 coord and return
+                return soc_desc.get_coord_at(c, CoordSystem::NOC0);
+            } else {
+                // soc desc is not created with noc1 mapping by default so will have to manually convert to noc0
+                CoreCoord noc0_coord(soc_desc.grid_size.x - 1 - c.x, soc_desc.grid_size.y - 1 - c.y);
+                // Check for noc 0 coord and return
+                return soc_desc.get_coord_at(noc0_coord, CoordSystem::NOC0);
+            }
         }
     } catch (const std::exception& e) {
-        log_error(tt::LogMetal, "Failed to translate virtual coordinate {},{} to physical", c.x, c.y);
-        return c;
+        TT_FATAL(
+            0,
+            "Failed to translate coordinate {},{} used on {} to NOC0 coordinates",
+            c.x,
+            c.y,
+            enchantum::to_string(noc_used_for_transfer));
     }
-    return c;
+    TT_FATAL(
+        0,
+        "Failed to translate coordinate {},{} used on {} to NOC0 coordinates",
+        c.x,
+        c.y,
+        enchantum::to_string(noc_used_for_transfer));
 }
 
 bool isMarkerAZoneEndpoint(const tracy::TTDeviceMarker& marker) {
@@ -459,8 +478,11 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                 CoreCoord local_noc_write_dst_virt = {local_noc_write.dst_x, local_noc_write.dst_y};
                 const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, local_noc_write_dst_virt);
                 if (core_type == HalProgrammableCoreType::TENSIX) {
+                    // disable linting here; slicing is __intended__
+                    // NOLINTBEGIN
                     CoreCoord local_noc_write_dst_phys =
-                        getPhysicalAddressFromVirtual(device_id, local_noc_write_dst_virt);
+                        translateNocCoordinatesToNoc0(device_id, local_noc_write_dst_virt, local_noc_write.noc_type);
+                    // NOLINTEND
                     if (fabric_mux_markers.find(local_noc_write_dst_phys) == fabric_mux_markers.end()) {
                         addFabricMuxEvents(markers, fabric_mux_markers, local_noc_write_dst_phys);
                     }
@@ -562,17 +584,23 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                         // DO NOT emit destination coord; it isn't meaningful
 
                     } else if (local_noc_event.noc_xfer_type == EMD::NocEventType::WRITE_MULTICAST) {
-                        auto phys_start_coord = getPhysicalAddressFromVirtual(
-                            device_marker.chip_id, {local_noc_event.dst_x, local_noc_event.dst_y});
+                        auto phys_start_coord = translateNocCoordinatesToNoc0(
+                            device_marker.chip_id,
+                            {local_noc_event.dst_x, local_noc_event.dst_y},
+                            local_noc_event.noc_type);
                         data["mcast_start_x"] = phys_start_coord.x;
                         data["mcast_start_y"] = phys_start_coord.y;
-                        auto phys_end_coord = getPhysicalAddressFromVirtual(
-                            device_marker.chip_id, {local_noc_event.mcast_end_dst_x, local_noc_event.mcast_end_dst_y});
+                        auto phys_end_coord = translateNocCoordinatesToNoc0(
+                            device_marker.chip_id,
+                            {local_noc_event.mcast_end_dst_x, local_noc_event.mcast_end_dst_y},
+                            local_noc_event.noc_type);
                         data["mcast_end_x"] = phys_end_coord.x;
                         data["mcast_end_y"] = phys_end_coord.y;
                     } else {
-                        auto phys_coord = getPhysicalAddressFromVirtual(
-                            device_marker.chip_id, {local_noc_event.dst_x, local_noc_event.dst_y});
+                        auto phys_coord = translateNocCoordinatesToNoc0(
+                            device_marker.chip_id,
+                            {local_noc_event.dst_x, local_noc_event.dst_y},
+                            local_noc_event.noc_type);
                         data["dx"] = phys_coord.x;
                         data["dy"] = phys_coord.y;
                     }
@@ -657,8 +685,10 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                 // and use corresponding write on fabric mux to get eth channel used on src device for the transfer
                 if (fabric_event_markers.fabric_mux_marker.has_value()) {
                     // mux core location is derived from the local noc write event
-                    auto mux_phys_coord = getPhysicalAddressFromVirtual(
-                        local_noc_write_marker.chip_id, {local_noc_write_event.dst_x, local_noc_write_event.dst_y});
+                    auto mux_phys_coord = translateNocCoordinatesToNoc0(
+                        local_noc_write_marker.chip_id,
+                        {local_noc_write_event.dst_x, local_noc_write_event.dst_y},
+                        local_noc_write_event.noc_type);
 
                     auto fabric_mux_marker = fabric_event_markers.fabric_mux_marker.value();
                     auto fabric_mux_event = std::get<EMD::LocalNocEvent>(EMD(fabric_mux_marker.data).getContents());
@@ -668,8 +698,10 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                         {"y", mux_phys_coord.y},
                         {"noc", enchantum::to_string(fabric_mux_event.noc_type)}};
 
-                    CoreCoord eth_router_phys_coord = getPhysicalAddressFromVirtual(
-                        fabric_mux_marker.chip_id, {fabric_mux_event.dst_x, fabric_mux_event.dst_y});
+                    auto eth_router_phys_coord = translateNocCoordinatesToNoc0(
+                        fabric_mux_marker.chip_id,
+                        {fabric_mux_event.dst_x, fabric_mux_event.dst_y},
+                        fabric_mux_event.noc_type);
                     auto eth_chan_opt =
                         routing_lookup.getRouterEthCoreToChannelLookup(device_id, eth_router_phys_coord);
                     if (!eth_chan_opt) {
@@ -690,8 +722,10 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                     fabric_event_json["fabric_send"]["eth_chan"] = eth_chan;
                 } else {
                     // router eth core location is derived from the local noc write event
-                    auto eth_router_phys_coord = getPhysicalAddressFromVirtual(
-                        local_noc_write_marker.chip_id, {local_noc_write_event.dst_x, local_noc_write_event.dst_y});
+                    auto eth_router_phys_coord = translateNocCoordinatesToNoc0(
+                        local_noc_write_marker.chip_id,
+                        {local_noc_write_event.dst_x, local_noc_write_event.dst_y},
+                        local_noc_write_event.noc_type);
                     auto eth_chan_opt =
                         routing_lookup.getRouterEthCoreToChannelLookup(device_id, eth_router_phys_coord);
                     if (!eth_chan_opt) {
@@ -717,11 +751,14 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                     auto fabric_write_marker = fabric_event_markers.fabric_write_markers[0];
                     auto fabric_write_event =
                         std::get<EMD::FabricNoCEvent>(EMD(fabric_write_marker.data).getContents());
-                    auto phys_coord = getPhysicalAddressFromVirtual(
-                        fabric_write_marker.chip_id, {fabric_write_event.dst_x, fabric_write_event.dst_y});
+                    auto phys_coord = translateNocCoordinatesToNoc0(
+                        fabric_write_marker.chip_id,
+                        {fabric_write_event.dst_x, fabric_write_event.dst_y},
+                        fabric_write_event.dst_noc_type);
                     fabric_event_json["dst"] = {
                         {{"dx", phys_coord.x},
                          {"dy", phys_coord.y},
+                         {"noc", enchantum::to_string(fabric_write_event.dst_noc_type)},
                          {"num_bytes", local_noc_write_event.getNumBytes()}}};
                 } else if (KernelProfilerNocEventMetadata::isFabricScatterEventType(noc_xfer_type)) {
                     // add all chunks for scatter write and compute last chunk size
@@ -731,12 +768,14 @@ std::unordered_map<RuntimeID, nlohmann::json::array_t> convertNocTracePacketsToJ
                         auto fabric_scatter_write_marker = fabric_event_markers.fabric_write_markers[j];
                         auto fabric_scatter_write =
                             std::get<EMD::FabricNoCScatterEvent>(EMD(fabric_scatter_write_marker.data).getContents());
-                        auto phys_coord = getPhysicalAddressFromVirtual(
+                        auto phys_coord = translateNocCoordinatesToNoc0(
                             fabric_scatter_write_marker.chip_id,
-                            {fabric_scatter_write.dst_x, fabric_scatter_write.dst_y});
+                            {fabric_scatter_write.dst_x, fabric_scatter_write.dst_y},
+                            fabric_scatter_write.dst_noc_type);
                         fabric_event_json["dst"].push_back({
                             {"dx", phys_coord.x},
                             {"dy", phys_coord.y},
+                            {"noc", enchantum::to_string(fabric_scatter_write.dst_noc_type)},
                             {"num_bytes", fabric_scatter_write.chunk_size},
                         });
                         last_chunk_size -= fabric_scatter_write.chunk_size;
@@ -1130,8 +1169,11 @@ void DeviceProfiler::readRiscProfilerResults(
                                 PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC;
 
     // translate worker core virtual coord to phys coordinates
-    const CoreCoord phys_coord = getPhysicalAddressFromVirtual(device_id, worker_core);
-
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    // disable linting here; slicing is __intended__
+    // NOLINTBEGIN
+    const CoreCoord phys_coord = soc_desc.translate_coord_to(worker_core, CoordSystem::TRANSLATED, CoordSystem::NOC0);
+    // NOLINTEND
     // helper function to lookup opname from runtime id if metadata is available
     auto getOpNameIfAvailable = [&metadata](auto device_id, auto runtime_id) {
         return (metadata.has_value()) ? metadata->get_op_name(device_id, runtime_id) : "";

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -89,7 +89,8 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         int8_t dst_y;
         int8_t mcast_end_dst_x;
         int8_t mcast_end_dst_y;
-        FabricPacketType routing_fields_type;
+        NocType dst_noc_type : 4;
+        FabricPacketType routing_fields_type : 4;
     };
 
     struct FabricNoCScatterEvent {
@@ -98,7 +99,8 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         int8_t dst_y;
         int16_t chunk_size;
         int8_t num_chunks;
-        FabricPacketType routing_fields_type;
+        NocType dst_noc_type : 4;
+        FabricPacketType routing_fields_type : 4;
     };
 
     // represents a fabric routing fields event; follows a FabricNoCEvent

--- a/tt_metal/tools/profiler/fabric_event_profiler.hpp
+++ b/tt_metal/tools/profiler/fabric_event_profiler.hpp
@@ -12,6 +12,104 @@
 
 namespace kernel_profiler {
 
+// For Unicasts
+template <typename NocAddrU64, uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordFabricNocEvent(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
+    NocAddrU64 noc_addr) {
+    static_assert(std::is_same_v<NocAddrU64, uint64_t>);
+    auto [decoded_x, decoded_y] = noc_event_profiler::decode_noc_addr_to_coord(noc_addr);
+
+    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
+    KernelProfilerNocEventMetadata ev_md;
+
+    auto& fabric_noc_event = ev_md.data.fabric_event;
+    fabric_noc_event.noc_xfer_type = noc_event_type;
+    fabric_noc_event.dst_x = decoded_x;
+    fabric_noc_event.dst_y = decoded_y;
+    fabric_noc_event.mcast_end_dst_x = -1;
+    fabric_noc_event.mcast_end_dst_y = -1;
+    fabric_noc_event.dst_noc_type = tt::tt_fabric::edm_to_local_chip_noc == 1
+                                        ? KernelProfilerNocEventMetadata::NocType::NOC_1
+                                        : KernelProfilerNocEventMetadata::NocType::NOC_0;
+    fabric_noc_event.routing_fields_type = packet_type;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordFabricNocEventMulticast(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
+    uint8_t noc_x_start,
+    uint8_t noc_y_start,
+    uint8_t mcast_rect_size_x,
+    uint8_t mcast_rect_size_y) {
+    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
+    KernelProfilerNocEventMetadata ev_md;
+
+    auto& fabric_noc_event = ev_md.data.fabric_event;
+    fabric_noc_event.noc_xfer_type = noc_event_type;
+    fabric_noc_event.dst_x = noc_x_start;
+    fabric_noc_event.dst_y = noc_y_start;
+    fabric_noc_event.mcast_end_dst_x = noc_x_start + mcast_rect_size_x - 1;
+    fabric_noc_event.mcast_end_dst_y = noc_y_start + mcast_rect_size_y - 1;
+    fabric_noc_event.dst_noc_type = tt::tt_fabric::edm_to_local_chip_noc == 1
+                                        ? KernelProfilerNocEventMetadata::NocType::NOC_1
+                                        : KernelProfilerNocEventMetadata::NocType::NOC_0;
+    fabric_noc_event.routing_fields_type = packet_type;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordFabricScatterEvent(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
+    const volatile uint64_t* noc_addr_array,
+    const volatile uint16_t* chunk_sizes,
+    uint32_t num_chunks) {
+    // Record each address as a separate event
+    for (uint32_t i = 0; i < num_chunks; i++) {
+        auto [decoded_x, decoded_y] = noc_event_profiler::decode_noc_addr_to_coord(noc_addr_array[i]);
+
+        // profiler packet stores XY address data as well as packet type tag and address index
+        KernelProfilerNocEventMetadata ev_md;
+
+        auto& fabric_scatter_event = ev_md.data.fabric_scatter_event;
+        fabric_scatter_event.noc_xfer_type = noc_event_type;
+        fabric_scatter_event.dst_x = decoded_x;
+        fabric_scatter_event.dst_y = decoded_y;
+        fabric_scatter_event.dst_noc_type = tt::tt_fabric::edm_to_local_chip_noc == 1
+                                                ? KernelProfilerNocEventMetadata::NocType::NOC_1
+                                                : KernelProfilerNocEventMetadata::NocType::NOC_0;
+        if (i < num_chunks - 1) {
+            fabric_scatter_event.chunk_size = chunk_sizes[i];
+        } else {
+            fabric_scatter_event.chunk_size = 0;
+        }
+        fabric_scatter_event.num_chunks = num_chunks;
+        fabric_scatter_event.routing_fields_type = packet_type;
+
+        kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+        kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+    }
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordRoutingFields1D(uint32_t routing_fields) {
+    KernelProfilerNocEventMetadata event_routing_fields;
+    event_routing_fields.data.fabric_routing_fields_1d.noc_xfer_type =
+        KernelProfilerNocEventMetadata::NocEventType::FABRIC_ROUTING_FIELDS_1D;
+    event_routing_fields.data.fabric_routing_fields_1d.routing_fields_value = routing_fields;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(event_routing_fields.asU64());
+}
+
 // how slow is this? alternative is sotring entire route buffer which isn't ideal either...
 template <uint32_t STATIC_ID = 12345>
 FORCE_INLINE void recordRoutingFields2D(
@@ -76,7 +174,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
     switch (noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_write;
-            noc_event_profiler::recordFabricNocEvent(
+            recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_WRITE,
                 routing_fields_type,
                 unicast_write_cmd.noc_address);
@@ -84,7 +182,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_seminc;
-            noc_event_profiler::recordFabricNocEvent(
+            recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_ATOMIC_INC,
                 routing_fields_type,
                 unicast_write_cmd.noc_address);
@@ -92,7 +190,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_seminc_fused;
-            noc_event_profiler::recordFabricNocEvent(
+            recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_FUSED_UNICAST_ATOMIC_INC,
                 routing_fields_type,
                 unicast_write_cmd.noc_address);
@@ -100,7 +198,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_inline_write;
-            noc_event_profiler::recordFabricNocEvent(
+            recordFabricNocEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_INLINE_WRITE,
                 routing_fields_type,
                 unicast_write_cmd.noc_address);
@@ -108,7 +206,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
             const volatile auto& unicast_write_cmd = fabric_header_ptr->get_command_fields().unicast_scatter_write;
-            noc_event_profiler::recordFabricScatterEvent(
+            recordFabricScatterEvent(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_UNICAST_SCATTER_WRITE,
                 routing_fields_type,
                 unicast_write_cmd.noc_address,
@@ -118,7 +216,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_WRITE: {
             const volatile auto& mcast_write_cmd = fabric_header_ptr->get_command_fields().mcast_write;
-            noc_event_profiler::recordFabricNocEventMulticast(
+            recordFabricNocEventMulticast(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_MULTICAST_WRITE,
                 routing_fields_type,
                 mcast_write_cmd.noc_x_start,
@@ -129,7 +227,7 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         }
         case tt::tt_fabric::NocSendType::NOC_MULTICAST_ATOMIC_INC: {
             const volatile auto& mcast_write_cmd = fabric_header_ptr->get_command_fields().mcast_seminc;
-            noc_event_profiler::recordFabricNocEventMulticast(
+            recordFabricNocEventMulticast(
                 KernelProfilerNocEventMetadata::NocEventType::FABRIC_MULTICAST_ATOMIC_INC,
                 routing_fields_type,
                 mcast_write_cmd.noc_x_start,
@@ -146,9 +244,9 @@ void record_fabric_header(const volatile PACKET_HEADER_TYPE* fabric_header_ptr) 
         recordRoutingFields2D(fabric_header_ptr->routing_fields, fabric_header_ptr->route_buffer);
 #endif
     } else if constexpr (std::is_base_of_v<tt::tt_fabric::LowLatencyRoutingFields, ROUTING_FIELDS_TYPE>) {
-        noc_event_profiler::recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
+        recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
     } else if constexpr (std::is_base_of_v<tt::tt_fabric::RoutingFields, ROUTING_FIELDS_TYPE>) {
-        noc_event_profiler::recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
+        recordRoutingFields1D(fabric_header_ptr->routing_fields.value);
     }
 }
 }  // namespace kernel_profiler

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -20,14 +20,6 @@ FORCE_INLINE std::pair<uint32_t, uint32_t> decode_noc_coord_reg_to_coord(uint16_
     constexpr uint32_t NOC_COORD_MASK = 0x3F;
     uint32_t x = noc_xy_bits & NOC_COORD_MASK;
     uint32_t y = (noc_xy_bits >> NOC_ADDR_NODE_ID_BITS) & NOC_COORD_MASK;
-#if defined(ARCH_WORMHOLE)
-    if constexpr (DRAM) {
-        if (noc_index == 1) {
-            x = noc_size_x - 1 - x;
-            y = noc_size_y - 1 - y;
-        }
-    }
-#endif
     return {x, y};
 }
 
@@ -127,95 +119,6 @@ FORCE_INLINE void recordNocEventWithAddr(
     static_assert(std::is_same_v<NocAddrU64, uint64_t>);
     auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr);
     recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
-}
-
-template <uint32_t STATIC_ID = 12345>
-FORCE_INLINE void recordRoutingFields1D(uint32_t routing_fields) {
-    KernelProfilerNocEventMetadata event_routing_fields;
-    event_routing_fields.data.fabric_routing_fields_1d.noc_xfer_type =
-        KernelProfilerNocEventMetadata::NocEventType::FABRIC_ROUTING_FIELDS_1D;
-    event_routing_fields.data.fabric_routing_fields_1d.routing_fields_value = routing_fields;
-
-    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(event_routing_fields.asU64());
-}
-
-// For Unicasts
-template <typename NocAddrU64, uint32_t STATIC_ID = 12345>
-FORCE_INLINE void recordFabricNocEvent(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
-    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
-    NocAddrU64 noc_addr) {
-    static_assert(std::is_same_v<NocAddrU64, uint64_t>);
-    auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr);
-
-    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
-    KernelProfilerNocEventMetadata ev_md;
-
-    auto& fabric_noc_event = ev_md.data.fabric_event;
-    fabric_noc_event.noc_xfer_type = noc_event_type;
-    fabric_noc_event.dst_x = decoded_x;
-    fabric_noc_event.dst_y = decoded_y;
-    fabric_noc_event.mcast_end_dst_x = -1;
-    fabric_noc_event.mcast_end_dst_y = -1;
-    fabric_noc_event.routing_fields_type = packet_type;
-
-    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
-}
-
-template <uint32_t STATIC_ID = 12345>
-FORCE_INLINE void recordFabricNocEventMulticast(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
-    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
-    uint8_t noc_x_start,
-    uint8_t noc_y_start,
-    uint8_t mcast_rect_size_x,
-    uint8_t mcast_rect_size_y) {
-    // first profiler packet stores XY address data as well as packet type tag (used to decode routing fields)
-    KernelProfilerNocEventMetadata ev_md;
-
-    auto& fabric_noc_event = ev_md.data.fabric_event;
-    fabric_noc_event.noc_xfer_type = noc_event_type;
-    fabric_noc_event.dst_x = noc_x_start;
-    fabric_noc_event.dst_y = noc_y_start;
-    fabric_noc_event.mcast_end_dst_x = noc_x_start + mcast_rect_size_x - 1;
-    fabric_noc_event.mcast_end_dst_y = noc_y_start + mcast_rect_size_y - 1;
-    fabric_noc_event.routing_fields_type = packet_type;
-
-    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
-}
-
-template <uint32_t STATIC_ID = 12345>
-FORCE_INLINE void recordFabricScatterEvent(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
-    KernelProfilerNocEventMetadata::FabricPacketType packet_type,
-    const volatile uint64_t* noc_addr_array,
-    const volatile uint16_t* chunk_sizes,
-    uint32_t num_chunks) {
-    // Record each address as a separate event
-    for (uint32_t i = 0; i < num_chunks; i++) {
-        auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr_array[i]);
-
-        // profiler packet stores XY address data as well as packet type tag and address index
-        KernelProfilerNocEventMetadata ev_md;
-
-        auto& fabric_scatter_event = ev_md.data.fabric_scatter_event;
-        fabric_scatter_event.noc_xfer_type = noc_event_type;
-        fabric_scatter_event.dst_x = decoded_x;
-        fabric_scatter_event.dst_y = decoded_y;
-        if (i < num_chunks - 1) {
-            fabric_scatter_event.chunk_size = chunk_sizes[i];
-        } else {
-            fabric_scatter_event.chunk_size = 0;
-        }
-        fabric_scatter_event.num_chunks = num_chunks;
-        fabric_scatter_event.routing_fields_type = packet_type;
-
-        kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
-        kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
-    }
 }
 }  // namespace noc_event_profiler
 

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -62,7 +62,7 @@ public:
 
     // lookup Eth Channel ID given a physical chip id and physical EDM router core coordinate
     std::optional<tt::tt_fabric::chan_id_t> getRouterEthCoreToChannelLookup(
-        chip_id_t phys_chip_id, CoreCoord eth_router_phys_core_coord) const {
+        chip_id_t phys_chip_id, CoreCoord& eth_router_phys_core_coord) const {
         auto it = eth_core_to_channel_lookup_.find(std::make_tuple(phys_chip_id, eth_router_phys_core_coord));
         if (it != eth_core_to_channel_lookup_.end()) {
             return it->second;


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-npe/issues/83

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes