### PR TITLE
Add ttnn.rand to the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,10 @@ example: `http://10.250.37.37:4242`, for port ``4242``.
 
 If you forwarded your port, navigate to `http://localhost:8888`.
 
+`http://<ip address>:<port>` will redirect you to the tt-metallium docs at `http://<ip address>:<port>/tt-metalium/`.
+
+To view the tt-nn docs, navigate to `http://<ip address>:<port>/ttnn`.
+
 4. If you make changes, you may need to check spelling errors.
 
 We use the spell-checker, Aspell, to ensure we don't sneak in some typos in
@@ -546,7 +550,7 @@ To set up pre-commit on your local machine, follow these steps:
   and without CI failure.
 
 ### Skipping CI/CD for documentation updates
-- CI/CD can be skipped for *documentation only* updates that incur no functional change.
+- CI/CD can be skipped for *documentation only* updates that incur no functional change. Modifying `.rst` files in `docs/` is *not a documentation only* update, as the CI step for building documentation needs to run.
 - Upon submitting a PR and getting the necessary approvals:
   - Click Squash and Merge
   - Before confirming, edit the top level commit message by prepending the token `[skip ci]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ If you forwarded your port, navigate to `http://localhost:8888`.
 
 `http://<ip address>:<port>` will redirect you to the tt-metallium docs at `http://<ip address>:<port>/tt-metalium/`.
 
-To view the tt-nn docs, navigate to `http://<ip address>:<port>/ttnn`.
+To view the ttnn docs, navigate to `http://<ip address>:<port>/ttnn`.
 
 4. If you make changes, you may need to check spelling errors.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ example: `http://10.250.37.37:4242`, for port ``4242``.
 
 If you forwarded your port, navigate to `http://localhost:8888`.
 
-`http://<ip address>:<port>` will redirect you to the tt-metallium docs at `http://<ip address>:<port>/tt-metalium/`.
+`http://<ip address>:<port>` will redirect you to the tt-metalium docs at `http://<ip address>:<port>/tt-metalium/`.
 
 To view the ttnn docs, navigate to `http://<ip address>:<port>/ttnn`.
 
@@ -550,7 +550,7 @@ To set up pre-commit on your local machine, follow these steps:
   and without CI failure.
 
 ### Skipping CI/CD for documentation updates
-- CI/CD can be skipped for *documentation only* updates that incur no functional change. Modifying `.rst` files in `docs/` is *not a documentation only* update, as the CI step for building documentation needs to run.
+- CI/CD can be skipped for *documentation only* updates that incur no functional change. However, note that modifying `.rst` files in `docs/` is *not a documentation only* update, as the CI step for building documentation needs to run.
 - Upon submitting a PR and getting the necessary approvals:
   - Click Squash and Merge
   - Before confirming, edit the top level commit message by prepending the token `[skip ci]`

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -71,6 +71,7 @@ Tensor Creation
    ttnn.ones_like
    ttnn.full
    ttnn.full_like
+   ttnn.rand
 
 Matrix Multiplication
 =====================


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28906)

### Problem description
ttnn.rand was added in https://github.com/tenstorrent/tt-metal/pull/23521 but it was not added to the tensor creation section of https://github.com/tenstorrent/tt-metal/blob/main/docs/source/ttnn/ttnn/api.rst

### What's changed
Added the function to the docs
Added clarifications to sections of contributing.md relevant to encountered problems.

### Checklist