### PR TITLE
Add waypoint information to triage

### DIFF
--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -225,7 +225,7 @@ class DispatcherData:
             pass
         try:
             waypoint_int = mem_access(fw_elf, f"mailboxes->watcher.debug_waypoint[{proc_type}]", loc_mem_reader)[0][0]
-            waypoint = waypoint_int.to_bytes(4, "little").rstrip(b"\x00").decode("utf-8")
+            waypoint = waypoint_int.to_bytes(4, "little").rstrip(b"\x00").decode("utf-8", errors="replace")
         except:
             pass
 

--- a/scripts/debugging_scripts/dispatcher_data.py
+++ b/scripts/debugging_scripts/dispatcher_data.py
@@ -46,6 +46,7 @@ class DispatcherCoreData:
     subdevice: int = triage_field("Subdevice")
     go_message: str = triage_field("Go Message")
     preload: bool = triage_field("Preload")
+    waypoint: str = triage_field("Waypoint")
 
 
 class DispatcherData:
@@ -158,6 +159,7 @@ class DispatcherData:
         go_message_index = -1
         go_data = -1
         preload = False
+        waypoint = None
         try:
             # Indexed with enum ProgrammableCoreType - tt_metal/hw/inc/*/core_config.h
             kernel_config_base = mem_access(
@@ -221,6 +223,11 @@ class DispatcherData:
             )
         except:
             pass
+        try:
+            waypoint_int = mem_access(fw_elf, f"mailboxes->watcher.debug_waypoint[{proc_type}]", loc_mem_reader)[0][0]
+            waypoint = waypoint_int.to_bytes(4, "little").rstrip(b"\x00").decode("utf-8")
+        except:
+            pass
 
         if proc_name.lower() == "erisc" or proc_name.lower() == "erisc0":
             firmware_path = self._a_kernel_path + "../../../firmware/idle_erisc/idle_erisc.elf"
@@ -262,6 +269,7 @@ class DispatcherData:
             subdevice=go_message_index,
             go_message=go_data_state,
             preload=preload,
+            waypoint=waypoint,
         )
 
     @staticmethod


### PR DESCRIPTION
Waypoints are very useful for determining what kernels are doing (even if their PC is inaccessible or incorrect), so add that information to triage.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes