### PR TITLE
[tt-train] Fix RMSNorm backward computation and improve tests

### DIFF
--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/compute/rmsnorm_bw_kernel.cpp
@@ -30,13 +30,13 @@ constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+constexpr uint32_t cb_zero_idx = tt::CBIndex::c_7;
 // CBs with output data
-constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
-constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_9;
 // CBs with intermediate computations
-constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
-constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
-constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_11;
 
 constexpr uint32_t onetile = 1;
 
@@ -54,10 +54,17 @@ constexpr bool do_mask_w = false;
 inline void compute_gained_dL_dout(uint32_t col, uint32_t working_register, uint32_t tile_register) {
     // The output of this function is gained_dL_dout, which is stored in working_register.
 
+    // NOTE(maciek): We need to manually zero the working register, as mul_tiles_bcast_rows accumulates into
+    // the dst register.
+    copy_tile_init(cb_zero_idx);
+    copy_tile(cb_zero_idx, /* tile_idx */ 0, working_register);
+
     // Compute scaled_gain = gamma * 1/rms_a
-    // NOTE: cb_recip_rms_a_bcasted is ready to be used, so we do not need to wait for it.
-    mul_tiles_init(cb_gamma_idx, cb_recip_rms_a_bcasted_idx);
-    mul_tiles(cb_gamma_idx, cb_recip_rms_a_bcasted_idx, col, 0, working_register);
+    // NOTE: cb_recip_rms_a_bcasted is ready to be used, so we do not need to wait for it, but we need to broadcast
+    // gamma.
+    mul_bcast_rows_init_short(cb_recip_rms_a_bcasted_idx, cb_gamma_idx);
+    mul_tiles_bcast_rows(
+        cb_recip_rms_a_bcasted_idx, cb_gamma_idx, /* tile_idx */ 0, /* tile_idx */ col, working_register);
 
     // Compute gained_dL_dout = scaled_gain * dL_out
     copy_tile_init(cb_dL_out_idx);
@@ -75,10 +82,21 @@ inline void compute_dL_da(
     // Formula: dL_da = gained_dL_dout - (scale * a) / (c * rms_a^2)
     // where gained_dL_dout = (gamma / rms_a) * dL_dout
 
+    // NOTE(maciek): We need to manually zero the rhs register, as mul_tiles_bcast_cols accumulates into
+    // the dst register.
+    copy_tile_init(cb_zero_idx);
+    copy_tile(cb_zero_idx, /* tile_idx */ 0, rhs_register);
+
     // Compute scaled_outer = scale * a (broadcasted multiplication)
-    reconfig_data_format(cb_input_idx, cb_scale_bcasted_idx);
-    mul_tiles_init(cb_input_idx, cb_scale_bcasted_idx);
-    mul_tiles(cb_input_idx, cb_scale_bcasted_idx, /* tile_idx */ input_tile_idx, /* tile_idx */ 0, rhs_register);
+    reconfig_data_format(cb_input_idx, cb_scale_idx);
+    mul_bcast_cols_init_short(cb_input_idx, cb_scale_idx);
+    mul_tiles_bcast_cols(
+        cb_input_idx,
+        cb_scale_idx,
+        /* tile_idx */
+        input_tile_idx,
+        /* tile_idx */ 0,
+        rhs_register);
 
     // Compute rhs = scaled_outer / (c * rms_a^2)
     // Uses pre-computed reciprocal of rms_a and scaler (1/c) for efficiency
@@ -296,26 +314,13 @@ inline void compute_scale(const uint32_t row) {
 }
 #endif  // EVERYTHING_FITS_IN_L1
 
-inline void bcast_scale() {
-    // Broadcasts the reduced scale factor across columns.
-    cb_reserve_back(cb_scale_bcasted_idx, onetile);
-    const uint32_t reg_scale_bcasted = 0;
-    tile_regs_acquire();
-    reconfig_data_format(cb_scale_idx, cb_scale_bcasted_idx);
-
-    unary_bcast_init<BroadcastType::COL>(cb_scale_idx, cb_scale_bcasted_idx);
-    unary_bcast<BroadcastType::COL>(cb_scale_idx, /* tile idx */ 0, /* reg tile idx */ reg_scale_bcasted);
-    tile_regs_commit();
-
-    pack_and_push(reg_scale_bcasted, cb_scale_bcasted_idx);
-}
-
 inline void MAIN {
     if constexpr (do_mask_w) {
         cb_wait_front(cb_mask_w_idx, onetile);
     }
     cb_wait_front(cb_scaler_idx, onetile);
     cb_wait_front(cb_mat_mul_reduce, onetile);
+    cb_wait_front(cb_zero_idx, onetile);
 
     init_sfpu(cb_input_idx, cb_dL_da_idx);
     binary_op_init_common(cb_input_idx, cb_gamma_idx, cb_dL_da_idx);
@@ -328,8 +333,6 @@ inline void MAIN {
         compute_scale(row);
         // Wait for the reduced cb_scale to be ready.
         cb_wait_front(cb_scale_idx, onetile);
-        bcast_scale();
-        cb_wait_front(cb_scale_bcasted_idx, onetile);
 
         for (uint32_t col = 0; col < Wt; col += block_size) {
             cb_reserve_back(cb_dL_da_idx, block_size);
@@ -397,13 +400,13 @@ inline void MAIN {
         cb_pop_front(cb_rms_a_idx, onetile);
         cb_pop_front(cb_recip_rms_a_bcasted_idx, onetile);
         cb_pop_front(cb_scale_idx, onetile);
-        cb_pop_front(cb_scale_bcasted_idx, onetile);
     }
 #ifdef EVERYTHING_FITS_IN_L1
     cb_pop_front(cb_gamma_idx, Wt);
 #endif
     cb_pop_front(cb_scaler_idx, onetile);
     cb_pop_front(cb_mat_mul_reduce, onetile);
+    cb_pop_front(cb_zero_idx, onetile);
     if constexpr (do_mask_w) {
         cb_pop_front(cb_mask_w_idx, onetile);
     }

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/reader_rmsnorm_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/reader_rmsnorm_bw_interleaved_start_id.cpp
@@ -13,13 +13,13 @@ constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+constexpr uint32_t cb_zero_idx = tt::CBIndex::c_7;
 // CBs with output data
-constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
-constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_9;
 // CBs with intermediate computations
-constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
-constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
-constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_11;
 
 constexpr uint32_t packed_scaler = get_compile_time_arg_val(0);
 constexpr uint32_t block_size = get_compile_time_arg_val(1);
@@ -68,6 +68,8 @@ void kernel_main() {
     generate_tile_with_packed_bfloat16_value(cb_scaler_idx, packed_scaler);
     // Generate tile for matmul row reduce.
     generate_matmul_row_reduce_tile(cb_mat_mul_reduce);
+    // Generate tile with zeros.
+    generate_tile_with_bfloat16_value(cb_zero_idx, zero);
 
     const uint32_t tile_bytes = get_tile_size(cb_input_idx);
     constexpr auto input_args = TensorAccessorArgs<4>();

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/writer_rmsnorm_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/kernels/dataflow/writer_rmsnorm_bw_interleaved_start_id.cpp
@@ -12,13 +12,13 @@ constexpr uint32_t cb_gamma_idx = tt::CBIndex::c_3;
 constexpr uint32_t cb_rms_a_idx = tt::CBIndex::c_4;
 constexpr uint32_t cb_dL_out_idx = tt::CBIndex::c_5;
 constexpr uint32_t cb_mat_mul_reduce = tt::CBIndex::c_6;
+constexpr uint32_t cb_zero_idx = tt::CBIndex::c_7;
 // CBs with output data
-constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_7;
-constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_da_idx = tt::CBIndex::c_8;
+constexpr uint32_t cb_dL_dgamma_components = tt::CBIndex::c_9;
 // CBs with intermediate computations
-constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_9;
-constexpr uint32_t cb_scale_idx = tt::CBIndex::c_10;
-constexpr uint32_t cb_scale_bcasted_idx = tt::CBIndex::c_11;
+constexpr uint32_t cb_recip_rms_a_bcasted_idx = tt::CBIndex::c_10;
+constexpr uint32_t cb_scale_idx = tt::CBIndex::c_11;
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
@@ -134,8 +134,6 @@ ttsl::hash::hash_t RMSNormBackwardDeviceOperation::compute_program_hash(
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();
     auto program_factory = select_program_factory(args, tensor_args);
-    // TODO(maciek): Consider adding gamma shape to the hash as well. It is not strictly necessary, as gamma shape is
-    // derived from input shape, but it would make the hash more robust to changes in the code I guess.
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RMSNormBackwardDeviceOperation>(
         args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
 

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
@@ -134,6 +134,8 @@ ttsl::hash::hash_t RMSNormBackwardDeviceOperation::compute_program_hash(
     const auto& input_tensor = tensor_args.input;
     const auto& input_logical_shape = input_tensor.logical_shape();
     auto program_factory = select_program_factory(args, tensor_args);
+    // TODO(maciek): Consider adding gamma shape to the hash as well. It is not strictly necessary, as gamma shape is
+    // derived from input shape, but it would make the hash more robust to changes in the code I guess.
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RMSNormBackwardDeviceOperation>(
         args, program_factory.index(), input_tensor.dtype(), input_logical_shape);
 

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
@@ -39,13 +39,13 @@ constexpr auto kGammaCbIndex = tt::CBIndex::c_3;
 constexpr auto kRmsACbIndex = tt::CBIndex::c_4;
 constexpr auto kDLoutCbIndex = tt::CBIndex::c_5;
 constexpr auto kMatMulReduceCbIndex = tt::CBIndex::c_6;
+constexpr auto kZeroCbIndex = tt::CBIndex::c_7;
 // CBs with output data
-constexpr auto kDLdaCbIndex = tt::CBIndex::c_7;
-constexpr auto kDLdgammaComponentsCbIndex = tt::CBIndex::c_8;
+constexpr auto kDLdaCbIndex = tt::CBIndex::c_8;
+constexpr auto kDLdgammaComponentsCbIndex = tt::CBIndex::c_9;
 // CBs with intermediate computations
-constexpr auto kRecipRmsACbIndex = tt::CBIndex::c_9;
-constexpr auto kScaleCbIndex = tt::CBIndex::c_10;
-constexpr auto kScaleBcastedCbIndex = tt::CBIndex::c_11;
+constexpr auto kRecipRmsACbIndex = tt::CBIndex::c_10;
+constexpr auto kScaleCbIndex = tt::CBIndex::c_11;
 
 // Some of the below constants are set to 2U because we might need to push a new value before popping the old one.
 constexpr uint32_t kNumMaskTiles = 1U;
@@ -54,7 +54,7 @@ constexpr uint32_t kNumRmsATiles = 2U;
 constexpr uint32_t kNumMatMulReduceTiles = 1U;
 constexpr uint32_t kNumRecipRmsATiles = 1U;
 constexpr uint32_t kNumScaleTiles = 2U;
-constexpr uint32_t kNumScaleBcastedTiles = 1U;
+constexpr uint32_t kNumZeroTiles = 1U;
 
 const std::string kMaskWDefineKey = "DO_MASK_W";
 const std::string kEverythingFitsInL1DefineKey = "EVERYTHING_FITS_IN_L1";
@@ -147,13 +147,11 @@ bool fits_in_l1_check(
     // Memory for intermediate computations
     const uint64_t recip_rms_a_bcasted_memory = kNumRecipRmsATiles * bfloat16_single_tile_size_bytes;
     const uint64_t scale_memory = kNumScaleTiles * float32_single_tile_size_bytes;
-    const uint64_t scale_bcasted_memory = kNumScaleBcastedTiles * float32_single_tile_size_bytes;
 
     // Total L1 memory required
     const uint64_t required_L1_in_bytes = input_memory + mask_memory + scaler_memory + gamma_memory + rms_a_memory +
                                           dL_dout_memory + matmul_reduce_memory + dL_da_memory +
-                                          dL_dgamma_components_memory + recip_rms_a_bcasted_memory + scale_memory +
-                                          scale_bcasted_memory;
+                                          dL_dgamma_components_memory + recip_rms_a_bcasted_memory + scale_memory;
 
     return required_L1_in_bytes <= available_L1_in_bytes;
 }
@@ -233,6 +231,8 @@ RMSNormBackwardProgramFactory::cached_program_t RMSNormBackwardProgramFactory::c
         program, all_cores, kDLoutCbIndex, data_format, bfloat16_single_tile_size_bytes, num_input_tiles);
     [[maybe_unused]] auto cb_mat_mul_reduce = create_circular_buffer(
         program, all_cores, kMatMulReduceCbIndex, data_format, bfloat16_single_tile_size_bytes, kNumMatMulReduceTiles);
+    [[maybe_unused]] auto cb_zero = create_circular_buffer(
+        program, all_cores, kZeroCbIndex, data_format, bfloat16_single_tile_size_bytes, kNumZeroTiles);
     [[maybe_unused]] auto cb_dL_da = create_circular_buffer(
         program, all_cores, kDLdaCbIndex, data_format, bfloat16_single_tile_size_bytes, num_input_tiles);
     [[maybe_unused]] auto cb_dL_dgamma_components = create_circular_buffer(
@@ -241,13 +241,6 @@ RMSNormBackwardProgramFactory::cached_program_t RMSNormBackwardProgramFactory::c
         program, all_cores, kRecipRmsACbIndex, data_format, bfloat16_single_tile_size_bytes, kNumRecipRmsATiles);
     [[maybe_unused]] auto cb_scale = create_circular_buffer(
         program, all_cores, kScaleCbIndex, precise_data_format, float32_single_tile_size_bytes, kNumScaleTiles);
-    [[maybe_unused]] auto cb_scale_bcasted = create_circular_buffer(
-        program,
-        all_cores,
-        kScaleBcastedCbIndex,
-        precise_data_format,
-        float32_single_tile_size_bytes,
-        kNumScaleBcastedTiles);
 
     // -------------------------------------------------------------------------
     // 3) Create reader/writer kernels

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -463,7 +463,7 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
     CompareKernelVsComposite({64U, 1U, 256U, 384U});
 }
 
-// Test training-like shapes with NanoGPT dimensions
+// Test training-like shapes with LLaMA 7B dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoGPT) {
     CompareKernelVsComposite({1U, 1U, 512U, 4096U});
 }

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -371,8 +371,8 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
     EXPECT_TRUE(xt::all(xt::isfinite(gamma_grad_composite)));
 
     // Compare backward results
-    EXPECT_TRUE(xt::allclose(x_grad_kernel, x_grad_composite, 1.0e-3F, 3e-2F));
-    EXPECT_TRUE(xt::allclose(gamma_grad_kernel, gamma_grad_composite, 1.0e-3F, 3e-2F));
+    EXPECT_TRUE(xt::allclose(x_grad_kernel, x_grad_composite, 1.0e-3F, 2e-3F));
+    EXPECT_TRUE(xt::allclose(gamma_grad_kernel, gamma_grad_composite, 1.0e-3F, 2e-3F));
 
     autograd::ctx().reset_graph();
 }
@@ -389,6 +389,10 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
 // - Scale testing: small to very large tensor dimensions
 // - Training scenarios: realistic model shapes (NanoLlama, etc.)
 // ============================================================================
+
+TEST_F(RMSNormOpTest, RMSNorm_Compare_Basic_Small) {
+    CompareKernelVsComposite({1U, 1U, 2U, 32U});
+}
 
 // Test aligned dimensions (C % 32 == 0) that fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
@@ -453,10 +457,15 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize2_EvenC) {
     CompareKernelVsComposite({1U, 1U, 1U, 126U});  // C = 126 (even)
 }
 
-// Test training-like shapes with realistic model dimensions
+// Test training-like shapes with NanoLlama dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
     // NanoLlama training shape: batch=64, seq_len=256, hidden_dim=384
     CompareKernelVsComposite({64U, 1U, 256U, 384U});
+}
+
+// Test training-like shapes with NanoGPT dimensions
+TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoGPT) {
+    CompareKernelVsComposite({1U, 1U, 512U, 4096U});
 }
 
 // Test small batch and sequence dimensions (non-1 values)


### PR DESCRIPTION
### Problem description
While running `llama3_7B` training using:

```bash
./build/sources/examples/nano_gpt/nano_gpt \
    -c configs/training_shakespeare_llama3_7B_tensor_parallel.yaml
```

we observed that the **training loss was exploding** after a few steps.  
Investigation showed two main issues in the RMSNorm backward fused kernel:

1. **Incorrect `gamma` broadcasting** – gamma was not being broadcast along rows as required leading to incorrect gradients.  
2. **Missing explicit zeroing** – certain compute ops accumulate into destination registers rather than overwrite them, which left stale values in intermediate buffers.

Both issues resulted in diverging gradients.

### What's changed
- **Fixed gamma broadcasting**: Now correctly broadcast along rows in the backward pass.
- **Added explicit zeroing**: Introduced a dedicated zero-filled circular buffer to reset registers used in intermediate accumulations.
- **Simplified scaling path**: Removed explicit column broadcast and scale CB; replaced with `mul_tiles_bcast_cols`.
- **Improved test coverage**:
  - Tightened error tolerance thresholds.
  - Added a basic correctness test.
  - Added test with NanoGPT-like dimensions to cover real training shapes.
- **Validated fix in real training**:
  - Reran `llama3_7B` training — loss remains stable and decreases over time.
  - See plots in comparison section.

## Comparison: fused vs composite
The main goal was **correctness and training stability**. We compared the *loss curves* of the **composite implementation** vs the **fused implementation** to ensure similar convergence behavior.

Loss comparison plot for **NanoLlama3**:  
<img width="2000" height="1000" alt="image" src="https://github.com/user-attachments/assets/b6422401-413f-4858-904a-516fd39cb387" />

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes