### PR TITLE
force fabric to use noc1 only in BH

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -231,6 +231,11 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
         this->is_receiver_channel_serviced_);
 }
 
+static bool requires_forced_assignment_to_noc1() {
+    return tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE &&
+           get_num_riscv_cores() == 1;
+}
+
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topology(topology) {
     const bool is_2D_routing = FabricContext::is_2D_topology(topology);
     uint32_t num_sender_channels = get_sender_channel_count(is_2D_routing);
@@ -257,6 +262,14 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
     this->num_riscv_cores = get_num_riscv_cores();
     for (uint32_t risc_id = 0; risc_id < this->num_riscv_cores; risc_id++) {
         this->risc_configs.emplace_back(risc_id);
+    }
+    // temporary work-around for BH until 2-erisc is enabled. We are required to switch entirely to noc1 for
+    // routers when only using a single erisc because erisc0 will be used by base FW and may periodically use
+    // noc0 for link health related functionality.
+    if (requires_forced_assignment_to_noc1()) {
+        for (uint32_t risc_id = 0; risc_id < this->num_riscv_cores; risc_id++) {
+            this->risc_configs[risc_id].set_configured_noc(tt::tt_metal::NOC::NOC_1);
+        }
     }
 
     if (this->sender_txq_id != this->receiver_txq_id) {
@@ -930,10 +943,19 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         this->receiver_channel_forwarding_sync_cmd_buf_ids[i] = FabricEriscDatamoverConfig::RD_CMD_BUF;
         this->receiver_channel_local_write_noc_ids[i] = FabricEriscDatamoverConfig::DEFAULT_RECEIVER_LOCAL_WRITE_NOC;
         this->receiver_channel_local_write_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_CMD_BUF;
+
+        if (requires_forced_assignment_to_noc1()) {
+            this->receiver_channel_forwarding_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC;
+            this->receiver_channel_local_write_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC;
+        }
     }
     for (uint32_t i = 0; i < FabricEriscDatamoverConfig::num_sender_channels; i++) {
         this->sender_channel_ack_noc_ids[i] = FabricEriscDatamoverConfig::DEFAULT_SENDER_ACK_NOC;
         this->sender_channel_ack_cmd_buf_ids[i] = FabricEriscDatamoverConfig::AT_CMD_BUF;
+
+        if (requires_forced_assignment_to_noc1()) {
+            this->sender_channel_ack_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC;
+        }
     }
     this->edm_noc_vc = FabricEriscDatamoverConfig::DEFAULT_NOC_VC;
 }
@@ -1340,6 +1362,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         this->get_configured_risc_count(),
 
         update_pkt_hdr_on_rx_ch,
+
+        requires_forced_assignment_to_noc1(),
 
         // Special marker to help with identifying misalignment bugs
         0x00c0ffee};

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -946,7 +946,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
         if (requires_forced_assignment_to_noc1()) {
             this->receiver_channel_forwarding_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC;
-            this->receiver_channel_local_write_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC;
+            this->receiver_channel_local_write_noc_ids[i] =
+                FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_LOCAL_WRITE_NOC;
+            this->receiver_channel_forwarding_data_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_CMD_BUF;
         }
     }
     for (uint32_t i = 0; i < FabricEriscDatamoverConfig::num_sender_channels; i++) {
@@ -955,6 +957,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
         if (requires_forced_assignment_to_noc1()) {
             this->sender_channel_ack_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC;
+            this->sender_channel_ack_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_CMD_BUF;
         }
     }
     this->edm_noc_vc = FabricEriscDatamoverConfig::DEFAULT_NOC_VC;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -956,8 +956,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         this->sender_channel_ack_cmd_buf_ids[i] = FabricEriscDatamoverConfig::AT_CMD_BUF;
 
         if (requires_forced_assignment_to_noc1()) {
-            this->sender_channel_ack_noc_ids[i] = FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC;
-            this->sender_channel_ack_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_CMD_BUF;
+            this->sender_channel_ack_noc_ids[i] =
+                FabricEriscDatamoverConfig::BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC;
         }
     }
     this->edm_noc_vc = FabricEriscDatamoverConfig::DEFAULT_NOC_VC;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -238,6 +238,8 @@ struct FabricEriscDatamoverConfig {
     static constexpr uint32_t DEFAULT_RECEIVER_FORWARDING_NOC = 1;
     static constexpr uint32_t DEFAULT_RECEIVER_LOCAL_WRITE_NOC = 1;
     static constexpr uint32_t DEFAULT_SENDER_ACK_NOC = 0;
+    static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC = 1;
+    static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC = 1;
 
     // If a mesh axis spans eight or more devices, use more buffer slot configuration.
     // Threshold (8 devices) was determined empirically.
@@ -433,6 +435,7 @@ struct FabricRiscConfig {
         is_sender_channel_serviced_[channel_idx] = enabled;
     }
 
+    void set_configured_noc(tt::tt_metal::NOC noc) { noc_ = noc; };
 private:
     tt::tt_metal::NOC noc_ = tt::tt_metal::NOC::NOC_0;
     size_t iterations_between_ctx_switch_and_teardown_checks_ = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -239,6 +239,7 @@ struct FabricEriscDatamoverConfig {
     static constexpr uint32_t DEFAULT_RECEIVER_LOCAL_WRITE_NOC = 1;
     static constexpr uint32_t DEFAULT_SENDER_ACK_NOC = 0;
     static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_FORWARDING_NOC = 1;
+    static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_LOCAL_WRITE_NOC = 1;
     static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC = 1;
 
     // If a mesh axis spans eight or more devices, use more buffer slot configuration.

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -24,11 +24,17 @@ FORCE_INLINE void send_chunk_from_address_with_trid(
     uint8_t trid,
     uint8_t noc,
     uint8_t cmd_buf) {
+#ifdef ARCH_BLACKHOLE
+    // forced true
+    constexpr bool update_counter = true;
+#else
+    constexpr bool update_counter = false;
+#endif
     if constexpr (stateful_api && !vc1_has_different_downstream_dest) {
-        noc_async_write_one_packet_with_trid_with_state<false, true>(
+        noc_async_write_one_packet_with_trid_with_state<update_counter, true>(
             local_l1_address, remote_l1_write_addr_l, page_size * num_pages, trid, cmd_buf, noc);
     } else {
-        noc_async_write_one_packet_with_trid<false, true>(
+        noc_async_write_one_packet_with_trid<update_counter, true>(
             local_l1_address,
             get_noc_addr_helper(remote_l1_write_addr_h, remote_l1_write_addr_l),
             page_size * num_pages,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -262,7 +262,9 @@ static_assert(MY_ERISC_ID < NUM_ACTIVE_ERISCS, "MY_ERISC_ID must be less than NU
 // channel updates the packet header before sending it over Ethernet.
 constexpr bool UPDATE_PKT_HDR_ON_RX_CH = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 17) != 0;
 
-constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 18;
+constexpr bool FORCE_ALL_PATHS_TO_USE_SAME_NOC = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 18) != 0;
+
+constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 19;
 constexpr size_t SPECIAL_MARKER_0 = 0x00c0ffee;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_0_IDX) == SPECIAL_MARKER_0,


### PR DESCRIPTION
In Blackhole, the base Ethernet firmware that is responsible for link retraining must use the noc to communicate with the subsystem. When running fabric in single erisc mode, the fabric will not be able to know when the fabric firmware may be performing link training, and therefore won't know when it may be using the noc. Therefore to avoid and cmd buf conflicts on noc0, we force fabric to be on noc1 when in single erisc mode .

Depends on the following PRs being merged:
- [x] https://github.com/tenstorrent/tt-metal/pull/28704 (posted + nonposted writes sent check in the spoof inline write func)
- [x] https://github.com/tenstorrent/tt-metal/pull/28656 rearrange l1 mem map
- [x] https://github.com/tenstorrent/tt-metal/pull/28721 add missing cmd buf ready check
- [x] https://github.com/tenstorrent/tt-metal/pull/28557 force enable noc counters in BH
- [x] https://github.com/tenstorrent/tt-metal/pull/28510
- [x] https://github.com/tenstorrent/tt-metal/pull/28754

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17846797672
 - passes after sped up tests https://github.com/tenstorrent/tt-metal/actions/runs/17869878629/job/50821616831
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/17846757110
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17846744733
- [x] BH Multi Card Tests: https://github.com/tenstorrent/tt-metal/actions/runs/17846754295