### PR TITLE
Address TODOs with HAL

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -848,10 +848,8 @@ void MetalContext::initialize_firmware(
                                        .get_target_out_path("");
                     const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                     uint32_t fw_size = binary_mem.get_text_size();
-                    if (riscv_id + build_idx == 1) {  // TODO: clean up how brisc/ncrisc are handled
-                        // In this context, ncrisc_kernel_size16 is the size of the fw
-                        launch_msg.kernel_config().ncrisc_kernel_size16() = (fw_size + 15) >> 4;
-                    }
+                    hal_->set_iram_text_size(
+                        launch_msg, core_type, static_cast<HalProcessorClassType>(processor_class), riscv_id, fw_size);
                     log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
 
                     if (not rtoptions_.get_skip_loading_fw()) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -314,7 +314,8 @@ uint32_t finalize_kernel_bins(
     uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
     uint32_t max_offset = 0;
-    uint32_t num_processors = hal.get_num_risc_processors(hal.get_programmable_core_type(programmable_core_type_index));
+    HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
+    uint32_t num_processors = hal.get_num_risc_processors(programmable_core_type);
     for (auto& kg : kernel_groups) {
         auto kernel_config = kg->launch_msg.view().kernel_config();
         uint32_t offset = base_offset;
@@ -324,51 +325,31 @@ uint32_t finalize_kernel_bins(
         for (auto kernel_id : kg->kernel_ids) {
             const auto& kernel = kernels.at(kernel_id);
             const auto& kernel_impl = KernelImpl::from(*kernel);
-            auto class_id = kernel->dispatch_class();
-            const std::vector<const ll_api::memory*>& binaries = kernel_impl.binaries(
+            const auto& binaries = kernel_impl.binaries(
                 BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-            // TODO: this is really ugly, save me future-HAL!
-            if (programmable_core_type_index == hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
-                const auto binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
-
-                if (class_id == DISPATCH_CLASS_TENSIX_COMPUTE) {
-                    constexpr uint32_t k_MaxMathProcessorsCount = 3;
-                    for (uint32_t proc_type_index = 0; proc_type_index < k_MaxMathProcessorsCount; proc_type_index++) {
-                        uint32_t binary_packed_size = kernel_impl.get_binary_packed_size(device, proc_type_index);
-                        kg->kernel_text_offsets[2 + proc_type_index] = offset;
-                        kernel_config.kernel_text_offset()[2 + proc_type_index] = offset;
-                        offset += binary_packed_size;
-                        offset = tt::align(offset, l1_alignment);
-                    }
-                } else {
-                    kg->kernel_text_offsets[class_id] = offset;
-                    kernel_config.kernel_text_offset()[class_id] = offset;
-                    offset += binary_packed_size;
+            uint32_t num_binaries = kernel->expected_num_binaries();
+            TT_ASSERT(kernel->get_kernel_programmable_core_type() == programmable_core_type);
+            for (uint32_t i = 0; i < num_binaries; i++) {
+                uint32_t kernel_text_offset = 0;
+                if (hal.get_core_kernel_stored_in_config_buffer(programmable_core_type)) {
+                    kernel_text_offset = offset;
+                    offset += kernel_impl.get_binary_packed_size(device, i);
                     offset = tt::align(offset, l1_alignment);
-
-                    // Provide text size for copying to NCRISC IRAM
-                    if (class_id == DISPATCH_CLASS_TENSIX_DM1) {
-                        const auto binary_text_size = kernel_impl.get_binary_text_size(device, 0);
-                        TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
-                        kernel_config.ncrisc_kernel_size16() = (binary_text_size + 15) >> 4;
-                    }
+                } else {
+                    kernel_text_offset = binaries[i]->get_text_addr();
                 }
-            } else {
-                // All other core types
-                const auto binary_packed_size = kernel_impl.get_binary_packed_size(device, 0);
-                if (hal.get_core_kernel_stored_in_config_buffer(
-                        hal.get_programmable_core_type(programmable_core_type_index))) {
-                    kg->kernel_text_offsets[class_id] = offset;
-                    kernel_config.kernel_text_offset()[class_id] = offset;
-                    offset += binary_packed_size;
-                    offset = tt::align(offset, l1_alignment);
-                } else {
-                    kg->kernel_text_offsets[class_id] = binaries[0]->get_text_addr();
-                    kernel_config.kernel_text_offset()[class_id] = binaries[0]->get_text_addr();
+                uint32_t processor_index = hal.get_processor_index(
+                    programmable_core_type, kernel->get_kernel_processor_class(), kernel->get_kernel_processor_type(i));
+                kg->kernel_text_offsets[processor_index] = kernel_text_offset;
+                kernel_config.kernel_text_offset()[processor_index] = kernel_text_offset;
+                // Provide text size for copying to NCRISC IRAM
+                if (kernel->dispatch_class() == DISPATCH_CLASS_TENSIX_DM1) {
+                    const auto binary_text_size = kernel_impl.get_binary_text_size(device, 0);
+                    TT_ASSERT(binary_text_size >> 4 <= std::numeric_limits<uint16_t>::max());
+                    kernel_config.ncrisc_kernel_size16() = (binary_text_size + 15) >> 4;
                 }
             }
         }
-
         max_offset = std::max(offset, max_offset);
     }
     kernel_text_offset = base_offset;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -238,6 +238,8 @@ public:
     using StackSizeFunc = std::function<uint32_t(uint32_t)>;
     using EthFwArgAddrFunc = std::function<uint32_t(int, uint32_t)>;
     using DispatchFeatureQueryFunc = std::function<bool(DispatchFeature)>;
+    using SetIRAMTextSizeFunc = std::function<void(
+        dev_msgs::launch_msg_t::View, HalProgrammableCoreType, HalProcessorClassType, uint32_t, uint32_t)>;
 
 private:
     tt::ARCH arch_;
@@ -294,6 +296,7 @@ private:
     EthFwArgAddrFunc eth_fw_arg_addr_func_;
     DispatchFeatureQueryFunc device_features_func_;
     std::unique_ptr<HalJitBuildQueryInterface> jit_build_query_;
+    SetIRAMTextSizeFunc set_iram_text_size_func_;
 
 public:
     Hal(tt::ARCH arch, bool is_base_routing_fw_enabled);
@@ -442,6 +445,19 @@ public:
     // Code that assumes that should use this interface to create go_msg_t values,
     // as it is otherwise not guaranteed by the HAL interface.
     uint32_t make_go_msg_u32(uint8_t signal, uint8_t master_x, uint8_t master_y, uint8_t dispatch_message_offset) const;
+
+    // If the specified processor uses IRAM, update the launch message to set the IRAM text size.
+    void set_iram_text_size(
+        dev_msgs::launch_msg_t::View launch_msg,
+        HalProgrammableCoreType programmable_core_type,
+        HalProcessorClassType processor_class,
+        uint32_t processor_type_idx,
+        uint32_t iram_text_size) const {
+        if (this->set_iram_text_size_func_) {
+            this->set_iram_text_size_func_(
+                launch_msg, programmable_core_type, processor_class, processor_type_idx, iram_text_size);
+        }
+    }
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -354,6 +354,18 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
         NOC_CFG(NOC_Y_ID_TRANSLATE_TABLE_3)};
 
     this->jit_build_query_ = std::make_unique<HalJitBuildQueryWormhole>();
+
+    this->set_iram_text_size_func_ = [](dev_msgs::launch_msg_t::View launch_msg,
+                                        HalProgrammableCoreType programmable_core_type,
+                                        HalProcessorClassType processor_class,
+                                        uint32_t processor_type_idx,
+                                        uint32_t iram_text_size) {
+        // Only NCRISC on Wormhole needs to set the field ncrisc_kernel_size16 in launch message.
+        if (programmable_core_type == HalProgrammableCoreType::TENSIX && processor_class == HalProcessorClassType::DM &&
+            processor_type_idx == 1) {
+            launch_msg.kernel_config().ncrisc_kernel_size16() = (iram_text_size + 15) >> 4;
+        }
+    };
 }
 
 }  // namespace tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17729

### What's changed
- Added a function in HAL to set IRAM text size (for NCRISC on Wormhole; no-op otherwise), so caller doesn't need to know which processor uses IRAM (doesn't even need to know which field to set in launch msg).
- Reduced code duplication and assumptions on number of processors in `finalize_kernel_bins`.  (One fewer use of dispatch class)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17844914207) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17844925075) CI with demo tests passes (if applicable)