### PR TITLE
fix a bug with BH noc inline writes

### DIFF
--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -686,11 +686,22 @@ inline __attribute__((always_inline)) void noc_fast_spoof_write_dw_inline(
     ASSERT((dest_addr & 0x3) == 0);
     uint32_t src_addr = noc_get_interim_inline_value_addr(noc, dest_addr);
 
-    // Flush to make sure write left L1 before updating it
+    // Flush to make sure write left L1 before updating it. Both posted and non-posted counters
+    // need to be checked because we don't know, in the moment, the history of spoofed writes and
+    // if they were posted or non-posted.
+    //
+    // An alternative to this is to force the spoofed write to be posted. However this breaks some
+    // niche user code cases. For example, when a user wants to send some data via an inline write
+    // (say if they need to send data where src/dest are not aligned), and they need to signal to
+    // a consumer when the write has completed (when the data and consumer are on different cores -
+    // a completion ack is needed to avoid race). Forcing posted removes this as asupported use
+    // case; it was not chosen as an approach.
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc));
+        while (!ncrisc_dynamic_noc_posted_writes_sent(noc));
     } else {
         while (!ncrisc_noc_nonposted_writes_sent(noc));
+        while (!ncrisc_noc_posted_writes_sent(noc));
     }
 
     volatile tt_l1_ptr uint32_t* interim_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -694,7 +694,7 @@ inline __attribute__((always_inline)) void noc_fast_spoof_write_dw_inline(
     // niche user code cases. For example, when a user wants to send some data via an inline write
     // (say if they need to send data where src/dest are not aligned), and they need to signal to
     // a consumer when the write has completed (when the data and consumer are on different cores -
-    // a completion ack is needed to avoid race). Forcing posted removes this as asupported use
+    // a completion ack is needed to avoid race). Forcing posted removes this as a supported use
     // case; it was not chosen as an approach.
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc));


### PR DESCRIPTION
There is a hardware bug in Blackhole, and the inline write noc APIs were updated to workaround the issue. The workaround moves the inline write to an async write, but there was a small hole with validating prior writes are cleared before issuing the next. This change patches the hole.

An alternative approach could have been to force the spoofed writes to be posted, always, so we could limit the number of checks we need to do but the change describes why that approach was not taken.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/17802605020
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17802580938 (1 failure; same on main)