### PR TITLE
Fix hangs with block sharded conv2d with col_major input tensor

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4606,12 +4606,14 @@ def test_conv_bs_grid_pre_sharded(
     input_channels,
     transpose_shard,
 ):
+    if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
+        pytest.skip("Test is not supported on n300 (8,7) grid")
+
     input_height = input_width = 32
     batch = 1
-    grid_size = device.compute_with_storage_grid_size()
     sharded_cfg = ttnn.create_sharded_memory_config(
         shape=(1, 1, batch * input_height * input_width, input_channels),
-        core_grid=ttnn.CoreGrid(x=grid_size.x, y=grid_size.y),
+        core_grid=ttnn.CoreGrid(x=8, y=8),
         strategy=ttnn.ShardStrategy.BLOCK,
         orientation=ttnn.ShardOrientation.ROW_MAJOR if not transpose_shard else ttnn.ShardOrientation.COL_MAJOR,
     )
@@ -4781,6 +4783,8 @@ def test_conv2d_activation_reuse_unet_conv_group_4(
 
     # Get device grid size and create core range set based on num_cores
     grid_size = device.compute_with_storage_grid_size()
+    if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
+        pytest.skip("Test is not supported on n300 (8,7) grid")
 
     # Use ttnn's built-in function to create core range set with row-wise allocation
     input_core_range_set = ttnn.num_cores_to_corerangeset(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -714,10 +714,8 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
         .shard_scheme = input_tensor_sharded_memory_config.memory_layout(),
         .shard_orientation = input_tensor_sharded_memory_config.shard_spec().value().orientation};
 
-    ShardOrientation shard_orientation =
-        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
     ParallelConfig output_parallel_config = determine_output_parallel_config(
-        parallel_config, compute_grid_size, out_channels, shard_orientation, is_mm_conv);
+        parallel_config, compute_grid_size, out_channels, parallel_config.shard_orientation, is_mm_conv);
 
     // We can have flat and unflattened (n, h, w, c) tensors here
     const auto flattened_input_shape = flatten_4d_shape(input_tensor.logical_shape());

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -238,7 +238,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     const uint32_t num_cores_x = parallelization_config.grid_size.x;
     const uint32_t num_cores_y = parallelization_config.grid_size.y;
-    // log_info(tt::LogOp, "Conv2D parallelization grid size: {} x {}", num_cores_x, num_cores_y);
     const uint32_t total_num_cores = all_cores.num_cores();
 
     const uint32_t per_core_out_matrix_width_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
@@ -1193,7 +1192,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             std::vector<uint32_t> receiver_args;
             if (block_sharded) {
                 if (transpose_mcast) {
-                    CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.x};
+                    CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
                     CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
                     receiver_args = create_receiver_args(top_left_core_physical.x, right_core_physical.y);
                 } else {


### PR DESCRIPTION
We had two bugs here:
* Weight receiver cores had incorrect runtime args for col_major inputs.
* If tensor is presharded, layout of input tensor wasn't detected properly in conv2d factory.

Shield team hit this issue while developing panoptic model.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17824271118)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17827310618)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17824284235) 
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17829443139)
