### PR TITLE
[skip ci] Correct package version when using single-config generators

### DIFF
--- a/cmake/packaging.d/cpack-project-config.cmake.in
+++ b/cmake/packaging.d/cpack-project-config.cmake.in
@@ -3,6 +3,11 @@
 # multi-config generator was used.
 
 string(TOLOWER "${CPACK_BUILD_CONFIG}" BUILD_CONFIG_LOWER)
+if(NOT BUILD_CONFIG_LOWER)
+    # Multi-config generators should have CPACK_BUILD_CONFIG set, but single-config
+    # generators we need to read CMAKE_BUILD_TYPE from the CMake pass.
+    string(TOLOWER "@CMAKE_BUILD_TYPE@" BUILD_CONFIG_LOWER)
+endif()
 
 if(BUILD_CONFIG_LOWER STREQUAL "asan" OR BUILD_CONFIG_LOWER STREQUAL "tsan")
     set(CPACK_DEBIAN_DEBUGINFO_PACKAGE FALSE)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The package version is glitching when building with a single-config generator (as we do in CI).
eg: https://github.com/tenstorrent/tt-metal/actions/runs/17786586526/job/50555385886#step:12:11
> -- Package version: 0.62.0~rc35+237.8f8a678937~ubuntu22.04~

The trailing `~` should only be present when non-Release, and it should be followed by the actual build type.  Never a stand-alone `~`.

### What's changed
Fixed it.

eg:
https://github.com/tenstorrent/tt-metal/actions/runs/17810758424/job/50633762473?pr=28750#step:12:11
> -- Package version: 0.0~alpha0+1.c3c21a92f9+m~ubuntu22.04~asan

https://github.com/tenstorrent/tt-metal/actions/runs/17810758424/job/50633752439?pr=28750#step:12:11
> -- Package version: 0.0~alpha0+1.c3c21a92f9+m~ubuntu22.04