### PR TITLE
Revert "[skip ci] Run bh multicard demo tests on VM runners for now s…

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -27,7 +27,7 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 2
           # - name: RackBox Demo tests
           #   runner-label: BH-RackBox

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -23,7 +23,7 @@ jobs:
         test-group:
           - name: LLMBox Demo tests
             runner-label: BH-LLMBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -53,7 +53,7 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 2
           # - name: RackBox Demo tests
           #   runner-label: BH-RackBox

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -49,7 +49,7 @@ jobs:
         test-group:
           - name: LLMBox Demo tests
             runner-label: BH-LLMBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox


### PR DESCRIPTION
…ince the one BM runner is OOS (#28624)"

This reverts commit e4f4c9bffb3edfa4ef0388222b9c6e450d8a44af.

### Ticket
None

### What's changed
Partial revert of the label changes to the LLMBox demo workflow calls
Reason: we have 2 new baremetal LLMBox runners that we should be using for this, so I'm changing the label back