### PR TITLE
Fix the dynamic routing hang by updating counter

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -135,6 +135,8 @@ FORCE_INLINE
     const auto& header = *packet_start;
     uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(PACKET_HEADER_TYPE);
 
+    constexpr bool update_counter = false;
+
     tt::tt_fabric::NocSendType noc_send_type = header.noc_send_type;
     if (noc_send_type > tt::tt_fabric::NocSendType::NOC_SEND_TYPE_LAST) {
         __builtin_unreachable();
@@ -142,7 +144,7 @@ FORCE_INLINE
     switch (noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
             const auto dest_address = header.command_fields.unicast_write.noc_address;
-            noc_async_write_one_packet_with_trid<false, false>(
+            noc_async_write_one_packet_with_trid<update_counter, false>(
                 payload_start_address,
                 dest_address,
                 payload_size_bytes,
@@ -179,7 +181,7 @@ FORCE_INLINE
 
         case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
             const auto dest_address = header.command_fields.unicast_seminc_fused.noc_address;
-            noc_async_write_one_packet_with_trid<false, false>(
+            noc_async_write_one_packet_with_trid<update_counter, false>(
                 payload_start_address,
                 dest_address,
                 payload_size_bytes,
@@ -210,7 +212,7 @@ FORCE_INLINE
                     chunk_size = header.command_fields.unicast_scatter_write.chunk_size[i];
                 }
                 const auto dest_address = header.command_fields.unicast_scatter_write.noc_address[i];
-                noc_async_write_one_packet_with_trid<false, false>(
+                noc_async_write_one_packet_with_trid<update_counter, false>(
                     payload_start_address + offset,
                     dest_address,
                     chunk_size,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -135,14 +135,6 @@ FORCE_INLINE
     const auto& header = *packet_start;
     uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(PACKET_HEADER_TYPE);
 
-    // Issue: https://github.com/tenstorrent/tt-metal/issues/28446
-    constexpr bool ENABLE_COUNTERS =
-#ifdef ARCH_BLACKHOLE
-        true;
-#else
-        false;
-#endif
-
     tt::tt_fabric::NocSendType noc_send_type = header.noc_send_type;
     if (noc_send_type > tt::tt_fabric::NocSendType::NOC_SEND_TYPE_LAST) {
         __builtin_unreachable();
@@ -150,7 +142,7 @@ FORCE_INLINE
     switch (noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
             const auto dest_address = header.command_fields.unicast_write.noc_address;
-            noc_async_write_one_packet_with_trid<ENABLE_COUNTERS, false>(
+            noc_async_write_one_packet_with_trid<false, false>(
                 payload_start_address,
                 dest_address,
                 payload_size_bytes,
@@ -187,7 +179,7 @@ FORCE_INLINE
 
         case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
             const auto dest_address = header.command_fields.unicast_seminc_fused.noc_address;
-            noc_async_write_one_packet_with_trid<ENABLE_COUNTERS, false>(
+            noc_async_write_one_packet_with_trid<false, false>(
                 payload_start_address,
                 dest_address,
                 payload_size_bytes,
@@ -218,7 +210,7 @@ FORCE_INLINE
                     chunk_size = header.command_fields.unicast_scatter_write.chunk_size[i];
                 }
                 const auto dest_address = header.command_fields.unicast_scatter_write.noc_address[i];
-                noc_async_write_one_packet_with_trid<ENABLE_COUNTERS, false>(
+                noc_async_write_one_packet_with_trid<false, false>(
                     payload_start_address + offset,
                     dest_address,
                     chunk_size,

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1887,8 +1887,8 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
 #ifdef ARCH_BLACKHOLE
     // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
-    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
-    // this restriction once all inline write change to stream reg write.
+    // workaround for avoiding hangs in fabric router, as counters will be checked inside the
+    // noc_fast_spoof_write_dw_inline, will remove this restriction once all inline write change to stream reg write.
     constexpr bool update_counter_in_callee = true;
 #else
     constexpr bool update_counter_in_callee = update_counter;
@@ -2128,8 +2128,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
 
 #ifdef ARCH_BLACKHOLE
     // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
-    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
-    // this restriction once all inline write change to stream reg write.
+    // workaround for avoiding hangs in fabric router, as counters will be checked inside the
+    // noc_fast_spoof_write_dw_inline, will remove this restriction once all inline write change to stream reg write.
     constexpr bool update_counter_in_callee = true;
 #else
     constexpr bool update_counter_in_callee = update_counter;
@@ -2225,8 +2225,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
 
 #ifdef ARCH_BLACKHOLE
     // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
-    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
-    // this restriction once all inline write change to stream reg write.
+    // workaround for avoiding hangs in fabric router, as counters will be checked inside the
+    // noc_fast_spoof_write_dw_inline, will remove this restriction once all inline write change to stream reg write.
     constexpr bool update_counter_in_callee = true;
 #else
     constexpr bool update_counter_in_callee = update_counter;

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1885,9 +1885,23 @@ template <
     bool update_val = false>
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
+#ifdef ARCH_BLACKHOLE
+    // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
+    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
+    // this restriction once all inline write change to stream reg write.
+    constexpr bool update_counter_in_callee = true;
+#else
+    constexpr bool update_counter_in_callee = update_counter;
+#endif
+
     WAYPOINT("NWIW");
-    noc_fast_write_dw_inline_with_state<noc_mode, update_addr_lo, update_addr_hi, update_val, posted, update_counter>(
-        noc, cmd_buf, val, addr);
+    noc_fast_write_dw_inline_with_state<
+        noc_mode,
+        update_addr_lo,
+        update_addr_hi,
+        update_val,
+        posted,
+        update_counter_in_callee>(noc, cmd_buf, val, addr);
     WAYPOINT("NWID");
 }
 
@@ -2113,13 +2127,10 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     while (!noc_cmd_buf_ready(noc, cmd_buf));
 
 #ifdef ARCH_BLACKHOLE
-    // We must do this because in BH, inline writes spoof their inline writes
-    // by first writing the value to L1 and then sending a noc write out of that
-    // L1 location to avoid a HW bug. A result of this is that those inline write
-    // calls on BH implicitly barrier. That barrier call compares against
-    // `noc_nonposted_writes_num_issued`, which will NOT be updated if `update_counter` is false.
-    // Therefore, we must override `update_counter` to true if `posted` is false.
-    constexpr bool update_counter_in_callee = update_counter || !posted;
+    // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
+    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
+    // this restriction once all inline write change to stream reg write.
+    constexpr bool update_counter_in_callee = true;
 #else
     constexpr bool update_counter_in_callee = update_counter;
 #endif
@@ -2213,13 +2224,10 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_local_l1_addr, src_local_l1_addr, size);
 
 #ifdef ARCH_BLACKHOLE
-    // We must do this because in BH, inline writes spoof their inline writes
-    // by first writing the value to L1 and then sending a noc write out of that
-    // L1 location to avoid a HW bug. A result of this is that those inline write
-    // calls on BH implicitly barrier. That barrier call compares against
-    // `noc_nonposted_writes_num_issued`, which will NOT be updated if `update_counter` is false.
-    // Therefore, we must override `update_counter` to true if `posted` is false.
-    constexpr bool update_counter_in_callee = update_counter || !posted;
+    // Issue https://github.com/tenstorrent/tt-metal/issues/28758: always update counter for blackhole as a temporary
+    // workaround for avoiding hangs, as counters will be checked inside the noc_fast_spoof_write_dw_inline, will remove
+    // this restriction once all inline write change to stream reg write.
+    constexpr bool update_counter_in_callee = true;
 #else
     constexpr bool update_counter_in_callee = update_counter;
 #endif


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27801)

### Problem description
With all the fixes going in:
https://github.com/tenstorrent/tt-metal/pull/28704 (posted + nonposted writes sent check in the spoof inline write func)
https://github.com/tenstorrent/tt-metal/pull/28656 rearrange l1 mem map
https://github.com/tenstorrent/tt-metal/pull/28721 add missing cmd buf ready check
https://github.com/tenstorrent/tt-metal/pull/28557 fix noc ctr usage for inline writes

we still see dynamic routing tests hang, the problem is not all the path have been updated to use counters.

### What's changed
Force all paths to use counters in BH fabric router.

### Checklist
- [ ] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17830578244
- [ ] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17830593284
- [ ] BH nightly https://github.com/tenstorrent/tt-metal/actions/runs/17830604807