### PR TITLE
Add triage check that CBs are inactive

### DIFF
--- a/scripts/debugging_scripts/check_cb_inactive.py
+++ b/scripts/debugging_scripts/check_cb_inactive.py
@@ -41,7 +41,7 @@ def check_cb_inactive(location: OnChipCoordinate, noc_id: int):
         log_check(
             value == 0,
             f"Device {location._device._id} {location._device.get_block_type(location)} "
-            f"[{location.to_str('logical')}] at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X})",
+            f"[{location.to_str('logical')}] at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
         )
 
 

--- a/scripts/debugging_scripts/check_cb_inactive.py
+++ b/scripts/debugging_scripts/check_cb_inactive.py
@@ -26,7 +26,7 @@ script_config = ScriptConfig(
 def generate_cb_reg_name(cb_index: int) -> str:
     if not (0 <= cb_index <= 3):
         raise ValueError(f"CB index {cb_index} out of range [0, 3]")
-    
+
     return f"NOC_CMD_CTRL_CB{cb_index}"
 
 
@@ -48,8 +48,12 @@ def check_cb_inactive(location: OnChipCoordinate, noc_id: int):
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
-    run_checks.run_per_block_check(lambda location: check_cb_inactive(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK)
-    run_checks.run_per_block_check(lambda location: check_cb_inactive(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK)
+    run_checks.run_per_block_check(
+        lambda location: check_cb_inactive(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK
+    )
+    run_checks.run_per_block_check(
+        lambda location: check_cb_inactive(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/debugging_scripts/check_cb_inactive.py
+++ b/scripts/debugging_scripts/check_cb_inactive.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_cb_inactive
+
+Description:
+    Checks that no command buffers (CB0..CB3) are currently inactive by reading
+    NOC_CMD_CTRL_CB0..3 on both NoCs for tensix and eth blocks. If any is nonzero,
+    it prints an error with the device, location, NoC, and CB index.
+"""
+
+from ttexalens.coordinate import OnChipCoordinate
+from run_checks import run as get_run_checks
+from ttexalens.context import Context
+from triage import ScriptConfig, log_check, run_script
+
+script_config = ScriptConfig(
+    depends=["run_checks"],
+)
+
+
+def generate_cb_reg_name(cb_index: int) -> str:
+    if not (0 <= cb_index <= 3):
+        raise ValueError(f"CB index {cb_index} out of range [0, 3]")
+    
+    return f"NOC_CMD_CTRL_CB{cb_index}"
+
+
+def check_cb_inactive(location: OnChipCoordinate, noc_id: int):
+    noc_str = f"noc{noc_id}"
+    noc_block = location._device.get_block(location)
+    register_store = noc_block.get_register_store(noc_id)
+    # Read all CB command control registers and emit errors immediately
+    for cb_index in range(4):  # CB indices 0-3
+        reg_name = generate_cb_reg_name(cb_index)
+        value = register_store.read_register(reg_name)
+        log_check(
+            value == 0,
+            f"Device {location._device._id} {location._device.get_block_type(location)} "
+            f"[{location.to_str('logical')}] at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X})",
+        )
+
+
+def run(args, context: Context):
+    BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
+    run_checks = get_run_checks(args, context)
+    run_checks.run_per_block_check(lambda location: check_cb_inactive(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK)
+    run_checks.run_per_block_check(lambda location: check_cb_inactive(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK)
+
+
+if __name__ == "__main__":
+    run_script()

--- a/scripts/debugging_scripts/check_cb_inactive.py
+++ b/scripts/debugging_scripts/check_cb_inactive.py
@@ -8,7 +8,7 @@ Usage:
     check_cb_inactive
 
 Description:
-    Checks that no command buffers (CB0..CB3) are currently inactive by reading
+    Checks that no command buffers (CB0..CB3) are currently active by reading
     NOC_CMD_CTRL_CB0..3 on both NoCs for tensix and eth blocks. If any is nonzero,
     it prints an error with the device, location, NoC, and CB index.
 """
@@ -30,7 +30,7 @@ def generate_cb_reg_name(cb_index: int) -> str:
     return f"NOC_CMD_CTRL_CB{cb_index}"
 
 
-def check_cb_inactive(location: OnChipCoordinate, noc_id: int):
+def check_cb_idle(location: OnChipCoordinate, noc_id: int):
     noc_str = f"noc{noc_id}"
     noc_block = location._device.get_block(location)
     register_store = noc_block.get_register_store(noc_id)
@@ -49,10 +49,10 @@ def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
     run_checks.run_per_block_check(
-        lambda location: check_cb_inactive(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK
+        lambda location: check_cb_idle(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK
     )
     run_checks.run_per_block_check(
-        lambda location: check_cb_inactive(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK
+        lambda location: check_cb_idle(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK
     )
 
 


### PR DESCRIPTION
### Problem description
Sometimes the NOC can get hung, and it would be useful if triage could check for that.

### What's changed
Add a triage check that NOC_CMD_CTRL is 0 for all CBs for all NOCs on all tensix and ethernet cores. If it's nonzero for a long time, that's a sign that the NOC is unable to initiate a transaction and may be hung.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes