### PR TITLE
[skip ci] Add workflow_call and guards for dry-run in package and release workflow

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -1,5 +1,12 @@
 name: Package and release
 on:
+  workflow_call:
+    inputs:
+      dry-run:
+        description: "Dry-run: If true, do not upload tag or draft release."
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       dry-run:
@@ -74,7 +81,7 @@ jobs:
       bump_each_commit: false
       # tag-type is now set in release-precheck and passed as output
       tag-type: ${{ needs.release-precheck.outputs.tag-type }}
-      dry-run: ${{ inputs.dry-run }}
+      dry-run: ${{ inputs.dry-run || false }}
 
 
   build-test-publish:
@@ -86,7 +93,7 @@ jobs:
         version: [22.04, 24.04]
     with:
       version: ${{ matrix.version }}
-      dry-run: ${{ inputs.dry-run }}
+      dry-run: ${{ inputs.dry-run || false }}
       tag-version: ${{ needs.create-tag.outputs.version }}
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
 


### PR DESCRIPTION
### Problem description
Scheduled runs are failing for Package and Release because `dry-run` in not defined

### What's changed
Added workflow_call and guards for dry-run