### PR TITLE
PanopticDeepLab maxpool and upsample unit tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -378,7 +378,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ttnn nightly conv tests
         timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode" -k panoptic
+        run: pytest tests/ttnn/nightly/unit_tests/operations -xv -m "not disable_fast_runtime_mode" -k panoptic
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -652,7 +652,7 @@ def test_max_pool2d_output_formats_and_layouts(
     )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
 @pytest.mark.parametrize(
-    "input_shape",
+    "input_shape_nchw",
     (([1, 128, 256, 512],)),
 )
 @pytest.mark.parametrize(
@@ -672,14 +672,7 @@ def test_max_pool2d_output_formats_and_layouts(
     ((2, 2),),
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-def test_panoptic_maxpool_sliced(device, input_shape, kernel_size, padding, dilation, stride, dtype, tensor_map):
-    input_shape_nchw = input_shape
-    kernel_size = kernel_size
-    padding = padding
-    stride = stride
-    dilation = dilation
-    dtype = ttnn.bfloat16
-
+def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
     num_slices = 4
 
     batch_size, channels, input_h, input_w = input_shape_nchw

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -650,3 +650,96 @@ def test_max_pool2d_output_formats_and_layouts(
         output_layout=output_layout,
         nightly_skips=False,
     )
+@pytest.mark.parametrize(
+    "input_shape",
+    (([1, 128, 256, 512],)),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    ((3, 3),),
+)
+@pytest.mark.parametrize(
+    "padding",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((2, 2),),
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_panoptic_maxpool_sliced(device, input_shape, kernel_size, padding, dilation, stride, dtype, tensor_map):
+    input_shape_nchw = input_shape
+    kernel_size = kernel_size
+    padding = padding
+    stride = stride
+    dilation = dilation
+    dtype = ttnn.bfloat16
+
+    num_slices = 4
+
+    batch_size, channels, input_h, input_w = input_shape_nchw
+    assert channels % num_slices == 0, "Channels must be divisible by num_slices"
+    slice_channels = channels // num_slices
+
+    logger.info(f"Running Panoptic MaxPool2D with Channel Slicing (slices={num_slices})")
+
+    torch.manual_seed(0)
+    torch_input_nchw = randomize_torch_tensor(tensor_map, input_shape_nchw)
+
+    torch_output = torch.nn.MaxPool2d(
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        return_indices=False,
+        ceil_mode=False,
+    )(torch_input_nchw)
+
+    out_h, out_w = torch_output.shape[2], torch_output.shape[3]
+
+    ttnn_input_nhwc = ttnn.from_torch(
+        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype
+    )
+    output_slices = []
+    for i in range(num_slices):
+        start_idx = i * slice_channels
+        end_idx = (i + 1) * slice_channels
+
+        x_slice = ttnn.slice(ttnn_input_nhwc, [0, 0, 0, start_idx], [batch_size, input_h, input_w, end_idx])
+
+        x_slice_reshaped = ttnn.reshape(x_slice, (1, 1, batch_size * input_h * input_w, slice_channels))
+        ttnn.deallocate(x_slice)
+
+        x_slice_pooled = ttnn.max_pool2d(
+            x_slice_reshaped,
+            batch_size=batch_size,
+            input_h=input_h,
+            input_w=input_w,
+            channels=slice_channels,
+            kernel_size=list(kernel_size),
+            stride=list(stride),
+            padding=list(padding),
+            dilation=list(dilation),
+            ceil_mode=False,
+        )
+        ttnn.deallocate(x_slice_reshaped)
+
+        x_slice_output_nhwc = ttnn.reshape(x_slice_pooled, (batch_size, out_h, out_w, slice_channels))
+        ttnn.deallocate(x_slice_pooled)
+        x_slice_output_nhwc = ttnn.to_memory_config(x_slice_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
+        output_slices.append(x_slice_output_nhwc)
+
+    ttnn.deallocate(ttnn_input_nhwc)
+    ttnn_output_nhwc = ttnn.concat(output_slices, dim=3)
+    for s in output_slices:
+        ttnn.deallocate(s)
+
+    ttnn_output_torch = ttnn.to_torch(ttnn_output_nhwc)
+    ttnn_output_torch_nchw = torch.permute(ttnn_output_torch, (0, 3, 1, 2))
+    passed, pcc_score = assert_with_pcc(ttnn_output_torch_nchw, torch_output, pcc=0.999)
+    logger.info(f"PCC Score: {pcc_score}")
+    assert passed, f"PCC check failed. PCC: {pcc_score}"

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -650,6 +650,8 @@ def test_max_pool2d_output_formats_and_layouts(
         output_layout=output_layout,
         nightly_skips=False,
     )
+
+
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape_nchw",

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -650,6 +650,7 @@ def test_max_pool2d_output_formats_and_layouts(
         output_layout=output_layout,
         nightly_skips=False,
     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",
     (([1, 128, 256, 512],)),

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -226,10 +226,10 @@ def test_panoptic_upsample_sliced(device, batch_size, num_channels, height, widt
     sliced_results = []
     for slice_idx in range(num_slices):
         start_ch = slice_idx * slice_channels
-        end_ch_inclusive = (slice_idx + 1) * slice_channels
+        end_ch_exclusive = (slice_idx + 1) * slice_channels
 
         x_slice_nhwc = ttnn.slice(
-            ttnn_input_nhwc, [0, 0, 0, start_ch], [batch_size, input_h, input_w, end_ch_inclusive]
+            ttnn_input_nhwc, [0, 0, 0, start_ch], [batch_size, input_h, input_w, end_ch_exclusive]
         )
 
         x_slice_upsampled = ttnn.upsample(

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -191,7 +191,7 @@ def test_upsample_various(device, input_shape, core_range, scale_h, scale_w, sha
     assert isequal
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, num_channels, height, width, scale_h, scale_w, num_slices",
     (

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -189,3 +189,70 @@ def test_upsample_various(device, input_shape, core_range, scale_h, scale_w, sha
     isequal = torch.equal(output_tensor, torch_result)
 
     assert isequal
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, num_channels, height, width, scale_h, scale_w, num_slices",
+    (
+        (1, 256, 64, 128, 2, 2, 2),
+        (1, 128, 64, 128, 2, 2, 2),
+    ),
+)
+def test_panoptic_upsample_sliced(device, batch_size, num_channels, height, width, scale_h, scale_w, num_slices):
+    input_shape_nchw = [batch_size, num_channels, height, width]
+    scale_factor = (scale_h, scale_w)
+    mode_pytorch = "nearest"  # we only did nearest in panoptic due to pcc dropping very little and bilinear not being able to fit in memory as of now
+    mode_ttnn = "nearest"
+    dtype_torch = torch.bfloat16
+    dtype_ttnn = ttnn.bfloat16
+
+    batch_size, channels, input_h, input_w = input_shape_nchw
+    assert channels % num_slices == 0, "Channels must be divisible by num_slices"
+    slice_channels = channels // num_slices
+
+    logger.info(f"Running Panoptic Upsample with Channel Slicing (slices={num_slices})")
+
+    torch.manual_seed(0)
+    torch_input_nchw = torch.rand(input_shape_nchw, dtype=dtype_torch)
+
+    torch_upsample = nn.Upsample(scale_factor=scale_factor, mode=mode_pytorch)
+    torch_output_nchw = torch_upsample(torch_input_nchw)
+
+    ttnn_input_nhwc = ttnn.from_torch(
+        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype_ttnn
+    )
+
+    sliced_results = []
+    for slice_idx in range(num_slices):
+        start_ch = slice_idx * slice_channels
+        end_ch_inclusive = (slice_idx + 1) * slice_channels
+
+        x_slice_nhwc = ttnn.slice(
+            ttnn_input_nhwc, [0, 0, 0, start_ch], [batch_size, input_h, input_w, end_ch_inclusive]
+        )
+
+        x_slice_upsampled = ttnn.upsample(
+            x_slice_nhwc,
+            scale_factor=scale_factor,
+            mode=mode_ttnn,
+        )
+        x_slice_upsampled = ttnn.to_memory_config(x_slice_upsampled, ttnn.DRAM_MEMORY_CONFIG)
+        sliced_results.append(x_slice_upsampled)
+
+        ttnn.deallocate(x_slice_nhwc)
+
+    ttnn.deallocate(ttnn_input_nhwc)
+
+    ttnn_output_nhwc = ttnn.concat(sliced_results, dim=3, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    for slice_result in sliced_results:
+        ttnn.deallocate(slice_result)
+
+    torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1)
+
+    ttnn_output_torch_nhwc = ttnn.to_torch(ttnn_output_nhwc)
+
+    passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch_nhwc, pcc=0.99)
+    logger.info(pcc_message)
+    assert passed, f"PCC check failed. {pcc_message}"


### PR DESCRIPTION
### Ticket

### Problem description
Created unit tests for Panoptic Deelab model.

### What's changed
I created new functions that have panoptic in their name in nightly maxpool and nightly upsample files for respective tests.
I also changed tt-metal-l2 nightly impl to consider now every op in nightly that has "panoptic" in it, to now not catch only convs but also upsample and maxpool

### Checklist
- [ passed ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/17860688297
- [ passed ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/17860702975
- [ passed ] Nightly tt-metal L2 tests: https://github.com/tenstorrent/tt-metal/actions/runs/17860717785