### PR TITLE
[Fabric] Try re-enabling 1D Mux tests in CI

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -28,7 +28,9 @@ jobs:
       matrix:
         test-group:
           - name: fabric 1D unit tests
-            cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
+            cmd: |
+              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
+              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DMuxFixture.*"
             timeout: 15
           - name: fabric 2D fixture unit tests
             cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -105,6 +105,7 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
         sleep 5
     done
     TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
+    TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DMuxFixture.*"
     TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/unit_tests_eth
 }


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/25288

### Problem description
The test was previously disabled because of some bug around inline writes in BH

### What's changed
A lot of fixes have gone in, in the past couple of days and looks like the bug is no longer reproducible. Ran the problematic  test suite in a loop locally and didnt see any issues, hence enabling it back. 

### Checklist
- [x] [BH multi-card] (https://github.com/tenstorrent/tt-metal/actions/runs/17844929623)