### PR TITLE
fix t3k unit tests for llama3.2-90b

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1756,7 +1756,9 @@ class ModelArgs:
 )"""
 
     def is_llama_vision(self):
-        return ("vision" in self.CKPT_DIR.lower()) and ("llama" in self.model_name.lower())
+        hf_llama_vision = ("vision" in self.CKPT_DIR.lower()) and ("llama" in self.model_name.lower())
+        llama_dir_llama_vision = self.vision_chunk_size > 0
+        return hf_llama_vision or llama_dir_llama_vision
 
     def get_state_dict_prefix(self, module_name, layer_num, is_vision=False):
         text_prefix = self.state_dict_text_prefix

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1756,9 +1756,7 @@ class ModelArgs:
 )"""
 
     def is_llama_vision(self):
-        hf_llama_vision = ("vision" in self.CKPT_DIR.lower()) and ("llama" in self.model_name.lower())
-        llama_dir_llama_vision = self.vision_chunk_size > 0
-        return hf_llama_vision or llama_dir_llama_vision
+        return ("llama" in self.CKPT_DIR.lower()) and ("vision" in self.CKPT_DIR.lower())
 
     def get_state_dict_prefix(self, module_name, layer_num, is_vision=False):
         text_prefix = self.state_dict_text_prefix


### PR DESCRIPTION
### Ticket


### Problem description
Failing "t3k llama3.2-90b-vision tests" and "t3k llama3.2-90b tests" in t3k unit tests

### What's changed
Changed is_llama_vision function which fixes "t3k llama3.2-90b-vision tests" and "t3k llama3.2-90b tests"

### Checklist
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/17797456374) CI passes (if applicable, since this is run on push to main)