### PR TITLE
Stable_diffusion weights caching

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -51,7 +51,7 @@ jobs:
         -e GTEST_OUTPUT=xml:generated/test_reports/
         -e GITHUB_ACTIONS=true
         -e LOGURU_LEVEL=INFO
-        ${{ matrix.test-info.arch == 'wormhole_b0' && '-e HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub' || '' }}
+        ${{ (matrix.test-info.arch == 'wormhole_b0' || (matrix.test-info.arch == 'blackhole' && matrix.test-info.model-group == 'cnn_javelin')) && '-e HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub' || '' }}
       PIPELINE: model-perf
     steps:
       - name: ⬇️ Checkout

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -30,7 +30,7 @@ jobs:
           {name: "N300 WH B0", model-group: "other", timeout: 5, arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
           {name: "N300 WH B0", model-group: "other_magic_env", timeout: 45, arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
           # Doesn't work on blackhole P150 {name: "P150 BH", model-group: "llm_javelin", timeout: 20, arch: blackhole, runs-on: ["P150", "pipeline-functional", "cloud-virtual-machine", "${{ inputs.extra-tag }}"], machine-type: "virtual_machine"},
-          {name: "P150 BH", model-group: "cnn_javelin", timeout: 10, arch: blackhole, runs-on: ["P150", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
+          {name: "P150 BH", model-group: "cnn_javelin", timeout: 10, arch: blackhole, runs-on: ["P150", "pipeline-functional", "cloud-virtual-machine", "${{ inputs.extra-tag }}"], machine-type: "virtual_machine"},
           {name: "P150 BH", model-group: "other", timeout: 5, arch: blackhole, runs-on: ["P150", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
           {name: "P150 BH", model-group: "other_magic_env", timeout: 45, arch: blackhole, runs-on: ["P150", "pipeline-perf", "bare-metal", "${{ inputs.extra-tag }}"], machine-type: "bare_metal"},
         ]

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -22,10 +22,10 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_T
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     compile_trace_sd,
-    get_refference_clip_text_encoder,
-    get_refference_clip_tokenizer,
-    get_refference_unet,
-    get_refference_vae,
+    get_reference_clip_text_encoder,
+    get_reference_clip_tokenizer,
+    get_reference_unet,
+    get_reference_vae,
 )
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
@@ -92,15 +92,15 @@ def run_demo_inference(
 
     torch_device = "cpu"
     # 1. Load the autoencoder model which will be used to decode the latents into image space.
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     tt_vae = Vae(torch_vae=vae, device=device)
     # 2. Load the tokenizer and text encoder to tokenize and encode the text.
-    tokenizer = get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
-    text_encoder = get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
+    tokenizer = get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
+    text_encoder = get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 3. The UNet model for generating the latents.
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 4. load the K-LMS scheduler with some fitting parameters.
     ttnn_scheduler = TtPNDMScheduler(
@@ -249,16 +249,16 @@ def run_interactive_demo_inference(
 
     torch_device = "cpu"
     # 1. Load the autoencoder model which will be used to decode the latents into image space.
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     tt_vae = Vae(torch_vae=vae, device=device)
 
     # 2. Load the tokenizer and text encoder to tokenize and encode the text.
-    tokenizer = get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
-    text_encoder = get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
+    tokenizer = get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
+    text_encoder = get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 3. The UNet model for generating the latents.
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 4. load the K-LMS scheduler with some fitting parameters.
     ttnn_scheduler = TtPNDMScheduler(
@@ -398,16 +398,16 @@ def run_demo_inference_diffusiondb(
 
     torch_device = "cpu"
     # 1. Load the autoencoder model which will be used to decode the latents into image space.
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     tt_vae = Vae(torch_vae=vae, device=device)
 
     # 2. Load the tokenizer and text encoder to tokenize and encode the text.
-    tokenizer = get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
-    text_encoder = get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
+    tokenizer = get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
+    text_encoder = get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 3. The UNet model for generating the latents.
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 4. load the K-LMS scheduler with some fitting parameters.
     ttnn_scheduler = TtPNDMScheduler(

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -17,10 +17,10 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_T
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     compile_trace_sd,
-    get_refference_clip_text_encoder,
-    get_refference_clip_tokenizer,
-    get_refference_unet,
-    get_refference_vae,
+    get_reference_clip_text_encoder,
+    get_reference_clip_tokenizer,
+    get_reference_unet,
+    get_reference_vae,
 )
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
@@ -56,15 +56,15 @@ def create_model_pipeline(
 
     torch_device = "cpu"
     # 1. Load the autoencoder model which will be used to decode the latents into image space.
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     tt_vae = Vae(torch_vae=vae, device=device)
     # 2. Load the tokenizer and text encoder to tokenize and encode the text.
-    tokenizer = get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
-    text_encoder = get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
+    tokenizer = get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
+    text_encoder = get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 3. The UNet model for generating the latents.
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 4. load the K-LMS scheduler with some fitting parameters.
     ttnn_scheduler = TtPNDMScheduler(

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -7,17 +7,21 @@ import random
 import string
 
 import torch
-from diffusers import AutoencoderKL, UNet2DConditionModel
 from loguru import logger
 from PIL import Image
-from transformers import CLIPTextModel, CLIPTokenizer
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import disable_persistent_kernel_cache, is_wormhole_b0
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import compile_trace_sd
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
+    compile_trace_sd,
+    get_refference_clip_text_encoder,
+    get_refference_clip_tokenizer,
+    get_refference_unet,
+    get_refference_vae,
+)
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
@@ -52,37 +56,15 @@ def create_model_pipeline(
 
     torch_device = "cpu"
     # 1. Load the autoencoder model which will be used to decode the latents into image space.
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    vae.to(torch_device)
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     tt_vae = Vae(torch_vae=vae, device=device)
     # 2. Load the tokenizer and text encoder to tokenize and encode the text.
-    model_location = model_location_generator("clip-vit-large-patch14", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
-    tokenizer = CLIPTokenizer.from_pretrained(
-        "openai/clip-vit-large-patch14" if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    text_encoder = CLIPTextModel.from_pretrained(
-        "openai/clip-vit-large-patch14" if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    tokenizer = get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator)
+    text_encoder = get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 3. The UNet model for generating the latents.
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    unet = UNet2DConditionModel.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="unet" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # 4. load the K-LMS scheduler with some fitting parameters.
     ttnn_scheduler = TtPNDMScheduler(

--- a/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
+++ b/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
@@ -278,7 +278,7 @@ STABLE_DIFFUSION_CIV2_MODEL_LOCATION = "stable-diffusion-v1-4"
 CLIP_VIT_LARGE_PATCH14_CIV2_MODEL_LOCATION = "clip-vit-large-patch14"
 
 
-def get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator):
+def get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator):
     model_location = model_location_generator(
         f"{STABLE_DIFFUSION_CIV2_MODEL_LOCATION}/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -291,7 +291,7 @@ def get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator):
     return vae.to("cpu")
 
 
-def get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator):
+def get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator):
     model_location = model_location_generator(
         f"{STABLE_DIFFUSION_CIV2_MODEL_LOCATION}/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -304,7 +304,7 @@ def get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator):
     return unet.to("cpu")
 
 
-def get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator):
+def get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generator):
     model_location = model_location_generator(
         CLIP_VIT_LARGE_PATCH14_CIV2_MODEL_LOCATION, download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -316,7 +316,7 @@ def get_refference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_genera
     return tokenizer
 
 
-def get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator):
+def get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_generator):
     model_location = model_location_generator(
         CLIP_VIT_LARGE_PATCH14_CIV2_MODEL_LOCATION, download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -328,7 +328,7 @@ def get_refference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_gen
     return text_encoder
 
 
-def get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator):
+def get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator):
     model_location = model_location_generator(
         STABLE_DIFFUSION_CIV2_MODEL_LOCATION, download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )

--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -10,7 +10,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_basic_transformer_block import basic_transformer_block
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -42,7 +42,7 @@ def test_basic_transformer_block_512x512(
 
     N, C, H, W = input_shape
 
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     config = unet.config
 
     if block == "up":

--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -20,14 +20,12 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
-@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
     TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_basic_transformer_block_512x512(
     device,
-    model_name,
     input_shape,
     shard_layout,
     shard_end_core,
@@ -36,12 +34,22 @@ def test_basic_transformer_block_512x512(
     block,
     block_index,
     attention_index,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     torch.manual_seed(0)
 
     N, C, H, W = input_shape
 
-    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     model = pipe.unet
     model.eval()
     config = model.config

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -9,7 +9,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention import cross_attention
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -43,7 +43,7 @@ def test_cross_attention_512x512(
 
     N, C, H, W = input_shape
 
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     hidden_states_shape = torch.Size(input_shape)
     hidden_states = torch.rand(hidden_states_shape)

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
@@ -5,13 +5,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention_down_block_2d_new_conv import (
     cross_attention_down_block_2d,
 )
@@ -47,17 +47,8 @@ def test_cross_attention_downblock_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    unet = pipe.unet
-    unet.eval()
+    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     torch_down_block = unet.down_blocks[block_index]
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
@@ -11,7 +11,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention_down_block_2d_new_conv import (
     cross_attention_down_block_2d,
 )
@@ -48,7 +48,7 @@ def test_cross_attention_downblock_512x512(
     model_location_generator,
 ):
     # Initialize PyTorch component
-    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     torch_down_block = unet.down_blocks[block_index]
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
@@ -43,9 +43,19 @@ def test_cross_attention_downblock_512x512(
     shard_shape,
     out_channels,
     temb,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     torch_down_block = unet.down_blocks[block_index]

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -30,10 +30,26 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
 def test_cross_attention_midblock_512x512(
-    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb
+    reset_seeds,
+    device,
+    hidden_states,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    temb,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     torch_midblock = unet.mid_block

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -5,13 +5,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_mid_block_2d_cross_attn_new_conv import (
     unet_mid_block_2d_cross_attn,
@@ -42,16 +42,7 @@ def test_cross_attention_midblock_512x512(
     model_location_generator,
 ):
     # Initialize PyTorch component
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    unet = pipe.unet
-    unet.eval()
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_midblock = unet.mid_block
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -11,7 +11,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_mid_block_2d_cross_attn_new_conv import (
     unet_mid_block_2d_cross_attn,
@@ -42,7 +42,7 @@ def test_cross_attention_midblock_512x512(
     model_location_generator,
 ):
     # Initialize PyTorch component
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_midblock = unet.mid_block
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attn_upblock_new_conv import (
     cross_attention_upblock2d,
 )
@@ -88,21 +88,9 @@ def test_cross_attn_up_block_2d_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet",
-        download_if_ci_v2=True,
-        ci_v2_timeout_in_s=1800,
-    )
-    # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    unet = pipe.unet
-    unet.eval()
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     config = unet.config
-    unet_upblock = pipe.unet.up_blocks[index]
+    unet_upblock = unet.up_blocks[index]
 
     parameters = preprocess_model_parameters(
         initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
@@ -84,10 +84,21 @@ def test_cross_attn_up_block_2d_512x512(
     out_channels,
     shard_end_core,
     shard_shape,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    # TODO
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet",
+        download_if_ci_v2=True,
+        ci_v2_timeout_in_s=1800,
+    )
     # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     config = unet.config

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attn_upblock_new_conv import (
     cross_attention_upblock2d,
 )
@@ -88,7 +88,7 @@ def test_cross_attn_up_block_2d_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     config = unet.config
     unet_upblock = unet.up_blocks[index]
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -9,7 +9,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_T
 from models.demos.wormhole.stable_diffusion.demo.demo import load_inputs
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference as demo
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_diffusiondb as demo_db
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -71,7 +71,7 @@ def test_demo_sd(device, reset_seeds, input_path, is_ci_env, is_ci_v2_env, model
 
     inputs = load_inputs(input_path)
     input_prompts = inputs[:1]
-    pipe = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator)
+    pipe = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator)
 
     import torch
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -4,12 +4,12 @@
 
 import pytest
 import torchvision.transforms as transforms
-from diffusers import StableDiffusionPipeline
 
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_TRACE_REGION_SIZE
 from models.demos.wormhole.stable_diffusion.demo.demo import load_inputs
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference as demo
 from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_diffusiondb as demo_db
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -71,12 +71,7 @@ def test_demo_sd(device, reset_seeds, input_path, is_ci_env, is_ci_v2_env, model
 
     inputs = load_inputs(input_path)
     input_prompts = inputs[:1]
-    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    pipe = pipe.to("cpu")
+    pipe = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator)
 
     import torch
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -26,9 +26,27 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
-def test_downblock_512x512(reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb):
+def test_downblock_512x512(
+    reset_seeds,
+    device,
+    hidden_states,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    temb,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
+):
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     torch_down_block = pipe.unet.down_blocks[3]

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downblock_2d_new_conv import downblock2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -38,7 +38,7 @@ def test_downblock_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_down_block = unet.down_blocks[3]
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downsample_2d_new_conv import downsample_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -43,7 +43,7 @@ def test_downsample_512x512(
     model_location_generator,
 ):
     # Initialize PyTorch component
-    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     torch_downsample = unet.down_blocks[block_index].downsamplers[0]
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downsample_2d_new_conv import downsample_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -43,7 +43,7 @@ def test_downsample_512x512(
     model_location_generator,
 ):
     # Initialize PyTorch component
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     torch_downsample = unet.down_blocks[block_index].downsamplers[0]
 
     # Initialize ttnn component

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -30,9 +30,25 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[2] + (2,),
     ),
 )
-def test_downsample_512x512(reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, block_index):
+def test_downsample_512x512(
+    reset_seeds,
+    device,
+    hidden_states,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    block_index,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
+):
+    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     torch_downsample = pipe.unet.down_blocks[block_index].downsamplers[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downsample_2d_new_conv import downsample_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -42,16 +42,9 @@ def test_downsample_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
     # Initialize PyTorch component
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    unet = pipe.unet
-    unet.eval()
-    torch_downsample = pipe.unet.down_blocks[block_index].downsamplers[0]
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    torch_downsample = unet.down_blocks[block_index].downsamplers[0]
 
     # Initialize ttnn component
     parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -4,11 +4,11 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_embeddings import TtTimestepEmbedding
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -16,16 +16,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_embeddings(device, is_ci_env, is_ci_v2_env, model_location_generator):
     torch.manual_seed(0)
-    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
-    # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-
-    model = pipe.unet
-    model.eval()
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = unet
     time_embedding = model.time_embedding
 
     parameters = preprocess_model_parameters(initialize_model=lambda: time_embedding, device=device)

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -14,10 +14,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
-def test_embeddings(device):
+def test_embeddings(device, is_ci_env, is_ci_v2_env, model_location_generator):
     torch.manual_seed(0)
+    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
     # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     model = pipe.unet
     model.eval()

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -8,7 +8,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_embeddings import TtTimestepEmbedding
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -16,7 +16,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_embeddings(device, is_ci_env, is_ci_v2_env, model_location_generator):
     torch.manual_seed(0)
-    model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     time_embedding = model.time_embedding
 
     parameters = preprocess_model_parameters(initialize_model=lambda: time_embedding, device=device)

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -8,7 +8,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_embeddings import TtTimestepEmbedding
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -16,8 +16,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
 def test_embeddings(device, is_ci_env, is_ci_v2_env, model_location_generator):
     torch.manual_seed(0)
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
-    model = unet
+    model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     time_embedding = model.time_embedding
 
     parameters = preprocess_model_parameters(initialize_model=lambda: time_embedding, device=device)

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward import feedforward
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -38,7 +38,7 @@ def test_feedforward_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "up":
         basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import UNet2DConditionModel
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward import feedforward
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -38,14 +38,7 @@ def test_feedforward_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    model = UNet2DConditionModel.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="unet" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    ).eval()
+    model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "up":
         basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import UNet2DConditionModel
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_geglu import geglu
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -38,14 +38,7 @@ def test_geglu_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    model = UNet2DConditionModel.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="unet" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    ).eval()
+    model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "up":
         basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_geglu import geglu
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -38,7 +38,7 @@ def test_geglu_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "up":
         basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -20,14 +20,12 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
-@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
     TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_geglu_512x512(
     device,
-    model_name,
     input_shape,
     shard_layout,
     shard_end_core,
@@ -36,8 +34,18 @@ def test_geglu_512x512(
     block,
     block_index,
     attention_index,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    model = UNet2DConditionModel.from_pretrained(model_name, subfolder="unet").eval()
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/unet", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    model = UNet2DConditionModel.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="unet" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    ).eval()
 
     if block == "up":
         basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -15,7 +15,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_T
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_unet,
+    get_refference_stable_diffusion_pipeline,
     get_refference_vae,
     run,
 )
@@ -62,7 +62,7 @@ def test_stable_diffusion_unet_trace(device, is_ci_env, is_ci_v2_env, model_loca
     profiler.clear()
     torch.manual_seed(0)
 
-    torch_model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    torch_model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     config = torch_model.config
 
     # Setup scheduler
@@ -283,7 +283,7 @@ def test_stable_diffusion_perf(
 
     # setup pytorch model
     torch.manual_seed(0)
-    model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     config = model.config
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -283,8 +283,9 @@ def test_stable_diffusion_perf(
 
     # setup pytorch model
     torch.manual_seed(0)
-    model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
-    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    ref_model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = ref_model.unet
+    vae = ref_model.vae
     config = model.config
 
     # setup scheduler

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -15,8 +15,8 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE, SD_T
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_stable_diffusion_pipeline,
-    get_refference_vae,
+    get_reference_stable_diffusion_pipeline,
+    get_reference_vae,
     run,
 )
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -62,7 +62,7 @@ def test_stable_diffusion_unet_trace(device, is_ci_env, is_ci_v2_env, model_loca
     profiler.clear()
     torch.manual_seed(0)
 
-    torch_model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    torch_model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     config = torch_model.config
 
     # Setup scheduler
@@ -185,7 +185,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
     profiler.clear()
     torch.manual_seed(0)
 
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     ttnn_model = Vae(torch_vae=vae, device=device)
 
     input_channels = 4
@@ -283,8 +283,8 @@ def test_stable_diffusion_perf(
 
     # setup pytorch model
     torch.manual_seed(0)
-    model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     config = model.config
 
     # setup scheduler

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -9,7 +9,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_resnetblock2d_new_conv import resnetBlock2D
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
@@ -86,7 +86,7 @@ def test_resnet_block_2d_512x512(
     if not load_from_disk:
         # setup pytorch model
 
-        unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+        unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
         config = unet.config
 
         parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -4,12 +4,12 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_resnetblock2d_new_conv import resnetBlock2D
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
@@ -86,32 +86,22 @@ def test_resnet_block_2d_512x512(
     if not load_from_disk:
         # setup pytorch model
 
-        model_location = model_location_generator(
-            "stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-        )
-        pipe = StableDiffusionPipeline.from_pretrained(
-            "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-            torch_dtype=torch.float32,
-            local_files_only=is_ci_env or is_ci_v2_env,
-        )
-
-        model = pipe.unet
-        model.eval()
-        config = model.config
+        unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+        config = unet.config
 
         parameters = preprocess_model_parameters(
-            initialize_model=lambda: model, custom_preprocessor=custom_preprocessor, device=device
+            initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
         )
 
         if block_name == "up":
             parameters = parameters.up_blocks[block_index].resnets[resnet_index]
-            resnet = pipe.unet.up_blocks[block_index].resnets[resnet_index]
+            resnet = unet.up_blocks[block_index].resnets[resnet_index]
         elif block_name == "down":
             parameters = parameters.down_blocks[block_index].resnets[resnet_index]
-            resnet = pipe.unet.down_blocks[block_index].resnets[resnet_index]
+            resnet = unet.down_blocks[block_index].resnets[resnet_index]
         else:
             parameters = parameters.mid_block.resnets[resnet_index]
-            resnet = pipe.unet.mid_block.resnets[resnet_index]
+            resnet = unet.mid_block.resnets[resnet_index]
         torch.save(resnet, "resnet.pt")
         torch.save(config, "config.pt")
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -78,11 +78,22 @@ def test_resnet_block_2d_512x512(
     block_name,
     block_index,
     resnet_index,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     load_from_disk = False
     if not load_from_disk:
         # setup pytorch model
-        pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+
+        model_location = model_location_generator(
+            "stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+        )
+        pipe = StableDiffusionPipeline.from_pretrained(
+            "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+            torch_dtype=torch.float32,
+            local_files_only=is_ci_env or is_ci_v2_env,
+        )
 
         model = pipe.unet
         model.eval()

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -9,7 +9,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_resnetblock2d_new_conv import resnetBlock2D
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
@@ -86,7 +86,7 @@ def test_resnet_block_2d_512x512(
     if not load_from_disk:
         # setup pytorch model
 
-        unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+        unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
         config = unet.config
 
         parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -11,7 +11,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_unet,
+    get_refference_stable_diffusion_pipeline,
 )
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_transformer_2d_new_conv import transformer_2d_model
@@ -61,7 +61,7 @@ def test_transformer_2d_model_512x512(
     input = torch.randn(input_shape) * 0.01
     encoder_hidden_states = torch.rand(encoder_hidden_states)
 
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     config = unet.config
 
     parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -11,7 +11,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_stable_diffusion_pipeline,
+    get_reference_stable_diffusion_pipeline,
 )
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_transformer_2d_new_conv import transformer_2d_model
@@ -61,7 +61,7 @@ def test_transformer_2d_model_512x512(
     input = torch.randn(input_shape) * 0.01
     encoder_hidden_states = torch.rand(encoder_hidden_states)
 
-    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     config = unet.config
 
     parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -14,7 +14,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_unet,
+    get_refference_stable_diffusion_pipeline,
 )
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
@@ -75,7 +75,7 @@ def test_unet_2d_condition_model_512x512(
     torch.manual_seed(0)
     load_from_disk = False
     if not load_from_disk:
-        model = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+        model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
         config = model.config
         torch.save(model, "unet.pt")
         torch.save(config, "unet_config.pt")

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -14,7 +14,7 @@ from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.sd_helper_funcs import (
     STABLE_DIFFUSION_V1_4_MODEL_LOCATION,
-    get_refference_stable_diffusion_pipeline,
+    get_reference_stable_diffusion_pipeline,
 )
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
@@ -75,7 +75,7 @@ def test_unet_2d_condition_model_512x512(
     torch.manual_seed(0)
     load_from_disk = False
     if not load_from_disk:
-        model = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+        model = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
         config = model.config
         torch.save(model, "unet.pt")
         torch.save(config, "unet_config.pt")

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upblock_2d_new_conv import upblock_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -40,16 +40,9 @@ def test_upblock_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-    unet = pipe.unet
-    unet.eval()
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
     state_dict = unet.state_dict()
-    unet_upblock = pipe.unet.up_blocks[0]
+    unet_upblock = unet.up_blocks[0]
 
     parameters = preprocess_model_parameters(
         initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upblock_2d_new_conv import upblock_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -40,7 +40,7 @@ def test_upblock_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     state_dict = unet.state_dict()
     unet_upblock = unet.up_blocks[0]
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upblock_2d_new_conv import upblock_2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
@@ -40,7 +40,7 @@ def test_upblock_512x512(
     is_ci_v2_env,
     model_location_generator,
 ):
-    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     state_dict = unet.state_dict()
     unet_upblock = unet.up_blocks[0]
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -36,8 +36,16 @@ def test_upblock_512x512(
     shard_end_core,
     shard_shape,
     temb,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -4,13 +4,13 @@
 
 import pytest
 import torch
-from diffusers import StableDiffusionPipeline
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import (
     CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
     DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,
@@ -51,17 +51,9 @@ def test_upsample2d_512x512(
     model_location_generator,
 ):
     torch.manual_seed(0)
-    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
     # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        torch_dtype=torch.float32,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
-
-    unet = pipe.unet
-    unet.eval()
-    unet_upblock = pipe.unet.up_blocks[index]
+    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet_upblock = unet.up_blocks[index]
     resnet_upsampler = unet_upblock.upsamplers[0]
 
     parameters = preprocess_model_parameters(

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -39,9 +39,25 @@ def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], indirect=True)
-def test_upsample2d_512x512(device, input_shape, shard_layout, shard_end_core, shard_shape, index):
+def test_upsample2d_512x512(
+    device,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    index,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
+):
+    torch.manual_seed(0)
+    model_location = model_location_generator("stable-diffusion-v1-4", download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
     # setup pytorch model
-    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        torch_dtype=torch.float32,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     unet = pipe.unet
     unet.eval()

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import (
     CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
     DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,
@@ -52,7 +52,7 @@ def test_upsample2d_512x512(
 ):
     torch.manual_seed(0)
     # setup pytorch model
-    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
+    unet = get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     unet_upblock = unet.up_blocks[index]
     resnet_upsampler = unet_upblock.upsamplers[0]
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -10,7 +10,7 @@ import ttnn
 from models.common.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_unet
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_stable_diffusion_pipeline
 from models.demos.wormhole.stable_diffusion.tests.parameterizations import (
     CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
     DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,
@@ -52,7 +52,7 @@ def test_upsample2d_512x512(
 ):
     torch.manual_seed(0)
     # setup pytorch model
-    unet = get_refference_unet(is_ci_env, is_ci_v2_env, model_location_generator)
+    unet = get_refference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_location_generator).unet
     unet_upblock = unet.up_blocks[index]
     resnet_upsampler = unet_upblock.upsamplers[0]
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -4,10 +4,10 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -40,14 +40,7 @@ def test_decoder(
 ):
     torch.manual_seed(0)
 
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # Run pytorch model
     torch_input = torch.randn([1, input_channels, input_height, input_width])

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -34,10 +34,20 @@ def test_decoder(
     out_channels,
     output_height,
     output_width,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     torch.manual_seed(0)
 
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     # Run pytorch model
     torch_input = torch.randn([1, input_channels, input_height, input_width])

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -7,7 +7,7 @@ import torch
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -40,7 +40,7 @@ def test_decoder(
 ):
     torch.manual_seed(0)
 
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     # Run pytorch model
     torch_input = torch.randn([1, input_channels, input_height, input_width])

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
@@ -20,8 +20,18 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 def test_vae_attention(
     device,
     input_shape,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     torch_attention = vae.decoder.mid_block.attentions[0]
 
     batch_size, in_channels, height, width = input_shape

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
@@ -4,9 +4,9 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_attention import Attention
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -24,14 +24,7 @@ def test_vae_attention(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_attention = vae.decoder.mid_block.attentions[0]
 
     batch_size, in_channels, height, width = input_shape

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_attention.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import ttnn
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_attention import Attention
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -24,7 +24,7 @@ def test_vae_attention(
     is_ci_v2_env,
     model_location_generator,
 ):
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_attention = vae.decoder.mid_block.attentions[0]
 
     batch_size, in_channels, height, width = input_shape

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -4,10 +4,10 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     GROUPNORM_DECODER_NUM_BLOCKS,
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
@@ -69,14 +69,7 @@ def test_decoder(
 ):
     torch.manual_seed(0)
 
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_decoder = vae.decoder
 
     # Run pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -7,7 +7,7 @@ import torch
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     GROUPNORM_DECODER_NUM_BLOCKS,
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
@@ -69,7 +69,7 @@ def test_decoder(
 ):
     torch.manual_seed(0)
 
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_decoder = vae.decoder
 
     # Run pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder.py
@@ -63,10 +63,20 @@ def test_decoder(
     upblock_resnet_conv_in_channel_split_factors,
     upblock_upsample_conv_channel_split_factors,
     norm_num_blocks,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     torch.manual_seed(0)
 
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     torch_decoder = vae.decoder
 
     # Run pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -36,7 +36,7 @@ def test_vae_midblock(
     is_ci_v2_env,
     model_location_generator,
 ):
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     torch_midblock = vae.decoder.mid_block
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -4,11 +4,11 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -36,14 +36,7 @@ def test_vae_midblock(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     torch_midblock = vae.decoder.mid_block
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -26,9 +26,24 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 def test_vae_midblock(
-    device, input_channels, input_height, input_width, norm_num_blocks, conv_in_channel_split_factors
+    device,
+    input_channels,
+    input_height,
+    input_width,
+    norm_num_blocks,
+    conv_in_channel_split_factors,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     torch_midblock = vae.decoder.mid_block
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -57,7 +57,7 @@ def test_vae_resnet(
     is_ci_v2_env,
     model_location_generator,
 ):
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "mid":
         torch_resnet = vae.decoder.mid_block.resnets[resnet_block_id]

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
@@ -4,11 +4,11 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -57,14 +57,7 @@ def test_vae_resnet(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     if block == "mid":
         torch_resnet = vae.decoder.mid_block.resnets[resnet_block_id]

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_resnet.py
@@ -53,8 +53,18 @@ def test_vae_resnet(
     block,
     block_id,
     resnet_block_id,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     if block == "mid":
         torch_resnet = vae.decoder.mid_block.resnets[resnet_block_id]

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
@@ -4,11 +4,11 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     UPBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -90,14 +90,7 @@ def test_vae_upblock(
     model_location_generator,
 ):
     torch.manual_seed(0)
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     torch_upblock = vae.decoder.up_blocks[block_id]
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
@@ -85,9 +85,19 @@ def test_vae_upblock(
     resnet_conv_in_channel_split_factors,
     upsample_conv_channel_split_factors,
     block_id,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
     torch.manual_seed(0)
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
 
     torch_upblock = vae.decoder.up_blocks[block_id]
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 from models.common.utility_functions import skip_for_blackhole
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
     UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
     UPBLOCK_RESNET_NORM_NUM_BLOCKS,
@@ -90,7 +90,7 @@ def test_vae_upblock(
     model_location_generator,
 ):
     torch.manual_seed(0)
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
 
     torch_upblock = vae.decoder.up_blocks[block_id]
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -7,7 +7,7 @@ import torch
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
-from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_reference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -36,7 +36,7 @@ def test_upsample(
     is_ci_v2_env,
     model_location_generator,
 ):
-    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
+    vae = get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_upsample = vae.decoder.up_blocks[block_id].upsamplers[0]
 
     # Run pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -4,10 +4,10 @@
 
 import pytest
 import torch
-from diffusers import AutoencoderKL
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.common import SD_L1_SMALL_SIZE
+from models.demos.wormhole.stable_diffusion.sd_helper_funcs import get_refference_vae
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -36,14 +36,7 @@ def test_upsample(
     is_ci_v2_env,
     model_location_generator,
 ):
-    model_location = model_location_generator(
-        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
-    )
-    vae = AutoencoderKL.from_pretrained(
-        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
-        subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
-    )
+    vae = get_refference_vae(is_ci_env, is_ci_v2_env, model_location_generator)
     torch_upsample = vae.decoder.up_blocks[block_id].upsamplers[0]
 
     # Run pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -32,8 +32,18 @@ def test_upsample(
     output_width,
     conv_channel_split_factor,
     block_id,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
 ):
-    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    model_location = model_location_generator(
+        "stable-diffusion-v1-4/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "CompVis/stable-diffusion-v1-4" if not is_ci_v2_env else model_location,
+        subfolder="vae" if not is_ci_v2_env else None,
+        local_files_only=is_ci_env or is_ci_v2_env,
+    )
     torch_upsample = vae.decoder.up_blocks[block_id].upsamplers[0]
 
     # Run pytorch model


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/29906

### Problem description
Stable_diffusion weights are downloaded from HF each run. 
They need to be cached.

### What's changed
- Added civ1 and civ2 caching to each usage of weights in stable_diffusion

### Checklist
- [X] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18521911133)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18497900435) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18495818836)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [sd passes](https://github.com/tenstorrent/tt-metal/actions/runs/18532428669)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18499879799)