### PR TITLE
conv3.0 batch fix

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -497,9 +497,7 @@ class resnet50:
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
             # otherwise act block h is not big enough for the reuse
-            enable_activation_reuse=(
-                not is_blackhole_p100(device) and (not is_wormhole_b0() or device.get_num_devices() <= 8)
-            ),
+            enable_activation_reuse=(not is_wormhole_b0() or device.get_num_devices() <= 8),
         )
         self.conv1_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -47,9 +47,11 @@ struct ActivationReuseConfig {
     CoreCoord partial_work_core{0, 0};
     uint32_t partial_core_reader_tiles_to_push = 0;
     uint32_t partial_core_writer_remaining_tiles_to_push_to_push = 0;
+    bool single_core_processes_multiple_batches = false;
 };
 
 ActivationReuseConfig calculate_activation_reuse_params(
+    uint32_t output_image_height,
     uint32_t output_image_width,
     uint32_t filter_w,
     uint32_t filter_h,
@@ -65,7 +67,8 @@ ActivationReuseConfig calculate_activation_reuse_params(
     uint32_t padded_total_output_height_ntiles,
     const std::vector<CBInfo>& cb_info,
     bool enable_split_reader,
-    const CoreRangeSet& input_cores) {
+    const CoreRangeSet& input_cores,
+    uint32_t batch) {
     ActivationReuseConfig config;
 
     // Calculate compile time args needed for activation reuse feature
@@ -150,6 +153,13 @@ ActivationReuseConfig calculate_activation_reuse_params(
     for (uint32_t i = start_idx; i < all_input_cores.size(); i++) {
         config.cores_with_non_meaningful_work.insert(all_input_cores[i]);
     }
+
+    // If we have cores processing data from more than 1 batch, we need to trigger a check inside the kernel
+    // to 'restart' the optimization and fill in the whole output image width
+    // before the reuse for the new batch starts
+    const uint32_t per_core_out_hw = single_core_height_ntiles * tt::constants::TILE_HEIGHT;
+    const uint32_t total_batch_out_hw = output_image_height * output_image_width;
+    config.single_core_processes_multiple_batches = (batch > 1) && (total_batch_out_hw % per_core_out_hw != 0);
 
     return config;
 }
@@ -720,6 +730,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     ActivationReuseConfig activation_reuse_config;
     if (enable_activation_reuse) {
         activation_reuse_config = calculate_activation_reuse_params(
+            output_image_height,
             output_image_width,
             filter_w,
             filter_h,
@@ -735,7 +746,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             act_matrix_height_ntiles,
             cb_info,
             enable_split_reader,
-            input_cores);
+            input_cores,
+            batch);
     }
 
     std::vector<uint32_t> reader_compile_time_args = {
@@ -795,7 +807,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             activation_reuse_config.image_width_tiles,
             output_image_width,
             activation_reuse_config.reuse_window_offset,
-            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0)};
+            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
+            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
 
         reader_compile_time_args.insert(
             reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
@@ -894,7 +907,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     activation_reuse_config.image_width_tiles,
                     output_image_width,
                     activation_reuse_config.reuse_window_offset,
-                    static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0)};
+                    static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
+                    static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
                 split_reader_args.insert(
                     split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -39,9 +39,9 @@ FORCE_INLINE void read_sticks(
     uint32_t reader_offset,
     uint32_t& l1_write_addr_act,
     uint32_t& reader_idx) {
-    uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint16_t num_segments = packed_reader_indices_ptr[reader_idx] & 0xffff;
 
-    while (num_elems--) {
+    while (num_segments--) {
         reader_idx++;
         uint16_t start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
         uint16_t end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
@@ -77,12 +77,20 @@ FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_of
 #ifdef ACTIVATION_REUSE
 template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
 FORCE_INLINE void pass_to_the_next_image_width(
-    uint32_t& l1_write_addr_act, uint32_t cb_start_addr, uint32_t& pixel_row, uint32_t& pixel_column) {
+    uint32_t& l1_write_addr_act,
+    uint32_t cb_start_addr,
+    uint32_t& pixel_row,
+    uint32_t& pixel_column,
+    uint32_t& new_batch_image_rows_to_fill) {
     pixel_column = 0;
     pixel_row++;
     cb_reserve_back(cb_id_act, act_cb_tiles);
     l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
     get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+
+    if (new_batch_image_rows_to_fill > 0) {
+        new_batch_image_rows_to_fill--;
+    }
 }
 
 template <uint32_t cb_id_act, uint32_t act_cb_w_tiles>
@@ -135,6 +143,33 @@ FORCE_INLINE void read_image_row_window_with_reuse(uint32_t& l1_write_addr_act, 
     read_kernel_w<coalesced_read_bytes, stride_h_bytes>(l1_write_addr_act, act_l1_offset);
 }
 
+template <uint32_t window_inner, bool single_core_processes_multiple_batches>
+FORCE_INLINE void load_next_segment(
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
+    uint32_t& reader_idx,
+    uint16_t& start_ind,
+    uint16_t& end_ind,
+    uint32_t& new_batch_image_rows_to_fill,
+    uint16_t& num_segments) {
+    num_segments--;
+    reader_idx++;
+    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    if constexpr (single_core_processes_multiple_batches) {
+        // Check if new batch is starting
+        // Feature currently works for stride and dilation h/w == 1, to be updated if the support is expanded
+        if (start_ind > end_ind + window_inner) {
+            // When we start a new batch, we need to 'restart' the optimization and fill in the whole output image width
+            // before the reuse starts; Since we might encounter new batch in the middle of the output image width
+            // where we have the reuse activated for the previous one, we need to:
+            // - finish the current width without the reuse
+            // - use the next width to 'restart optimization' and fill in the CB with new batch data
+            // - only then start reusing data
+            new_batch_image_rows_to_fill = 2;
+        }
+    }
+    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+}
+
 template <
     uint32_t coalesced_read_bytes,
     uint32_t conv_act_c_read_bytes,
@@ -149,7 +184,8 @@ template <
     bool readers_process_full_image_widths,
     uint32_t image_width_tiles,
     uint32_t output_image_width,
-    uint32_t window_reuse_offset>
+    uint32_t window_reuse_offset,
+    bool single_core_processes_multiple_batches>
 FORCE_INLINE void read_sticks_activation_reuse(
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr,
     uint32_t reader_offset,
@@ -162,12 +198,13 @@ FORCE_INLINE void read_sticks_activation_reuse(
     constexpr uint32_t outer_coalesced_read_bytes = reuse_outer * coalesced_read_bytes;
     constexpr uint32_t outer_stride_h_bytes = reuse_outer * stride_h_bytes;
 
-    uint16_t num_elems = packed_reader_indices_ptr[reader_idx] & 0xffff;
+    uint16_t num_segments = packed_reader_indices_ptr[reader_idx] & 0xffff;
     uint32_t pixel_row = 0, pixel_column = 0;
+    uint32_t new_batch_image_rows_to_fill = 0;
 
     cb_reserve_back(cb_id_act, act_cb_tiles);
 
-    if (num_elems == 0) {
+    if (num_segments == 0) {
         return;
     }
 
@@ -187,13 +224,11 @@ FORCE_INLINE void read_sticks_activation_reuse(
             act_block_w_extra_align_bytes>(l1_write_addr_act, reader_offset, ind, pixel_column);
     }
 
-    num_elems--;
-    reader_idx++;
-    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
-    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+    load_next_segment<window_inner, single_core_processes_multiple_batches>(
+        packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill, num_segments);
 
     if constexpr (!readers_process_full_image_widths) {
-        if (num_elems) {
+        if (num_segments) {
             // The first image width might be split between two rows
             uint16_t leftover_row_width = image_width_padded_to_tile - pixel_column;
             uint16_t second_row_width = leftover_row_width, third_row_width = 0;
@@ -223,10 +258,13 @@ FORCE_INLINE void read_sticks_activation_reuse(
 
             if constexpr (!output_image_width_full_tile) {
                 if (third_row_width > 0) {
-                    num_elems--;
-                    reader_idx++;
-                    start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
-                    end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+                    load_next_segment<window_inner, single_core_processes_multiple_batches>(
+                        packed_reader_indices_ptr,
+                        reader_idx,
+                        start_ind,
+                        end_ind,
+                        new_batch_image_rows_to_fill,
+                        num_segments);
 
                     for (uint16_t ind = start_ind; ind < start_ind + third_row_width; ind += stride_w) {
                         read_first_image_row_window<
@@ -246,13 +284,13 @@ FORCE_INLINE void read_sticks_activation_reuse(
     }
     // Move on to the next output image width
     pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-        l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+        l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
 
     // ------ HANDLE REMAINING INPUT, WHERE WE READ JUST THE LAST KERNEL WIDTH OF THE WINDOW ------
-    while (num_elems--) {
+    while (num_segments) {
         for (uint16_t ind = start_ind; ind <= end_ind; ind += stride_w) {
             uint32_t act_l1_offset = reader_offset + (ind * conv_act_c_read_bytes);
-            if constexpr (output_image_width_full_tile) {
+            if constexpr (output_image_width_full_tile && !single_core_processes_multiple_batches) {
                 // In this case, everything is reused after the first image width
                 read_image_row_window_with_reuse<
                     coalesced_read_bytes,
@@ -261,7 +299,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                     outer_stride_h_bytes>(l1_write_addr_act, act_l1_offset);
             } else {
                 // In this case, we need to check if we are in the limits of image width since we pad it to tile size
-                if (pixel_column < output_image_width) {
+                if (pixel_column < output_image_width && new_batch_image_rows_to_fill == 0) {
                     read_image_row_window_with_reuse<
                         coalesced_read_bytes,
                         stride_h_bytes,
@@ -284,7 +322,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
                 if constexpr (!readers_process_full_image_widths) {
                     if (pixel_column == image_width_padded_to_tile) {
                         pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                            l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+                            l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
                     }
                 }
             }
@@ -293,12 +331,11 @@ FORCE_INLINE void read_sticks_activation_reuse(
         if constexpr (readers_process_full_image_widths) {
             // Move on to the next output image width
             pass_to_the_next_image_width<cb_id_act, act_cb_tiles, window_reuse_offset>(
-                l1_write_addr_act, cb_start_addr, pixel_row, pixel_column);
+                l1_write_addr_act, cb_start_addr, pixel_row, pixel_column, new_batch_image_rows_to_fill);
         }
 
-        reader_idx++;
-        start_ind = packed_reader_indices_ptr[reader_idx] & 0xffff;
-        end_ind = packed_reader_indices_ptr[reader_idx] >> 16;
+        load_next_segment<window_inner, single_core_processes_multiple_batches>(
+            packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill, num_segments);
     }
 }
 #endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -39,6 +39,7 @@ void kernel_main() {
     constexpr uint32_t output_image_width = get_compile_time_arg_val(34);
     constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
     constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(36) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(37) == 1;
 
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(0);
 #endif
@@ -115,7 +116,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset>(
+                window_reuse_offset,
+                single_core_processes_multiple_batches>(
                 packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
 #endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -42,6 +42,7 @@ void kernel_main() {
     constexpr uint32_t output_image_width = get_compile_time_arg_val(32);
     constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(33);
     constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(34) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(35) == 1;
 #endif
 #endif
 
@@ -143,7 +144,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset>(
+                window_reuse_offset,
+                single_core_processes_multiple_batches>(
                 packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
             if constexpr (need_to_push_remaining_tiles) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -46,7 +46,8 @@ void kernel_main() {
     constexpr uint32_t output_image_width = get_compile_time_arg_val(32);
     constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(33);
     constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(34) == 1;
-    constexpr uint32_t ct_arg_idx = 35;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(35) == 1;
+    constexpr uint32_t ct_arg_idx = 36;
 #else
     constexpr uint32_t ct_arg_idx = 27;
 #endif
@@ -190,7 +191,8 @@ void kernel_main() {
                 readers_process_full_image_widths,
                 image_width_tiles,
                 output_image_width,
-                window_reuse_offset>(
+                window_reuse_offset,
+                single_core_processes_multiple_batches>(
                 packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
             if constexpr (need_to_push_remaining_tiles) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28386

### Problem description
When a single core has to process more than 1 batch, once it is done with the previous batch, we need to 'restart' the optimization and fill in the whole CB before starting to reuse data again. 

### What's changed
- Added a compile time arg to know whether we need to check for situations like this one (to avoid additional if-s in the code in case we know that no core will process more than 1 batch. 
- When a new reader indices segment is encountered, we check if the new start index is further than expected from the previous end index - if so, we need to initialize the reuse again and fill in the whole CB
- Refactored out repeated code to `load_new_segment` function

Note 1: This means that `we determine on-flight whether we need to restart the reuse` - each time we load a new segment. Another option was to calculate this on host and pass to each core runtime info on where to expect the new batch starts, however, this has a potential to explode as there is no limit on how many batches to expect on one core. Moreover, it would require extra if-s in the code as frequent as we do with the proposed solution in the PR. 

Note 2: The 'restart' means that we:
1. finish processing the pixels from the current image width without any reuse
2. use the next whole image width to fill in the CB and 'initialize' the optimization
3. start the reuse from the next image width

This means that we accept the fact that we didn't maximize the reuse - point 1; we essentially could start the new image width right when we encounter new batch, however, this would mean that compute kernel would need to be aware of this and update the reader pointers accordingly, and I chose to avoid this.

Note 3: We already had tests with batch > 1 in the suite, but the PCC check wasn't strict enough - this means the output could be bad only on a couple of rows of couple of cores. Updated the PCC to be 0.999 - the test would fail this check before the fix. 

### Checklist

- [x] Nightly l2: https://github.com/tenstorrent/tt-metal/actions/runs/17860097848
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/17860088099
- [x] BH post commit (p100): https://github.com/tenstorrent/tt-metal/actions/runs/17860093781 
- [x] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/17860083969