### PR TITLE
Fix reshape writing OOB

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -651,17 +651,18 @@ def test_reshape_oob(device):
         return ttnn.from_torch(tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
 
     B, T, H, W, U = 1, 1, 90, 20, 768
+    SENTINEL_TENSOR_SIZE = 2**15
     for i in range(10):
         print(f"running test {i}")
         torch_input_tensor = torch.randn(B, T, H, W, U, dtype=torch.bfloat16)
         torch_output = torch_input_tensor.reshape(B, T, H, W, 2, U // 2)
         # Known data below input and output tensors
-        pre_tensor = bf16_tensor(torch.full((2**15, 2**15), 2.0, dtype=torch.bfloat16))
+        pre_tensor = bf16_tensor(torch.full((SENTINEL_TENSOR_SIZE, SENTINEL_TENSOR_SIZE), 2.0, dtype=torch.bfloat16))
         tt_input_tensor = bf16_tensor(torch_input_tensor)
         # Allocate space for output tensor
         dummy_tensor = bf16_tensor(torch.zeros(B, T, H, W, U))
         # Known data above output tensor
-        post_tensor = bf16_tensor(torch.full((2**15, 2**15), 2.0, dtype=torch.bfloat16))
+        post_tensor = bf16_tensor(torch.full((SENTINEL_TENSOR_SIZE, SENTINEL_TENSOR_SIZE), 2.0, dtype=torch.bfloat16))
         ttnn.deallocate(dummy_tensor)
         tt_output_tensor = ttnn.reshape(tt_input_tensor, (B, T, H, W, 2, U // 2))
         tt_output_tensor_host = ttnn.to_torch(tt_output_tensor)

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -639,3 +639,40 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
     for tensor_shard in ttnn.get_device_tensors(tt_output_tensor):
         tt_output_tensor = ttnn.to_torch(tensor_shard)
         assert tt_output_tensor.shape == torch.Size(output_shape)
+
+
+def test_reshape_oob(device):
+    """
+    Test proves that this reshape op writes data out of bounds, corrupting
+    tensors at other memory locations.
+    """
+
+    def bf16_tensor(tensor):
+        return ttnn.from_torch(tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+
+    B, T, H, W, U = 1, 1, 90, 20, 768
+    for i in range(10):
+        print(f"running test {i}")
+        torch_input_tensor = torch.randn(B, T, H, W, U, dtype=torch.bfloat16)
+        torch_output = torch_input_tensor.reshape(B, T, H, W, 2, U // 2)
+        # Known data below input and output tensors
+        pre_tensor = bf16_tensor(torch.full((2**15, 2**15), 2.0, dtype=torch.bfloat16))
+        tt_input_tensor = bf16_tensor(torch_input_tensor)
+        # Allocate space for output tensor
+        dummy_tensor = bf16_tensor(torch.zeros(B, T, H, W, U))
+        # Known data above output tensor
+        post_tensor = bf16_tensor(torch.full((2**15, 2**15), 2.0, dtype=torch.bfloat16))
+        ttnn.deallocate(dummy_tensor)
+        tt_output_tensor = ttnn.reshape(tt_input_tensor, (B, T, H, W, 2, U // 2))
+        tt_output_tensor_host = ttnn.to_torch(tt_output_tensor)
+        tt_input_tensor_host = ttnn.to_torch(tt_input_tensor)
+        pre_tensor_host = ttnn.to_torch(pre_tensor)
+        post_tensor_host = ttnn.to_torch(post_tensor)
+        assert torch.allclose(torch_output, tt_output_tensor_host), "Output tensors do not match"
+        assert torch.allclose(torch_input_tensor, tt_input_tensor_host), "Input tensors do not match"
+        assert torch.all(pre_tensor_host == 2.0), "Pre tensors do not match"
+        assert torch.all(post_tensor_host == 2.0), "Post tensors do not match"
+        ttnn.deallocate(tt_input_tensor)
+        ttnn.deallocate(tt_output_tensor)
+        ttnn.deallocate(pre_tensor)
+        ttnn.deallocate(post_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -65,7 +65,6 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
     while ((responsibility * source_page_size_bytes) % dest_page_size_bytes != 0) {
         responsibility++;
     }
-    const uint32_t write_jump = (responsibility * source_page_size_bytes) / dest_page_size_bytes;
     const uint32_t cb_size0 = source_read_size_bytes;
     const uint32_t cb_size1 = ((dest_page_size_bytes - 1) & MASK_64) + 80;
 
@@ -138,20 +137,23 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
                 const uint32_t start_of_read = read_start_page;
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < input_log_shape[-2] ? end_of_read : input_log_shape[-2];
+                uint32_t pages_for_this_core = end_of_read - start_of_read;
+                uint32_t write_jump = (pages_for_this_core * source_page_size_bytes) / dest_page_size_bytes;
 
                 if (can_use_dual_kernel) {
                     // Split work in half - determine split point and second write position
                     uint32_t mid_read, second_write_pos;
                     if (source_page_size_bytes >= dest_page_size_bytes) {
                         // Split by input pages
-                        uint32_t half_responsibility = responsibility / 2;
-                        mid_read = start_of_read + half_responsibility;
+                        uint32_t half_pages = pages_for_this_core / 2;
+                        mid_read = start_of_read + half_pages;
                         second_write_pos =
-                            write_start_page + (half_responsibility * source_page_size_bytes / dest_page_size_bytes);
+                            write_start_page + (half_pages * source_page_size_bytes / dest_page_size_bytes);
                     } else {
                         // Split by output pages
-                        uint32_t half_output_pages =
-                            ((responsibility * source_page_size_bytes) / dest_page_size_bytes) / 2;
+                        uint32_t total_bytes_for_core = pages_for_this_core * source_page_size_bytes;
+                        uint32_t total_output_pages_for_core = total_bytes_for_core / dest_page_size_bytes;
+                        uint32_t half_output_pages = total_output_pages_for_core / 2;
                         mid_read = start_of_read + (half_output_pages * dest_page_size_bytes / source_page_size_bytes);
                         second_write_pos = write_start_page + half_output_pages;
                     }


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/28678

### Problem description
The reshape operation is overwriting a tensor allocated outside of the output tensor. This is due to reshape assigning more pages than available for worker cores.

### What's changed
The current reshape implementation assigns the same page distribution to all the cores. Changing that to account for the number of pages available for a tensor. This avoids processing more pages and hence overwriting memory addresses outside of the reshape output tensor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17805710241
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17805725256
- [x] T3k unit tests https://github.com/tenstorrent/tt-metal/actions/runs/17805737121
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes