### PR TITLE
#25198: Fix output memory config being ignored in batch_norm's mean_NHW

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -21,8 +21,8 @@ inline Tensor mean_NHW(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     auto output_mem_config = memory_config.value_or(input_tensor.memory_config());
     ttnn::SmallVector<int> dims = {2, 3};
-    Tensor mean_hw = ttnn::mean(input_tensor, dims, true, std::nullopt, compute_kernel_config);
-    return ttnn::mean(mean_hw, 0, true, std::nullopt, compute_kernel_config);
+    Tensor mean_hw = ttnn::mean(input_tensor, dims, true, output_mem_config, compute_kernel_config);
+    return ttnn::mean(mean_hw, 0, true, output_mem_config, compute_kernel_config);
 }
 
 Tensor BatchNorm::invoke(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25198

### Problem description
Memory configuration passed to a function was being ignored, while it should be used to configure the output tensor.

### What's changed
This change passes along the configuration object to the operations being invoked from the function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes