### PR TITLE
Keep top-1 and top-5 acc target at 95 for Mistral

### DIFF
--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -46,8 +46,8 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Phi3.5-mini       | N300        |           |           | 57.8          | 62        |
 | Phi3.5-mini       | T3K         |           |           | 48.8          | 51        |
 | Mistral-7B        | N150        | 95        | 99        | 29.75         | 100.24    |
-| Mistral-7B        | N300        | 96        | 100       | 47.01         | 65.95     |
-| Mistral-7B        | T3K         | 96        | 100       | 67.82         | 53.93     |
+| Mistral-7B        | N300        | 95        | 100       | 47.01         | 65.95     |
+| Mistral-7B        | T3K         | 95        | 100       | 67.82         | 53.93     |
 | Phi-3-mini-128k-instruct | N150        | 89        | 99        | 45.0          | 73.32     |
 | Phi-3-mini-128k-instruct | N300        | 89        | 99        | 60.87         | 114.94    |
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Targets were changed in commit: eb1ed9fb73d.
Not sure we are ready to increase the target. Keep top-1 and top-5 acc target at 95 for Mistral



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes