### PR TITLE
vLLM workaround for pretokenized prompts

### DIFF
--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -490,7 +490,7 @@ class MultiModalProcessor(BaseMultiModalProcessor):
                 getattr(input_processor, "tokenizer") if hasattr(input_processor, "tokenizer") else input_processor
             )
             text_prompt = tokenizer.decode(prompt, skip_special_tokens=False)
-            logger.warning(f"Tokens decoded back to text")
+            logger.warning(f"Applied workaround: decoded {len(prompt)} tokens back to text for processor compatibility")
         else:
             text_prompt = prompt
 

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -484,7 +484,7 @@ class MultiModalProcessor(BaseMultiModalProcessor):
         # WORKAROUND
         # When using /v1/chat/completions endpoint prompt is already tokenized
         # Processor requires text, so we decode tokens back to text
-        if isinstance(prompt, list) and all(isinstance(x, int) for x in prompt):
+        if isinstance(prompt, list) and prompt and isinstance(prompt[0], int):
             # Use the processor's tokenizer to decode tokens back to text
             tokenizer = (
                 getattr(input_processor, "tokenizer") if hasattr(input_processor, "tokenizer") else input_processor

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -7,6 +7,7 @@ from typing import List, Mapping, Optional, Sequence, Union
 
 import torch
 from llama_models.llama3.api.chat_format import create_vision_mask
+from loguru import logger
 from PIL.Image import Image
 from tqdm import tqdm
 from transformers import BatchFeature
@@ -480,8 +481,21 @@ class MultiModalProcessor(BaseMultiModalProcessor):
         mm_processor_kwargs = getattr(self.info.ctx.model_config, "mm_processor_kwargs", None) or {}
         input_processor = self.info.get_hf_processor(**mm_processor_kwargs)
 
+        # WORKAROUND
+        # When using /v1/chat/completions endpoint prompt is already tokenized
+        # Processor requires text, so we decode tokens back to text
+        if isinstance(prompt, list) and all(isinstance(x, int) for x in prompt):
+            # Use the processor's tokenizer to decode tokens back to text
+            tokenizer = (
+                getattr(input_processor, "tokenizer") if hasattr(input_processor, "tokenizer") else input_processor
+            )
+            text_prompt = tokenizer.decode(prompt, skip_special_tokens=False)
+            logger.warning(f"Tokens decoded back to text")
+        else:
+            text_prompt = prompt
+
         processed_inputs = input_processor(
-            text=prompt,  # [INFO] Qwen2VLProcessor handles the case where text is a string or a list of strings
+            text=text_prompt,  # [INFO] Qwen2VLProcessor handles the case where text is a string or a list of strings
             images=mm_data["image"] if mm_data else None,
             videos=None,  # [INFO] videos are not supported yet
             return_tensors="pt",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28912

### Problem description
When using /v1/chat/completions the text prompt will be already tokenized before we want to use it in the Processor.
The Gemma3Processor expects text and will complain.

### What's changed
Workaround with decoding the tokens back to text.

### Checklist
[vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/17856623542) 🏃‍♂️