### PR TITLE
Add prefill mode support for MOE decoders

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -37,16 +37,16 @@ from models.demos.deepseek_v3.utils.test_utils import (
     [
         (DecoderBlock, None, 0),
         (MoEDecoderBlock, None, 3),
-        # (DecoderBlock, "model.layers.0", None),
-        # (MoEDecoderBlock, "model.layers.3", None), # TODO: Uncomment once PCC is fixed for MoE
+        (DecoderBlock, "model.layers.0", None),
+        (MoEDecoderBlock, "model.layers.3", None),
     ],
 )
 @pytest.mark.parametrize(
     "mode, seq_len, batch_size",
     [
         ("decode", 1, 32),
-        # ("prefill", 512), # TODO: Uncomment once MLA prefill works
-        # ("prefill", 2048),  # Test chunking # TODO: Uncomment once MLA prefill works
+        ("prefill", 128, 1),
+        # ("prefill", 2048, 1),  # Test chunking # TODO: Uncomment once MLA prefill works
     ],
 )
 def test_forward_pass(

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -98,7 +98,7 @@ def test_forward_pass(
                 (batch_size,), dtype=torch.long
             )  # TODO: investigate the PCC issue with real weights
 
-        logger.info("Running the model")
+        logger.info("Running the reference model")
         reference_output, input_cache, output_cache = run_reference_with_attention(
             reference_model, torch_input, position_ids, None, hf_config_short, mode, False
         )


### PR DESCRIPTION

### What's changed
Add support of prefill mode in forward method for model1d
PCC: 0.99

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes