### PR TITLE
Link kernels at pseudo-location, not firmware region.

### DIFF
--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -15,14 +15,18 @@ OUTPUT_ARCH(riscv)
 #include "dev_mem_map.h"
 #include "tensix_dev_map.h"
 
+// Unused region, where we link the XIP-loaded kernels at.
+#define MEM_KERNEL_PSEUDO_BASE 0x80000000
+
 #if defined(COMPILE_FOR_BRISC)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_BRISC_LOCAL_SIZE
 #define STACK_MIN_SIZE MEM_BRISC_STACK_MIN_SIZE
-#define TEXT_START MEM_BRISC_FIRMWARE_BASE
 #if defined(TYPE_FIRMWARE)
+#define TEXT_START MEM_BRISC_FIRMWARE_BASE
 #define TEXT_SIZE MEM_BRISC_FIRMWARE_SIZE
 #else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
 #define TEXT_SIZE MEM_BRISC_KERNEL_SIZE
 #endif
 
@@ -30,14 +34,15 @@ OUTPUT_ARCH(riscv)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_NCRISC_LOCAL_SIZE
 #define STACK_MIN_SIZE MEM_NCRISC_STACK_MIN_SIZE
-#if defined(TYPE_FIRMWARE) || !defined(ARCH_WORMHOLE)
-#define TEXT_START MEM_NCRISC_FIRMWARE_BASE
-#else
-#define TEXT_START MEM_NCRISC_KERNEL_BASE
-#endif
 #if defined(TYPE_FIRMWARE)
+#define TEXT_START MEM_NCRISC_FIRMWARE_BASE
 #define TEXT_SIZE MEM_NCRISC_FIRMWARE_SIZE
 #else
+#if defined(ARCH_WORMHOLE)
+#define TEXT_START MEM_NCRISC_KERNEL_BASE
+#else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
+#endif
 #define TEXT_SIZE MEM_NCRISC_KERNEL_SIZE
 #endif
 
@@ -45,10 +50,11 @@ OUTPUT_ARCH(riscv)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_IERISC_LOCAL_SIZE
 #define STACK_MIN_SIZE MEM_IERISC_STACK_MIN_SIZE
-#define TEXT_START MEM_IERISC_FIRMWARE_BASE
 #if defined(TYPE_FIRMWARE)
+#define TEXT_START MEM_IERISC_FIRMWARE_BASE
 #define TEXT_SIZE MEM_IERISC_FIRMWARE_SIZE
 #else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
 #define TEXT_SIZE MEM_IERISC_KERNEL_SIZE
 #endif
 
@@ -56,8 +62,13 @@ OUTPUT_ARCH(riscv)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_SUBORDINATE_IERISC_LOCAL_SIZE
 #define STACK_MIN_SIZE MEM_SUBORDINATE_IERISC_STACK_MIN_SIZE
+#if defined(TYPE_FIRMWARE)
 #define TEXT_START MEM_SUBORDINATE_IERISC_FIRMWARE_BASE
 #define TEXT_SIZE MEM_SUBORDINATE_IERISC_FIRMWARE_SIZE
+#else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
+#define TEXT_SIZE MEM_IERISC_KERNEL_SIZE
+#endif
 
 #elif defined(COMPILE_FOR_TRISC)
 #define TRISC_SELECT__(BEFORE,MIDDLE,AFTER) BEFORE##TRISC##MIDDLE##AFTER
@@ -67,10 +78,11 @@ OUTPUT_ARCH(riscv)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_TRISC_LOCAL_SIZE
 #define STACK_MIN_SIZE TRISC_SELECT(MEM_,_STACK_MIN_SIZE)
-#define TEXT_START TRISC_SELECT(MEM_,_FIRMWARE_BASE)
 #if defined(TYPE_FIRMWARE)
+#define TEXT_START TRISC_SELECT(MEM_,_FIRMWARE_BASE)
 #define TEXT_SIZE TRISC_SELECT(MEM_,_FIRMWARE_SIZE)
 #else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
 #define TEXT_SIZE TRISC_SELECT(MEM_,_KERNEL_SIZE)
 #endif
 
@@ -79,10 +91,11 @@ OUTPUT_ARCH(riscv)
 #define DATA_START MEM_LOCAL_BASE
 #define DATA_SIZE MEM_IERISC_LOCAL_SIZE
 #define STACK_MIN_SIZE MEM_AERISC_STACK_MIN_SIZE
-#define TEXT_START MEM_AERISC_FIRMWARE_BASE
 #if defined(TYPE_FIRMWARE)
+#define TEXT_START MEM_AERISC_FIRMWARE_BASE
 #define TEXT_SIZE MEM_IERISC_FIRMWARE_SIZE
 #else
+#define TEXT_START MEM_KERNEL_PSEUDO_BASE
 #define TEXT_SIZE MEM_IERISC_KERNEL_SIZE
 #endif
 
@@ -100,11 +113,7 @@ PHDRS {
 
 SECTIONS
 {
-#if defined(TYPE_FIRMWARE) || (defined(COMPILE_FOR_NCRISC) && defined(ARCH_WORMHOLE))
   .text TEXT_START :
-#else
-  .text __fw_export_text_end :
-#endif
   {
 #if defined(TYPE_KERNEL) && defined(COMPILE_FOR_NCRISC)
     __kernel_text_start = ABSOLUTE(.);
@@ -137,7 +146,6 @@ SECTIONS
 #endif
 /* FW must align to 16 byte boundary so kernel begins aligned to meet noc alignment constraints */
   . = ALIGN(ABSOLUTE(.) + MEM_PAD, 16);
-  __fw_export_text_end = ABSOLUTE(.);
 #else
   __kernel_data_lma = .;
 #endif
@@ -212,11 +220,7 @@ SECTIONS
      We don't do it here, as the failure mode would be bad (no executable to examine).  */
   .phdrs 0 (INFO) :
   {
-    LONG(TEXT_SIZE
-#if defined(TYPE_KERNEL) && !(defined(COMPILE_FOR_NCRISC) && defined(ARCH_WORMHOLE))
-         - (__fw_export_text_end - TEXT_START)
-#endif
-         )
+    LONG(TEXT_SIZE)
     LONG(DATA_SIZE - STACK_MIN_SIZE
 #if defined(TYPE_KERNEL)
          - (__fw_export_ldm_end - DATA_START)


### PR DESCRIPTION
### Ticket
NA

### Problem description
@nhuang-tt is working on aeric code, and I noticed the linker scripts are still linking kernels as-if they are executed from directly after the firmware. That is not true, the are all executed as XIP, except for ncrisc on wormhole which remains at a fixed address. There is no need to reduce the kernel space by the size of the firmware it is no longer placed after.

### What's changed
Link kernels as-if placed in an unused region, and not reduced by the size of firmware code.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes