### PR TITLE
add distil-whisper/distil-large-v3.5 demo

### DIFF
--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -56,7 +56,7 @@ def load_conditional_generation_ref_model(model_repo):
     Args:
         model_repo: HuggingFace model repository ID. Must be one of the supported models.
     """
-    allowed_models = ["distil-whisper/distil-large-v3", "openai/whisper-large-v3"]
+    allowed_models = ["distil-whisper/distil-large-v3", "distil-whisper/distil-large-v3.5", "openai/whisper-large-v3"]
     if model_repo not in allowed_models:
         raise ValueError(f"Unknown model_repo: {model_repo}. Valid options are {allowed_models}")
 
@@ -484,7 +484,7 @@ def test_demo_for_audio_classification_dataset(ttnn_model, device, is_ci_env):
 )
 @pytest.mark.parametrize(
     "model_repo",
-    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3"),
+    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3", "distil-whisper/distil-large-v3.5"),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inputs, model_repo, is_ci_env):
@@ -510,7 +510,7 @@ def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inp
 )
 @pytest.mark.parametrize(
     "model_repo",
-    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3"),
+    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3", "distil-whisper/distil-large-v3.5"),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_demo_for_conditional_generation_dataset(ttnn_model, device, model_repo, is_ci_env):


### PR DESCRIPTION
### Ticket
#28770 

### Problem description
The new distil-whisper model (`distil-whisper/distil-large-v3.5`) is missing.

### What's changed
Added the new `distil-whisper/distil-large-v3.5` model demo.


### Test results

Avg 50 tokens/sec/user

<img width="1894" height="1405" alt="image" src="https://github.com/user-attachments/assets/296c638f-cf3b-4066-98de-37686ea461e9" />


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes