### PR TITLE
Sharding Support for Composite RS & AG

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -559,7 +559,6 @@ def test_reduce_scatter_async_sharded_to_sharded(
     buffer_type,
     enable_trace,
     num_iters,
-    ones_tensor,
     rs_topology,
 ):
     adjusted_intermediate_shard_shape = intermediate_shard_shape[:]
@@ -601,7 +600,6 @@ def test_reduce_scatter_async_sharded_to_sharded(
         rs_topology=rs_topology,
         enable_trace=enable_trace,
         num_iters=num_iters,
-        ones_tensor=ones_tensor,
         mem_config_intermediate=mem_config_intermediate,
     )
 

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -642,10 +642,10 @@ def test_reduce_scatter_async_sharded_to_sharded(
         (
             [1, 1, 384, 240],
             3,
-            [256, 256],
+            [64, 256],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            [256, 32],
+            [64, 32],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -184,7 +184,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
     } else {
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(output_tensors.at(0).buffer()).append_to(writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(writer_compile_args);
     }
     auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -184,7 +184,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
         shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
     } else {
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensors.at(0).buffer()).append_to(writer_compile_args);
     }
     auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -175,15 +175,28 @@ ttnn::Tensor composite_all_gather(
     int32_t rank = input_tensor.logical_shape().rank();
     int32_t gather_dim = (dim < 0) ? rank + dim : dim;
 
-    bool is_tiled_and_not_tile_aligned = input_tensor.layout() == ttnn::Layout::TILE &&
-                                         (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0);
-
     // If we need to convert to row-major, then if the input dtype is bfloat8_b we need to typecast before untilizing
     // and after re-tilizing
     ttnn::DataType input_dtype = input_tensor.dtype();
+    bool is_tiled_and_not_tile_aligned = input_tensor.layout() == ttnn::Layout::TILE &&
+                                         (input_shape[2] % tile_height != 0 || input_shape[3] % tile_width != 0);
     bool convert_to_bfloat16_for_composite = is_tiled_and_not_tile_aligned && input_dtype == ttnn::DataType::BFLOAT8_B;
+
     auto input_memory_config = input_tensor.memory_config();
+    TT_FATAL(
+        !(input_memory_config.is_sharded() && !memory_config.has_value()),
+        "If input memory config is sharded, then output memory config must be provided. Defaulting the output memory "
+        "config to the input sharded memory config will break the op as the input and output shapes are different.");
     auto output_memory_config = memory_config.value_or(input_memory_config);
+
+    /*
+     * Concat does not fully support sharding. Inserting s2i and i2s at either ends of
+     * the composite ensures the concat always executes with an interleaved memory config,
+     * and also means the other ops used in the composite don't need to support sharding.
+     */
+    if (input_memory_config.is_sharded()) {
+        input_tensor = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
+    }
 
     // Convert to row major
     if (is_tiled_and_not_tile_aligned) {
@@ -195,9 +208,11 @@ ttnn::Tensor composite_all_gather(
     }
 
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, num_links, input_memory_config, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+        input_tensor, num_links, std::nullopt, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
 
+    // Do the gather itself
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, gather_dim);
+
     // Convert back to tiled
     if (is_tiled_and_not_tile_aligned) {
         all_gather_output_tensor = ttnn::to_layout(all_gather_output_tensor, ttnn::Layout::TILE);
@@ -208,7 +223,7 @@ ttnn::Tensor composite_all_gather(
         }
     }
 
-    if (input_memory_config.memory_layout() != output_memory_config.memory_layout()) {
+    if (output_memory_config.is_sharded()) {
         all_gather_output_tensor = ttnn::to_memory_config(all_gather_output_tensor, output_memory_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -51,21 +51,18 @@ ttnn::Tensor composite_reduce_scatter(
     auto output_memory_config = memory_config.value_or(input_memory_config);
 
     if (input_memory_config.is_sharded()) {
-        input_tensor = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
+        /*
+         * If sharded to interleaved, convert to the final interleaved memory config.
+         * If sharded to sharded, use DRAM interleaved as the intermediate memory
+         * config for executing the composite.
+         */
+        auto intermediate_memory_config =
+            output_memory_config.is_sharded() ? ttnn::DRAM_MEMORY_CONFIG : output_memory_config;
+        input_tensor = ttnn::to_memory_config(input_tensor, intermediate_memory_config);
     }
 
-    // If input to all_broadcast is interleaved DRAM and output of op is interleaved L1 (or vice-versa), do the
-    // conversion during the all_broadcast Otherwise if the output of the op is sharded, we do the conversion at the end
-    // of the composite
-    auto all_broadcast_output_memory_config =
-        output_memory_config.is_sharded() ? input_tensor.memory_config() : output_memory_config;
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor,
-        num_links,
-        all_broadcast_output_memory_config,
-        ttnn::ccl::Topology::Linear,
-        cluster_axis,
-        subdevice_id);
+        input_tensor, num_links, input_tensor.memory_config(), ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -54,9 +54,18 @@ ttnn::Tensor composite_reduce_scatter(
         input_tensor = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
     }
 
-    // Broadcast each tensor to all other devices in the mesh
+    // If input to all_broadcast is interleaved DRAM and output of op is interleaved L1 (or vice-versa), do the
+    // conversion during the all_broadcast Otherwise if the output of the op is sharded, we do the conversion at the end
+    // of the composite
+    auto all_broadcast_output_memory_config =
+        output_memory_config.is_sharded() ? input_tensor.memory_config() : output_memory_config;
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, num_links, std::nullopt, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+        input_tensor,
+        num_links,
+        all_broadcast_output_memory_config,
+        ttnn::ccl::Topology::Linear,
+        cluster_axis,
+        subdevice_id);
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -16,7 +16,7 @@
 namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor composite_reduce_scatter(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor input_tensor,
     const int32_t dim,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
@@ -43,9 +43,20 @@ ttnn::Tensor composite_reduce_scatter(
     bool is_tiled_and_not_tile_aligned = input_tensor.layout() == Layout::TILE &&
                                          (output_shape[2] % tile_height != 0 || output_shape[3] % tile_width != 0);
 
+    auto input_memory_config = input_tensor.memory_config();
+    TT_FATAL(
+        !(input_memory_config.is_sharded() && !memory_config.has_value()),
+        "If input memory config is sharded, then output memory config must be provided. Defaulting the output memory "
+        "config to the input sharded memory config will break the op as the input and output shapes are different.");
+    auto output_memory_config = memory_config.value_or(input_memory_config);
+
+    if (input_memory_config.is_sharded()) {
+        input_tensor = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
+    }
+
     // Broadcast each tensor to all other devices in the mesh
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
-        input_tensor, num_links, input_tensor.memory_config(), ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
+        input_tensor, num_links, std::nullopt, ttnn::ccl::Topology::Linear, cluster_axis, subdevice_id);
 
     // Reduce broadcasted tensors into a single reduced tensor
     ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
@@ -64,8 +75,8 @@ ttnn::Tensor composite_reduce_scatter(
     }
 
     // Partition the reduced tensor (scatter)
-    ttnn::Tensor reduce_scatter_output_tensor = ttnn::prim::mesh_partition(
-        all_reduced_tensor, scatter_dim, cluster_axis, memory_config.value_or(all_reduced_tensor.memory_config()));
+    ttnn::Tensor reduce_scatter_output_tensor =
+        ttnn::prim::mesh_partition(all_reduced_tensor, scatter_dim, cluster_axis, all_reduced_tensor.memory_config());
 
     // Convert back to tiled (if necessary)
     if (is_tiled_and_not_tile_aligned) {
@@ -74,6 +85,10 @@ ttnn::Tensor composite_reduce_scatter(
         if (input_tensor.dtype() == DataType::BFLOAT8_B) {
             reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, DataType::BFLOAT8_B);
         }
+    }
+
+    if (output_memory_config.is_sharded()) {
+        reduce_scatter_output_tensor = ttnn::to_memory_config(reduce_scatter_output_tensor, output_memory_config);
     }
 
     return reduce_scatter_output_tensor;


### PR DESCRIPTION
### Problem description
The composite RS and composite AG didn't fully support sharding

### What's changed
- Add conditional s2i and i2s ops at either ends of the composites
  - All of the ops that currently make up the composites don't all 100% support sharding, which is why we need to execute the body of the composite with interleaved tensors, and do the conversions at either ends
  - If we wanted to avoid the conversions, we'd need every op in the composite to fully support sharding so that stuff doesn't break at different points in the pipeline when we have sharded inputs and/or outputs
- Potential fusion for the s2i:
  - We could theoretically fuse the s2i with the `all_broadcast`
  - i.e. update `all_broadcast` to support input sharded & output interleaved (and vice-versa)
  - for tiled, this would be a trivial change (the native minimal RS & AG that operate on tiles already support this fused i2s and s2i functionality)
  - however, making it work for row-major would be a bit complicated due to alignment issues
  - imo not the most important thing to work on in the near term since we're really just trying to get coverage with the composites, but just wanted to point it out as a potential perf optimization we could look into if push comes to shove
- s2i limitation:
  - s2i currently doesn't support DRAM sharding
  - however, the native minimal implementations do support DRAM sharding (since they use the sharded addr gen), i2s also supports DRAM sharding (I updated it to use the sharded addr gen back in June)
  - tldr: the composites won't support input DRAM sharding due to this s2i limitation, while the native minimals do indeed support input DRAM sharding
     - and adding DRAM sharding support to s2i would require integrating the sharded addr gen (or maby the tensor accessor) into the op, which is non trivial

### Pipelines
- APC https://github.com/tenstorrent/tt-metal/actions/runs/17848449290
- BH APC https://github.com/tenstorrent/tt-metal/actions/runs/17818667955
- T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17883492522


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
