### PR TITLE
Enable stringop-overflow warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-restrict>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-sign-compare>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-strict-aliasing>"
-    "$<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overflow>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overread>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-unused-local-typedefs>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-volatile>"

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -738,7 +738,7 @@ GlobalNodeId MeshGraphDescriptor::populate_mesh_instance(
 }
 
 GlobalNodeId MeshGraphDescriptor::populate_device_instance(LocalNodeId local_id, std::vector<GlobalNodeId>& hierarchy) {
-    const std::string name = "D" + std::to_string(local_id);
+    const std::string name = std::string("D") + std::to_string(local_id);
     InstanceData data{
         .local_id = local_id,
         .name = name,

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -30,9 +30,10 @@ Alignment legacyShapeToAlignment(
         return Alignment{};
     }
 
-    const int padded_rank = legacy_padded_shape.rank();
+    const size_t padded_rank = legacy_padded_shape.rank();
+    const int padded_rank_i = static_cast<int>(padded_rank);
     bool alignment_can_be_2D = true;
-    for (int i = -3; i >= -padded_rank; i--) {
+    for (int i = -3; i >= -padded_rank_i; i--) {
         alignment_can_be_2D &= logical_shape[i] == legacy_padded_shape[i];
     }
 
@@ -55,7 +56,7 @@ Alignment legacyShapeToAlignment(
 
     // INTERLEAVED with only height/width padding
     if (alignment_can_be_2D) {
-        ttnn::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
+        ttnn::SmallVector<uint32_t> values(std::min<size_t>(padded_rank, static_cast<size_t>(2)));
         const auto alignment_size = values.size();
         if (alignment_size >= 1) {
             values[alignment_size - 1] = legacy_padded_shape[-1];
@@ -69,11 +70,11 @@ Alignment legacyShapeToAlignment(
 
     // INTERLEAVED with (deprecated) non-height/width padding
     // NOTE: Rank > 2 is guaranteed in this case
-    ttnn::SmallVector<uint32_t> values(padded_rank);
-    values[padded_rank - 1] = legacy_padded_shape[-1];
-    values[padded_rank - 2] = legacy_padded_shape[-2];
+    ttnn::SmallVector<uint32_t> values(static_cast<size_t>(padded_rank));
+    values[padded_rank_i - 1] = legacy_padded_shape[-1];
+    values[padded_rank_i - 2] = legacy_padded_shape[-2];
 
-    for (int i = padded_rank - 3; i >= 0; i--) {
+    for (int i = padded_rank_i - 3; i >= 0; i--) {
         values[i] = legacy_padded_shape[i] * values[i + 1];
     }
 

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -31,9 +31,9 @@ Alignment legacyShapeToAlignment(
     }
 
     const size_t padded_rank = legacy_padded_shape.rank();
-    const int padded_rank_i = static_cast<int>(padded_rank);
+    const int negative_padded_rank = -padded_rank;
     bool alignment_can_be_2D = true;
-    for (int i = -3; i >= -padded_rank_i; i--) {
+    for (int i = -3; i >= negative_padded_rank; i--) {
         alignment_can_be_2D &= logical_shape[i] == legacy_padded_shape[i];
     }
 
@@ -56,7 +56,7 @@ Alignment legacyShapeToAlignment(
 
     // INTERLEAVED with only height/width padding
     if (alignment_can_be_2D) {
-        ttnn::SmallVector<uint32_t> values(std::min<size_t>(padded_rank, static_cast<size_t>(2)));
+        ttnn::SmallVector<uint32_t> values(std::min<size_t>(padded_rank, 2));
         const auto alignment_size = values.size();
         if (alignment_size >= 1) {
             values[alignment_size - 1] = legacy_padded_shape[-1];
@@ -70,11 +70,11 @@ Alignment legacyShapeToAlignment(
 
     // INTERLEAVED with (deprecated) non-height/width padding
     // NOTE: Rank > 2 is guaranteed in this case
-    ttnn::SmallVector<uint32_t> values(static_cast<size_t>(padded_rank));
-    values[padded_rank_i - 1] = legacy_padded_shape[-1];
-    values[padded_rank_i - 2] = legacy_padded_shape[-2];
+    ttnn::SmallVector<uint32_t> values(padded_rank);
+    values[padded_rank - 1] = legacy_padded_shape[-1];
+    values[padded_rank - 2] = legacy_padded_shape[-2];
 
-    for (int i = padded_rank_i - 3; i >= 0; i--) {
+    for (int i = padded_rank - 3; i >= 0; i--) {
         values[i] = legacy_padded_shape[i] * values[i + 1];
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -922,7 +922,8 @@ std::map<std::string, std::string> get_block_defines(
 
 // update split eltwise ops include macros
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines) {
-    defines[get_macro_definition(op_type)] = "1";
+    auto key = get_macro_definition(op_type);
+    defines[key] = std::string("1");
 }
 
 std::string get_compute_kernel_path(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -922,8 +922,7 @@ std::map<std::string, std::string> get_block_defines(
 
 // update split eltwise ops include macros
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines) {
-    auto key = get_macro_definition(op_type);
-    defines[key] = std::string("1");
+    defines[get_macro_definition(op_type)] = std::string("1");
 }
 
 std::string get_compute_kernel_path(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -77,7 +77,11 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
 std::string cores_to_string(const std::vector<CoreCoord>& cores) {
     std::string result = "{";
     for (const auto& core : cores) {
-        result += "{" + std::to_string(core.x) + ", " + std::to_string(core.y) + "}, ";
+        result += "{";
+        result += std::to_string(core.x);
+        result += ", ";
+        result += std::to_string(core.y);
+        result += "}, ";
     }
     result += "}";
     return result;
@@ -198,9 +202,13 @@ std::string schedule_to_string(const std::vector<std::vector<ReadRequest>>& sche
     auto flattened_schedule = flatten_schedule(schedule);
     std::string result = "{";
     for (uint32_t i = 0; i < flattened_schedule.size(); ++i) {
-        result += "{" + std::to_string(flattened_schedule[i].bank_id) + ", " +
-                  std::to_string(flattened_schedule[i].read_offset) + ", " +
-                  std::to_string(flattened_schedule[i].read_size) + "}, ";
+        result += "{";
+        result += std::to_string(flattened_schedule[i].bank_id);
+        result += ", ";
+        result += std::to_string(flattened_schedule[i].read_offset);
+        result += ", ";
+        result += std::to_string(flattened_schedule[i].read_size);
+        result += "}, ";
     }
     result += "}";
     return result;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -77,7 +77,11 @@ std::string device_order_array_string(uint32_t ring_size, uint32_t ring_index, t
 std::string cores_to_string(const std::vector<CoreCoord>& cores) {
     std::string result = "{";
     for (const auto& core : cores) {
-        result += "{" + std::to_string(core.x) + ", " + std::to_string(core.y) + "}, ";
+        result += "{";
+        result += std::to_string(core.x);
+        result += ", ";
+        result += std::to_string(core.y);
+        result += "}, ";
     }
     result += "}";
     return result;
@@ -210,9 +214,13 @@ std::string schedule_to_string(const std::vector<std::vector<ReadRequest>>& sche
     auto flattened_schedule = flatten_schedule(schedule);
     std::string result = "{";
     for (uint32_t i = 0; i < flattened_schedule.size(); ++i) {
-        result += "{" + std::to_string(flattened_schedule[i].bank_id) + ", " +
-                  std::to_string(flattened_schedule[i].read_offset) + ", " +
-                  std::to_string(flattened_schedule[i].read_size) + "}, ";
+        result += "{";
+        result += std::to_string(flattened_schedule[i].bank_id);
+        result += ", ";
+        result += std::to_string(flattened_schedule[i].read_offset);
+        result += ", ";
+        result += std::to_string(flattened_schedule[i].read_size);
+        result += "}, ";
     }
     result += "}";
     return result;

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -551,7 +551,11 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
                 if (!cores_str.empty()) {
                     cores_str += ", ";
                 }
-                cores_str += "(" + std::to_string(core.x) + "," + std::to_string(core.y) + ")";
+                cores_str += "(";
+                cores_str += std::to_string(core.x);
+                cores_str += ",";
+                cores_str += std::to_string(core.y);
+                cores_str += ")";
             }
 
             CoreCoord reducer_core = {
@@ -608,8 +612,11 @@ tt::tt_metal::operation::ProgramWithCallbacks conv3d_factory(
             if (!worker_cores_str.empty()) {
                 worker_cores_str += ", ";
             }
-            worker_cores_str += "(" + std::to_string(worker_core_physical_xs[reduction_group_id][i]) + "," +
-                                std::to_string(worker_core_physical_ys[reduction_group_id][i]) + ")";
+            worker_cores_str += "(";
+            worker_cores_str += std::to_string(worker_core_physical_xs[reduction_group_id][i]);
+            worker_cores_str += ",";
+            worker_cores_str += std::to_string(worker_core_physical_ys[reduction_group_id][i]);
+            worker_cores_str += ")";
         }
         log_debug(
             tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -99,16 +99,16 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -93,17 +93,17 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -95,17 +95,17 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -95,17 +95,17 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -94,16 +94,16 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
     if (op == MorehSoftmaxOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -68,18 +68,18 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
+        reader_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     std::vector<uint32_t> reader_ct_args = {};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -72,18 +72,18 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
     std::map<std::string, std::string> writer_defines;
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
+        reader_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     std::vector<uint32_t> reader_ct_args = {};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -88,17 +88,17 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     // create compute kernel

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -72,18 +72,18 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
     std::map<std::string, std::string> writer_defines;
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
-        reader_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
+        reader_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
 
     std::vector<uint32_t> reader_ct_args = {};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -87,17 +87,17 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
 
     std::map<std::string, std::string> compute_defines;
     if (op == MorehSoftmaxBackwardOp::SOFTMAX) {
-        compute_defines["SOFTMAX"] = "1";
+        compute_defines["SOFTMAX"] = std::string("1");
     } else {
-        compute_defines["SOFTMIN"] = "1";
+        compute_defines["SOFTMIN"] = std::string("1");
     }
 
     if (op == MorehSoftmaxBackwardOp::LOGSOFTMAX) {
-        compute_defines["LOG"] = "1";
+        compute_defines["LOG"] = std::string("1");
     }
 
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
     // create compute kernel
     CreateComputeKernel(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -122,7 +122,7 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
 
     std::map<std::string, std::string> compute_defines;
     if (fp32_dest_acc_en) {
-        compute_defines["FP32_DEST_ACC_EN"] = "1";
+        compute_defines["FP32_DEST_ACC_EN"] = std::string("1");
     }
     const auto compute_kernel_file{
         "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp"};


### PR DESCRIPTION
### Ticket
#23444 

### Problem description
We have `stringop-overflow` warning disabled on gcc.

### What's changed
- Enable warning
- Adjust code to make compiler happy

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17867250616) CI passes
- [x] New/Existing tests provide coverage for changes