### PR TITLE
Use scaling factor to compute ttnn.mean for multi-dim non w,h case + scaling factor fixes  (#28644)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -53,7 +53,6 @@ def test_mean_scaling(device, shape, dim, keepdim):
 @pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
 @pytest.mark.parametrize("scalar", [2.0])
-@pytest.mark.skip("reducing across some dimensions do not apply scalar correctly #29721")
 def test_mean_scaling_factor(device, shape, dim, scalar):
     torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, construct_pcc_assert_message
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
 from models.common.utility_functions import torch_random, comp_allclose
 
 
@@ -28,3 +28,41 @@ def test_mean(device, batch_size, h, w, dim, keepdim):
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_mean_scaling(device, shape, dim, keepdim):
+    """Use assert_allclose with ones() to test that mean's scaling factor is
+    computed correctly.
+    """
+    torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
+    torch_output_tensor = torch_output_tensor
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(input_tensor, 42)  # garbage padding to test that mean removes it
+
+    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3, [0, 1], [2, 3], [0, 1, 2]])
+@pytest.mark.parametrize("scalar", [2.0])
+@pytest.mark.skip("reducing across some dimensions do not apply scalar correctly #29721")
+def test_mean_scaling_factor(device, shape, dim, scalar):
+    torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch.bfloat16)
+    torch_output_tensor = torch_output_tensor * scalar
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(input_tensor, 42)  # garbage padding to test that mean removes it
+
+    output_tensor = ttnn.mean(input_tensor, dim=dim, scalar=scalar)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -203,6 +203,9 @@ static Tensor reduce_impl(
             Tensor output_tensor = input_tensor_arg;
             for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
                 bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
+                // Only apply the scalar once when reducing dim-by-dim,
+                // otherwise the result will be scaled multiple times.
+                bool effective_scalar = i_dim == rank - 1 ? scalar : 1.0;
                 if (found) {
                     bool transpose = i_dim < rank - 2;
                     int reduce_dim = i_dim;
@@ -217,7 +220,7 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar,
+                            effective_scalar,
                             non_height_width_dims);
                     } else {
                         output_tensor = reduce_impl<ReduceType::Sum>(
@@ -226,7 +229,7 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar,
+                            effective_scalar,
                             non_height_width_dims);
                     }
                     if (transpose) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -244,9 +244,13 @@ static Tensor reduce_impl(
         if (dim.size() == 1 || linear_type) {
             output_tensor = reduce_nd_loop(/*use_reduce_type=*/true);
         } else if constexpr (reduce_type == ReduceType::Mean) {
+            int reduced_volume = 1;
+            for (int axis : dim) {
+                reduced_volume *= input_shape[axis];
+            }
             output_tensor = reduce_nd_loop(
                 /*use_reduce_type=*/false);
-            float inv_volume = 1.0f / input_tensor_arg.logical_volume();
+            float inv_volume = 1.0f / reduced_volume;
             output_tensor = ttnn::mul_sfpu(inv_volume, output_tensor, memory_config);
         } else {
             TT_THROW("Unsupported reduction operation");


### PR DESCRIPTION
### Ticket

#28644

### Problem description
Remove ttnn.mul_sfpu call when computing multidimensional ttnn.mean on dimensions that are not the last 2 dimensions.

### What's changed

1. Fixed `reduce_nd_loop` applying scalars per axis reduction, and instead only apply it on the first axis. This corrects the issue that multipliers are effectively applied multiple times, once per reduction axis. Note: that behavior of `scalar` param is still sometimes incorrect when hitting other code paths (for example, ttnn.sum with a non -1, -2 dimension will call code that ignores scalar param).

2. Fixed scaling factor computation for multi-dimensional non w,h mean reduction. This used to use the volume of the input tensor, which is only correct for reducing to scalar tensors. Added a test to check this, existing tests do not cover this as assert_with_pcc ignores differences by constant factors.

3. The original ticket: multi-dim non w,h mean scaling is performed in `reduce_nd_loop`  instead of a separate mul_sfpu call.

### Perf

The performance improvement should be most apparent on reductions on small axis. Test was performed on P150. The effect of mul_sfpu seems small in even this worst-case scenario, however the traces demonstrate that it has indeed been eliminated.

Aggregate report from tracy:

*shape=(2, 2, 1024, 1024) dim=(0, 1)*

Before:
```
    %                                OP Code Joined  Device_Time_Sum_us  Ops_Count
52.21              Transpose (in0:dram_interleaved)            13251.46         10
25.57 PermuteDeviceOperation (in0:dram_interleaved)             6490.56         10
21.83                 Reduce (in0:dram_interleaved)             5539.40         10
 0.39   UnaryDeviceOperation (in0:dram_interleaved)               99.17          5
```

After:
```
    %                                OP Code Joined  Device_Time_Sum_us
52.29              Transpose (in0:dram_interleaved)            13232.29
25.81 PermuteDeviceOperation (in0:dram_interleaved)             6531.49
21.90                 Reduce (in0:dram_interleaved)             5542.71
```


*shape=(2, 2, 4096, 4096) dim=(0, 1)*

Before:
```
    %                                OP Code Joined  Device_Time_Sum_us  Ops_Count
52.56              Transpose (in0:dram_interleaved)           210945.69         10
25.54 PermuteDeviceOperation (in0:dram_interleaved)           102496.66         10
21.67                 Reduce (in0:dram_interleaved)            86981.73         10
 0.23   UnaryDeviceOperation (in0:dram_interleaved)              925.89          5
```

After:
```
    %                                OP Code Joined  Device_Time_Sum_us  Ops_Count
52.53              Transpose (in0:dram_interleaved)           209601.36         10
25.63 PermuteDeviceOperation (in0:dram_interleaved)           102254.18         10
21.84                 Reduce (in0:dram_interleaved)            87148.82         10
```


Test code:
```
@pytest.mark.parametrize("shape", [(2, 2, 1024, 1024), (2, 2, 4096, 4096)])
@pytest.mark.parametrize("dim", [[0, 1]])
def test_benchmark_perf_mean_nd(device, shape, dim):
    import tracy

    # best case for mul_sfpu removal.
    torch.manual_seed(0)
    torch_input_tensor = torch_random(shape, -1, 1, dtype=torch.bfloat16)

    tracy.signpost(f"warmup-{"-".join(str(x) for x in shape)}")
    # warmup
    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=True)

    tracy.signpost(f"test-{"-".join(str(x) for x in shape)}")
    # test
    for _ in range(5):
        output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=True)
        output_tensor = ttnn.to_torch(output_tensor)
```


### Checklist
- [x] test_reduction.py tests pass
- [x] test_reduction_mean.py tests pass

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes