### PR TITLE
#22999: Adds a pytest entry point to the softmax_sharded test sweep

### DIFF
--- a/tests/sweep_framework/sweeps/normalization/softmax/softmax.py
+++ b/tests/sweep_framework/sweeps/normalization/softmax/softmax.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
+import pytest
 
 import torch
 import random
@@ -11,7 +11,7 @@ import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from models.utility_functions import torch_random
 
@@ -20,10 +20,9 @@ TIMEOUT = 30
 
 random.seed(0)
 
-# Parameters provided to the test vector generator are defined here.
-# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
-# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
-# Developers can create their own generator functions and pass them to the parameters as inputs.
+# Parameters provided to the test vector generator,
+# defined as dict-type suites that contain the arguments to the run function as keys,
+# and lists of possible inputs as values.
 parameters = {
     "xfail": {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 16)
@@ -37,11 +36,8 @@ parameters = {
 }
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+# The actual test function that will be run.
+def run_softmax(
     input_shape,
     input_a_dtype,
     input_a_layout,
@@ -74,3 +70,27 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, result]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+# Entry point for the sweep framework.
+# Takes one test vector (as defined above) as the input.
+def run(
+    params,
+    *,
+    device,
+) -> list:
+    [input_shape, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config] = params
+    return run_softmax(
+        input_shape, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device=device
+    )
+
+
+# Entry point for pytest.
+@pytest.mark.xfail
+@pytest.mark.parametrize("input_shape", parameters["xfail"]["input_shape"])
+@pytest.mark.parametrize("input_a_dtype", parameters["xfail"]["input_a_dtype"])
+@pytest.mark.parametrize("input_a_layout", parameters["xfail"]["input_a_layout"])
+@pytest.mark.parametrize("input_a_memory_config", parameters["xfail"]["input_a_memory_config"])
+@pytest.mark.parametrize("output_memory_config", parameters["xfail"]["output_memory_config"])
+def test_softmax(device, input_shape, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config):
+    run_softmax(input_shape, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device=device)

--- a/tests/sweep_framework/sweeps/normalization/softmax/softmax_sharded.py
+++ b/tests/sweep_framework/sweeps/normalization/softmax/softmax_sharded.py
@@ -1,16 +1,15 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional, Tuple
 from functools import partial
 
-import json
+import pytest
 import torch
 import random
 import ttnn
-import math
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.utils import sanitize_shape_rm
 from tests.sweep_framework.sweep_utils.sharding_utils import (
     gen_sharded_spec_unary,
     parse_sharding_spec,
@@ -18,7 +17,7 @@ from tests.sweep_framework.sweep_utils.sharding_utils import (
 )
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 from models.utility_functions import torch_random
 
@@ -27,10 +26,9 @@ TIMEOUT = 120
 
 random.seed(0)
 
-# Parameters provided to the test vector generator are defined here.
-# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
-# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
-# Developers can create their own generator functions and pass them to the parameters as inputs.
+# Parameters provided to the test vector generator,
+# defined as dict-type suites that contain the arguments to the run function as keys,
+# and lists of possible inputs as values.
 parameters = {
     "xfail": {
         "input_spec": gen_sharded_spec_unary(16, max_tensor_size_per_core=20 * 1024, layouts=["TILE_LAYOUT"]),
@@ -53,14 +51,10 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+# The actual test function.
+def run_softmax_sharded(
     input_spec,
     input_a_dtype,
-    *,
     device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
@@ -111,3 +105,22 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+# Entry point for the sweep framework.
+# Takes one test vector (as defined above) as the input.
+def run(
+    params,
+    *,
+    device,
+) -> list:
+    [input_spec, input_a_dtype] = params
+    return run_softmax_sharded(input_spec, input_a_dtype, device)
+
+
+# Entry point for pytest.
+@pytest.mark.xfail
+@pytest.mark.parametrize("input_spec", parameters["xfail"]["input_spec"])
+@pytest.mark.parametrize("input_a_dtype", parameters["xfail"]["input_a_dtype"])
+def test_softmax_sharded(device, input_spec, input_a_dtype):
+    run_softmax_sharded(input_spec, input_a_dtype, device)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22999

### Problem description
The softmax_sharded test sweep file was lacking a plain pytest definition for the test cases defined in the sweep. In consequence, it was not possible to simply use the softmax_sharded.py file as a pytest, for example, to debug a test failure from a sweeps run.

### What's changed
A generic pytest was added to the softmax_sharded.py file. Some refactoring of the code was done. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes