### PR TITLE
Fix bug involving invalid sweep vectors: not labelling and skipping invalid vectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,7 +205,7 @@ tests/ttnn/unit_tests/operations/data_movement/ @sjameelTT @ntarafdar @nardoTT @
 /tests/ttnn/**/unit_tests/operations/reduce/ @bbradelTT @sjameelTT @nsorabaTT @vsureshTT @edwinleeTT @rmillerTT @aczajkowskiTT @jbbieniekTT @mgajewskiTT @nmauriceTT @tenstorrent/metalium-codeowners-large-changes
 tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-codeowners-large-changes
 tests/ttnn/nightly/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-codeowners-large-changes
-tests/sweep_framework/ @stevendae @tenstorrent/metalium-codeowners-large-changes
+tests/sweep_framework/ @stevendae @bbradelTT @tenstorrent/metalium-codeowners-large-changes
 tests/ttnn/nightly/unit_tests/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @nsorabaTT @vsureshTT @edwinleeTT @rmillerTT @tenstorrent/metalium-codeowners-large-changes
 tests/sweep_framework/sweeps @tenstorrent/metalium-codeowners-large-changes
 tests/sweep_framework/sweeps/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/metalium-codeowners-large-changes

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -549,11 +549,12 @@ on:
         description: "Which sweep suite to run?"
         type: string
       upload_results:
-        description: "Upload sweep results to SFTP server?"
+        description: "Upload sweep results to Superset?"
         type: boolean
         default: true
   schedule:
     - cron: "0 4 * * 4" # This cron schedule runs the workflow at 4:00 AM UTC on Thursdays (Wednesday 11 PM EST)
+    - cron: "0 5 * * 6" # This cron schedule runs the workflow at 5:00 AM UTC on Saturdays (Friday 9 PM PST)
 
 concurrency:
   group: ttnn-sweeps-${{ github.ref }}
@@ -637,7 +638,12 @@ jobs:
           import os, json, math
           d = '/tmp/vectors'
           modules = sorted([f[:-5] for f in os.listdir(d) if f.endswith('.json')])
-          BATCH_SIZE = 10
+          # Use smaller batch size for Friday night runs (more comprehensive tests)
+          # Use larger batch size for Thursday runs (nightly suite only)
+          if "${{ github.event.schedule }}" == "0 5 * * 6":
+              BATCH_SIZE = 4  # Smaller batches for Friday night comprehensive runs
+          else:
+              BATCH_SIZE = 10  # Larger batches for Thursday nightly runs
           batches = [",".join(modules[i:i+BATCH_SIZE]) for i in range(0, len(modules), BATCH_SIZE)]
           print(json.dumps({"module": modules, "batches": batches}))
           PY
@@ -777,7 +783,12 @@ jobs:
           name: sweeps-vectors
           path: /work/tests/sweep_framework/vectors_export/
       - name: Run ttnn sweeps (batch)
-        run: python3 tests/sweep_framework/sweeps_runner.py --module-name ${{ matrix.batch }} --vector-source vectors_export --result-dest results_export --tag ci-main --suite-name nightly --summary --skip-on-timeout
+        run: |
+          if [[ "${{ github.event.schedule }}" == "0 5 * * 6" ]]; then
+            python3 tests/sweep_framework/sweeps_runner.py --module-name ${{ matrix.batch }} --vector-source vectors_export --result-dest results_export --tag ci-main --summary --skip-on-timeout
+          else
+            python3 tests/sweep_framework/sweeps_runner.py --module-name ${{ matrix.batch }} --vector-source vectors_export --result-dest results_export --tag ci-main --suite-name nightly --summary --skip-on-timeout
+          fi
       - name: Compute artifact suffix
         shell: bash
         run: |

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,6 +82,7 @@ python tests/sweep_framework/sweeps_runner.py --module-name "eltwise.unary.relu.
 - `--tag`: Tag to filter vectors in Elasticsearch (defaults to `$USER`)
 - `--skip-modules`: Comma-separated modules to skip when running all modules
 - `--skip-on-timeout`: Skip remaining tests in a suite if a test times out
