### PR TITLE
Add Whisper-large-v3-turbo demo

### DIFF
--- a/models/demos/whisper/README.md
+++ b/models/demos/whisper/README.md
@@ -5,7 +5,10 @@
 
 ## Introduction
 
-Read more about Whisper at [huggingface.co/distil-whisper/distil-large-v3](https://huggingface.co/distil-whisper/distil-large-v3)
+Read more about Whisper:
+- [huggingface.co/distil-whisper/distil-large-v3](https://huggingface.co/distil-whisper/distil-large-v3)
+- [huggingface.co/openai/whisper-large-v3](https://huggingface.co/openai/whisper-large-v3)
+- [huggingface.co/openai/whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo)
 
 ## Prerequisites
 - Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
@@ -15,7 +18,7 @@ Read more about Whisper at [huggingface.co/distil-whisper/distil-large-v3](https
 ### Conditional Generation
 - To run the conditional generation demo with custom inputs:
 ```sh
-pytest --disable-warnings --input-path="models/demos/whisper/demo/dataset/conditional_generation" models/demos/whisper/demo/demo.py::test_demo_for_conditional_generation
+pytest --disable-warnings --input-path="models/demos/whisper/demo/dataset/conditional_generation" models/demos/whisper/demo/demo.py::test_demo_for_conditional_generation -k "openai/whisper-large-v3-turbo"
 ```
 
 - To run the conditional generation demo with inputs from the `hf-internal-testing/librispeech_asr_dummy` dataset:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28686

### Problem description
A customer asked for `openai/whisper-large-v3-turbo' demo.
The demo script does not exist, so the customer thinks we don't support it.
We'll add the demo script to show we can support this model.

### What's changed
Added code to existing whisper demo script.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes

### Test results

- `pytest --disable-warnings --input-path="models/demos/whisper/demo/dataset/conditional_generation" models/demos/whisper/demo/demo.py::test_demo_for_conditional_generation -k "openai/whisper-large-v3-turbo"` successfully ran.

<img width="1895" height="1359" alt="image" src="https://github.com/user-attachments/assets/555f3605-aae4-48dc-8ac0-4e761dd537d6" />