### PR TITLE
Remove 4D shape constraint from ttnn.Tensor pybind constructor

### DIFF
--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -696,7 +696,7 @@ void pytensor_module(py::module& m_tensor) {
     pyTensor.def(py::init<ttnn::Tensor&>())
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           const std::optional<Tile>& tile,
@@ -746,7 +746,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,
@@ -808,7 +808,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/28739

### Problem description
ttnn.Tensor constructor requires exactly 4D shapes. Creating tensors with 1D, 2D, or 3D data fails with the error provided in the issue.

### What's changed
Relax ttnn.Tensor shape parameter to support arbitrary dimensions.

Changedthe  pybind constructor from fixed 4D std::array<uint32_t, 4> to flexible std::vector<uint32_t> to allow tensors with 1D, 2D, 3D, or higher dimensional shapes. The ttnn::Shape class already supports this via its existing constructors.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes