### PR TITLE
Log information about previous kernel in triage

### DIFF
--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -35,7 +35,9 @@ class DispatcherCoreData:
     kernel_config_base: int = triage_field("Base", hex_serializer)
     kernel_text_offset: int = triage_field("Offset", hex_serializer)
     watcher_kernel_id: int = combined_field("kernel_name", "Kernel ID:Name", collection_serializer(":"))
-    watcher_previous_kernel_id: int = combined_field("previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":"))
+    watcher_previous_kernel_id: int = combined_field(
+        "previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":")
+    )
     kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer)
     firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"))
     kernel_path: str | None = combined_field()
@@ -140,9 +142,14 @@ class DispatcherData:
             }
             self._launch_msg_buffer_num_entries = get_const_value("launch_msg_buffer_num_entries")
 
-        log_check(launch_msg_rd_ptr < self._launch_msg_buffer_num_entries, f"On device {location._device._id} at {location.to_user_str()}, launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.")
+        log_check(
+            launch_msg_rd_ptr < self._launch_msg_buffer_num_entries,
+            f"On device {location._device._id} at {location.to_user_str()}, launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.",
+        )
 
-        previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries) % self._launch_msg_buffer_num_entries
+        previous_launch_msg_rd_ptr = (
+            launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries
+        ) % self._launch_msg_buffer_num_entries
 
         kernel_config_base = -1
         kernel_text_offset = -1
@@ -159,11 +166,10 @@ class DispatcherData:
                 fw_elf,
                 f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.kernel_config_base[{programmable_core_type}]",
                 loc_mem_reader,
-                )[0][0]
+            )[0][0]
         except:
             pass
         try:
-
             # Size 5 (NUM_PROCESSORS_PER_CORE_TYPE) - seems to be DM0,DM1,MATH0,MATH1,MATH2
             kernel_text_offset = mem_access(
                 fw_elf,

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -140,7 +140,7 @@ class DispatcherData:
             }
             self._launch_msg_buffer_num_entries = get_const_value("launch_msg_buffer_num_entries")
 
-        log_check(launch_msg_rd_ptr < self._launch_msg_buffer_num_entries, f"On core {location} Launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.")
+        log_check(launch_msg_rd_ptr < self._launch_msg_buffer_num_entries, f"On device {location._device._id} at {location.to_user_str()}, launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.")
 
         previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries) % self._launch_msg_buffer_num_entries
 

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -205,9 +205,6 @@ class DispatcherData:
             pass
         try:
             go_message_index = mem_access(fw_elf, f"mailboxes->go_message_index", loc_mem_reader)[0][0]
-        except:
-            pass
-        try:
             go_data = mem_access(fw_elf, f"mailboxes->go_messages[{go_message_index}]", loc_mem_reader)[0][0]
         except:
             pass

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 import os
 from inspector_data import run as get_inspector_data, InspectorData
 from elfs_cache import run as get_elfs_cache, ElfsCache
-from triage import triage_singleton, ScriptConfig, run_script
+from triage import triage_singleton, ScriptConfig, run_script, log_check
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.firmware import ELF
 from ttexalens.parse_elf import mem_access
@@ -139,6 +139,8 @@ class DispatcherData:
                 get_const_value("RUN_MSG_RESET_READ_PTR_FROM_HOST"): "RESET_READ_PTR_FROM_HOST",
             }
             self._launch_msg_buffer_num_entries = get_const_value("launch_msg_buffer_num_entries")
+
+        log_check(launch_msg_rd_ptr < self._launch_msg_buffer_num_entries, f"On core {location} Launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.")
 
         previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries) % self._launch_msg_buffer_num_entries
 

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -148,7 +148,7 @@ class DispatcherData:
         )
 
         previous_launch_msg_rd_ptr = (
-            launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries
+            launch_msg_rd_ptr - 1
         ) % self._launch_msg_buffer_num_entries
 
         kernel_config_base = -1

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -35,10 +35,12 @@ class DispatcherCoreData:
     kernel_config_base: int = triage_field("Base", hex_serializer)
     kernel_text_offset: int = triage_field("Offset", hex_serializer)
     watcher_kernel_id: int = combined_field("kernel_name", "Kernel ID:Name", collection_serializer(":"))
+    watcher_previous_kernel_id: int = combined_field("previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":"))
     kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer)
     firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"))
     kernel_path: str | None = combined_field()
     kernel_name: str | None = combined_field()
+    previous_kernel_name: str | None = combined_field()
     subdevice: int = triage_field("Subdevice")
     go_message: str = triage_field("Go Message")
     preload: bool = triage_field("Preload")
@@ -136,14 +138,29 @@ class DispatcherData:
                 get_const_value("RUN_MSG_RESET_READ_PTR"): "RESET_READ_PTR",
                 get_const_value("RUN_MSG_RESET_READ_PTR_FROM_HOST"): "RESET_READ_PTR_FROM_HOST",
             }
