### PR TITLE
#8648: remove skips for bloom tests

### DIFF
--- a/tests/ttnn/integration_tests/bloom/test_ttnn_functional_bloom.py
+++ b/tests/ttnn/integration_tests/bloom/test_ttnn_functional_bloom.py
@@ -143,8 +143,6 @@ def test_bloom_block(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.997)
 
 
-@pytest.mark.skip(reason="Issue #8648.")
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -183,8 +181,6 @@ def test_bloom(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.924)
 
 
-@pytest.mark.skip(reason="Issue #8648.")
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])


### PR DESCRIPTION
### Ticket
Link to Github Issue #8648

### Problem description
These tests did not work a long time ago.

### What's changed
Tested again and these tests pass. Therefore enabling them.

Local testing:
- verified works on BH and WH

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI all tests are green between https://github.com/tenstorrent/tt-metal/actions/runs/17855818439 and https://github.com/tenstorrent/tt-metal/actions/runs/17860247666 (rest are known nd issues)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17855822420
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes