### PR TITLE
[WIP] Remove a usage of logical sharding, part 2

### DIFF
--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -205,7 +205,11 @@ void py_module(py::module& module) {
             >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
             >>> tensor = ttnn.to_memory_config(tensor, memory_config)
         )doc",
-        ttnn::pybind_arguments_t{py::arg("tensor"), py::arg("memory_config"), py::arg("dtype") = std::nullopt});
+        ttnn::pybind_arguments_t{
+            py::arg("tensor"),
+            py::arg("memory_config"),
+            py::arg("dtype") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -756,18 +756,27 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
             }
             if (!auto_shard_mm) {
                 ttnn::MemoryConfig input_tensor_sharded_memory_config_to_layout = input_tensor_sharded_memory_config;
+                tt::tt_metal::Alignment alignment = {};
                 if (!input_tensor.is_sharded()) {
                     // In case we need to run Interleaved2Sharded switch fron physical sharding
                     // to logical sharding, in order to get smaller allocation size of sharded buffer.
+                    const auto& shard_spec = input_tensor_sharded_memory_config.shard_spec().value();
                     input_tensor_sharded_memory_config_to_layout =
-                        input_tensor_sharded_memory_config_to_layout.with_shard_spec(tt::tt_metal::ShardSpec(
-                            input_tensor_sharded_memory_config.shard_spec().value().grid,
-                            input_tensor_sharded_memory_config.shard_spec().value().shape,
-                            input_tensor_sharded_memory_config.shard_spec().value().shape,
-                            input_tensor_sharded_memory_config.shard_spec().value().orientation));
+                        input_tensor_sharded_memory_config_to_layout.with_shard_spec(
+                            tt::tt_metal::ShardSpec(shard_spec.grid, shard_spec.shape, shard_spec.orientation));
+                    alignment = tt::tt_metal::Alignment{shard_spec.shape[0], shard_spec.shape[1]};
                 }
-                Tensor resharded_input_tensor =
-                    ttnn::to_memory_config(input_tensor, input_tensor_sharded_memory_config_to_layout, std::nullopt);
+                Tensor resharded_input_tensor = tt::tt_metal::create_device_tensor(
+                    TensorSpec(
+                        input_tensor.logical_shape(),
+                        tt::tt_metal::TensorLayout(
+                            input_tensor.dtype(),
+                            tt::tt_metal::PageConfig(input_tensor.layout()),
+                            input_tensor_sharded_memory_config_to_layout,
+                            alignment)),
+                    input_tensor.device());
+                ttnn::to_memory_config(
+                    input_tensor, input_tensor_sharded_memory_config_to_layout, std::nullopt, resharded_input_tensor);
                 if (conv_config.deallocate_activation) {
                     input_tensor.deallocate(/*force*/ true);
                     resharded_input_tensor = ttnn::move(resharded_input_tensor);

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -26,12 +26,21 @@ struct ToMemoryConfig {
     static Tensor invoke(
         const ttnn::Tensor& tensor,
         const ttnn::MemoryConfig& memory_config,
-        std::optional<ttnn::DataType> dtype = std::nullopt) {
+        std::optional<ttnn::DataType> dtype = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt) {
         using namespace tt::tt_metal;
         // Temporary until we see why buffer data not being populated
         const auto original_memory_config = ttnn::get_memory_config(tensor);
-        if (original_memory_config.has_value() && original_memory_config.value() == memory_config) {
+        if (original_memory_config.has_value() && original_memory_config.value() == memory_config &&
+            !output_tensor.has_value()) {
             return tensor;
+        }
+        std::vector<std::optional<Tensor>> optional_output_tensors;
+        if (output_tensor.has_value()) {
+            TT_FATAL(
+                output_tensor->memory_config() == memory_config,
+                "Output tensor memory config must match the target memory config");
+            optional_output_tensors.push_back(output_tensor);
         }
 
         if (memory_config.is_sharded()) {
@@ -41,47 +50,27 @@ struct ToMemoryConfig {
                 const auto input_memory_config = ttnn::get_memory_config(tensor);
                 const auto input_shard_spec = input_memory_config.value().shard_spec().value();
                 const auto output_shard_spec = memory_config.shard_spec().value();
-                // Check if we need to use the s2i->i2s workaround
-                bool use_reshard_workaround =
-                    (input_shard_spec.shape[1] != output_shard_spec.shape[1]) &&
-                    (input_memory_config.value().memory_layout() != memory_config.memory_layout() &&
-                     tensor.layout() == Layout::ROW_MAJOR);
-                if (!use_reshard_workaround) {
-                    if (dtype.has_value()) {
-                        throw std::runtime_error(
-                            "dtype cannot be specified when converting sharded tensor to sharded tensor");
-                    }
-                    return tt::tt_metal::operation::run(
-                               data_movement::ReshardDeviceOperation{
-                                   .output_mem_config = memory_config,
-                               },
-                               {tensor},
-                               {},
-                               {std::nullopt})
-                        .at(0);
-                } else {
-                    // for row-major tensors where shard-spec[1] is different for input shard and output shard
-
-                    TT_FATAL(memory_config.is_sharded(), "Error");
-                    Tensor temp = tt::tt_metal::operation::run(
-                                      data_movement::ShardedToInterleavedDeviceOperation{
-                                          .output_mem_config = ttnn::DRAM_MEMORY_CONFIG,
-                                          .output_dtype = dtype.value_or(tensor.dtype())},
-                                      {tensor})
-                                      .at(0);
-                    return tt::tt_metal::operation::run(
-                               data_movement::InterleavedToShardedDeviceOperation{
-                                   .output_mem_config = memory_config, .output_dtype = dtype.value_or(temp.dtype())},
-                               {temp})
-                        .at(0);
+                if (dtype.has_value()) {
+                    throw std::runtime_error(
+                        "dtype cannot be specified when converting sharded tensor to sharded tensor");
                 }
+                return tt::tt_metal::operation::run(
+                           data_movement::ReshardDeviceOperation{
+                               .output_mem_config = memory_config,
+                           },
+                           {tensor},
+                           {},
+                           optional_output_tensors)
+                    .at(0);
             } else {
                 auto bbox = memory_config.shard_spec().value().grid.bounding_box();
                 CoreCoord grid_size(bbox.end_coord.x + 1, bbox.end_coord.y + 1);
                 return tt::tt_metal::operation::run(
                            data_movement::InterleavedToShardedDeviceOperation{
                                .output_mem_config = memory_config, .output_dtype = dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             }
         } else {
@@ -90,14 +79,18 @@ struct ToMemoryConfig {
                 return tt::tt_metal::operation::run(
                            data_movement::ShardedToInterleavedDeviceOperation{
                                .output_mem_config = memory_config, .output_dtype = dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             } else {
                 // L1 to DRAM or DRAM to L1
                 return tt::tt_metal::operation::run(
                            ttnn::operations::data_movement::CopyDeviceOperation{
                                memory_config, dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -33,7 +33,7 @@ static inline Tensor move(QueueId queue_id, const Tensor& input_tensor, const st
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     auto input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
-    auto output_mem_config = mem_config.value_or(input_mem_config);
+    TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 
     if (not can_deallocate(input_tensor)) {
         // TODO: Should this throw error?
@@ -47,16 +47,12 @@ static inline Tensor move(QueueId queue_id, const Tensor& input_tensor, const st
         DeallocateBuffer(*input_tensor.buffer());
     }
 
-    auto output_tensor = create_device_tensor(
-        TensorSpec(
-            input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                input_tensor.dtype(),
-                PageConfig(input_tensor.layout()),
-                output_mem_config,
-                input_tensor.logical_shape(),
-                input_tensor.padded_shape())),
-        input_tensor.device());
+    if (mem_config) {
+        output_tensor_spec = output_tensor_spec.with_memory_config(*mem_config);
+    }
+
+    auto output_tensor = create_device_tensor(output_tensor_spec, input_tensor.device());
+    auto output_mem_config = output_tensor.memory_config();
 
     // get_parallelization_strategy
     bool move_within_same_mem_space = input_mem_config.buffer_type() == output_mem_config.buffer_type();
@@ -124,11 +120,8 @@ static inline Tensor move(QueueId queue_id, const Tensor& input_tensor, const st
 static inline Tensor move_sharded(
     QueueId queue_id, const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    auto input_mem_config = input_tensor.memory_config();
-    TT_FATAL(input_mem_config.is_sharded(), "Expected input tensor to be sharded");
+    TT_FATAL(input_tensor.memory_config().is_sharded(), "Expected input tensor to be sharded");
     [[maybe_unused]] auto input_address = input_tensor.buffer()->address();
-    auto output_mem_config = mem_config.value_or(input_mem_config);
-    TT_FATAL(output_mem_config.is_sharded(), "Expected output tensor memory config to be sharded");
     if (not can_deallocate(input_tensor)) {
         TT_FATAL(
             false,
@@ -137,10 +130,9 @@ static inline Tensor move_sharded(
         // TODO: Should this throw error?
         return {input_tensor};
     }
+
     auto shard_spec = input_tensor.shard_spec().value();
     auto shard_grid = shard_spec.grid;
-    auto input_dtype = input_tensor.dtype();
-    auto input_layout = input_tensor.layout();
     // Special handling for Mesh vs single device. Needs to be consolidated after full
     // migration
 
@@ -149,18 +141,15 @@ static inline Tensor move_sharded(
     } else {
         DeallocateBuffer(*input_tensor.buffer());
     }
-    // log_debug(LogOp, "OUTPUT SHARD SPEC: {}", out_shard_spec);
-    auto shard_mem_config = output_mem_config.with_shard_spec(shard_spec);
-    auto output_tensor = create_device_tensor(
-        TensorSpec(
-            input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                input_dtype,
-                PageConfig(input_layout),
-                shard_mem_config,
-                input_tensor.logical_shape(),
-                input_tensor.padded_shape())),
-        input_tensor.device());
+
+    auto output_tensor_spec = input_tensor.tensor_spec();
+    if (mem_config) {
+        TT_FATAL(mem_config->is_sharded(), "Expected output tensor memory config to be sharded");
+        auto output_mem_config = mem_config->with_shard_spec(shard_spec);
+        output_tensor_spec = output_tensor_spec.with_memory_config(output_mem_config);
+    }
+
+    auto output_tensor = create_device_tensor(output_tensor_spec, input_tensor.device());
     if (input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
         log_debug(
             tt::LogOp,
@@ -170,7 +159,8 @@ static inline Tensor move_sharded(
     }
     MoveOpParallelizationStrategy move_op_parallelization_strategy = MoveOpParallelizationStrategy::MULTI_CORE_SHARDED;
     return operation::run(
-               MoveDeviceOperation{output_mem_config, move_op_parallelization_strategy}, {input_tensor, output_tensor})
+               MoveDeviceOperation{output_tensor.memory_config(), move_op_parallelization_strategy},
+               {input_tensor, output_tensor})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -12,10 +12,14 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
-void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+void InterleavedToShardedDeviceOperation::validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
+
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        TT_FATAL(output_tensors[0].value().memory_config() == this->output_mem_config, "Error");
+    }
 
     TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(this->output_mem_config.is_sharded(), "Error");
@@ -31,7 +35,10 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 
-std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_output_specs(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_output_specs(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0]->tensor_spec()};
+    }
     const auto& input_tensor = input_tensors.at(0);
     return {TensorSpec(input_tensor.logical_shape(), TensorLayout::fromPaddedShape(
         output_dtype,
@@ -39,6 +46,16 @@ std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_outpu
         output_mem_config,
         input_tensor.logical_shape(),
         input_tensor.padded_shape()))};
+}
+
+std::vector<Tensor> InterleavedToShardedDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+    const auto& input_tensor = input_tensors.at(0);
+    auto spec = compute_output_specs(input_tensors, output_tensors)[0];
+    return {create_device_tensor(spec, input_tensor.device())};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -15,8 +15,12 @@ struct InterleavedToShardedDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
     const bool keep_l1_aligned = false;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
@@ -12,13 +12,17 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
-void ShardedToInterleavedDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+void ShardedToInterleavedDeviceOperation::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto shard_spec = input_tensor.shard_spec().value();
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Input tensor must be sharded");
     TT_FATAL(input_tensor.memory_config().buffer_type() == BufferType::L1, "Input tensor must be in L1");
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        TT_FATAL(output_tensors[0].value().memory_config() == this->output_mem_config, "Error");
+    }
     TT_FATAL(
         this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Output memory config must be Interleaved");
@@ -35,7 +39,10 @@ void ShardedToInterleavedDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 std::vector<ttnn::TensorSpec> ShardedToInterleavedDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0]->tensor_spec()};
+    }
     const auto& input_tensor = input_tensors.at(0);
     return {TensorSpec(
         input_tensor.logical_shape(),
@@ -45,6 +52,16 @@ std::vector<ttnn::TensorSpec> ShardedToInterleavedDeviceOperation::compute_outpu
             output_mem_config,
             input_tensor.logical_shape(),
             input_tensor.padded_shape()))};
+}
+
+std::vector<Tensor> ShardedToInterleavedDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+    const auto& input_tensor = input_tensors.at(0);
+    auto spec = compute_output_specs(input_tensors, output_tensors)[0];
+    return {create_device_tensor(spec, input_tensor.device())};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
@@ -15,8 +15,12 @@ struct ShardedToInterleavedDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
     const bool is_l1_aligned = false;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes