### PR TITLE
Enable Llama Galaxy in APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -203,7 +203,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   galaxy-apc-fast-tests:
-    if: false
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     needs: build-artifact
     secrets: inherit
     strategy:


### PR DESCRIPTION
Return Llama Galaxy test to APC

### Problem description
Test was removed due to failure on multiple commits.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17855222952)
- [ ] [Llama test for APC](https://github.com/tenstorrent/tt-metal/actions/runs/17854640137)