### PR TITLE
Enabled overriding the split reader heuristic in conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -779,7 +779,8 @@ Result conv2d_L1(
             conv_config.enable_weights_double_buffer,
             conv_config.full_inner_dim,
             conv_config.enable_activation_reuse,
-            conv_config.config_tensors_in_dram);
+            conv_config.config_tensors_in_dram,
+            conv_config.force_split_reader);
 
         if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
             conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -102,7 +102,7 @@ std::vector<CBInfo> get_cb_info(
 
     const bool split_reader_enabled =
         is_split_reader_supported(sharding_scheme, is_1d_depthwise_conv, block_config.act_block_h_ntiles) &&
-        is_split_reader_viable(
+        conv_config.force_split_reader.value_or(is_split_reader_viable(
             block_config.act_block_h_ntiles,
             input_channels_padded,
             kernel_size[1],
@@ -115,7 +115,7 @@ std::vector<CBInfo> get_cb_info(
             block_config.act_block_w_ntiles,
             fp32_dest_acc_en,
             output_datatype,
-            conv_config.enable_activation_reuse);
+            conv_config.enable_activation_reuse));
 
     // Block dims
     if (sharding_scheme != TensorMemoryLayout::HEIGHT_SHARDED || !split_reader_enabled || is_1d_depthwise_conv) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -319,7 +319,8 @@ void py_bind_conv2d(py::module& module) {
             bool,
             bool,
             bool,
-            bool>(),
+            bool,
+            std::optional<bool>>(),
         py::kw_only(),
         py::arg("weights_dtype") = std::nullopt,
         py::arg("activation") = std::nullopt,
@@ -339,7 +340,8 @@ void py_bind_conv2d(py::module& module) {
         py::arg("full_inner_dim") = false,
         py::arg("in_place") = false,
         py::arg("enable_kernel_stride_folding") = false,
-        py::arg("enable_activation_reuse") = false);
+        py::arg("enable_activation_reuse") = false,
+        py::arg("force_split_reader") = std::nullopt);
     py_conv_config.def_readwrite("weights_dtype", &Conv2dConfig::weights_dtype, R"doc(
         Optional argument which specifies the data type of the preprocessed weights & bias tensor if the Conv2D op is responsible for preparing the weights.
         Supports ttnn.bfloat16 and ttnn.bfloat8_b.
@@ -470,6 +472,17 @@ void py_bind_conv2d(py::module& module) {
         Enables reusing data between consecutive image rows.
         It can be enabled for height sharding only and boosts image2column performance,
         so its meant to be used for reader-bound convolutions.
+
+        ===============================================================
+    )doc");
+
+    py_conv_config.def_readwrite("force_split_reader", &Conv2dConfig::force_split_reader, R"doc(
+        ===================== EXPERIMENTAL FEATURE ======================
+
+        This uses both the reader & writer cores to carry out the activation reader operation.
+        This is useful when the input tensor is large, and the activation reader is a bottleneck.
+        This is only supported for Height Sharded Conv2D.
+        Setting this overrides the split reader heuristic.
 
         ===============================================================
     )doc");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -46,7 +46,8 @@ Tensor optimized_conv_new(
     bool enable_weights_double_buffer,
     bool full_inner_dim,
     bool enable_activation_reuse,
-    bool config_tensors_in_dram) {
+    bool config_tensors_in_dram,
+    std::optional<bool> force_split_reader) {
     TT_FATAL(b.layout() == Layout::TILE,
              "Weights should be in TILE layout.");  // Weights should already be formatted
     const auto& ashape = input_tensor_shape;
@@ -78,7 +79,8 @@ Tensor optimized_conv_new(
         enable_weights_double_buffer,
         full_inner_dim,
         enable_activation_reuse,
-        config_tensors_in_dram);
+        config_tensors_in_dram,
+        force_split_reader);
     IDevice* device = a.device();
 
     optimized_conv_op.pre_op_l1_allocation_size_bytes =
@@ -257,7 +259,8 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             enable_weights_double_buffer,
             full_inner_dim,
             enable_activation_reuse,
-            config_tensors_in_dram);
+            config_tensors_in_dram,
+            force_split_reader);
     }
 
     const uint32_t post_op_l1_allocation_size =
@@ -287,7 +290,8 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
             .enable_act_double_buffer = enable_act_double_buffer,
             .enable_weights_double_buffer = enable_weights_double_buffer,
-            .enable_activation_reuse = enable_activation_reuse},
+            .enable_activation_reuse = enable_activation_reuse,
+            .force_split_reader = force_split_reader},
         input_tensor_a.dtype(),
         this->dtype,
         output_image_width,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -178,7 +178,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool full_inner_dim,
     bool enable_activation_reuse,
-    bool config_tensors_in_dram) {
+    bool config_tensors_in_dram,
+    std::optional<bool> force_split_reader) {
     distributed::MeshDevice* device = a.device();
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
@@ -295,7 +296,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     const bool enable_split_reader =
         is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
-        is_split_reader_viable(
+        force_split_reader.value_or(is_split_reader_viable(
             act_block_h_ntiles,
             input_channels_padded,
             filter_w,
@@ -308,10 +309,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             act_block_w_ntiles,
             fp32_dest_acc_en,
             output.dtype(),
-            enable_activation_reuse);
+            enable_activation_reuse));
     log_debug(
         tt::LogOp,
-        "enable_split_reader: {}, num_blocks_act_h: {}, per_core_out_matrix_height_ntiles: {}, act_block_h_ntiles: {}",
+        "force_split_reader: {}, enable_split_reader: {}, num_blocks_act_h: {}, per_core_out_matrix_height_ntiles: {}, "
+        "act_block_h_ntiles: {}",
+        force_split_reader,
         enable_split_reader,
         per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles,
         per_core_out_matrix_height_ntiles,
@@ -638,7 +641,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         .output_layout = (untilize_out ? Layout::ROW_MAJOR : Layout::TILE),
         .enable_act_double_buffer = enable_act_double_buffer,
         .enable_weights_double_buffer = enable_weights_double_buffer,
-        .enable_activation_reuse = enable_activation_reuse};
+        .enable_activation_reuse = enable_activation_reuse,
+        .force_split_reader = force_split_reader};
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -291,7 +291,10 @@ Result conv_transpose2d(
         compute_config,
         conv_config.enable_act_double_buffer,
         conv_config.enable_weights_double_buffer,
-        conv_config.full_inner_dim);
+        false,
+        false,
+        false,
+        conv_config.force_split_reader);
     if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
         conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -291,9 +291,9 @@ Result conv_transpose2d(
         compute_config,
         conv_config.enable_act_double_buffer,
         conv_config.enable_weights_double_buffer,
-        false,
-        false,
-        false,
+        false,  // full_inner_dim
+        false,  // enable_activation_reuse
+        false,  // config_tensors_in_dram
         conv_config.force_split_reader);
     if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
         conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);


### PR DESCRIPTION
### Problem description
With the removal of `enable_split_reader` from `ttnn.Conv2dConfig` and using the split reader heuristic ([PR](https://github.com/tenstorrent/tt-metal/pull/27731))
the usage of `ttnn.conv2d` became simpler, but the heuristic itself is not perfect and relies on bandwidth values
calculated on TT hardware. When this code is used on custom IP, the heuristic can be off by a wide mark
which could be detrimental performance wise, so an option to override it is needed.

### What's changed
- added optional boolean `force_split_reader` member of `ttnn.Conv2dConfig`, which when set overrides the split_reader
heuristic, and if not set defaults to the heuristic

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17794295225)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17794309829)