### PR TITLE
Add Posthog to `tt-metalium` and `ttnn` docs directories

### DIFF
--- a/docs/source/tt-metalium/conf.py
+++ b/docs/source/tt-metalium/conf.py
@@ -104,6 +104,7 @@ html_baseurl = f"/tt-metal/" + os.environ["DOCS_VERSION"] + f"/{metal_sphinx_con
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_js_files = ["posthog.js"]
 
 html_context = {"logo_link_url": "https://docs.tenstorrent.com/"}
 

--- a/docs/source/ttnn/conf.py
+++ b/docs/source/ttnn/conf.py
@@ -105,6 +105,7 @@ html_baseurl = f"/tt-metal/" + os.environ["DOCS_VERSION"] + f"/{metal_sphinx_con
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_js_files = ["posthog.js"]
 
 html_context = {"logo_link_url": "https://docs.tenstorrent.com/"}
 


### PR DESCRIPTION
### Ticket
Unfortunately, the previous PR (https://github.com/tenstorrent/tt-metal/pull/28420) did not get Posthog onto the built `tt-metal` and `ttnn` docs sites.

This one should do it.