### PR TITLE
SQRT high precision workaround for PR-21623

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -499,9 +499,7 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::RSQRT:
             op_init_and_name = {"rsqrt_tile_init<false>();", fmt::format("rsqrt_tile<false>({});", idst)};
             break;
-        case UnaryOpType::SQRT:
-            op_init_and_name = {"sqrt_tile_init<false>();", fmt::format("sqrt_tile<false>({});", idst)};
-            break;
+        case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::LOG1P: op_init_and_name = {"log1p_tile_init();", fmt::format("log1p_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
https://github.com/tenstorrent/tt-metal/pull/21623 causes discrepancy in `sqrt` when running in debug and release mode

### What's changed
Changes Made
File Edited: `ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp`
This is where ttnn::sqrt dispatches to the low-level sqrt_tile kernel.
I changed the template parameter from <false> (new high-precision) to <true> (legacy mode) for sqrt_tile and its init function.
This ensures both debug and release builds use the legacy sqrt approximation, producing consistent values (~1.99414051, close to the asserted 1.99219f).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if