+            self._launch_msg_buffer_num_entries = get_const_value("launch_msg_buffer_num_entries")
 
+        previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1 + self._launch_msg_buffer_num_entries) % self._launch_msg_buffer_num_entries
+
+        kernel_config_base = -1
+        kernel_text_offset = -1
+        watcher_kernel_id = -1
+        watcher_previous_kernel_id = -1
+        kernel = None
+        previous_kernel = None
+        go_message_index = -1
+        go_data = -1
+        preload = False
         try:
             # Indexed with enum ProgrammableCoreType - tt_metal/hw/inc/*/core_config.h
             kernel_config_base = mem_access(
                 fw_elf,
                 f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.kernel_config_base[{programmable_core_type}]",
                 loc_mem_reader,
-            )[0][0]
+                )[0][0]
+        except:
+            pass
+        try:
 
             # Size 5 (NUM_PROCESSORS_PER_CORE_TYPE) - seems to be DM0,DM1,MATH0,MATH1,MATH2
             kernel_text_offset = mem_access(
@@ -151,7 +168,9 @@ class DispatcherData:
                 f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.kernel_text_offset[{proc_type}]",
                 loc_mem_reader,
             )[0][0]
-
+        except:
+            pass
+        try:
             # enum dispatch_core_processor_classes
             watcher_kernel_id = (
                 mem_access(
@@ -161,10 +180,36 @@ class DispatcherData:
                 )[0][0]
                 & 0xFFFF
             )
-
+        except:
+            pass
+        try:
+            watcher_previous_kernel_id = (
+                mem_access(
+                    fw_elf,
+                    f"mailboxes->launch[{previous_launch_msg_rd_ptr}].kernel_config.watcher_kernel_ids[{proc_type}]",
+                    loc_mem_reader,
+                )[0][0]
+                & 0xFFFF
+            )
+        except:
+            pass
+        try:
             kernel = self.inspector_data.kernels.get(watcher_kernel_id)
+        except:
+            pass
+        try:
+            previous_kernel = self.inspector_data.kernels.get(watcher_previous_kernel_id)
+        except:
+            pass
+        try:
             go_message_index = mem_access(fw_elf, f"mailboxes->go_message_index", loc_mem_reader)[0][0]
+        except:
+            pass
+        try:
             go_data = mem_access(fw_elf, f"mailboxes->go_messages[{go_message_index}]", loc_mem_reader)[0][0]
+        except:
+            pass
+        try:
             preload = (
                 mem_access(fw_elf, f"mailboxes->launch[{launch_msg_rd_ptr}].kernel_config.preload", loc_mem_reader)[0][
                     0
@@ -172,13 +217,7 @@ class DispatcherData:
                 != 0
             )
         except:
-            kernel_config_base = -1
-            kernel_text_offset = -1
-            watcher_kernel_id = -1
-            kernel = None
-            go_message_index = -1
-            go_data = -1
-            preload = False
+            pass
 
         if proc_name.lower() == "erisc" or proc_name.lower() == "erisc0":
             firmware_path = self._a_kernel_path + "../../../firmware/idle_erisc/idle_erisc.elf"
@@ -209,12 +248,14 @@ class DispatcherData:
         return DispatcherCoreData(
             firmware_path=firmware_path,
             kernel_path=kernel_path,
+            previous_kernel_name=previous_kernel.name if previous_kernel else None,
             kernel_offset=kernel_offset,
             kernel_name=kernel.name if kernel else None,
             launch_msg_rd_ptr=launch_msg_rd_ptr,
             kernel_config_base=kernel_config_base,
             kernel_text_offset=kernel_text_offset,
             watcher_kernel_id=watcher_kernel_id,
+            watcher_previous_kernel_id=watcher_previous_kernel_id,
             subdevice=go_message_index,
             go_message=go_data_state,
             preload=preload,

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -147,9 +147,7 @@ class DispatcherData:
             f"On device {location._device._id} at {location.to_user_str()}, launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.",
         )
 
-        previous_launch_msg_rd_ptr = (
-            launch_msg_rd_ptr - 1
-        ) % self._launch_msg_buffer_num_entries
+        previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1) % self._launch_msg_buffer_num_entries
 
         kernel_config_base = -1
         kernel_text_offset = -1


### PR DESCRIPTION
### Problem description
The previous kernel on a core may be the source of corruption in memory, but triage doesn't currently report information about it.

### What's changed
Log information about the previous kernel that ran. Fast dispatch ensures that the previous launch message slot isn't overwritten, which should ensure this code works. Also read each variable in a separate try block, to ensure failure to read one variable doesn't break everything, and also validate launch_msg_rd_ptr.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes