### PR TITLE
#0: Fix FreeListOpt bug with reallocating at same address with allocate_at_address

### DIFF
--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -185,11 +185,13 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     ssize_t target_block_index = -1;
     DeviceAddr start_address = absolute_start_address - offset_bytes_;
     for (size_t i = 0; i < block_address_.size(); i++) {
-        size_t block_start = block_address_[i];
-        size_t block_end = block_start + block_size_[i];
-        if (start_address >= block_start && start_address + alloc_size <= block_end) {
-            target_block_index = i;
-            break;
+        if (meta_block_is_allocated_[i]) {
+            size_t block_start = block_address_[i];
+            size_t block_end = block_start + block_size_[i];
+            if (start_address >= block_start && start_address + alloc_size <= block_end) {
+                target_block_index = i;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
There were no tests for calling `deallocate` in between `allocate_at_address`. If you try to deallocate and reallocate at same address, it will fail at this check: `TT_ASSERT(it != segregated_list.end(), "Block not found in size segregated list")`.

### What's changed
- Add check for stale metablocks when iterating through block_addresses_
- Add test to guard expose and guard against bug


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17800017830
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes