### PR TITLE
removed split_reader mention from l2 nightly test that caused failure

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4357,7 +4357,6 @@ def test_conv2d_panoptic(
         has_bias=has_bias,
         deallocate_activation=True,
         shard_layout=shard_layout,
-        enable_split_reader=True if shard_layout == HS else False,
         enable_act_double_buffer=True,
         enable_weights_double_buffer=True if shard_layout == BS else False,
 
@@ -4454,7 +4453,6 @@ def test_conv_dram_panoptic(
             slice_type=slice_type,
             num_slices=num_slices,
         ),
-        enable_split_reader=True if shard_layout == HS else False,
         enable_act_double_buffer=True,
         enable_weights_double_buffer=True if shard_layout == BS else False,
     )


### PR DESCRIPTION
### Problem description
Test [failed](https://github.com/tenstorrent/tt-metal/actions/runs/17788397676/job/50560803500#step:5:161) due to split_reader mention  

### What's changed
- removed sending non-existent `enable_split_reader`