### PR TITLE
Enable perf tests for resnet p100 BH 

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -4,20 +4,59 @@
 
 import pytest
 
+import ttnn
 from models.common.utility_functions import run_for_blackhole
-from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_device
+from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
+from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_model_utils import is_blackhole_p100
+
+
+# Determine device type at module level to avoid conflicts
+def get_device_type():
+    device = ttnn.open_device(device_id=0)
+    device_type = "p100" if is_blackhole_p100(device) else "p150"
+    ttnn.close_device(device)
+    return device_type
+
+
+DEVICE_TYPE = get_device_type()
 
 
 @run_for_blackhole()
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
-    "batch_size, test, expected_perf",
+    "batch_size, test, expected_perf, device_type",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10601.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14779.0],
+        pytest.param(
+            16,
+            "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
+            8371.0,
+            "p100",
+            marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
+        ),
+        pytest.param(
+            16,
+            "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
+            10601.0,
+            "p150",
+            marks=pytest.mark.skipif(DEVICE_TYPE != "p150", reason=f"Skipping P150 test on {DEVICE_TYPE} device"),
+        ),
+        pytest.param(
+            32,
+            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
+            14779.0,
+            "p150",
+            marks=pytest.mark.skipif(DEVICE_TYPE != "p150", reason=f"Skipping P150 test on {DEVICE_TYPE} device"),
+        ),
+        pytest.param(
+            32,
+            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
+            9380.0,
+            "p100",
+            marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
+        ),
     ],
 )
-def test_perf_device(batch_size, test, expected_perf):
+def test_perf_device(batch_size, test, expected_perf, device_type):
     command = (
         f"pytest models/demos/blackhole/resnet50/tests/test_resnet50_performant.py::test_run_resnet50_inference[{test}]"
     )

--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -6,7 +6,7 @@ import pytest
 
 import ttnn
 from models.common.utility_functions import run_for_blackhole
-from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
+from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_device
 from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_model_utils import is_blackhole_p100
 
 
@@ -24,40 +24,36 @@ DEVICE_TYPE = get_device_type()
 @run_for_blackhole()
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
-    "batch_size, test, expected_perf, device_type",
+    "batch_size, test, expected_perf",
     [
         pytest.param(
             16,
-            "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
+            "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
             8371.0,
-            "p100",
             marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
         ),
         pytest.param(
             32,
-            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
+            "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
             9380.0,
-            "p100",
             marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
         ),
         pytest.param(
             16,
-            "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
+            "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
             10601.0,
-            "p150",
             marks=pytest.mark.skipif(DEVICE_TYPE != "p150", reason=f"Skipping P150 test on {DEVICE_TYPE} device"),
         ),
         pytest.param(
             32,
-            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
+            "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
             14779.0,
-            "p150",
             marks=pytest.mark.skipif(DEVICE_TYPE != "p150", reason=f"Skipping P150 test on {DEVICE_TYPE} device"),
         ),
     ],
     ids=["batch16-p100", "batch32-p100", "batch16-p150", "batch32-p150"],
 )
-def test_perf_device(batch_size, test, expected_perf, device_type):
+def test_perf_device(batch_size, test, expected_perf):
     command = (
         f"pytest models/demos/blackhole/resnet50/tests/test_resnet50_performant.py::test_run_resnet50_inference[{test}]"
     )

--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -34,6 +34,13 @@ DEVICE_TYPE = get_device_type()
             marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
         ),
         pytest.param(
+            32,
+            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
+            9380.0,
+            "p100",
+            marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
+        ),
+        pytest.param(
             16,
             "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0",
             10601.0,
@@ -47,14 +54,8 @@ DEVICE_TYPE = get_device_type()
             "p150",
             marks=pytest.mark.skipif(DEVICE_TYPE != "p150", reason=f"Skipping P150 test on {DEVICE_TYPE} device"),
         ),
-        pytest.param(
-            32,
-            "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0",
-            9380.0,
-            "p100",
-            marks=pytest.mark.skipif(DEVICE_TYPE != "p100", reason=f"Skipping P100 test on {DEVICE_TYPE} device"),
-        ),
     ],
+    ids=["batch16-p100", "batch32-p100", "batch16-p150", "batch32-p150"],
 )
 def test_perf_device(batch_size, test, expected_perf, device_type):
     command = (


### PR DESCRIPTION
### Problem description
Currently, perf tests are not available in resent device perf tests. They were disabled in #28691 because of device hang.

### What's changed
Use module level approach to find out device type instead of in test case and enable test case. 

### Checklist
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passse](https://github.com/tenstorrent/tt-metal/actions/runs/17850796813) same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/17851116605)