### PR TITLE
Increase batch size to 8 for convert_to_chw op for bh

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -27,13 +27,7 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
 }
 namespace NAMESPACE {
 void MAIN {
-#ifdef ARCH_BLACKHOLE
-    // Until #28611 is closed - pack_untilize_dest on BH can't work with block_rt_dim > 1 (BATCH_SIZE = 1 ->
-    // block_rt_dim = 1)
-    constexpr int BATCH_SIZE = 1;
-#else
     constexpr int BATCH_SIZE = 8;
-#endif
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
     const uint32_t num_batches = total_tiles / BATCH_SIZE;
     const uint32_t leftover = total_tiles % BATCH_SIZE;


### PR DESCRIPTION
### What's changed
After https://github.com/tenstorrent/tt-metal/pull/28878 is merged, there is no more issue https://github.com/tenstorrent/tt-metal/issues/28611. That means batch size can be > 1 for `convert_to_chw` op on BH.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17909361020) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17909379675)