### PR TITLE
add missing cmd buf ready

### DIFF
--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -705,6 +705,7 @@ inline __attribute__((always_inline)) void noc_fast_spoof_write_dw_inline(
     constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
 #endif
 
+    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
     ncrisc_noc_fast_write<noc_mode>(
         noc,
         write_cmd_buf,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27801

### Problem description
missed a cmd buf ready, could lead to racing condition in noc


### Checklist
- [ ] [BH  post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17804988999