### PR TITLE
Refactoring device pointer check in Matmul Op Validation

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1347,7 +1347,9 @@ Matmul create_matmul_struct(
     const Tensor& input_tensor_b,
     const struct Matmul& parameters,
     const std::vector<std::optional<Tensor>>& optional_output_tensors) {
-    auto arch = input_tensor_a.device()->arch();
+    tt::tt_metal::IDevice* device = input_tensor_a.device();
+    TT_FATAL(device != nullptr, "Operand to matmul must be on device");
+    auto arch = device->arch();
     const bool has_user_grid = parameters.user_core_coord.has_value();
     const bool has_program_config = parameters.program_config.has_value();
     bool are_inputs_low_precision_df =
@@ -1585,7 +1587,9 @@ void Matmul::validate(
     const auto& b_shape_aligned = input_tensor_b.padded_shape();
     auto in0_tile_shape = input_tensor_a.tensor_spec().tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.tensor_spec().tile().get_tile_shape();
-
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Operands to matmul need to be on device!");
     TT_FATAL(
         (in0_tile_shape[1] == TILE_WIDTH && in1_tile_shape[0] == TILE_WIDTH),
         "Input tile dims must have inner dim equal to 32 due to llk constraints");
@@ -1672,9 +1676,7 @@ void Matmul::validate(
     }
 
     TT_FATAL(is_floating_point(input_tensor_a.dtype()), "Unsupported data format");
-    TT_FATAL(
-        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
-        "Operands to matmul need to be on device!");
+
     TT_FATAL(
         input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
         "Operands to matmul need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1682,15 +1682,6 @@ void Matmul::validate(
         "Operands to matmul need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
-    if (input_tensor_a.device()->arch() == tt::ARCH::GRAYSKULL) {
-        TT_FATAL(
-            (in0_tile_shape[1] == TILE_WIDTH && in0_tile_shape[0] == TILE_HEIGHT),
-            "Grayskull does not support tiny tile");
-        TT_FATAL(
-            (in1_tile_shape[1] == TILE_WIDTH && in1_tile_shape[0] == TILE_HEIGHT),
-            "Grayskull does not support tiny tile");
-    }
-
     const auto& optional_bias = optional_input_tensors.at(0);
     uint32_t bias_single_tile_size = 0;
     if (optional_bias.has_value()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1586,15 +1586,6 @@ void Matmul::validate(
     auto in0_tile_shape = input_tensor_a.tensor_spec().tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.tensor_spec().tile().get_tile_shape();
 
-    if (input_tensor_a.device()->arch() == tt::ARCH::GRAYSKULL) {
-        TT_FATAL(
-            (in0_tile_shape[1] == TILE_WIDTH && in0_tile_shape[0] == TILE_HEIGHT),
-            "Grayskull does not support tiny tile");
-        TT_FATAL(
-            (in1_tile_shape[1] == TILE_WIDTH && in1_tile_shape[0] == TILE_HEIGHT),
-            "Grayskull does not support tiny tile");
-    }
-
     TT_FATAL(
         (in0_tile_shape[1] == TILE_WIDTH && in1_tile_shape[0] == TILE_WIDTH),
         "Input tile dims must have inner dim equal to 32 due to llk constraints");
@@ -1688,6 +1679,15 @@ void Matmul::validate(
         input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
         "Operands to matmul need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
+
+    if (input_tensor_a.device()->arch() == tt::ARCH::GRAYSKULL) {
+        TT_FATAL(
+            (in0_tile_shape[1] == TILE_WIDTH && in0_tile_shape[0] == TILE_HEIGHT),
+            "Grayskull does not support tiny tile");
+        TT_FATAL(
+            (in1_tile_shape[1] == TILE_WIDTH && in1_tile_shape[0] == TILE_HEIGHT),
+            "Grayskull does not support tiny tile");
+    }
 
     const auto& optional_bias = optional_input_tensors.at(0);
     uint32_t bias_single_tile_size = 0;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27201

### Problem description
If a user creates a tensor on host and tries to call ttnn.matmul on it with `ttnn.matmul`, it would result in a segfault not a validation assert, which can confuse the user and it provides poor understanding with the wrong error. This was because there is a device access to access the architecture inside `create_matmul_struct`.  On top of that, there are also device accesses that check for gray skull architecture that happen before null device pointer check.   

### What's changed
- Added a check to ensure device pointer is not null
- Moved any use of device pointer after confirming storage type is not host

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/17793534457)
- [ ] If there are other tests I should run please let me know

NOTE:
There was no failing test for this but was discovered with the following piece of code, the whole script passes if `ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)` has the attribute device=device, otherwise it will segfault with no proper assertion.
```
import ttnn
import torch

class TTModule:
    def __init__(self, mesh_device, state_dict):
        self.mesh_device = mesh_device

        # fc1
        w_fc1 = state_dict["fc1.weight"].T.view(1, 1, 1024, 128)  # transpose to (in_features, out_features)
        b_fc1 = state_dict["fc1.bias"]
        self.w_fc1 = ttnn.from_torch(w_fc1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
   
        self.b_fc1 = ttnn.from_torch(b_fc1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

        # fc2
        w_fc2 = state_dict["fc2.weight"].T.view(1, 1, 128, 96)
        b_fc2 = state_dict["fc2.bias"]
        self.w_fc2 = ttnn.from_torch(w_fc2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

        self.b_fc2 = ttnn.from_torch(b_fc2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

        # fc3
        w_fc3 = state_dict["fc3.weight"].T.view(1, 1, 96, 32)
        b_fc3 = state_dict["fc3.bias"]
        self.w_fc3 = ttnn.from_torch(w_fc3, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)

        self.b_fc3 = ttnn.from_torch(b_fc3, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,device=mesh_device)

    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
        # x is expected on device in TILE_LAYOUT
        # fc1
        breakpoint()
        out = ttnn.matmul(x, self.w_fc1)
        out = ttnn.add(out, self.b_fc1)
        out = ttnn.relu(out)

        # fc2
        out = ttnn.matmul(out, self.w_fc2)
        out = ttnn.add(out, self.b_fc2)
        out = ttnn.relu(out)

        # fc3
        out = ttnn.matmul(out, self.w_fc3)
        out = ttnn.add(out, self.b_fc3)
        out = ttnn.relu(out)

        # softmax output
        out = ttnn.softmax(out, dim=-1)
        return out


class MnistModel(torch.nn.Module):
    def __init__(self):
        super().__init__()

        self.fc1 = torch.nn.Linear(1024, 128)
        self.fc2 = torch.nn.Linear(128, 96)
        self.fc3 = torch.nn.Linear(96, 32)

        # self.load_state_dict(state_dict)

    def forward(self, x):
        x = x.view(x.shape[0], -1)

        x = self.fc1(x)
        x = torch.nn.functional.relu(x)

        x = self.fc2(x)
        x = torch.nn.functional.relu(x)

        x = self.fc3(x)
        x = torch.nn.functional.relu(x)

        return torch.nn.functional.softmax(x)


import pytest

@pytest.mark.parametrize(
    "device",
    [
        (1, 1),
    ],
    indirect=True,
)
def test_run(
    device,
    reset_seeds,
):
    torch_input = torch.randn((1, 1, 1, 1024))
    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)

    mnist_ref = MnistModel()
    mnist_ref.eval()
    state_dict = mnist_ref.state_dict()


    tt_model = TTModule(device, state_dict)

    tt_output = tt_model.forward(ttnn_input)
```