### PR TITLE
#0: Add get_tensor_coord to TensorTopology

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_topology.cpp
@@ -159,4 +159,50 @@ TEST_F(TensorTopology2x4Test, Shard1DRowMajor) {
     EXPECT_EQ(mesh_coords[6], MeshCoordinate(1, 2));
     EXPECT_EQ(mesh_coords[7], MeshCoordinate(1, 3));
 }
+
+TEST_F(TensorTopology2x4Test, GetTensorCoord) {
+    const int num_devices = mesh_device_->num_devices();
+    // Test only works on 8 devices in 2x4 mesh
+    ASSERT_EQ(num_devices, 8);
+    ASSERT_EQ(mesh_device_->shape(), MeshShape(2, 4));
+
+    std::vector<float> test_data;
+    for (int i = 0; i < num_devices; i++) {
+        test_data.insert(test_data.end(), {i * 1.F, i * 2.F, i * 3.F});
+    }
+    const auto tensor_spec = TensorSpec(
+        ttnn::Shape{1, num_devices, 3, 1}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    Tensor input_tensor = Tensor::from_vector(test_data, tensor_spec);
+
+    // The sharding creates a 1D distribution with 8 devices in row-major order
+    auto mapper = shard_tensor_to_mesh_mapper(*mesh_device_, 1);
+    Tensor sharded_tensor = distribute_tensor(input_tensor, *mapper);
+
+    const auto& tensor_topology = sharded_tensor.tensor_topology();
+    const auto& mesh_coords = tensor_topology.mesh_coords();
+
+    // Test that get_tensor_coord returns the correct tensor coordinate for each device coordinate
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(0, 0)), MeshCoordinate(0));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(0, 1)), MeshCoordinate(1));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(0, 2)), MeshCoordinate(2));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(0, 3)), MeshCoordinate(3));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(1, 0)), MeshCoordinate(4));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(1, 1)), MeshCoordinate(5));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(1, 2)), MeshCoordinate(6));
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(1, 3)), MeshCoordinate(7));
+
+    // Test that get_tensor_coord is the inverse of get_device_coord
+    for (const auto& device_coord : mesh_coords) {
+        auto tensor_coord = tensor_topology.get_tensor_coord(device_coord);
+        ASSERT_TRUE(tensor_coord.has_value());
+        EXPECT_EQ(tensor_topology.get_device_coord(tensor_coord.value()), device_coord);
+    }
+
+    // Test that get_tensor_coord returns nullopt for invalid device coordinates
+    // ie. These device coordinates don't exist in the mesh
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(2, 0)), std::nullopt);
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(0, 4)), std::nullopt);
+    EXPECT_EQ(tensor_topology.get_tensor_coord(MeshCoordinate(3, 3)), std::nullopt);
+}
+
 }  // namespace ttnn::distributed::test

--- a/ttnn/api/ttnn/distributed/tensor_topology.hpp
+++ b/ttnn/api/ttnn/distributed/tensor_topology.hpp
@@ -32,20 +32,27 @@ public:
     const std::vector<tt::tt_metal::distributed::MeshCoordinate>& mesh_coords() const { return mesh_coords_; }
 
     tt::tt_metal::distributed::MeshCoordinate get_neighbor(
-        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t offset, int32_t dim) const;
+        const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t offset, int32_t dim) const;
 
     tt::tt_metal::distributed::MeshCoordinate get_next_neighbor(
-        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const;
+        const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t dim) const;
 
     tt::tt_metal::distributed::MeshCoordinate get_prev_neighbor(
-        const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const;
+        const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t dim) const;
 
+    // Returns the physical device coordinate for the given tensor coordinate
     tt::tt_metal::distributed::MeshCoordinate get_device_coord(
-        const tt::tt_metal::distributed::MeshCoordinate& coord) const;
+        const tt::tt_metal::distributed::MeshCoordinate& tensor_coord) const;
+
+    // Returns the tensor coordinate for the given physical device coordinate
+    // If no tensor coordinate corresponds to the given physical device coordinate, returns std::nullopt
+    std::optional<tt::tt_metal::distributed::MeshCoordinate> get_tensor_coord(
+        const tt::tt_metal::distributed::MeshCoordinate& device_coord) const;
 
 private:
     tt::tt_metal::distributed::MeshShape distribution_shape_;
     tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements_;
+    // Physical device coordinates
     std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords_;
 };
 

--- a/ttnn/core/distributed/tensor_topology.cpp
+++ b/ttnn/core/distributed/tensor_topology.cpp
@@ -7,13 +7,13 @@
 namespace tt::tt_metal {
 
 tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_neighbor(
-    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t offset, int32_t dim) const {
-    const auto neighbor_coord = coord.get_neighbor(
+    const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t offset, int32_t dim) const {
+    const auto neighbor_coord = tensor_coord.get_neighbor(
         distribution_shape_, offset, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
     TT_FATAL(
         neighbor_coord.has_value(),
         "Failed to get neighbor for coordinate {} at dim {} with offset {}",
-        coord,
+        tensor_coord,
         dim,
         offset);
 
@@ -21,35 +21,62 @@ tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_neighbor(
 }
 
 tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_next_neighbor(
-    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const {
-    const auto next_coord =
-        coord.get_neighbor(distribution_shape_, 1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
-    TT_FATAL(next_coord.has_value(), "Failed to get next neighbor for coordinate {} at dim {}", coord, dim);
+    const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t dim) const {
+    const auto next_coord = tensor_coord.get_neighbor(
+        distribution_shape_, 1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
+    TT_FATAL(next_coord.has_value(), "Failed to get next neighbor for coordinate {} at dim {}", tensor_coord, dim);
 
     return next_coord.value();
 }
 
 tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_prev_neighbor(
-    const tt::tt_metal::distributed::MeshCoordinate& coord, int32_t dim) const {
-    const auto prev_coord =
-        coord.get_neighbor(distribution_shape_, -1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
-    TT_FATAL(prev_coord.has_value(), "Failed to get previous neighbor for coordinate {} at dim {}", coord, dim);
+    const tt::tt_metal::distributed::MeshCoordinate& tensor_coord, int32_t dim) const {
+    const auto prev_coord = tensor_coord.get_neighbor(
+        distribution_shape_, -1, dim, tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP);
+    TT_FATAL(prev_coord.has_value(), "Failed to get previous neighbor for coordinate {} at dim {}", tensor_coord, dim);
 
     return prev_coord.value();
 }
 
 tt::tt_metal::distributed::MeshCoordinate TensorTopology::get_device_coord(
-    const tt::tt_metal::distributed::MeshCoordinate& coord) const {
+    const tt::tt_metal::distributed::MeshCoordinate& tensor_coord) const {
     // Convert mesh coordinate to flattened index (row-major order)
     std::size_t flattened_index = 0;
 
     // Calculate row-major flattened index
     for (std::size_t i = 0; i < distribution_shape_.dims(); ++i) {
-        flattened_index += coord[i] * distribution_shape_.get_stride(i);
+        flattened_index += tensor_coord[i] * distribution_shape_.get_stride(i);
     }
 
     // Return the mesh coordinate at the flattened position
     return mesh_coords_[flattened_index];
+}
+
+std::optional<tt::tt_metal::distributed::MeshCoordinate> TensorTopology::get_tensor_coord(
+    const tt::tt_metal::distributed::MeshCoordinate& device_coord) const {
+    // Search through all stored mesh coordinates to find a match
+    // Assume that the mesh coordinates are unique (ie. tensor to device coords mapping is one-to-one)
+    for (std::size_t tensor_coord_idx = 0; tensor_coord_idx < mesh_coords_.size(); ++tensor_coord_idx) {
+        if (mesh_coords_[tensor_coord_idx] == device_coord) {
+            // Convert the position index to tensor coordinate
+            // This assumes that mesh coordinates are stored in row-major order
+
+            // Create tensor coordinate container based on rank of distribution shape
+            tt::stl::SmallVector<uint32_t> tensor_coord_values(distribution_shape_.dims());
+
+            // Convert flattened index to tensor coordinate assuming row-major order
+            // This is the inverse logic of get_device_coord
+            for (int dim = static_cast<int>(distribution_shape_.dims()) - 1; dim >= 0; --dim) {
+                tensor_coord_values[dim] = tensor_coord_idx % distribution_shape_[dim];
+                tensor_coord_idx /= distribution_shape_[dim];
+            }
+
+            return tt::tt_metal::distributed::MeshCoordinate(tensor_coord_values);
+        }
+    }
+
+    // No match found
+    return std::nullopt;
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
None

### Problem description
Adoption of `TensorTopology` exposed an issue with not having a reverse lookup from device coord -> tensor coord. This PR adds new `get_tensor_coord` which is essentially inverse of `get_device_coord`. One small difference is that it will return `std::nullopt` if provided device_coord does not exist. 

### What's changed
- Inverse of get_device_coord
  * Looks through stored device coordinates and returns the corresponding tensor coord
  * If not found, return std::nullopt

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17840100239
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes