### PR TITLE
Replace dev_msg.h with HAL dev msgs in host code (part 2)

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -183,9 +183,9 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                     // Active eth core only has one available erisc to test on.
                     (device->arch() == ARCH::BLACKHOLE and not is_active) ? waypoint : "   X");
                 if (device->arch() == ARCH::BLACKHOLE) {
-                    expected += fmt::format("rmsg:???|?? h_id:  0 smsg:? k_ids:{}", k_id_s);
+                    expected += fmt::format("rmsg:???|?? h_id:  ? smsg:? k_ids:{}", k_id_s);
                 } else {
-                    expected += fmt::format("rmsg:???|? h_id:  0 k_ids:{}", k_id_s);
+                    expected += fmt::format("rmsg:???|? h_id:  ? k_ids:{}", k_id_s);
                 }
             } else {
                 // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
@@ -199,8 +199,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                 }
                 expected = fmt::format(
                     "Device {} worker core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},{},{},{}  rmsg:???|??? h_id:  "
-                    "0 "
-                    "smsg:???? k_ids:{}",
+                    "? smsg:???? k_ids:{}",
                     device->id(),
                     logical_core.x,
                     logical_core.y,

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -204,7 +204,8 @@ string get_noc_target_str(
 dev_msgs::launch_msg_t::ConstView get_valid_launch_message(dev_msgs::mailboxes_t::ConstView mbox_data) {
     uint32_t launch_msg_read_ptr = mbox_data.launch_msg_rd_ptr();
     if (mbox_data.launch()[launch_msg_read_ptr].kernel_config().enables() == 0) {
-        launch_msg_read_ptr = (launch_msg_read_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
+        launch_msg_read_ptr = (launch_msg_read_ptr - 1 + dev_msgs::launch_msg_buffer_num_entries) %
+                              dev_msgs::launch_msg_buffer_num_entries;
     }
     return mbox_data.launch()[launch_msg_read_ptr];
 }
@@ -545,15 +546,16 @@ void WatcherDeviceReader::Core::Dump() const {
     ValidateKernelIDs();
 
     // Whether or not watcher data is available depends on a flag set on the device.
-    if (mbox_data_.watcher().enable() != WatcherEnabled and mbox_data_.watcher().enable() != WatcherDisabled) {
+    if (mbox_data_.watcher().enable() != dev_msgs::WatcherEnabled and
+        mbox_data_.watcher().enable() != dev_msgs::WatcherDisabled) {
         TT_THROW(
             "Watcher read invalid watcher.enable on {}. Read {}, valid values are {} and {}.",
             core_str_,
             mbox_data_.watcher().enable(),
-            WatcherEnabled,
-            WatcherDisabled);
+            dev_msgs::WatcherEnabled,
+            dev_msgs::WatcherDisabled);
     }
-    bool enabled = (mbox_data_.watcher().enable() == WatcherEnabled);
+    bool enabled = (mbox_data_.watcher().enable() == dev_msgs::WatcherEnabled);
 
     if (enabled) {
         // Dump state only gathered if device is compiled w/ watcher
@@ -877,19 +879,19 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
 
 void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
     char code = 'U';
-    if (state == RUN_MSG_INIT) {
+    if (state == dev_msgs::RUN_MSG_INIT) {
         code = 'I';
-    } else if (state == RUN_MSG_GO) {
+    } else if (state == dev_msgs::RUN_MSG_GO) {
         code = 'G';
-    } else if (state == RUN_MSG_DONE) {
+    } else if (state == dev_msgs::RUN_MSG_DONE) {
         code = 'D';
-    } else if (state == RUN_MSG_RESET_READ_PTR) {
+    } else if (state == dev_msgs::RUN_MSG_RESET_READ_PTR) {
         code = 'R';
-    } else if (state == RUN_SYNC_MSG_LOAD) {
+    } else if (state == dev_msgs::RUN_SYNC_MSG_LOAD) {
         code = 'L';
-    } else if (state == RUN_SYNC_MSG_WAITING_FOR_RESET) {
+    } else if (state == dev_msgs::RUN_SYNC_MSG_WAITING_FOR_RESET) {
         code = 'W';
-    } else if (state == RUN_SYNC_MSG_INIT_SYNC_REGISTERS) {
+    } else if (state == dev_msgs::RUN_SYNC_MSG_INIT_SYNC_REGISTERS) {
         code = 'S';
     }
     if (code == 'U') {
@@ -898,11 +900,11 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
             "Watcher data corruption, unexpected run state on core{}: {} (expected {}, {}, {}, {}, or {})",
             virtual_coord_.str(),
             state,
-            RUN_MSG_INIT,
-            RUN_MSG_GO,
-            RUN_MSG_DONE,
-            RUN_SYNC_MSG_LOAD,
-            RUN_SYNC_MSG_WAITING_FOR_RESET);
+            dev_msgs::RUN_MSG_INIT,
+            dev_msgs::RUN_MSG_GO,
+            dev_msgs::RUN_MSG_DONE,
+            dev_msgs::RUN_SYNC_MSG_LOAD,
+            dev_msgs::RUN_SYNC_MSG_WAITING_FOR_RESET);
     } else {
         fprintf(reader_.f, "%c", code);
     }
@@ -935,7 +937,7 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
             virtual_coord_.str(),
             launch_msg_.kernel_config().brisc_noc_id());
     }
-    if (mbox_data_.go_message_index() < go_message_num_entries) {
+    if (mbox_data_.go_message_index() < dev_msgs::go_message_num_entries) {
         DumpRunState(mbox_data_.go_messages()[mbox_data_.go_message_index()].signal());
     } else {
         LogRunningKernels();
@@ -943,7 +945,7 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
             "Watcher data corruption, unexpected go message index on core {}: {} (expected < {})",
             virtual_coord_.str(),
             mbox_data_.go_message_index(),
-            go_message_num_entries);
+            dev_msgs::go_message_num_entries);
     }
 
     fprintf(reader_.f, "|");

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -27,11 +27,11 @@
 #include "core_descriptor.hpp"
 #include "debug_helpers.hpp"
 #include "dev_msgs.h"
+#include "llrt/hal.hpp"
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "hw/inc/debug/ring_buffer.h"
 #include "impl/context/metal_context.hpp"
-#include "llrt.hpp"
 #include "watcher_device_reader.hpp"
 
 using namespace tt::tt_metal;
@@ -147,7 +147,7 @@ string get_noc_target_str(
     CoreCoord virtual_coord,
     HalProgrammableCoreType programmable_core_type,
     int noc,
-    const debug_sanitize_noc_addr_msg_t* san) {
+    dev_msgs::debug_sanitize_noc_addr_msg_t::ConstView san) {
     auto get_core_and_mem_type = [](chip_id_t device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
         // Get the virtual coord from the noc coord
         CoreCoord virtual_core = virtual_noc_coordinate(device_id, noc, noc_coord);
@@ -168,20 +168,20 @@ string get_noc_target_str(
     };
     string out = fmt::format(
         "{} using noc{} tried to {} {} {} bytes {} local L1[{:#08x}] {} ",
-        get_riscv_name(programmable_core_type, san->which_risc),
+        get_riscv_name(programmable_core_type, san.which_risc()),
         noc,
-        san->is_multicast ? "multicast" : "unicast",
-        san->is_write ? "write" : "read",
-        san->len,
-        san->is_write ? "from" : "to",
-        san->l1_addr,
-        san->is_write ? "to" : "from");
+        san.is_multicast() ? "multicast" : "unicast",
+        san.is_write() ? "write" : "read",
+        san.len(),
+        san.is_write() ? "from" : "to",
+        san.l1_addr(),
+        san.is_write() ? "to" : "from");
 
-    if (san->is_multicast) {
+    if (san.is_multicast()) {
         CoreCoord target_virtual_noc_core_start = {
-            NOC_MCAST_ADDR_START_X(san->noc_addr), NOC_MCAST_ADDR_START_Y(san->noc_addr)};
+            NOC_MCAST_ADDR_START_X(san.noc_addr()), NOC_MCAST_ADDR_START_Y(san.noc_addr())};
         CoreCoord target_virtual_noc_core_end = {
-            NOC_MCAST_ADDR_END_X(san->noc_addr), NOC_MCAST_ADDR_END_Y(san->noc_addr)};
+            NOC_MCAST_ADDR_END_X(san.noc_addr()), NOC_MCAST_ADDR_END_Y(san.noc_addr())};
         auto type_and_mem = get_core_and_mem_type(device_id, target_virtual_noc_core_start, noc);
         out += fmt::format(
             "{} core range w/ virtual coords {}-{} {}",
@@ -190,22 +190,22 @@ string get_noc_target_str(
             target_virtual_noc_core_end.str(),
             type_and_mem.second);
     } else {
-        CoreCoord target_virtual_noc_core = {NOC_UNICAST_ADDR_X(san->noc_addr), NOC_UNICAST_ADDR_Y(san->noc_addr)};
+        CoreCoord target_virtual_noc_core = {NOC_UNICAST_ADDR_X(san.noc_addr()), NOC_UNICAST_ADDR_Y(san.noc_addr())};
         auto type_and_mem = get_core_and_mem_type(device_id, target_virtual_noc_core, noc);
         out += fmt::format(
             "{} core w/ virtual coords {} {}", type_and_mem.first, target_virtual_noc_core.str(), type_and_mem.second);
     }
 
-    out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san->noc_addr));
+    out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san.noc_addr()));
     return out;
 }
 
-const launch_msg_t* get_valid_launch_message(const mailboxes_t* mbox_data) {
-    uint32_t launch_msg_read_ptr = mbox_data->launch_msg_rd_ptr;
-    if (mbox_data->launch[launch_msg_read_ptr].kernel_config.enables == 0) {
+dev_msgs::launch_msg_t::ConstView get_valid_launch_message(dev_msgs::mailboxes_t::ConstView mbox_data) {
+    uint32_t launch_msg_read_ptr = mbox_data.launch_msg_rd_ptr();
+    if (mbox_data.launch()[launch_msg_read_ptr].kernel_config().enables() == 0) {
         launch_msg_read_ptr = (launch_msg_read_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
     }
-    return &mbox_data->launch[launch_msg_read_ptr];
+    return mbox_data.launch()[launch_msg_read_ptr];
 }
 
 }  // anonymous namespace
@@ -240,9 +240,9 @@ private:
     CoreCoord virtual_coord_;
     HalProgrammableCoreType programmable_core_type_;
     std::string core_str_;
-    std::vector<uint32_t> l1_read_buf_;
-    const mailboxes_t* mbox_data_;
-    const launch_msg_t* launch_msg_;
+    std::vector<std::byte> l1_read_buf_;
+    dev_msgs::mailboxes_t::ConstView mbox_data_;
+    dev_msgs::launch_msg_t::ConstView launch_msg_;
     const WatcherDeviceReader& reader_;
     DumpData& dump_data_;
 
@@ -261,8 +261,25 @@ private:
     const std::string& GetKernelName(uint32_t processor_index) const;
     void ValidateKernelIDs() const;
 
-public:
     Core(
+        CoreCoord virtual_coord,
+        HalProgrammableCoreType programmable_core_type,
+        std::string core_str,
+        std::vector<std::byte> l1_read_buf,
+        dev_msgs::Factory dev_msgs_factory,
+        const WatcherDeviceReader& reader,
+        DumpData& dump_data) :
+        virtual_coord_(virtual_coord),
+        programmable_core_type_(programmable_core_type),
+        core_str_(std::move(core_str)),
+        l1_read_buf_(std::move(l1_read_buf)),
+        mbox_data_(dev_msgs_factory.create_view<dev_msgs::mailboxes_t>(l1_read_buf_.data())),
+        launch_msg_(get_valid_launch_message(mbox_data_)),
+        reader_(reader),
+        dump_data_(dump_data) {}
+
+public:
+    static Core Create(
         CoreCoord logical_coord,
         HalProgrammableCoreType programmable_core_type,
         const WatcherDeviceReader& reader,
@@ -364,7 +381,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord coord = {x, y};
             if (storage_only_cores.find(coord) == storage_only_cores.end()) {
-                Core(coord, HalProgrammableCoreType::TENSIX, *this, dump_data).Dump();
+                Core::Create(coord, HalProgrammableCoreType::TENSIX, *this, dump_data).Dump();
             }
         }
     }
@@ -372,11 +389,11 @@ void WatcherDeviceReader::Dump(FILE* file) {
     // Dump eth cores
     for (const CoreCoord& eth_core :
          tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
-        Core(eth_core, HalProgrammableCoreType::ACTIVE_ETH, *this, dump_data).Dump();
+        Core::Create(eth_core, HalProgrammableCoreType::ACTIVE_ETH, *this, dump_data).Dump();
     }
     for (const CoreCoord& eth_core :
          tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
-        Core(eth_core, HalProgrammableCoreType::IDLE_ETH, *this, dump_data).Dump();
+        Core::Create(eth_core, HalProgrammableCoreType::IDLE_ETH, *this, dump_data).Dump();
     }
 
     for (auto k_id : dump_data.used_kernel_names) {
@@ -449,9 +466,10 @@ void WatcherDeviceReader::Dump(FILE* file) {
 
         // Clear all pause flags
         for (auto& [virtual_core, processor_index] : dump_data.paused_cores) {
-            uint64_t addr =
-                hal.get_dev_addr(get_programmable_core_type(virtual_core, device_id), HalL1MemAddrType::WATCHER) +
-                offsetof(watcher_msg_t, pause_status);
+            auto programmable_core_type = get_programmable_core_type(virtual_core, device_id);
+            uint64_t addr = hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::WATCHER) +
+                            hal.get_dev_msgs_factory(programmable_core_type)
+                                .offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::pause_status);
 
             // Clear only the one flag that we saved, in case another one was raised on device
             auto pause_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
@@ -464,18 +482,17 @@ void WatcherDeviceReader::Dump(FILE* file) {
     fflush(f);
 }
 
-WatcherDeviceReader::Core::Core(
+WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
     CoreCoord logical_coord,
     HalProgrammableCoreType programmable_core_type,
     const WatcherDeviceReader& reader,
-    DumpData& dump_data) :
-    programmable_core_type_(programmable_core_type), reader_(reader), dump_data_(dump_data) {
+    DumpData& dump_data) {
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     const auto& hal = MetalContext::instance().hal();
     CoreType core_type = hal.get_core_type(hal.get_programmable_core_type_index(programmable_core_type));
-    virtual_coord_ =
+    auto virtual_coord =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            reader_.device_id, logical_coord, core_type);
+            reader.device_id, logical_coord, core_type);
 
     // Print device id, core coords (logical)
     string core_type_str = programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH ? "acteth"
@@ -485,25 +502,37 @@ WatcherDeviceReader::Core::Core(
         "core(x={:2},y={:2}) virtual(x={:2},y={:2})",
         logical_coord.x,
         logical_coord.y,
-        virtual_coord_.x,
-        virtual_coord_.y);
+        virtual_coord.x,
+        virtual_coord.y);
     if (rtoptions.get_watcher_phys_coords()) {
         CoreCoord phys_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_physical_coordinate_from_logical_coordinates(
-                reader_.device_id, logical_coord, core_type, true);
+                reader.device_id, logical_coord, core_type, true);
         core_coord_str += fmt::format(" phys(x={:2},y={:2})", phys_core.x, phys_core.y);
     }
-    core_str_ = fmt::format("Device {} {} {}", reader_.device_id, core_type_str, core_coord_str);
-    fprintf(reader_.f, "%s: ", core_str_.c_str());
+    auto core_str = fmt::format("Device {} {} {}", reader.device_id, core_type_str, core_coord_str);
+    fprintf(reader.f, "%s: ", core_str.c_str());
 
     uint64_t mailbox_addr =
         MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::MAILBOX);
 
-    constexpr uint32_t mailbox_read_size = offsetof(mailboxes_t, watcher) + sizeof(watcher_msg_t);
-    l1_read_buf_ = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        reader_.device_id, virtual_coord_, mailbox_addr, mailbox_read_size);
-    mbox_data_ = reinterpret_cast<mailboxes_t*>(l1_read_buf_.data());
-    launch_msg_ = get_valid_launch_message(mbox_data_);
+    auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type);
+    uint32_t mailbox_read_size =
+        dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher) +
+        dev_msgs_factory.size_of<dev_msgs::watcher_msg_t>();
+    // Watcher only reads the mailbox up to the end of the watcher struct.
+    // Should be ok if we never access past that.
+    std::vector<std::byte> l1_read_buf(mailbox_read_size);
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        l1_read_buf.data(), l1_read_buf.size(), {reader.device_id, virtual_coord}, mailbox_addr);
+    return Core(
+        virtual_coord,
+        programmable_core_type,
+        std::move(core_str),
+        std::move(l1_read_buf),
+        dev_msgs_factory,
+        reader,
+        dump_data);
 }
 
 void WatcherDeviceReader::Core::Dump() const {
@@ -515,15 +544,15 @@ void WatcherDeviceReader::Core::Dump() const {
     ValidateKernelIDs();
 
     // Whether or not watcher data is available depends on a flag set on the device.
-    if (mbox_data_->watcher.enable != WatcherEnabled and mbox_data_->watcher.enable != WatcherDisabled) {
+    if (mbox_data_.watcher().enable() != WatcherEnabled and mbox_data_.watcher().enable() != WatcherDisabled) {
         TT_THROW(
             "Watcher read invalid watcher.enable on {}. Read {}, valid values are {} and {}.",
             core_str_,
-            mbox_data_->watcher.enable,
+            mbox_data_.watcher().enable(),
             WatcherEnabled,
             WatcherDisabled);
     }
-    bool enabled = (mbox_data_->watcher.enable == WatcherEnabled);
+    bool enabled = (mbox_data_.watcher().enable() == WatcherEnabled);
 
     if (enabled) {
         // Dump state only gathered if device is compiled w/ watcher
@@ -562,20 +591,19 @@ void WatcherDeviceReader::Core::Dump() const {
         DumpSyncRegs();
     }
 
-    // Eth core only reports erisc kernel id, uses the brisc field
+    auto kernel_config = launch_msg_.kernel_config();
     fprintf(reader_.f, "k_ids:");
     auto num_processors = MetalContext::instance().hal().get_num_risc_processors(programmable_core_type_);
     for (size_t i = 0; i < num_processors; i++) {
         const char* separator = (i > 0) ? "|" : "";
-        fprintf(reader_.f, "%s%3d", separator, launch_msg_->kernel_config.watcher_kernel_ids[i]);
+        fprintf(reader_.f, "%s%3d", separator, kernel_config.watcher_kernel_ids()[i]);
     }
     if (!is_eth_core && rtoptions.get_watcher_text_start()) {
-        uint32_t kernel_config_base = launch_msg_->kernel_config.kernel_config_base[0];
+        uint32_t kernel_config_base = kernel_config.kernel_config_base()[0];
         fprintf(reader_.f, " text_start:");
         for (size_t i = 0; i < NUM_PROCESSORS_PER_CORE_TYPE; i++) {
             const char* separator = (i > 0) ? "|" : "";
-            fprintf(
-                reader_.f, "%s0x%x", separator, kernel_config_base + launch_msg_->kernel_config.kernel_text_offset[i]);
+            fprintf(reader_.f, "%s0x%x", separator, kernel_config_base + kernel_config.kernel_text_offset()[i]);
         }
     }
 
@@ -611,34 +639,34 @@ void WatcherDeviceReader::Core::DumpL1Status() const {
 }
 
 void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
-    const debug_sanitize_noc_addr_msg_t* san = &mbox_data_->watcher.sanitize_noc[noc];
+    auto san = mbox_data_.watcher().sanitize_noc()[noc];
     string error_msg;
     string error_reason;
 
-    switch (san->return_code) {
+    switch (san.return_code()) {
         case DebugSanitizeNocOK:
-            if (san->noc_addr != DEBUG_SANITIZE_NOC_SENTINEL_OK_64 ||
-                san->l1_addr != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 || san->len != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 ||
-                san->which_risc != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
-                san->is_multicast != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
-                san->is_write != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
-                san->is_target != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
+            if (san.noc_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_64 ||
+                san.l1_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 || san.len() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 ||
+                san.which_risc() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
+                san.is_multicast() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
+                san.is_write() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
+                san.is_target() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
                 error_msg = fmt::format(
                     "Watcher unexpected noc debug state on core {}, reported valid got noc{}{{0x{:08x}, {} }}",
                     virtual_coord_.str(),
-                    san->which_risc,
-                    san->noc_addr,
-                    san->len);
+                    san.which_risc(),
+                    san.noc_addr(),
+                    san.len());
                 error_msg += " (corrupted noc sanitization state - sanitization memory overwritten)";
             }
             break;
         case DebugSanitizeNocAddrUnderflow:
             error_msg = get_noc_target_str(reader_.device_id, virtual_coord_, programmable_core_type_, noc, san);
-            error_msg += string(san->is_target ? " (NOC target" : " (Local L1") + " address underflow).";
+            error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address underflow).";
             break;
         case DebugSanitizeNocAddrOverflow:
             error_msg = get_noc_target_str(reader_.device_id, virtual_coord_, programmable_core_type_, noc, san);
-            error_msg += string(san->is_target ? " (NOC target" : " (Local L1") + " address overflow).";
+            error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address overflow).";
             break;
         case DebugSanitizeNocAddrZeroLength:
             error_msg = get_noc_target_str(reader_.device_id, virtual_coord_, programmable_core_type_, noc, san);
@@ -670,7 +698,7 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             break;
         case DebugSanitizeNocAddrMailbox:
             error_msg = get_noc_target_str(reader_.device_id, virtual_coord_, programmable_core_type_, noc, san);
-            error_msg += string(san->is_target ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
+            error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
             break;
         case DebugSanitizeNocLinkedTransactionViolation:
             error_msg = get_noc_target_str(reader_.device_id, virtual_coord_, programmable_core_type_, noc, san);
@@ -680,7 +708,7 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",
                 virtual_coord_.str(),
-                san->return_code);
+                san.return_code());
             error_msg += " (corrupted noc sanitization state - unknown failure code).";
     }
 
@@ -698,23 +726,23 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
 }
 
 void WatcherDeviceReader::Core::DumpAssertStatus() const {
-    const debug_assert_msg_t* assert_status = &mbox_data_->watcher.assert_status;
-    if (assert_status->tripped == DebugAssertOK) {
-        if (assert_status->line_num != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
-            assert_status->which != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
+    auto assert_status = mbox_data_.watcher().assert_status();
+    if (assert_status.tripped() == DebugAssertOK) {
+        if (assert_status.line_num() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
+            assert_status.which() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
             TT_THROW(
                 "Watcher unexpected assert state on core {}, reported OK but got processor {}, line {}.",
                 virtual_coord_.str(),
-                assert_status->which,
-                assert_status->line_num);
+                assert_status.which(),
+                assert_status.line_num());
         }
         return;  // no assert tripped, nothing to do
     }
     std::string error_msg =
-        fmt::format("{}: {} ", core_str_, get_riscv_name(programmable_core_type_, assert_status->which));
-    switch (assert_status->tripped) {
+        fmt::format("{}: {} ", core_str_, get_riscv_name(programmable_core_type_, assert_status.which()));
+    switch (assert_status.tripped()) {
         case DebugAssertTripped: {
-            error_msg += fmt::format("tripped an assert on line {}.", assert_status->line_num);
+            error_msg += fmt::format("tripped an assert on line {}.", assert_status.line_num());
             // TODO: Get rid of this once #6098 is implemented.
             error_msg +=
                 " Note that file name reporting is not yet implemented, and the reported line number for the assert "
@@ -750,9 +778,9 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
             TT_THROW(
                 "Watcher data corruption, noc assert state on core {} unknown failure code: {}.\n",
                 virtual_coord_.str(),
-                assert_status->tripped);
+                assert_status.tripped());
     }
-    error_msg += fmt::format(" Current kernel: {}.", GetKernelName(assert_status->which));
+    error_msg += fmt::format(" Current kernel: {}.", GetKernelName(assert_status.which()));
     log_warning(tt::LogMetal, "Watcher stopped the device due to tripped assert, see watcher log for more details");
     log_warning(tt::LogMetal, "{}", error_msg);
     DumpWaypoints(true);
@@ -763,12 +791,12 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
 }
 
 void WatcherDeviceReader::Core::DumpPauseStatus() const {
-    const debug_pause_msg_t* pause_status = &mbox_data_->watcher.pause_status;
+    auto pause_status = mbox_data_.watcher().pause_status();
     const auto& hal = MetalContext::instance().hal();
     // Just record which cores are paused, printing handled at the end.
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (uint32_t processor_index = 0; processor_index < num_processors; processor_index++) {
-        auto pause = pause_status->flags[processor_index];
+        auto pause = pause_status.flags()[processor_index];
         if (pause == 1) {
             dump_data_.paused_cores.insert({virtual_coord_, processor_index});
         } else if (pause > 1) {
@@ -787,8 +815,8 @@ void WatcherDeviceReader::Core::DumpPauseStatus() const {
 }
 
 void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
-    const debug_eth_link_t* eth_link_status = &mbox_data_->watcher.eth_status;
-    if (eth_link_status->link_down == 0) {
+    auto eth_link_status = mbox_data_.watcher().eth_status();
+    if (eth_link_status.link_down() == 0) {
         return;
     }
     auto noc0_core = tt::tt_metal::MetalContext::instance()
@@ -808,22 +836,23 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 }
 
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
-    const debug_ring_buf_msg_t* ring_buf_data = &mbox_data_->watcher.debug_ring_buf;
+    auto ring_buf_data = mbox_data_.watcher().debug_ring_buf();
     string out = "";
-    if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {
+    if (ring_buf_data.current_ptr() != DEBUG_RING_BUFFER_STARTING_INDEX) {
         // Latest written idx is one less than the index read out of L1.
         out += "\n\tdebug_ring_buffer=\n\t[";
-        int curr_idx = ring_buf_data->current_ptr;
-        for (int count = 1; count <= DEBUG_RING_BUFFER_ELEMENTS; count++) {
-            out += fmt::format("0x{:08x},", ring_buf_data->data[curr_idx]);
+        int curr_idx = ring_buf_data.current_ptr();
+        size_t ring_buffer_elements = ring_buf_data.data().size();
+        for (int count = 1; count <= ring_buffer_elements; count++) {
+            out += fmt::format("0x{:08x},", ring_buf_data.data()[curr_idx]);
             if (count % 8 == 0) {
                 out += "\n\t ";
             }
             if (curr_idx == 0) {
-                if (ring_buf_data->wrapped == 0) {
+                if (ring_buf_data.wrapped() == 0) {
                     break;  // No wrapping, so no extra data available
                 } else {
-                    curr_idx = DEBUG_RING_BUFFER_ELEMENTS - 1;  // Loop
+                    curr_idx = ring_buffer_elements - 1;  // Loop
                 }
             } else {
                 curr_idx--;
@@ -879,47 +908,47 @@ void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {
 }
 
 void WatcherDeviceReader::Core::DumpLaunchMessage() const {
-    const subordinate_sync_msg_t* subordinate_sync = &mbox_data_->subordinate_sync;
+    auto subordinate_sync = mbox_data_.subordinate_sync();
     const auto& hal = MetalContext::instance().hal();
     fprintf(reader_.f, "rmsg:");
-    if (launch_msg_->kernel_config.mode == DISPATCH_MODE_DEV) {
+    if (launch_msg_.kernel_config().mode() == DISPATCH_MODE_DEV) {
         fprintf(reader_.f, "D");
-    } else if (launch_msg_->kernel_config.mode == DISPATCH_MODE_HOST) {
+    } else if (launch_msg_.kernel_config().mode() == DISPATCH_MODE_HOST) {
         fprintf(reader_.f, "H");
     } else {
         LogRunningKernels();
         TT_THROW(
             "Watcher data corruption, unexpected launch mode on core {}: {} (expected {} or {})",
             virtual_coord_.str(),
-            launch_msg_->kernel_config.mode,
+            launch_msg_.kernel_config().mode(),
             DISPATCH_MODE_DEV,
             DISPATCH_MODE_HOST);
     }
 
-    if (launch_msg_->kernel_config.brisc_noc_id == 0 || launch_msg_->kernel_config.brisc_noc_id == 1) {
-        fprintf(reader_.f, "%d", launch_msg_->kernel_config.brisc_noc_id);
+    if (launch_msg_.kernel_config().brisc_noc_id() == 0 || launch_msg_.kernel_config().brisc_noc_id() == 1) {
+        fprintf(reader_.f, "%d", launch_msg_.kernel_config().brisc_noc_id());
     } else {
         LogRunningKernels();
         TT_THROW(
             "Watcher data corruption, unexpected brisc noc_id on core {}: {} (expected 0 or 1)",
             virtual_coord_.str(),
-            launch_msg_->kernel_config.brisc_noc_id);
+            launch_msg_.kernel_config().brisc_noc_id());
     }
-    if (mbox_data_->go_message_index < go_message_num_entries) {
-        DumpRunState(mbox_data_->go_messages[mbox_data_->go_message_index].signal);
+    if (mbox_data_.go_message_index() < go_message_num_entries) {
+        DumpRunState(mbox_data_.go_messages()[mbox_data_.go_message_index()].signal());
     } else {
         LogRunningKernels();
         TT_THROW(
             "Watcher data corruption, unexpected go message index on core {}: {} (expected < {})",
             virtual_coord_.str(),
-            mbox_data_->go_message_index,
+            mbox_data_.go_message_index(),
             go_message_num_entries);
     }
 
     fprintf(reader_.f, "|");
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     uint32_t all_enable_mask = (1u << num_processors) - 1;
-    uint32_t enables = launch_msg_->kernel_config.enables;
+    uint32_t enables = launch_msg_.kernel_config().enables();
     if (enables & ~all_enable_mask) {
         LogRunningKernels();
         TT_THROW(
@@ -947,30 +976,30 @@ void WatcherDeviceReader::Core::DumpLaunchMessage() const {
         fputc(c, reader_.f);
     }
 
-    fprintf(reader_.f, " h_id:%3d ", launch_msg_->kernel_config.host_assigned_id);
+    fprintf(reader_.f, " h_id:%3d ", launch_msg_.kernel_config().host_assigned_id());
 
     if (programmable_core_type_ == HalProgrammableCoreType::TENSIX) {
         fprintf(reader_.f, "smsg:");
-        DumpRunState(subordinate_sync->dm1);
-        DumpRunState(subordinate_sync->trisc0);
-        DumpRunState(subordinate_sync->trisc1);
-        DumpRunState(subordinate_sync->trisc2);
+        DumpRunState(subordinate_sync.dm1());
+        DumpRunState(subordinate_sync.trisc0());
+        DumpRunState(subordinate_sync.trisc1());
+        DumpRunState(subordinate_sync.trisc2());
         fprintf(reader_.f, " ");
     } else if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
         fprintf(reader_.f, "smsg:");
-        DumpRunState(subordinate_sync->dm1);
+        DumpRunState(subordinate_sync.dm1());
         fprintf(reader_.f, " ");
     }
 }
 
 void WatcherDeviceReader::Core::DumpWaypoints(bool to_stdout) const {
-    const debug_waypoint_msg_t* debug_waypoint = mbox_data_->watcher.debug_waypoint;
+    auto debug_waypoint = mbox_data_.watcher().debug_waypoint();
     string out;
 
     for (int cpu = 0; cpu < MAX_RISCV_PER_CORE; cpu++) {
         string risc_status;
         for (int byte = 0; byte < num_waypoint_bytes_per_riscv; byte++) {
-            char v = ((char*)&debug_waypoint[cpu])[byte];
+            char v = debug_waypoint[cpu].waypoint()[byte];
             if (v == 0) {
                 break;
             }
@@ -1028,18 +1057,18 @@ void WatcherDeviceReader::Core::DumpSyncRegs() const {
 }
 
 void WatcherDeviceReader::Core::DumpStackUsage() const {
-    const debug_stack_usage_t* stack_usage_mbox = &mbox_data_->watcher.stack_usage;
+    auto stack_usage_mbox = mbox_data_.watcher().stack_usage();
     const auto& hal = MetalContext::instance().hal();
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (uint32_t processor_index = 0; processor_index < num_processors; processor_index++) {
-        const auto& usage = stack_usage_mbox->cpu[processor_index];
-        if (usage.min_free) {
+        const auto& usage = stack_usage_mbox.cpu()[processor_index];
+        if (usage.min_free()) {
             auto [processor_class, processor_type] =
                 hal.get_processor_class_and_type_from_index(programmable_core_type_, processor_index);
             HalProcessorIdentifier processor = {programmable_core_type_, processor_class, processor_type};
             auto& slot = dump_data_.highest_stack_usage[processor];
-            if (usage.min_free <= slot.stack_free) {
-                slot = {virtual_coord_, usage.min_free - 1, usage.watcher_kernel_id};
+            if (usage.min_free() <= slot.stack_free) {
+                slot = {virtual_coord_, usage.min_free() - 1, usage.watcher_kernel_id()};
             }
         }
     }
@@ -1049,7 +1078,7 @@ void WatcherDeviceReader::Core::ValidateKernelIDs() const {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     for (size_t i = 0; i < num_processors; i++) {
-        uint16_t watcher_kernel_id = launch_msg_->kernel_config.watcher_kernel_ids[i];
+        uint16_t watcher_kernel_id = launch_msg_.kernel_config().watcher_kernel_ids()[i];
         if (watcher_kernel_id >= reader_.kernel_names.size()) {
             TT_THROW(
                 "Watcher data corruption, unexpected {} kernel id on Device {} core {}: {} (last valid {})",
@@ -1068,14 +1097,13 @@ void WatcherDeviceReader::Core::LogRunningKernels() const {
     auto num_processors = hal.get_num_risc_processors(programmable_core_type_);
     log_info(tt::LogMetal, "While running kernels:");
     for (size_t i = 0; i < num_processors; i++) {
-        log_info(
-            tt::LogMetal, " {}: {}", get_riscv_name(programmable_core_type_, i), GetKernelName(i));
+        log_info(tt::LogMetal, " {}: {}", get_riscv_name(programmable_core_type_, i), GetKernelName(i));
     }
 }
 
 const std::string& WatcherDeviceReader::Core::GetKernelName(uint32_t processor_index) const {
     TT_FATAL(processor_index < NUM_PROCESSORS_PER_CORE_TYPE, "processor_index out of range");
-    return reader_.kernel_names[launch_msg_->kernel_config.watcher_kernel_ids[processor_index]];
+    return reader_.kernel_names[launch_msg_.kernel_config().watcher_kernel_ids()[processor_index]];
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -4,7 +4,6 @@
 
 #include "watcher_server.hpp"
 
-#include "dev_msgs.h"
 #include <unistd.h>
 #include <algorithm>
 #include <atomic>
@@ -18,6 +17,7 @@
 #include <set>
 #include <stdexcept>
 #include <thread>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <vector>
 
 #include "assert.hpp"
@@ -25,7 +25,7 @@
 #include "debug/ring_buffer.h"
 #include "debug_helpers.hpp"
 #include "hal_types.hpp"
-#include "llrt.hpp"
+#include "llrt/hal.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "metal_soc_descriptor.h"
 #include <tt_stl/span.hpp>
@@ -96,15 +96,6 @@ private:
     inline static const std::string KERNEL_FILE_NAME = "kernel_names.txt";
     inline static const std::string KERNEL_ELF_FILE_NAME = "kernel_elf_paths.txt";
 };
-
-#define GET_WATCHER_TENSIX_DEV_ADDR() \
-    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::WATCHER)
-
-#define GET_WATCHER_ERISC_DEV_ADDR() \
-    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::WATCHER)
-
-#define GET_WATCHER_IERISC_DEV_ADDR() \
-    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::WATCHER)
 
 void WatcherServer::Impl::init_devices() {
     auto all_devices = MetalContext::instance().get_cluster().all_chip_ids();
@@ -350,50 +341,50 @@ void WatcherServer::Impl::create_kernel_elf_file() {
 
 void WatcherServer::Impl::init_device(chip_id_t device_id) {
     const std::lock_guard<std::mutex> lock(watch_mutex_);
-    std::vector<uint32_t> watcher_init_val;
-    watcher_init_val.resize(sizeof(watcher_msg_t) / sizeof(uint32_t), 0);
-    watcher_msg_t* data = reinterpret_cast<watcher_msg_t*>(&(watcher_init_val[0]));
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& hal = MetalContext::instance().hal();
+    std::vector<dev_msgs::watcher_msg_t> watcher_init_val;
+    watcher_init_val.reserve(NumHalProgrammableCoreTypes);
 
-    // Initialize watcher enable flag according to user setting.
-    data->enable = (rtoptions.get_watcher_enabled()) ? WatcherEnabled : WatcherDisabled;
+    for (int programmable_core_type_index = 0; programmable_core_type_index < NumHalProgrammableCoreTypes;
+         programmable_core_type_index++) {
+        HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
+        auto factory = hal.get_dev_msgs_factory(programmable_core_type);
+        watcher_init_val.push_back(factory.create<dev_msgs::watcher_msg_t>());
+        auto data = watcher_init_val.back().view();
+        // Initialize watcher enable flag according to user setting.
+        data.enable() = (rtoptions.get_watcher_enabled()) ? dev_msgs::WatcherEnabled : dev_msgs::WatcherDisabled;
+        // Initialize debug status values to "unknown"
+        for (auto debug_waypoint : data.debug_waypoint()) {
+            debug_waypoint.waypoint()[0] = 'X';
+        }
 
-    // Initialize debug status values to "unknown"
-    for (int idx = 0; idx < MAX_RISCV_PER_CORE; idx++) {
-        data->debug_waypoint[idx].waypoint[0] = 'X';
+        // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
+        for (auto sanitize_noc : data.sanitize_noc()) {
+            sanitize_noc.noc_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
+            sanitize_noc.l1_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+            sanitize_noc.len() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+            sanitize_noc.which_risc() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+            sanitize_noc.return_code() = dev_msgs::DebugSanitizeNocOK;
+            sanitize_noc.is_multicast() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+            sanitize_noc.is_write() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+            sanitize_noc.is_target() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        }
+
+        // Initialize debug asserts to not tripped.
+        data.assert_status().line_num() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+        data.assert_status().tripped() = dev_msgs::DebugAssertOK;
+        data.assert_status().which() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+
+        // Initialize debug ring buffer to a known init val, we'll check against this to see if any
+        // data has been written.
+        data.debug_ring_buf().current_ptr() = DEBUG_RING_BUFFER_STARTING_INDEX;
+        data.debug_ring_buf().wrapped() = 0;
     }
-
-    // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
-    const auto NUM_NOCS = tt::tt_metal::MetalContext::instance().hal().get_num_nocs();
-    for (int i = 0; i < NUM_NOCS; i++) {
-        data->sanitize_noc[i].noc_addr = DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
-        data->sanitize_noc[i].l1_addr = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-        data->sanitize_noc[i].len = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-        data->sanitize_noc[i].which_risc = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
-        data->sanitize_noc[i].return_code = DebugSanitizeNocOK;
-        data->sanitize_noc[i].is_multicast = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-        data->sanitize_noc[i].is_write = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-        data->sanitize_noc[i].is_target = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-    }
-
-    // Initialize debug asserts to not tripped.
-    data->assert_status.line_num = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
-    data->assert_status.tripped = DebugAssertOK;
-    data->assert_status.which = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-
-    // Initialize pause flags to 0
-    memset(&data->pause_status, 0, sizeof data->pause_status);
-    // Initialize stack usage data to unset
-    memset(&data->stack_usage, 0, sizeof data->stack_usage);
-
-    // Initialize debug ring buffer to a known init val, we'll check against this to see if any
-    // data has been written.
-    std::vector<uint32_t> debug_ring_buf_init_val(sizeof(debug_ring_buf_msg_t) / sizeof(uint32_t), 0);
-    data->debug_ring_buf.current_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
-    data->debug_ring_buf.wrapped = 0;
 
     // Initialize Debug Delay feature
-    std::map<CoreCoord, debug_insert_delays_msg_t> debug_delays_val;
+    std::map<CoreCoord, dev_msgs::debug_insert_delays_msg_t> debug_delays_val;
     constexpr tt::llrt::RunTimeDebugFeatures debug_delay_features[] = {
         tt::llrt::RunTimeDebugFeatureReadDebugDelay,
         tt::llrt::RunTimeDebugFeatureWriteDebugDelay,
@@ -405,7 +396,7 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
         if (this_chip_enabled) {
             for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
                 const auto& delayed_cores = rtoptions.get_feature_cores(delay_feature);
-                if (delayed_cores.count(core_type) == 0) {
+                if (!delayed_cores.contains(core_type)) {
                     continue;
                 }
                 for (tt_xy_pair logical_core : delayed_cores.at(core_type)) {
@@ -413,9 +404,7 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
                     bool valid_logical_core = true;
                     try {
                         virtual_core =
-                            tt::tt_metal::MetalContext::instance()
-                                .get_cluster()
-                                .get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, core_type);
+                            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, core_type);
                     } catch (std::runtime_error& error) {
                         valid_logical_core = false;
                     }
@@ -424,17 +413,24 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
                         // Create the mask based on the feature
                         uint32_t processor_mask =
                             rtoptions.get_feature_processors(delay_feature).get_processor_mask(programmable_core_type);
+                        auto factory = hal.get_dev_msgs_factory(programmable_core_type);
                         // Update the masks for the core
-                        auto& delay_setup = debug_delays_val[virtual_core];
+                        auto iter = debug_delays_val.find(virtual_core);
+                        if (iter == debug_delays_val.end()) {
+                            iter = debug_delays_val
+                                       .emplace(virtual_core, factory.create<dev_msgs::debug_insert_delays_msg_t>())
+                                       .first;
+                        }
+                        auto delay_setup = iter->second.view();
                         switch (delay_feature) {
                             case tt::llrt::RunTimeDebugFeatureReadDebugDelay:
-                                delay_setup.read_delay_processor_mask |= processor_mask;
+                                delay_setup.read_delay_processor_mask() |= processor_mask;
                                 break;
                             case tt::llrt::RunTimeDebugFeatureWriteDebugDelay:
-                                delay_setup.write_delay_processor_mask |= processor_mask;
+                                delay_setup.write_delay_processor_mask() |= processor_mask;
                                 break;
                             case tt::llrt::RunTimeDebugFeatureAtomicDebugDelay:
-                                delay_setup.atomic_delay_processor_mask |= processor_mask;
+                                delay_setup.atomic_delay_processor_mask() |= processor_mask;
                                 break;
                             default: TT_THROW("Unexpected debug delay feature");
                         }
@@ -456,69 +452,49 @@ void WatcherServer::Impl::init_device(chip_id_t device_id) {
     }
 
     // Iterate over debug_delays_val and print what got configured where
-    for (auto& delay : debug_delays_val) {
+    for (auto& [core, delay_setup] : debug_delays_val) {
         log_info(
             tt::LogMetal,
             "Configured Watcher debug delays for device {}, core {}: read_delay_cores_mask=0x{:x}, "
             "write_delay_cores_mask=0x{:x}, atomic_delay_cores_mask=0x{:x}. Delay cycles: {}",
             device_id,
-            delay.first.str().c_str(),
-            delay.second.read_delay_processor_mask,
-            delay.second.write_delay_processor_mask,
-            delay.second.atomic_delay_processor_mask,
+            core.str().c_str(),
+            delay_setup.view().read_delay_processor_mask(),
+            delay_setup.view().write_delay_processor_mask(),
+            delay_setup.view().atomic_delay_processor_mask(),
             rtoptions.get_watcher_debug_delay());
     }
 
-    debug_insert_delays_msg_t debug_delays_val_zero = {0, 0, 0, 0};
-
-    // TODO: hal needs more work as of 8/6/24, but eventually loop over dispatch_core_types and get
-    // cores from that to consolidate the loops below
+    auto write_watcher_init_val = [&](const CoreCoord& logical_core, HalProgrammableCoreType programmable_core_type) {
+        auto programmable_core_type_index = hal.get_programmable_core_type_index(programmable_core_type);
+        CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core, hal.get_core_type(programmable_core_type_index));
+        auto data = watcher_init_val[programmable_core_type_index].view();
+        if (auto iter = debug_delays_val.find(virtual_core); iter != debug_delays_val.end()) {
+            std::copy_n(iter->second.data(), iter->second.size(), data.debug_insert_delays().data());
+        } else {
+            std::fill_n(data.debug_insert_delays().data(), data.debug_insert_delays().size(), std::byte{0});
+        }
+        auto addr = hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::WATCHER);
+        cluster.write_core(data.data(), data.size(), {device_id, virtual_core}, addr);
+    };
 
     // Initialize worker cores debug values
-    CoreCoord grid_size =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord grid_size = cluster.get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
-            CoreCoord logical_core(x, y);
-            CoreCoord worker_core =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                    device_id, logical_core, CoreType::WORKER);
-            if (debug_delays_val.find(worker_core) != debug_delays_val.end()) {
-                data->debug_insert_delays = debug_delays_val[worker_core];
-            } else {
-                data->debug_insert_delays = debug_delays_val_zero;
-            }
-            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-                device_id,
-                worker_core,
-                tt::stl::Span<const uint32_t>(watcher_init_val.data(), watcher_init_val.size()),
-                GET_WATCHER_TENSIX_DEV_ADDR());
+            write_watcher_init_val({x, y}, HalProgrammableCoreType::TENSIX);
         }
     }
 
     // Initialize ethernet cores debug values
-    auto init_eth_debug_values = [&](const CoreCoord& eth_core, bool is_active_eth_core) {
-        CoreCoord virtual_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-                device_id, eth_core, CoreType::ETH);
-        if (debug_delays_val.find(virtual_core) != debug_delays_val.end()) {
-            data->debug_insert_delays = debug_delays_val[virtual_core];
-        } else {
-            data->debug_insert_delays = debug_delays_val_zero;
-        }
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device_id,
-            virtual_core,
-            watcher_init_val,
-            is_active_eth_core ? GET_WATCHER_ERISC_DEV_ADDR() : GET_WATCHER_IERISC_DEV_ADDR());
-    };
     for (const CoreCoord& active_eth_core :
          tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id)) {
-        init_eth_debug_values(active_eth_core, true);
+        write_watcher_init_val(active_eth_core, HalProgrammableCoreType::ACTIVE_ETH);
     }
     for (const CoreCoord& inactive_eth_core :
          tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
-        init_eth_debug_values(inactive_eth_core, false);
+        write_watcher_init_val(inactive_eth_core, HalProgrammableCoreType::IDLE_ETH);
     }
 
     log_debug(LogLLRuntime, "Watcher initialized device {}", device_id);

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -17,7 +17,6 @@
 #include <set>
 #include <stdexcept>
 #include <thread>
-#include <umd/device/types/cluster_descriptor_types.hpp>
 #include <vector>
 
 #include "assert.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28083

### Problem description
https://github.com/tenstorrent/tt-metal/pull/27715 implemented generic accessors for dev msgs, which will work for different struct layouts on different architectures (and potentially different cores on the same architecture). To allow a single binary to handle different layouts, we need to port host code to use that interface instead of the raw structs, and eventually remove all #include `"dev_msgs.h"` outside of HAL.

### What's changed
This PR removes dev_msgs.h from:
- tt_metal/impl/debug/watcher_device_reader.cpp
- tt_metal/impl/debug/watcher_server.cpp

Remaining uses of dev_msgs.h are in profiler, which will be fixed in subsequent PRs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17805303449) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17805336659) CI with demo tests passes (if applicable)