### PR TITLE
#28730: Reorder kernel args to make optimization level last arg

### DIFF
--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -38,8 +38,6 @@ struct DataMovementConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Set the compiler and linker optimization level
-    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2;
     // Both compile_args and named_compile_args contain compile time arguments
     // The former is accessed by index, the latter by name
     // Can be used in new/existing kernels by explicitly defining them in the config
@@ -48,22 +46,24 @@ struct DataMovementConfig {
     //     CreateKernel(program, "kernel.cpp", core, DataMovementConfig{.compile_args = compile_args,
     //     .named_compile_args = named_compile_args})
     std::unordered_map<std::string, uint32_t> named_compile_args;
+    // Set the compiler and linker optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2;
 };
 
 struct ReaderDataMovementConfig : public DataMovementConfig {
     ReaderDataMovementConfig(
         std::vector<uint32_t> compile_args = {},
         std::map<std::string, std::string> defines = {},
-        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2,
-        std::unordered_map<std::string, uint32_t> named_compile_args = {});
+        std::unordered_map<std::string, uint32_t> named_compile_args = {},
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
 };
 
 struct WriterDataMovementConfig : public DataMovementConfig {
     WriterDataMovementConfig(
         std::vector<uint32_t> compile_args = {},
         std::map<std::string, std::string> defines = {},
-        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2,
-        std::unordered_map<std::string, uint32_t> named_compile_args = {});
+        std::unordered_map<std::string, uint32_t> named_compile_args = {},
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
 };
 
 struct ComputeConfig {
@@ -78,8 +78,6 @@ struct ComputeConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Set the compiler and linker optimization level
-    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
     // Both compile_args and named_compile_args contain compile time arguments
     // The former is accessed by index, the latter by name
     // Can be used in new/existing kernels by explicitly defining them in the config
@@ -88,6 +86,8 @@ struct ComputeConfig {
     //     CreateKernel(program, "kernel.cpp", core, ComputeConfig{.compile_args = compile_args, .named_compile_args =
     //     named_compile_args})
     std::unordered_map<std::string, uint32_t> named_compile_args;
+    // Set the compiler and linker optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
 };
 
 struct EthernetConfig {
@@ -99,8 +99,6 @@ struct EthernetConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Set the compiler and linker optimization level
-    KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
     // Both compile_args and named_compile_args contain compile time arguments
     // The former is accessed by index, the latter by name
     // Can be used in new/existing kernels by explicitly defining them in the config
@@ -109,6 +107,8 @@ struct EthernetConfig {
     //     CreateKernel(program, "kernel.cpp", core, EthernetConfig{.compile_args = compile_args, .named_compile_args =
     //     named_compile_args})
     std::unordered_map<std::string, uint32_t> named_compile_args;
+    // Set the compiler and linker optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/kernels/kernel_types.cpp
+++ b/tt_metal/impl/kernels/kernel_types.cpp
@@ -14,29 +14,29 @@ namespace tt::tt_metal {
 ReaderDataMovementConfig::ReaderDataMovementConfig(
     std::vector<uint32_t> compile_args,
     std::map<std::string, std::string> defines,
-    KernelBuildOptLevel opt_level,
-    std::unordered_map<std::string, uint32_t> named_compile_args) :
+    std::unordered_map<std::string, uint32_t> named_compile_args,
+    KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = detail::GetPreferredNOCForDRAMRead(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),
-        .opt_level = opt_level,
-        .named_compile_args = std::move(named_compile_args)} {}
+        .named_compile_args = std::move(named_compile_args),
+        .opt_level = opt_level} {}
 
 WriterDataMovementConfig::WriterDataMovementConfig(
     std::vector<uint32_t> compile_args,
     std::map<std::string, std::string> defines,
-    KernelBuildOptLevel opt_level,
-    std::unordered_map<std::string, uint32_t> named_compile_args) :
+    std::unordered_map<std::string, uint32_t> named_compile_args,
+    KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_0,
         .noc = detail::GetPreferredNOCForDRAMWrite(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),
-        .opt_level = opt_level,
-        .named_compile_args = std::move(named_compile_args)} {}
+        .named_compile_args = std::move(named_compile_args),
+        .opt_level = opt_level} {}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -267,12 +267,14 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                     return ReaderDataMovementConfig{
                         std::move(compile_args),
                         std::move(defines),
+                        {},
                         kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2)};
                 },
                 [&](const WriterConfigDescriptor&) -> std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> {
                     return WriterDataMovementConfig{
                         std::move(compile_args),
                         std::move(defines),
+                        {},
                         kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2)};
                 },
                 [&](const DataMovementConfigDescriptor& dm_descriptor)
