### PR TITLE
#28337: Fix handling GRID_2D mode with BufferDistributionSpec

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .buffer_type = BufferType::L1,
             },
             MeshBufferAllocationExpected{
-                .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}},
+                .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}, {2, 1}, {3, 1}, {0, 2}, {1, 2}, {2, 2}, {3, 2}, {0, 3}, {1, 3}, {2, 3}, {3, 3}},
                 .num_cores = 6,
                 .num_dev_pages = 10 * 6,  // Shard shape is 10 pages
                 .aligned_size = 2048 * 60,
@@ -151,7 +151,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .buffer_type = BufferType::L1,
             },
             MeshBufferAllocationExpected{
-                .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}},
+                .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}, {1, 0}, {1, 1}, {1, 2}, {1, 3}, {2, 0}, {2, 1}, {2, 2}, {2, 3}, {3, 0}, {3, 1}, {3, 2}, {3, 3}},
                 .num_cores = 4,
                 .num_dev_pages = 384 * 4,  // Shard shape is 384 pages
                 .aligned_size = 256 * 1536,

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -131,10 +131,10 @@ INSTANTIATE_TEST_SUITE_P(
                 .buffer_type = BufferType::L1,
             },
             MeshBufferAllocationExpected{
-                .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}, {2, 1}, {3, 1}, {0, 2}, {1, 2}, {2, 2}, {3, 2}, {0, 3}, {1, 3}, {2, 3}, {3, 3}},
-                .num_cores = 16,
-                .num_dev_pages = 10 * 16,  // Shard shape is 10 pages
-                .aligned_size = 2048 * 160,
+                .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}},
+                .num_cores = 6,
+                .num_dev_pages = 10 * 6,  // Shard shape is 10 pages
+                .aligned_size = 2048 * 60,
                 .aligned_size_per_bank = 2048 * 10,
             },
         },
@@ -151,10 +151,10 @@ INSTANTIATE_TEST_SUITE_P(
                 .buffer_type = BufferType::L1,
             },
             MeshBufferAllocationExpected{
-                .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}, {1, 0}, {1, 1}, {1, 2}, {1, 3}, {2, 0}, {2, 1}, {2, 2}, {2, 3}, {3, 0}, {3, 1}, {3, 2}, {3, 3}},
-                .num_cores = 16,
-                .num_dev_pages = 384 * 16,  // Shard shape is 384 pages
-                .aligned_size = 256 * 6144,
+                .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}},
+                .num_cores = 4,
+                .num_dev_pages = 384 * 4,  // Shard shape is 384 pages
+                .aligned_size = 256 * 1536,
                 .aligned_size_per_bank = 256 * 384,
             },
         },

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -607,6 +607,34 @@ INSTANTIATE_TEST_SUITE_P(
                                },
                        },
                        CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{1, 2, 32, 32},
+                           .layout = Layout::TILE,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {0, 1})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                                   .shard_distribution_strategy = ShardDistributionStrategy::GRID_2D,
+                               },
+                       },
+                       CopyParams{
+                           .tensor_shape = tt::tt_metal::Shape{2, 64, 128},
+                           .layout = Layout::ROW_MAJOR,
+                           .dtype = DataType::BFLOAT16,
+                           .buffer_type = BufferType::L1,
+
+                           .input_shard_spec =
+                               NdShardSpec{
+                                   .shard_shape = tt::tt_metal::Shape{32, 32},
+                                   .grid = CoreRangeSet(CoreRange({0, 0}, {7, 7})),
+                                   .orientation = ShardOrientation::ROW_MAJOR,
+                                   .shard_distribution_strategy = ShardDistributionStrategy::GRID_2D,
+                               },
+                       },
+                       CopyParams{
                            .tensor_shape = tt::tt_metal::Shape{18, 128, 64},
                            .layout = Layout::TILE,
                            .dtype = DataType::UINT8,

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -65,7 +65,7 @@ public:
     std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
     UncompressedBufferPageMapping compute_page_mapping() const {
-        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);
+        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_with_data_);
     }
 
 private:

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -65,7 +65,7 @@ public:
     std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
     UncompressedBufferPageMapping compute_page_mapping() const {
-        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_with_data_);
+        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);
     }
 
 private:

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -197,7 +197,7 @@ UncompressedBufferPageMapping generate_buffer_page_mapping(const Buffer& buffer)
         return buffer_page_mapping;
     }
 
-    if (!buffer.has_shard_spec()) {
+    if (buffer.buffer_distribution_spec().has_value()) {
         return buffer.buffer_distribution_spec()->compute_page_mapping();
     }
 
@@ -548,10 +548,10 @@ std::optional<uint32_t> Buffer::num_cores() const {
     if (!is_sharded(this->buffer_layout_)) {
         return std::nullopt;
     }
-    if (shard_spec_.has_value()) {
-        return shard_spec_->tensor_shard_spec.grid.num_cores();
+    if (buffer_distribution_spec_.has_value()) {
+        return buffer_distribution_spec_.value().num_cores_with_data();
     }
-    return buffer_distribution_spec_.value().num_cores();
+    return shard_spec_->tensor_shard_spec.grid.num_cores();
 }
 
 DeviceAddr Buffer::translate_page_address(DeviceAddr offset, uint32_t bank_id) const {

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -204,7 +204,8 @@ std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
     auto core_grid = core_range_set.ranges()[0];
 
     uint32_t num_shards_along_width = std::max(div_up(tensor_shape_in_pages[-1], shard_shape_in_pages[-1]), 1u);
-    uint32_t num_shards_along_height = std::max(div_up(tensor_shape_in_pages[-2], shard_shape_in_pages[-2]), 1u);
+    uint32_t tensor_height = tensor_shape_in_pages.volume() / tensor_shape_in_pages[-1];
+    uint32_t num_shards_along_height = std::max(div_up(tensor_height, shard_shape_in_pages[-2]), 1u);
     if (shard_orientation != ShardOrientation::ROW_MAJOR) {
         std::swap(num_shards_along_width, num_shards_along_height);
     }

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -204,7 +204,8 @@ std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
     auto core_grid = core_range_set.ranges()[0];
 
     uint32_t num_shards_along_width = std::max(div_up(tensor_shape_in_pages[-1], shard_shape_in_pages[-1]), 1u);
-    uint32_t tensor_height = tensor_shape_in_pages.volume() / tensor_shape_in_pages[-1];
+    uint64_t tensor_volume = tensor_shape_in_pages.volume();
+    uint32_t tensor_height = tensor_volume == 0 ? 0 : tensor_volume / tensor_shape_in_pages[-1];
     uint32_t num_shards_along_height = std::max(div_up(tensor_height, shard_shape_in_pages[-2]), 1u);
     if (shard_orientation != ShardOrientation::ROW_MAJOR) {
         std::swap(num_shards_along_width, num_shards_along_height);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28337

### Problem description
There is an issue with handling GRID_2D (used to represent block sharding) in BufferDistributionSpec, resulting in sometimes incorrect buffer reads/writes

### What's changed
Fixed ND tensor shape handling in BufferDistributionSpec
Updated the Buffer code to prefer buffer distribution spec over shard spec when available
Added tests provided by @philei-tt to reproduce the described issue

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17815385042)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/17815388386)
- [x] Verified that cherry-picking this commit onto the branch with the issue fixed the reported test failure
- [x] New/Existing tests provide coverage for changes