+- `--keep-invalid`: Include invalid vectors in results with NOT_RUN status (default: exclude invalid vectors from results entirely)
 - `--watcher`: Enable watcher
 - `--perf`: Measure end-to-end perf for ops that support it
 - `--device-perf`: Measure device perf (requires profiler build)

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -360,7 +360,6 @@ def execute_suite(test_vectors, pbar_manager, suite_name, module_name, header_in
             result["status"] = TestStatus.NOT_RUN
             result["exception"] = "INVALID VECTOR: " + test_vector["invalid_reason"]
             result["e2e_perf"] = None
-            invalid_vectors_count += 1
         else:
             test_vector.pop("invalid_reason")
             test_vector.pop("status")
@@ -657,7 +656,6 @@ def run_sweeps(
                 logger.info("=== EXECUTION SUMMARY ===")
                 logger.info(f"Total tests (module-suite combinations) executed: {total_tests_run}")
                 logger.info(f"Total test cases (vectors) executed: {total_vectors_run}")
-                logger.info(f"Total invalid vectors (skipped): {total_invalid_vectors}")
                 # Status breakdown across all executed tests
                 if status_counts:
                     logger.info("\n=== TEST STATUS COUNTS ===")

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -46,6 +46,7 @@ class SweepsConfig:
     sweeps_tag: Optional[str] = None
     skip_modules: Optional[str] = None
     skip_on_timeout: bool = False
+    keep_invalid: bool = False
     elastic_connection_string: Optional[str] = None
     elastic_username: Optional[str] = None
     elastic_password: Optional[str] = None
@@ -71,6 +72,7 @@ def create_config_from_args(args) -> SweepsConfig:
         sweeps_tag=args.tag,
         skip_modules=args.skip_modules,
         skip_on_timeout=args.skip_on_timeout,
+        keep_invalid=args.keep_invalid,
         summary=args.summary,
     )
 
@@ -358,10 +360,16 @@ def execute_suite(test_vectors, pbar_manager, suite_name, module_name, header_in
         validity = deserialize(test_vector["validity"])
         result["start_time_ts"] = dt.datetime.now()
         if validity.value == "INVALID":
-            result["status"] = TestStatus.NOT_RUN
-            result["exception"] = "INVALID VECTOR: " + test_vector["invalid_reason"]
-            result["e2e_perf"] = None
             invalid_vectors_count += 1
+            if not config.keep_invalid:
+                # Skip this vector entirely - don't add to results
+                suite_pbar.update()
+                continue
+            else:
+                # Include invalid vector in results with NOT_RUN status
+                result["status"] = TestStatus.NOT_RUN
+                result["exception"] = "INVALID VECTOR: " + test_vector["invalid_reason"]
+                result["e2e_perf"] = None
         else:
             test_vector.pop("invalid_reason")
             test_vector.pop("status")
@@ -661,7 +669,10 @@ def run_sweeps(
                 logger.info("=== EXECUTION SUMMARY ===")
                 logger.info(f"Total tests (module-suite combinations) executed: {total_tests_run}")
                 logger.info(f"Total test cases (vectors) executed: {total_vectors_run}")
-                logger.info(f"Total invalid vectors (skipped): {total_invalid_vectors}")
+                if config.keep_invalid:
+                    logger.info(f"Total invalid vectors (included in results as NOT_RUN): {total_invalid_vectors}")
+                else:
+                    logger.info(f"Total invalid vectors (excluded from results): {total_invalid_vectors}")
                 # Status breakdown across all executed tests
                 if status_counts:
                     logger.info("\n=== TEST STATUS COUNTS ===")
@@ -835,6 +846,13 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
         help="Skip remaining tests in suite when a test times out. Default behavior is to not skip.",
+    )
+
+    parser.add_argument(
+        "--keep-invalid",
+        action="store_true",
+        required=False,
+        help="Include invalid vectors in results with NOT_RUN status. Default behavior is to exclude invalid vectors from results entirely.",
     )
 
     parser.add_argument(

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -563,6 +563,7 @@ def run_sweeps(
     # Summary counters
     total_vectors_run = 0  # total number of test cases (vectors)
     total_tests_run = 0  # total number of suites executed
+    total_invalid_vectors = 0  # total number of invalid vectors (skipped)
     module_suite_test_count = {}  # module_name -> {suite_name: count}
     max_test_cases_module = None  # find the module with the most test cases
     max_test_cases_per_module = 0

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -356,10 +356,11 @@ def execute_suite(test_vectors, pbar_manager, suite_name, module_name, header_in
 
         validity = deserialize(test_vector["validity"])
         result["start_time_ts"] = dt.datetime.now()
-        if validity == VectorValidity.INVALID:
+        if validity.value == "INVALID":
             result["status"] = TestStatus.NOT_RUN
             result["exception"] = "INVALID VECTOR: " + test_vector["invalid_reason"]
             result["e2e_perf"] = None
+            invalid_vectors_count += 1
         else:
             test_vector.pop("invalid_reason")
             test_vector.pop("status")
@@ -656,6 +657,7 @@ def run_sweeps(
                 logger.info("=== EXECUTION SUMMARY ===")
                 logger.info(f"Total tests (module-suite combinations) executed: {total_tests_run}")
                 logger.info(f"Total test cases (vectors) executed: {total_vectors_run}")
+                logger.info(f"Total invalid vectors (skipped): {total_invalid_vectors}")
                 # Status breakdown across all executed tests
                 if status_counts:
                     logger.info("\n=== TEST STATUS COUNTS ===")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28837)

### Problem description
invalid vectors would not enter the invalid vector path due to misinterpretation of the deserialized enum

### What's changed
Fix to make the logic coherent

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes