### PR TITLE
Added blackhole check for sd trace region size

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -2,7 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from models.common.utility_functions import is_blackhole
+
 # L1 Small Size Constants
 SD_L1_SMALL_SIZE = 20928
 # Trace Region Size Constants
-SD_TRACE_REGION_SIZE = 814510080
+SD_TRACE_REGION_SIZE = 814510080 if is_blackhole() else 789835776


### PR DESCRIPTION
### Problem description
[PR](https://github.com/tenstorrent/tt-metal/pull/28617)  breaks Frequent model and ttnn tests  stable_diffusion with
OOM due to increased DRAM usage for trace

### What's changed
- added differing values for WH and BH

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17799220020)