@@ -283,6 +285,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .noc_mode = dm_descriptor.noc_mode,
                         .compile_args = std::move(compile_args),
                         .defines = std::move(defines),
+                        .named_compile_args = {},
                         .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O2),
                     };
                 },
@@ -297,6 +300,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .math_approx_mode = compute_descriptor.math_approx_mode,
                         .compile_args = std::move(compile_args),
                         .defines = std::move(defines),
+                        .named_compile_args = {},
                         .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::O3),
                     };
                 },
@@ -308,6 +312,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .processor = ethernet_descriptor.processor,
                         .compile_args = std::move(compile_args),
                         .defines = std::move(defines),
+                        .named_compile_args = {},
                         .opt_level = kernel_descriptor.opt_level.value_or(KernelBuildOptLevel::Os),
                     };
                 },

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -58,7 +58,7 @@ Fold::MultiCore::cached_program_t fold_multi_core(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
         all_cores,
-        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
+        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
     // Writer run-time args
     SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -82,8 +82,7 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "reader_permute_interleaved_rm_row_invariant.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     std::vector<uint32_t> writer_compile_time_args = {};
     std::unordered_map<std::string, uint32_t> writer_named_compile_time_args = {
@@ -94,8 +93,7 @@ PermuteDeviceOperation::MultiCoreRowInvariant::cached_program_t PermuteDeviceOpe
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "writer_permute_interleaved_rm_row_invariant.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, writer_named_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
 
     std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
 
@@ -261,8 +259,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "reader_permute_interleaved_rm_blocked_generic.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     std::vector<uint32_t> writer_compile_time_args = {};
 
@@ -290,8 +287,7 @@ PermuteDeviceOperation::MultiCoreBlockedGeneric::create(
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "writer_permute_interleaved_rm_blocked_generic.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, writer_named_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
 
     std::vector<uint32_t> compute_kernel_args = {x_block_size, w_block_size};
     std::unordered_map<std::string, uint32_t> compute_named_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -144,8 +144,7 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "reader_permute_interleaved_tiled_invariant.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
@@ -400,8 +399,7 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
         "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     uint32_t compute_kernel_id = 0;
     if (swap_hw) {
@@ -441,8 +439,7 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "writer_permute_interleaved_tiled_row_invariant.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, writer_named_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
 
     auto input_shape_view = input_shape.view();
 
@@ -753,8 +750,7 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "reader_permute_interleaved_tiled_generic.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     std::vector<uint32_t> compute_kernel_args = {};
 
@@ -801,8 +797,7 @@ PermuteDeviceOperation::MultiCoreTiledGeneric::cached_program_t PermuteDeviceOpe
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
         "writer_permute_interleaved_tiled_generic.cpp",
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, writer_named_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, {}, writer_named_compile_time_args));
 
     auto input_shape_view = input_shape.view();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -577,8 +577,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
         "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
         total_cores,
-        tt::tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args, {}, tt::tt_metal::KernelBuildOptLevel::O2, reader_named_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, {}, reader_named_compile_time_args));
 
     // create writer kernel with compile time and runtime args
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28730)

### Problem description
The `named_compile_time_args` map argument was appended as the last kernel argument. Any kernel using this map has to specify the kernel optimization level. We would like to make use of the default argument for the optimization level.

### What's changed

- Switched argument position named compile time args map and optimization level in kernel constructors and related calls

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/17839172024))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes