### PR TITLE
Remove l1 small from grid_sample

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -247,7 +247,6 @@ def prepare_sharded_ttnn_grid(
     return ttnn.to_memory_config(ttnn_grid_interleaved, grid_memory_config)
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize("use_precomputed_grid", [False, True])
 @pytest.mark.parametrize(
     "input_shape, grid_shape",
@@ -368,7 +367,6 @@ def test_grid_sample_batch_output_channels_flag(
     logger.info(pcc_message)
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize(
@@ -424,7 +422,6 @@ def test_grid_sample_sharded(device, input_shape, grid_shape, use_precomputed_gr
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize("batch_output_channels", [True, False])
 @pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])

--- a/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_grid_sample.py
@@ -11,7 +11,6 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape, grid_shape",
     [
@@ -64,7 +63,6 @@ def test_grid_sample_random_grid(device, input_shape, grid_shape, grid_dtype):
     assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape, grid_shape",
     [
@@ -122,7 +120,6 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, grid_dty
     assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",
     [
@@ -166,7 +163,6 @@ def test_grid_sample_identity_transform(device, input_shape):
     logger.info(f"Identity check: {identity_message}")
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",
     [


### PR DESCRIPTION
ttnn.grid_sample is not using l1_small allocator.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes