### PR TITLE
Fix the logic to get `optimizations` for token_accuracy

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -66,7 +66,7 @@ class TokenAccuracy:
         return accuracy_top1, accuracy_top5
 
 
-def get_accuracy_thresholds(model_args, optimizations):
+def get_accuracy_thresholds(model_args):
     """Parse accuracy thresholds from PERF.md for the given model, optimization mode, and device."""
     # Read PERF.md
     perf_file = "models/tt_transformers/PERF.md"
@@ -75,10 +75,8 @@ def get_accuracy_thresholds(model_args, optimizations):
 
     # Split into sections based on optimization mode
     sections = content.split("## ")
-    if callable(optimizations):
-        optimizations = optimizations(model_args)
-    first_decoder_conf = optimizations.decoder_optimizations[0]
-    target_section = next(s for s in sections if s.lower().startswith(f"{first_decoder_conf.__name__}\n"))
+    optimizations = model_args.optimizations
+    target_section = next(s for s in sections if s.lower().startswith(f"{optimizations.__name__}\n"))
 
     # Parse the table and find the row for our model and device
     # Potential lines have the form "| Llama-3.1-8b    | T3K    | 91        | 99        | 49.8          |"
@@ -1240,10 +1238,7 @@ def test_demo_text(
 
         if not json_config_file:
             # Get accuracy thresholds from PERF.md, unless the configuration is from a json
-            min_top1_acc, min_top5_acc = get_accuracy_thresholds(
-                model_args[0],
-                optimizations,
-            )
+            min_top1_acc, min_top5_acc = get_accuracy_thresholds(model_args[0])
             assert (
                 total_top1_acc >= min_top1_acc
             ), f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >={min_top1_acc}%)"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Current logic to get `optimizations.__name__` is too specific and breaks when a more specific __name__ was given to DecoderPrecision class instance. 

### What's changed
Use the higher level __name__ of `optimizations` as specified by the pytest test case parameter.

### Checklist
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/17863701452 --> failed test not related to this PR.