### PR TITLE
Support Deepseek prefill for seq_len=128

### DIFF
--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -42,7 +42,7 @@ from models.demos.deepseek_v3.utils.test_utils import (
     "mode, seq_len, batch_size",
     [
         ("decode", 1, 32),
-        # ("prefill", 512), # TODO: Uncomment once MLA prefill works
+        ("prefill", 128, 1),
         # ("prefill", 2048),  # Test chunking # TODO: Uncomment once MLA prefill works
     ],
 )

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -131,14 +131,19 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def forward_prefill(
-        cls, x: ttnn.Tensor, row_idx: int, user_id: int, rope_tensors: dict, cfg: RunPrefillConfig
+        cls,
+        x: ttnn.Tensor,
+        user_id: int,
+        row_idx: int,
+        cfg: RunPrefillConfig,
+        rope_tensors: dict,
+        page_table: ttnn.Tensor,
     ) -> ttnn.Tensor:
-        raise NotImplementedError("This is untested.")
         # MLA norm
         mla_norm_out = DistributedRMSNorm.forward_prefill(x, cfg["mla_norm"])
 
         # MLA
-        mla_out = MLA1D.forward_prefill(mla_norm_out, row_idx, user_id, rope_tensors, cfg["mla"])
+        mla_out = MLA1D.forward_prefill(mla_norm_out, user_id, row_idx, cfg["mla"], rope_tensors, page_table)
         ttnn.deallocate(mla_norm_out)
 
         # MLA Residual

--- a/models/demos/deepseek_v3/tt/embedding_1d.py
+++ b/models/demos/deepseek_v3/tt/embedding_1d.py
@@ -165,11 +165,8 @@ class Embedding1D(AbstractModule):
         embeddings = ttnn.embedding(x, **cfg["embedding"])
         embeddings = ttnn.unsqueeze(embeddings, 0)
 
-        embeddings_tc = ttnn.typecast(embeddings, **cfg["typecast"])
+        embeddings_ag = ttnn.experimental.all_gather_async(embeddings, **cfg["all_gather"])
         ttnn.deallocate(embeddings)
-
-        embeddings_ag = ttnn.experimental.all_gather_async(embeddings_tc, **cfg["all_gather"])
-        ttnn.deallocate(embeddings_tc)
 
         return embeddings_ag
 

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -244,6 +244,13 @@ class LMHead(AbstractModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
             ),
+            "all_gather": AllGatherAsyncConfig(
+                mesh_device=mesh_device,
+                cluster_axis=1,
+                dim=-1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+            ),
             "input_memory_config": ttnn.DRAM_MEMORY_CONFIG,
             "output_memory_config": ttnn.DRAM_MEMORY_CONFIG,
         }

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -114,6 +114,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
             "mlp_decoder_block": [DecoderBlock.prefill_model_config(hf_config, mesh_device)],
             "transfer_row": {"topology": ttnn.Topology.Linear},
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
+            "lm_head": LMHead.prefill_model_config(hf_config, mesh_device, input_row_idx=0),
         }
 
     @classmethod
@@ -287,6 +288,52 @@ class Model1D(SharedStateAddOn, AbstractModule):
     def forward_prefill(
         cls,
         x: ttnn.Tensor,
+        user_id: int,
         cfg: RunPrefillConfig,
+        rope_tensors: dict,
+        page_tables: Sequence[ttnn.Tensor],
     ) -> ttnn.Tensor:
-        raise NotImplementedError("Prefill mode is not implemented.")
+        """Forward pass for prefill mode."""
+
+        # Embedding
+        x = Embedding1D.forward_prefill(x, cfg["embedding"])
+
+        # Stage 1: MLP Decoder Block
+        mlp_is_padding_layer, mlp_meta_layer_indices = cls.get_meta_layer_mapping(
+            cfg["num_rows"], cfg["num_mlp_layers"]
+        )
+        for row_idx, (per_row_is_padding_layer, per_row_meta_layer_indices) in enumerate(
+            zip(mlp_is_padding_layer.transpose(0, 1), mlp_meta_layer_indices.transpose(0, 1), strict=True)
+        ):
+            for meta_layer_idx, (is_padding_layer, layer_idx) in enumerate(
+                zip(per_row_is_padding_layer, per_row_meta_layer_indices, strict=True)
+            ):
+                if is_padding_layer:
+                    continue
+                x_next = DecoderBlock.forward_prefill(
+                    x,
+                    user_id,
+                    row_idx,
+                    cfg["mlp_decoder_block"][meta_layer_idx],
+                    rope_tensors,
+                    page_tables[layer_idx],
+                )
+                ttnn.deallocate(x)
+                x = ttnn.clone(x_next)
+
+            # Transfer rows
+            cls.transfer_row(x, row_idx, (row_idx + 1) % cfg["num_rows"], **cfg["transfer_row"])
+
+        # Norm (no resharding needed for prefill)
+        x_norm = DistributedRMSNorm.forward_prefill(x, cfg["norm"])
+        ttnn.deallocate(x)
+
+        # All gather before LM Head (same as decode path)
+        x_ag = ttnn.experimental.all_gather_async(x_norm, **cfg["lm_head"]["all_gather"])
+        ttnn.deallocate(x_norm)
+
+        # LM Head
+        x_lmhead = LMHead.forward_prefill(x_ag, cfg["lm_head"])
+        ttnn.deallocate(x_ag)
+
+        return x_lmhead

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -310,7 +310,7 @@ class Model1D(SharedStateAddOn, AbstractModule):
             ):
                 if is_padding_layer:
                     continue
-                x_next = DecoderBlock.forward_prefill(
+                x = DecoderBlock.forward_prefill(
                     x,
                     user_id,
                     row_idx,
@@ -318,8 +318,6 @@ class Model1D(SharedStateAddOn, AbstractModule):
                     rope_tensors,
                     page_tables[layer_idx],
                 )
-                ttnn.deallocate(x)
-                x = ttnn.clone(x_next)
 
             # Transfer rows
             cls.transfer_row(x, row_idx, (row_idx + 1) % cfg["num_rows"], **cfg["transfer_row"])

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -306,9 +306,14 @@ def run_reference_with_attention(
             ),
             diagonal=1,
         )
-        input_cache = transformers_cache_from_torch(
-            tuple(torch.empty((batch_size, 1, 0, dim), dtype=torch.bfloat16) for _ in range(num_layers))
-        )
+        if layer_idx is not None:
+            input_cache = transformers_cache_single_layer_from_torch(
+                torch.empty((batch_size, 1, 0, dim), dtype=torch.bfloat16), layer_idx
+            )
+        else:
+            input_cache = transformers_cache_from_torch(
+                tuple(torch.empty((batch_size, 1, 0, dim), dtype=torch.bfloat16) for _ in range(num_layers))
+            )
     else:
         assert mode == "decode"
         position_ids = position_ids_or_seq_lens.unsqueeze(1)


### PR DESCRIPTION
This PR implements prefill support for Deepseek V3 model with sequence length of 128. The changes enable the model to process input sequences in prefill mode, which is essential for initializing the model state before autoregressive generation.

Adds prefill forward pass implementation for the main model and decoder blocks
Updates configuration to support prefill operations with proper all-gather settings
Enables prefill testing with seq_len=128 and batch_size=1

### Checklist
- [x] [TG Deepseek](https://github.com/tenstorrent/tt-metal/actions/runs/17800069904) CI passes