### PR TITLE
Increase throttle on LMHead and Conv didt tests

### DIFF
--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -53,10 +53,10 @@ jobs:
       - name: Run di/dt Tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
-          pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=1 pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=0 pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "without_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=0 pytest tests/didt/test_ff1_matmul.py::test_ff1_matmul -k "with_gelu and all" --didt-workload-iterations 100 --determinism-check-interval 1
+          TT_MM_THROTTLE_PERF=1 pytest tests/didt/test_lm_head_matmul.py::test_lm_head_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28607)

### Problem description
Didt tests on N300 are experiencing didt-related failures sometimes. Although this is expected, having failing tests is confusing and defeats the purpose.

### What's changed
Add throttle to the 2 tests which are most susceptible to didt in order to prevent false alarms.

### Checklist
- [x] Nightly run passes: https://github.com/tenstorrent/tt-metal/actions/runs/17839877133