### PR TITLE
[UMD] Remove SimulationDeviceInit usage

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -38,8 +38,8 @@ inline std::string get_env_arch_name() {
 inline std::string get_umd_arch_name() {
 
     if(tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
-        return tt::arch_to_str(init.get_arch_name());
+        auto soc_desc = tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
+        return tt::arch_to_str(tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc));
     }
 
     auto cluster_desc = tt::umd::Cluster::create_cluster_descriptor();

--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -38,7 +38,7 @@ inline std::string get_env_arch_name() {
 inline std::string get_umd_arch_name() {
 
     if(tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        auto soc_desc = tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
+        auto soc_desc = tt::umd::SimulationDevice::get_soc_descriptor_path_from_simulator_path(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
         return tt::arch_to_str(tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc));
     }
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -48,8 +48,10 @@ inline std::string get_core_descriptor_file(
 
     bool use_small_core_desc_yaml = false; // override to a different core descriptor for small RTL sims
     if (tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
-        if (init.get_soc_descriptor().grid_size.y <= 2) { // these SOC descriptors declare a 2x2 grid
+        auto soc_desc = tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(
+            tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
+        tt_xy_pair grid_size = tt::umd::SocDescriptor::get_grid_size_from_soc_descriptor_path(soc_desc);
+        if (grid_size.y <= 2) {  // these SOC descriptors declare a 2x2 grid
             use_small_core_desc_yaml = true;
         }
     }

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -48,7 +48,7 @@ inline std::string get_core_descriptor_file(
 
     bool use_small_core_desc_yaml = false; // override to a different core descriptor for small RTL sims
     if (tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        auto soc_desc = tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(
+        auto soc_desc = tt::umd::SimulationDevice::get_soc_descriptor_path_from_simulator_path(
             tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
         tt_xy_pair grid_size = tt::umd::SocDescriptor::get_grid_size_from_soc_descriptor_path(soc_desc);
         if (grid_size.y <= 2) {  // these SOC descriptors declare a 2x2 grid

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -86,7 +86,7 @@ inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtopti
         return arch;
     } else if (rtoptions.get_target_device() == tt::TargetDevice::Simulator) {
         auto soc_desc =
-            tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
+            tt::umd::SimulationDevice::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
         arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
     } else {
         arch = get_physical_architecture();

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -85,8 +85,9 @@ inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtopti
         }
         return arch;
     } else if (rtoptions.get_target_device() == tt::TargetDevice::Simulator) {
-        tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
-        arch = init.get_arch_name();
+        auto soc_desc =
+            tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
+        arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
     } else {
         arch = get_physical_architecture();
     }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -71,8 +71,9 @@ namespace tt {
 tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const tt_ClusterDescriptor* cluster_desc) {
     if (rtoptions.get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
-        auto arch = init.get_arch_name();
+        auto soc_desc =
+            tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
+        auto arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
         if (arch == tt::ARCH::WORMHOLE_B0) {
             return tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0;
         } else if (arch == tt::ARCH::BLACKHOLE) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -72,7 +72,7 @@ tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const tt_ClusterDescriptor* cluster_desc) {
     if (rtoptions.get_simulator_enabled()) {
         auto soc_desc =
-            tt::umd::SocDescriptor::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
+            tt::umd::SimulationDevice::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
         auto arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
         if (arch == tt::ARCH::WORMHOLE_B0) {
             return tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0;


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-umd/issues/1320

### Problem description
No functional changes.
Remove usage of this deprecated class. Instead, use static SocDescriptor methods for fetching what is needed.
Will remove umd bump from this change, and will rebase it once UMD with required changes is already merged to metal.

### What's changed
- Remove usages of SimulationDeviceInit
- Replace them with corresponding usages of SocDescriptor's static methods.

### Checklist
All runs on brosko/rem_simdevinit :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/17834436182