### PR TITLE
fix llama demo by using only 1 worker on reduce scatter minimal

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -907,6 +907,7 @@ class TT_CCL:
             topology=ttnn.Topology.Ring,
             subdevice_id=self.worker_sub_device_id,
             cluster_axis=cluster_axis,
+            num_workers_per_link=1,
         )
 
         # reshape input back


### PR DESCRIPTION
### Ticket
#28698

Revert to old default worker count in reduce scatter minimal async for llama prefill.

It appears that increasing worker count for bfp8 actually changes pcc and causes a perf drop. I'm guessing since the bfp8 packet rate is much lower, different thresholds to scale workers apply. Also seems like it changed the outputs which it definitely should not.

### Checklist
- [ ] Galaxy demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/17819785842