### PR TITLE
Added new stateful NOC APIs that enable 64-bit TARG/RET addresses. Up…

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -10,6 +10,8 @@
 #include <random>
 #include <tuple>
 #include <vector>
+#include <iomanip>
+#include <sstream>
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
@@ -31,6 +33,83 @@
 
 namespace tt::tt_metal::distributed::test {
 namespace {
+
+// Helper function to detect and print mismatch ranges with formatted output
+template <typename T>
+void print_mismatch_ranges(
+    const std::vector<T>& src_vec, const std::vector<T>& dst_vec, const std::string& context = "") {
+    if (src_vec.size() != dst_vec.size()) {
+        log_info(
+            tt::LogTest,
+            "{} Size mismatch: src_vec.size()={}, dst_vec.size()={}",
+            context,
+            src_vec.size(),
+            dst_vec.size());
+        return;
+    }
+
+    std::vector<std::pair<size_t, size_t>> mismatch_ranges;
+    bool in_mismatch = false;
+    size_t range_start = 0;
+
+    // Find all mismatch ranges
+    for (size_t i = 0; i < src_vec.size(); ++i) {
+        if (src_vec[i] != dst_vec[i]) {
+            if (!in_mismatch) {
+                range_start = i;
+                in_mismatch = true;
+            }
+        } else {
+            if (in_mismatch) {
+                mismatch_ranges.emplace_back(range_start, i - 1);
+                in_mismatch = false;
+            }
+        }
+    }
+    // Handle case where mismatch extends to end
+    if (in_mismatch) {
+        mismatch_ranges.emplace_back(range_start, src_vec.size() - 1);
+    }
+
+    if (mismatch_ranges.empty()) {
+        log_info(tt::LogTest, "{} Data matches perfectly!", context);
+        return;
+    }
+
+    log_info(tt::LogTest, "{} Found {} mismatch range(s):", context, mismatch_ranges.size());
+
+    for (const auto& [start, end] : mismatch_ranges) {
+        log_info(tt::LogTest, "  Mismatch range: [{}, {}] (length: {})", start, end, end - start + 1);
+
+        // Print first 128 mismatched values in this range
+        size_t print_count = std::min(size_t(128), end - start + 1);
+        log_info(tt::LogTest, "  First {} mismatched values:", print_count);
+
+        std::stringstream ss;
+        for (size_t i = 0; i < print_count; ++i) {
+            if (i % 8 == 0) {
+                if (i > 0) {
+                    log_info(tt::LogTest, "{}", ss.str());
+                    ss.str("");
+                    ss.clear();
+                }
+                ss << "    ";
+            }
+
+            // Format as 8-character wide hex values, aligned columns
+            ss << std::setw(8) << std::setfill('0') << std::hex << static_cast<uint64_t>(src_vec[start + i]) << ":"
+               << std::setw(8) << std::setfill('0') << std::hex << static_cast<uint64_t>(dst_vec[start + i]);
+
+            if ((i + 1) % 8 != 0 && i + 1 < print_count) {
+                ss << "  ";
+            }
+        }
+
+        if (!ss.str().empty()) {
+            log_info(tt::LogTest, "{}", ss.str());
+        }
+    }
+}
 
 using MeshBufferTest2x4 = MeshDevice2x4Fixture;
 using MeshBufferTestSuite = GenericMeshDeviceFixture;
@@ -107,7 +186,9 @@ TEST_P(InterleavedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
 
     // Create test data - use uint16_t for easy verification
     auto num_elements = tensor_size / ElementSize;
-    ASSERT_TRUE(num_elements <= max_num_elements_);
+    if (num_elements > max_num_elements_) {
+        TT_THROW("Buffer size {} elements exceeds test vector {} elements", num_elements, max_num_elements_);
+    }
     std::vector<ElementType> src_vec(src_vec_.begin(), src_vec_.begin() + num_elements);
 
     distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
@@ -130,6 +211,9 @@ TEST_P(InterleavedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
     mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
 
     for (auto& dst : dst_vec) {
+        std::string context =
+            "Device coord (" + std::to_string(dst.first[0]) + "," + std::to_string(dst.first[1]) + ")";
+        print_mismatch_ranges(src_vec, dst.second, context);
         EXPECT_EQ(dst.second, src_vec);
     }
 }
@@ -339,10 +423,10 @@ TEST_P(ShardedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
     auto mesh_buffer = MeshBuffer::create(buffer_config, per_device_buffer_config, mesh_device_.get());
     distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
 
-    std::vector<ElementType> src_vec(src_vec_.begin(), src_vec_.begin() + num_elements);
     if (num_elements > max_num_elements_) {
         TT_THROW("Buffer size {} elements exceeds test vector {} elements", num_elements, max_num_elements_);
     }
+    std::vector<ElementType> src_vec(src_vec_.begin(), src_vec_.begin() + num_elements);
     auto mesh_size = coord_range.shape().mesh_size();
     std::vector<MeshCommandQueue::ShardDataTransfer> input_shards = {};
     input_shards.reserve(mesh_size);
@@ -362,6 +446,9 @@ TEST_P(ShardedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
     mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
 
     for (auto& dst : dst_vec) {
+        std::string context =
+            "Device coord (" + std::to_string(dst.first[0]) + "," + std::to_string(dst.first[1]) + ")";
+        print_mismatch_ranges(src_vec, dst.second, context);
         EXPECT_EQ(dst.second, src_vec);
     }
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -150,9 +150,11 @@ TEST(DeviceCommandTest, AddDispatchWritePaged) {
     {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_paged<false>(1, 5);
-
+        // Do PCIE alignment for out-of-line data
+        calculator.add_alignment();
         HostMemDeviceCommand command(calculator.write_offset_bytes());
         command.add_dispatch_write_paged<false>(false, 0, 0, 0, 1, 5);
+        command.align_write_offset();
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -20,6 +20,7 @@
 
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/context/metal_context.hpp"
+#include <variant>
 
 using namespace tt::tt_metal;  // test only
 
@@ -612,21 +613,29 @@ inline void generate_random_payload(
     const CoreRange& workers,
     DeviceData& data,
     uint32_t length_words,
-    CQDispatchCmd cmd,
+    std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd,
     bool is_mcast = false,
     bool prepend_cmd = false) {
     static uint32_t coherent_count = 0;
 
+    auto num_uint32s = std::visit(
+        ttsl::overloaded{
+            [](const CQDispatchCmd& cmd1) { return sizeof(CQDispatchCmd) / sizeof(uint32_t); },
+            [](const CQDispatchCmdLarge& cmd1) { return sizeof(CQDispatchCmdLarge) / sizeof(uint32_t); }},
+        cmd);
+
     // Host data puts the command in the datastream...
     if (prepend_cmd) {
-        uint32_t datum = *(uint32_t*)&cmd;
-        data.push_range(workers, datum, is_mcast);
-        datum = *(((uint32_t*)&cmd) + 1);
-        data.push_range(workers, datum, is_mcast);
-        datum = *(((uint32_t*)&cmd) + 2);
-        data.push_range(workers, datum, is_mcast);
-        datum = *(((uint32_t*)&cmd) + 3);
-        data.push_range(workers, datum, is_mcast);
+        // just get a pointer
+        uint32_t* cmdp = std::visit(
+            ttsl::overloaded{
+                [](CQDispatchCmd& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); },
+                [](CQDispatchCmdLarge& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); }},
+            cmd);
+        TT_ASSERT(cmdp, "Obtaining pointer to the data in variant type failed");
+        for (int i = 0; i < num_uint32s; ++i) {
+            data.push_range(workers, cmdp[i], is_mcast);
+        }
     }
 
     // Note: the dst address marches in unison regardless of whether or not a core is written to
@@ -752,15 +761,27 @@ inline void generate_random_packed_large_payload(
     }
 }
 
-inline void add_bare_dispatcher_cmd(std::vector<uint32_t>& cmds, CQDispatchCmd cmd) {
+inline void add_bare_dispatcher_cmd(std::vector<uint32_t>& cmds, std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd) {
     static_assert(
         sizeof(CQDispatchCmd) % sizeof(uint32_t) == 0, "CQDispatchCmd size must be a multiple of uint32_t size");
-    const size_t num_uint32s = sizeof(CQDispatchCmd) / sizeof(uint32_t);
-    uint32_t buf[num_uint32s];
+    static_assert(
+        sizeof(CQDispatchCmdLarge) % sizeof(uint32_t) == 0,
+        "CQDispatchCmdLarge size must be a multiple of uint32_t size");
+    const size_t num_uint32s = std::visit(
+        ttsl::overloaded{
+            [](const CQDispatchCmd& cmd) { return sizeof(CQDispatchCmd) / sizeof(uint32_t); },
+            [](const CQDispatchCmdLarge& cmd) { return sizeof(CQDispatchCmdLarge) / sizeof(uint32_t); }},
+        cmd);
 
-    memcpy(buf, &cmd, sizeof(cmd));
+    // just get a pointer
+    uint32_t* cmdp = std::visit(
+        ttsl::overloaded{
+            [](CQDispatchCmd& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); },
+            [](CQDispatchCmdLarge& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); }},
+        cmd);
+    TT_ASSERT(cmdp, "Obtaining pointer to the data in variant type failed");
     for (size_t i = 0; i < num_uint32s; i++) {
-        cmds.push_back(buf[i]);
+        cmds.push_back(cmdp[i]);
     }
 }
 
@@ -799,7 +820,8 @@ inline void debug_epilogue(std::vector<uint32_t>& cmds, size_t prior_end) {
     }
 }
 
-inline void add_dispatcher_cmd(std::vector<uint32_t>& cmds, CQDispatchCmd cmd, uint32_t length) {
+inline void add_dispatcher_cmd(
+    std::vector<uint32_t>& cmds, std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd, uint32_t length) {
     size_t prior_end = debug_prologue(cmds);
 
     add_bare_dispatcher_cmd(cmds, cmd);
@@ -813,7 +835,7 @@ inline void add_dispatcher_cmd(
     std::vector<uint32_t>& cmds,
     const CoreRange& workers,
     DeviceData& device_data,
-    CQDispatchCmd cmd,
+    std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd,
     uint32_t length,
     bool is_mcast = false,
     bool prepend_cmd = false) {
@@ -866,8 +888,8 @@ inline void add_dispatcher_packed_cmd(
 // bare: doesn't generate random payload data, for use w/ eg, dram reads
 inline void gen_bare_dispatcher_unicast_write_cmd(
     IDevice* device, std::vector<uint32_t>& cmds, CoreCoord worker_core, DeviceData& device_data, uint32_t length) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
+    CQDispatchCmdLarge cmd{};
+    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
 
     CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
     const uint32_t bank_id = 0;  // No interleaved pages here.
@@ -887,8 +909,8 @@ inline void gen_bare_dispatcher_unicast_write_cmd(
 
 inline void gen_dispatcher_unicast_write_cmd(
     IDevice* device, std::vector<uint32_t>& cmds, CoreCoord worker_core, DeviceData& device_data, uint32_t length) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
+    CQDispatchCmdLarge cmd{};
+    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
 
     CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
     const uint32_t bank_id = 0;  // No interleaved pages here.
@@ -913,8 +935,8 @@ inline void gen_dispatcher_multicast_write_cmd(
     // TODO Hmm, ideally only need to relevel the core range
     device_data.relevel(CoreType::WORKER);
 
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
+    CQDispatchCmdLarge cmd{};
+    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
 
     CoreCoord physical_start = device->worker_core_from_logical_core(worker_core_range.start_coord);
     CoreCoord physical_end = device->worker_core_from_logical_core(worker_core_range.end_coord);

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -1460,6 +1460,26 @@ inline __attribute__((always_inline)) void noc_read_init_state(uint32_t noc) {
  * | wait (template parameter)     | Whether to wait for command buffer readiness             | enum CQNocWait   | CQ_NOC_WAIT or CQ_NOC_wait                               | False    |
  */
 // clang-format on
+template <uint8_t noc_mode, uint32_t cmd_buf, enum CQNocFlags flags, enum CQNocSend send, enum CQNocWait wait>
+inline __attribute__((always_inline)) void noc_common_read_with_state(uint32_t noc, uint32_t dst_addr, uint32_t size) {
+    if constexpr (send) {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+        } else if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_reads_num_issued[noc] += 1;
+        }
+    }
+    if constexpr (wait) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (flags & CQ_NOC_FLAG_DST) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_addr);
+    }
+    if constexpr (flags & CQ_NOC_FLAG_LEN) {
+        // TODO: Runtime assert for size < MAX_BURST_SIZE
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
+    }
+}
 template <
     uint8_t noc_mode = DM_DEDICATED_NOC,
     uint32_t cmd_buf,
@@ -1468,34 +1488,41 @@ template <
     enum CQNocWait wait = CQ_NOC_WAIT>
 inline __attribute__((always_inline)) void noc_read_with_state(
     uint32_t noc, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
-    }
-
-    if constexpr (wait) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-    }
+    noc_common_read_with_state<noc_mode, cmd_buf, flags, send, wait>(noc, dst_addr, size);
     if constexpr (flags & CQ_NOC_FLAG_SRC) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)src_addr);
-    }
-    if constexpr (flags & CQ_NOC_FLAG_DST) {
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(src_addr >> 32) & NOC_PCIE_MASK);
         NOC_CMD_BUF_WRITE_REG(
             noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(src_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     }
-    if constexpr (flags & CQ_NOC_FLAG_LEN) {
-        // TODO: Runtime assert for size < MAX_BURST_SIZE
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
-    }
     if constexpr (send) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
+}
 
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        noc_reads_num_issued[noc] += 1;
+// Same as above, but with src_noc_addr giving the source NOC address separately. This allows 64 bit addresses within
+// the NOC transactions.
+// clang-format on
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocSend send = CQ_NOC_SEND,
+    enum CQNocWait wait = CQ_NOC_WAIT>
+inline __attribute__((always_inline)) void noc_read_with_state(
+    uint32_t noc, uint32_t src_noc_addr, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
+    noc_common_read_with_state<noc_mode, cmd_buf, flags, send, wait>(noc, dst_addr, size);
+    if constexpr (flags & CQ_NOC_FLAG_SRC) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)src_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(src_addr >> 32));
+    }
+    if constexpr (flags & CQ_NOC_FLAG_NOC) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_addr);
+    }
+    if constexpr (send) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }
 
@@ -1560,6 +1587,42 @@ inline __attribute__((always_inline)) void noc_write_init_state(uint32_t noc, ui
  */
 // clang-format on
 template <
+    uint8_t noc_mode,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocWait wait,
+    bool update_counter,
+    bool posted>
+inline __attribute__((always_inline)) void noc_common_write_with_state(
+    uint32_t noc, uint32_t src_addr, uint32_t size, uint32_t ndests) {
+    if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
+        if constexpr (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, ndests);
+        }
+    }
+    if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
+        if constexpr (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += ndests;
+        }
+    }
+    if constexpr (wait) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
+    if constexpr (flags & CQ_NOC_FLAG_SRC) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
+    }
+    if constexpr (flags & CQ_NOC_FLAG_LEN) {
+        // TODO: Runtime assert for size < MAX_BURST_SIZE
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
+    }
+}
+template <
     uint8_t noc_mode = DM_DEDICATED_NOC,
     uint32_t cmd_buf,
     enum CQNocFlags flags,
@@ -1569,21 +1632,7 @@ template <
     bool posted = false>
 inline __attribute__((always_inline)) void noc_write_with_state(
     uint32_t noc, uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
-    if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
-        if constexpr (posted) {
-            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
-        } else {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, ndests);
-        }
-    }
-
-    if constexpr (wait) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-    }
-    if constexpr (flags & CQ_NOC_FLAG_SRC) {
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
-    }
+    noc_common_write_with_state<noc_mode, cmd_buf, flags, wait, update_counter, posted>(noc, src_addr, size, ndests);
     if constexpr (flags & CQ_NOC_FLAG_DST) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
     }
@@ -1593,20 +1642,35 @@ inline __attribute__((always_inline)) void noc_write_with_state(
         NOC_CMD_BUF_WRITE_REG(
             noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     }
-    if constexpr (flags & CQ_NOC_FLAG_LEN) {
-        // TODO: Runtime assert for size < MAX_BURST_SIZE
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
-    }
     if constexpr (send) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
-
-    if constexpr (update_counter && noc_mode == DM_DEDICATED_NOC) {
-        if constexpr (posted) {
-            noc_posted_writes_num_issued[noc] += 1;
-        } else {
-            noc_nonposted_writes_num_issued[noc] += 1;
-            noc_nonposted_writes_acked[noc] += ndests;
-        }
+}
+// clang-format off
+/**
+ * Similar to above except takes additional argument, \a  dst_noc_addr, to free up \a dst_addr to be 64 bits
+ *
+ */
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocSend send = CQ_NOC_SEND,
+    enum CQNocWait wait = CQ_NOC_WAIT,
+    bool update_counter = true,
+    bool posted = false>
+inline __attribute__((always_inline)) void noc_wwrite_with_state(
+    uint32_t noc, uint32_t src_addr, uint32_t dst_noc_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+    noc_common_write_with_state<noc_mode, cmd_buf, flags, wait, update_counter, posted>(noc, src_addr, size, ndests);
+    if constexpr (flags & CQ_NOC_FLAG_DST) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_addr >> 32));
+    }
+    if constexpr (flags & CQ_NOC_FLAG_NOC) {
+        // Handles writing to PCIe
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, dst_noc_addr);
+    }
+    if constexpr (send) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <limits>
 #include "noc_parameters.h"
 #include "dev_msgs.h"
 #include "noc_overlay_parameters.h"
@@ -1257,18 +1258,16 @@ inline __attribute__((always_inline)) void noc_read_init_state(uint32_t noc) {
  * | wait (template parameter)     | Whether to wait for command buffer readiness             | enum CQNocWait   | CQ_NOC_WAIT or CQ_NOC_wait                               | False    |
  */
 // clang-format on
-template <
-    uint8_t noc_mode = DM_DEDICATED_NOC,
-    uint32_t cmd_buf,
-    enum CQNocFlags flags,
-    enum CQNocSend send = CQ_NOC_SEND,
-    enum CQNocWait wait = CQ_NOC_WAIT>
-inline __attribute__((always_inline)) void noc_read_with_state(
-    uint32_t noc, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
-    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+template <uint8_t noc_mode, uint32_t cmd_buf, enum CQNocFlags flags, enum CQNocSend send, enum CQNocWait wait>
+inline __attribute__((always_inline)) void noc_common_read_with_state(
+    uint32_t noc, uint32_t src_addr, uint32_t dst_addr, uint32_t size) {
+    if constexpr (send) {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+        } else if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_reads_num_issued[noc] += 1;
+        }
     }
-
     if constexpr (wait) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
     }
@@ -1278,20 +1277,46 @@ inline __attribute__((always_inline)) void noc_read_with_state(
     if constexpr (flags & CQ_NOC_FLAG_DST) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_addr);
     }
-    if constexpr (flags & CQ_NOC_FLAG_NOC) {
-        NOC_CMD_BUF_WRITE_REG(
-            noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(src_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    }
     if constexpr (flags & CQ_NOC_FLAG_LEN) {
         // TODO: Runtime assert for size < MAX_BURST_SIZE
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     }
+}
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocSend send = CQ_NOC_SEND,
+    enum CQNocWait wait = CQ_NOC_WAIT>
+inline __attribute__((always_inline)) void noc_read_with_state(
+    uint32_t noc, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
+    noc_common_read_with_state<noc_mode, cmd_buf, flags, send, wait>(noc, (uint32_t)src_addr, dst_addr, size);
+    if constexpr (flags & CQ_NOC_FLAG_NOC) {
+        NOC_CMD_BUF_WRITE_REG(
+            noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(src_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    }
     if constexpr (send) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
+}
 
-    if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        noc_reads_num_issued[noc] += 1;
+// Same as above, but with src_noc_addr giving the source NOC address separately. This allows 64 bit addresses within
+// the NOC transactions.
+// clang-format on
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocSend send = CQ_NOC_SEND,
+    enum CQNocWait wait = CQ_NOC_WAIT>
+inline __attribute__((always_inline)) void noc_read_with_state(
+    uint32_t noc, uint32_t src_noc_addr, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
+    noc_common_read_with_state<noc_mode, cmd_buf, flags, send, wait>(noc, (uint32_t)src_addr, dst_addr, size);
+    if constexpr (flags & CQ_NOC_FLAG_NOC) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_addr);
+    }
+    if constexpr (send) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }
 
@@ -1343,7 +1368,8 @@ inline __attribute__((always_inline)) void noc_write_init_state(uint32_t noc, ui
  * |-------------------------------------|----------------------------------------------------------|-----------------|----------------------------------------------------------|----------|
  * | noc                                 | Which NOC to use for the transaction                     | uint32_t        | 0 or 1                                                   | True     |
  * | src_addr                            | Source address in local L1 memory                        | uint32_t        | 0..1 MB                                                  | True     |
- * | dst_addr                            | Destination NOC address (x,y)+local address              | uint64_t        | Results of \a get_noc_addr calls                         | True     |
+ * | dst_noc_addr                        | Destination NOC address (x,y)                            | uint32_t        |                                                          | True     |
+ * | dst_addr                            | Local address in destination NOC tile                    | uint64_t        | 0..4 GB                                                  | True     |
  * | size                                | Size of transaction in bytes                             | uint32_t        | 0..NOC_MAX_BURST_SIZE for single packet                  | False    |
  * | ndests                              | Number of destinations for multicast operations          | uint32_t        | 1 or more                                                | False    |
  * | noc_mode (template parameter)       | NOC mode for the transaction                             | uint8_t         | DM_DEDICATED_NOC, DM_DYNAMIC_NOC or DM_INVALID_NOC (0-2) | False    |
@@ -1363,8 +1389,8 @@ template <
     enum CQNocWait wait = CQ_NOC_WAIT,
     bool update_counter = true,
     bool posted = false>
-inline __attribute__((always_inline)) void noc_write_with_state(
-    uint32_t noc, uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+inline __attribute__((always_inline)) void noc_wwrite_with_state(
+    uint32_t noc, uint32_t src_addr, uint32_t dst_noc_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
     if constexpr (update_counter && noc_mode == DM_DYNAMIC_NOC) {
         if constexpr (posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
@@ -1384,8 +1410,7 @@ inline __attribute__((always_inline)) void noc_write_with_state(
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
-        NOC_CMD_BUF_WRITE_REG(
-            noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, dst_noc_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_LEN) {
         // TODO: Runtime assert for size < MAX_BURST_SIZE
@@ -1403,6 +1428,28 @@ inline __attribute__((always_inline)) void noc_write_with_state(
             noc_nonposted_writes_acked[noc] += ndests;
         }
     }
+}
+// clang-format off
+/**
+ * Wrapper around the above. \a dst_addr is a composite of NOC-xy coordinate and address within  NOC tile, result of \a get_noc_addr calls
+ */
+// clang-format on
+template <
+    uint8_t noc_mode = DM_DEDICATED_NOC,
+    uint32_t cmd_buf,
+    enum CQNocFlags flags,
+    enum CQNocSend send = CQ_NOC_SEND,
+    enum CQNocWait wait = CQ_NOC_WAIT,
+    bool update_counter = true,
+    bool posted = false>
+inline __attribute__((always_inline)) void noc_write_with_state(
+    uint32_t noc, uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+    uint32_t dst_noc_addr = 0;
+    if constexpr (flags & CQ_NOC_FLAG_NOC) {
+        dst_noc_addr = (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK;
+    }
+    noc_wwrite_with_state<noc_mode, cmd_buf, flags, send, wait, update_counter, posted>(
+        noc, src_addr, dst_noc_addr, dst_addr, size, ndests);
 }
 
 // clang-format off

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -259,10 +259,11 @@ public:
         Buffer* buffer,
         uint32_t total_pages_to_write,
         uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids) :
         buffer_page_mapping(buffer->get_buffer_page_mapping()),
         buffer(buffer),
-        are_pages_large(are_pages_larger_than_max_prefetch_cmd_size(*buffer)) {
+        are_pages_large(are_pages_larger_than_max_prefetch_cmd_size(*buffer, sub_device_ids.size())) {
         this->cq_id = cq_id;
         this->device = buffer->device();
         this->expected_num_workers_completed = expected_num_workers_completed;
@@ -379,9 +380,9 @@ int32_t calculate_num_pages_available_in_cq(
     return num_pages_available;
 }
 
-bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer) {
+bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t num_subdevices) {
     const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    const uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type);
+    const uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type, num_subdevices);
     return buffer.aligned_page_size() > max_data_size;
 }
 
@@ -427,13 +428,14 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
     const Buffer& buffer,
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
-    const BufferRegion& region) {
+    const BufferRegion& region,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     InterleavedBufferWriteDispatchParamsVariant dispatch_params;
 
     uint32_t total_pages_to_write = region.size / buffer.page_size();
     const uint32_t dst_page_index = region.offset / buffer.page_size();
 
-    if (are_pages_larger_than_max_prefetch_cmd_size(buffer)) {
+    if (are_pages_larger_than_max_prefetch_cmd_size(buffer, sub_device_ids.size())) {
         const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
         const uint32_t num_full_pages = total_pages_to_write;
         total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
@@ -510,6 +512,7 @@ void populate_interleaved_buffer_write_dispatch_cmds(
                 data_size_bytes);
         }
     }
+    command_sequence.align_write_offset();
 }
 
 void populate_sharded_buffer_write_dispatch_cmds(
@@ -531,12 +534,11 @@ void populate_sharded_buffer_write_dispatch_cmds(
     ptrdiff_t dst_offset = reinterpret_cast<ptrdiff_t>(dst - (uint8_t*)command_sequence.data());
     TT_ASSERT(dst_offset >= 0, "Offset into command sequence is negative");
     if (dispatch_params.write_large_pages()) {
+        const auto cur_host_page = *dispatch_params.core_page_mapping_it;
+        if (!cur_host_page) {
+            return;
+        }
         for (uint32_t i = 0; i < dispatch_params.pages_per_txn; ++i) {
-            const auto cur_host_page = *dispatch_params.core_page_mapping_it;
-            if (!cur_host_page) {
-                dst_offset += dispatch_params.page_size_to_write;
-                continue;
-            }
             const uint64_t src_offset =
                 (*cur_host_page * (uint64_t)buffer.page_size()) +
                 (dispatch_params.num_partial_pages_written_for_current_transaction_full_page() + i) *
@@ -551,7 +553,7 @@ void populate_sharded_buffer_write_dispatch_cmds(
         while (true) {
             auto range = dispatch_params.core_page_mapping_it.next_range(end_device_page_offset);
             if (range.num_pages == 0) {
-                break;
+                return;
             }
             uint64_t src_offset = (uint64_t)(range.host_page_start) * dispatch_params.page_size_to_write;
             auto cmd_region_offset =
@@ -588,7 +590,12 @@ void issue_buffer_dispatch_command_sequence(
     uint32_t num_worker_counters = sub_device_ids.size();
     uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
     tt::tt_metal::DeviceCommandCalculator calculator;
-    calculator.add_dispatch_write_linear<true, true>(data_size_bytes);
+    if constexpr (std::is_same_v<T, ShardedBufferWriteDispatchParams>) {
+        calculator.add_dispatch_write_linear<true, false>(data_size_bytes);
+    } else {
+        calculator.add_dispatch_write_paged<false>(dispatch_params.page_size_to_write, dispatch_params.pages_per_txn);
+    }
+    calculator.add_data<false>(data_size_bytes);
     if (dispatch_params.issue_wait) {
         for (int i = 0; i < num_worker_counters; ++i) {
             calculator.add_dispatch_wait();
@@ -633,11 +640,9 @@ void write_interleaved_buffer_to_device(
     uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(
         HalMemType::HOST);  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
                             // + CQ_DISPATCH_CMD_WRITE_PAGED
+    dispatch_params.calculate_issue_wait();
+    update_offset_on_issue_wait_cmd(byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
     while (dispatch_params.total_pages_to_write > 0) {
-        dispatch_params.calculate_issue_wait();
-
-        update_offset_on_issue_wait_cmd(byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
-
         if (dispatch_params.is_page_offset_out_of_bounds()) {
             dispatch_params.update_params_to_be_within_bounds();
         }
@@ -678,15 +683,12 @@ void write_sharded_buffer_to_core(
     }
 
     dispatch_params.reset_params_for_core(core, core_page_mapping);
+    // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
+    uint32_t data_offset_bytes = (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd));
+    dispatch_params.calculate_issue_wait();
+    update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
     while (dispatch_params.core_num_pages_remaining_to_write != 0) {
-        // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
-        uint32_t data_offset_bytes = (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd));
-
-        dispatch_params.calculate_issue_wait();
-
-        update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
-
         const int32_t num_pages_available_in_cq =
             calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, data_offset_bytes);
         if (num_pages_available_in_cq <= 0) {
@@ -725,7 +727,7 @@ void write_to_device_buffer(
 
     if (is_sharded(buffer.buffer_layout())) {
         ShardedBufferWriteDispatchParams dispatch_params(
-            &buffer, buffer.size() / buffer.page_size(), cq_id, expected_num_workers_completed);
+            &buffer, buffer.size() / buffer.page_size(), cq_id, expected_num_workers_completed, sub_device_ids);
         const std::vector<CoreCoord>& cores = dispatch_params.buffer_page_mapping->all_cores;
         // Since we read core by core we are reading the device pages sequentially
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
@@ -747,7 +749,8 @@ void write_to_device_buffer(
         auto root_buffer = buffer.root_buffer();
         auto region = buffer.root_buffer_region();
         InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant =
-            initialize_interleaved_buf_dispatch_params(*root_buffer, cq_id, expected_num_workers_completed, region);
+            initialize_interleaved_buf_dispatch_params(
+                *root_buffer, cq_id, expected_num_workers_completed, region, sub_device_ids);
 
         InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
             ttsl::overloaded{

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -150,7 +150,7 @@ std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_sharded_buffer
 std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_interleaved_buffer_read_descriptor(
     void* dst, const BufferReadDispatchParams& dispatch_params, Buffer& buffer);
 
-bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer);
+bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t num_subdevices);
 
 PartialPageSpec calculate_partial_page_spec(const Buffer& buffer);
 }  // namespace buffer_dispatch

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -12,10 +12,14 @@
 namespace tt {
 namespace tt_metal {
 
-uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& dispatch_core_type) {
-    return tt::tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() -
-           (tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST) *
-            2);  // * 2 to account for issue
+uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& dispatch_core_type, uint32_t num_subdevices) {
+    // CQ capacity would be reduced by the commands and alignment padding.
+    // prefetch_relay_inline, dispatch_wait (x #workers), and dispatch_write_linear would add alignment padding
+    const auto host_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    auto padded_commands_size = tt::align(sizeof(CQPrefetchCmd), host_alignment) +
+                                num_subdevices * tt::align(sizeof(CQDispatchCmd), host_alignment) +
+                                tt::align(sizeof(CQDispatchCmdLarge), host_alignment);
+    return tt::tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() - padded_commands_size;
 }
 
 namespace device_dispatch {
@@ -108,7 +112,7 @@ void write_to_core(
         const CoreType dispatch_core_type =
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
         const uint32_t size_bytes_to_write =
-            std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type));
+            std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
 
         CoreWriteDispatchParams dispatch_params{
             {virtual_core,

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -19,7 +19,7 @@ struct ReadCoreDataDescriptor {
     uint32_t size_bytes = 0;
 };
 
-uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& dispatch_core_type);
+uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& dispatch_core_type, uint32_t num_subdevices);
 
 namespace device_dispatch {
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -141,15 +141,17 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
         cq_file << fmt::format("{:#010x}: {}", cmd_addr, cmd_id);
         switch (cmd_id) {
             case CQ_DISPATCH_CMD_WRITE_LINEAR:
-            case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
+            case CQ_DISPATCH_CMD_WRITE_LINEAR_H: {
+                CQDispatchCmdLarge* cmd_large = reinterpret_cast<CQDispatchCmdLarge*>(cmd);
+                stride = sizeof(CQDispatchCmdLarge);
                 cq_file << fmt::format(
                     " (num_mcast_dests={}, noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
-                    val(cmd->write_linear.num_mcast_dests),
-                    val(cmd->write_linear.noc_xy_addr),
-                    val(cmd->write_linear.addr),
-                    val(cmd->write_linear.length));
-                stride += cmd->write_linear.length;
-                break;
+                    val(cmd_large->write_linear.num_mcast_dests),
+                    val(cmd_large->write_linear.noc_xy_addr),
+                    val(cmd_large->write_linear.addr),
+                    val(cmd_large->write_linear.length));
+                stride += cmd_large->write_linear.length;
+            } break;
             case CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST:
                 if (cmd->write_linear_host.is_event) {
                     uint32_t* event_ptr = (uint32_t*)(cmd + 1);
@@ -230,14 +232,15 @@ uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream&
     if (cmd_id < CQ_PREFETCH_CMD_MAX_COUNT) {
         iq_file << fmt::format("{:#010x}: {}", cmd_addr, cmd_id);
         switch (cmd_id) {
-            case CQ_PREFETCH_CMD_RELAY_LINEAR:
+            case CQ_PREFETCH_CMD_RELAY_LINEAR: {
+                CQPrefetchCmdLarge* cmd_large = (CQPrefetchCmdLarge*)cmd;
                 iq_file << fmt::format(
-                    " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x}, length_hi={:#010x})",
-                    val(cmd->relay_linear.noc_xy_addr),
-                    val(cmd->relay_linear.addr),
-                    val(cmd->relay_linear.length),
-                    val(cmd->relay_linear.length_hi));
+                    " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
+                    val(cmd_large->relay_linear.noc_xy_addr),
+                    val(cmd_large->relay_linear.addr),
+                    val(cmd_large->relay_linear.length));
                 break;
+            }
             case CQ_PREFETCH_CMD_RELAY_PAGED:
                 iq_file << fmt::format(
                     " (start_page={:#02x}, is_dram_and_length_adjust={:#x}, base_addr={:#010x}, page_size={:#010x}, "

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -157,20 +157,19 @@ void DeviceCommand<hugepage_write>::add_dispatch_wait_with_prefetch_stall(
 
 template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_prefetch_relay_linear(uint32_t noc_xy_addr, DeviceAddr lengthB, uint32_t addr) {
-    uint32_t increment_sizeB = tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
-    auto initialize_relay_linear_cmd = [&](CQPrefetchCmd* relay_linear_cmd) {
+    uint32_t increment_sizeB = tt::align(sizeof(CQPrefetchCmdLarge), this->pcie_alignment);
+    auto initialize_relay_linear_cmd = [&](CQPrefetchCmdLarge* relay_linear_cmd) {
         relay_linear_cmd->base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR;
         relay_linear_cmd->relay_linear.noc_xy_addr = noc_xy_addr;
         relay_linear_cmd->relay_linear.length = lengthB;
-        relay_linear_cmd->relay_linear.length_hi = (lengthB >> 32) & 0xff;
         relay_linear_cmd->relay_linear.addr = addr;
     };
-    CQPrefetchCmd* relay_linear_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    CQPrefetchCmdLarge* relay_linear_cmd_dst = this->reserve_space<CQPrefetchCmdLarge*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
-        alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_linear_cmd{};
+        alignas(MEMCPY_ALIGNMENT) CQPrefetchCmdLarge relay_linear_cmd{};
         initialize_relay_linear_cmd(&relay_linear_cmd);
-        this->memcpy(relay_linear_cmd_dst, &relay_linear_cmd, sizeof(CQPrefetchCmd));
+        this->memcpy(relay_linear_cmd_dst, &relay_linear_cmd, sizeof(CQPrefetchCmdLarge));
     } else {
         initialize_relay_linear_cmd(relay_linear_cmd_dst);
     }
@@ -305,14 +304,16 @@ template <bool flush_prefetch, bool inline_data>
 void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
     uint8_t num_mcast_dests,
     uint32_t noc_xy_addr,
-    uint32_t addr,
-    uint32_t data_sizeB,
+    DeviceAddr addr,
+    DeviceAddr data_sizeB,
     const void* data,
     uint32_t write_offset_index) {
-    uint32_t payload_sizeB = sizeof(CQDispatchCmd) + (flush_prefetch ? data_sizeB : 0);
+    // payload to prefetch relay inline will always be limited to the length of the cmddat queue, i.e. < 64 bits
+    // Conversely if data_sizeB > 32-bits, then the data won't be inline
+    uint32_t payload_sizeB = static_cast<uint32_t>(sizeof(CQDispatchCmdLarge) + (flush_prefetch ? data_sizeB : 0));
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
-    auto initialize_write_cmd = [&](CQDispatchCmd* write_cmd) {
+    auto initialize_write_cmd = [&](CQDispatchCmdLarge* write_cmd) {
         write_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
         write_cmd->write_linear.num_mcast_dests = num_mcast_dests;
         write_cmd->write_linear.write_offset_index = write_offset_index;
@@ -320,12 +321,12 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
         write_cmd->write_linear.addr = addr;
         write_cmd->write_linear.length = data_sizeB;
     };
-    CQDispatchCmd* write_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    CQDispatchCmdLarge* write_cmd_dst = this->reserve_space<CQDispatchCmdLarge*>(sizeof(CQDispatchCmdLarge));
 
     if constexpr (hugepage_write) {
-        alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_cmd{};
+        alignas(MEMCPY_ALIGNMENT) CQDispatchCmdLarge write_cmd{};
         initialize_write_cmd(&write_cmd);
-        this->memcpy(write_cmd_dst, &write_cmd, sizeof(CQDispatchCmd));
+        this->memcpy(write_cmd_dst, &write_cmd, sizeof(CQDispatchCmdLarge));
     } else {
         initialize_write_cmd(write_cmd_dst);
     }
@@ -333,19 +334,19 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
     // Case 1: flush_prefetch
     //  a) there is inline_data: data is provided here and follows prefetch relay inline and cq dispatch write
     //  linear so total increment size is:
-    //          tt::align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + data_sizeB, pcie_alignment)
+    //          tt::align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmdLarge) + data_sizeB, pcie_alignment)
     //  b) don't have inline_data: next command should be to add_data (don't do aligned increment) so total
     //  increment size is:
-    //          sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)
+    //          sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmdLarge)
     // Case 2: !flush_prefetch: no data, increment size is:
-    //          tt::align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment)
+    //          tt::align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmdLarge), pcie_alignment)
     // Note that adding prefetch_relay_inline and writing the dispatch command already increment cmd_write_offsetB
     // via calls to reserve_space
     if constexpr (flush_prefetch) {
         if constexpr (inline_data) {
             TT_ASSERT(data != nullptr);  // compiled out?
             this->add_data(data, data_sizeB, data_sizeB);
-            // this->cmd_write_offsetB has been incremented by sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) +
+            // this->cmd_write_offsetB has been incremented by sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmdLarge) +
             // data_sizeB need to ensure this is aligned for next cmds to be written at the correct location
             this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
         }
@@ -451,8 +452,10 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged(
 
     if (inline_data) {
         TT_ASSERT(data != nullptr);  // compiled out?
-        uint32_t increment_sizeB = tt::align(data_sizeB, this->pcie_alignment);
-        this->add_data(data, data_sizeB, increment_sizeB);
+        this->add_data(data, data_sizeB, data_sizeB);
+        // Increment wr offset to aligned address only if data is inline. Out-of-line data will
+        // follow right after the command, so defer alignment to after it.
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 }
 
@@ -671,6 +674,11 @@ void DeviceCommand<hugepage_write>::add_data(
     this->validate_cmd_write(cmd_write_offset_incrementB);
     this->memcpy((uint8_t*)this->cmd_region + this->cmd_write_offsetB, data, data_size_to_copyB);
     this->cmd_write_offsetB += cmd_write_offset_incrementB;
+}
+
+template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::align_write_offset() {
+    this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
 }
 
 template <bool hugepage_write>
@@ -1023,13 +1031,13 @@ template void DeviceCommand<true>::add_dispatch_write_paged<true>(bool, uint8_t,
 template void DeviceCommand<false>::add_dispatch_write_paged<false>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
 template void DeviceCommand<false>::add_dispatch_write_paged<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
 
-template void DeviceCommand<true>::add_dispatch_write_linear<true, false>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<true>::add_dispatch_write_linear<true, true>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<true>::add_dispatch_write_linear<false, false>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<true>::add_dispatch_write_linear<false, true>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_linear<true, false>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_linear<true, true>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_linear<false, false>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_linear<false, true>(uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_linear<true, false>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_linear<true, true>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_linear<false, false>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_linear<false, true>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_linear<true, false>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_linear<true, true>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_linear<false, false>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_linear<false, true>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
 // clang-format on
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -84,8 +84,8 @@ public:
     void add_dispatch_write_linear(
         uint8_t num_mcast_dests,
         uint32_t noc_xy_addr,
-        uint32_t addr,
-        uint32_t data_sizeB,
+        DeviceAddr addr,
+        DeviceAddr data_sizeB,
         const void* data = nullptr,
         uint32_t write_offset_index = 0);
 
@@ -133,6 +133,8 @@ public:
 
     void add_data(const void* data, uint32_t data_size_to_copyB, uint32_t cmd_write_offset_incrementB)
         __attribute((nonnull(2)));
+
+    void align_write_offset();
 
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -30,7 +30,7 @@ public:
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
     void add_prefetch_relay_linear() {
-        this->cmd_write_offsetB += sizeof(CQPrefetchCmd);
+        this->cmd_write_offsetB += sizeof(CQPrefetchCmdLarge);
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
@@ -39,12 +39,20 @@ public:
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
-    void add_data(uint32_t cmd_write_offset_incrementB) { this->cmd_write_offsetB += cmd_write_offset_incrementB; }
+    template <bool pcie_aligned = true>
+    void add_data(uint32_t cmd_write_offset_incrementB) {
+        this->cmd_write_offsetB += cmd_write_offset_incrementB;
+        if constexpr (not pcie_aligned) {
+            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+        }
+    }
+
+    void add_alignment() { this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment); }
 
     template <bool flush_prefetch = true, bool inline_data = false>
     void add_dispatch_write_linear(uint32_t data_sizeB) {
         this->add_prefetch_relay_inline();
-        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB += sizeof(CQDispatchCmdLarge);
 
         if constexpr (flush_prefetch) {
             if constexpr (inline_data) {
@@ -109,11 +117,12 @@ public:
 
     template <bool inline_data = false>
     void add_dispatch_write_paged(uint32_t page_size, uint32_t pages) {
-        uint32_t data_sizeB = page_size * pages;
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd);
         if constexpr (inline_data) {
-            this->add_data(tt::align(data_sizeB, this->pcie_alignment));
+            uint32_t data_sizeB = page_size * pages;
+            this->add_data(data_sizeB);
+            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
         }
     }
 
@@ -232,6 +241,9 @@ public:
 
     // Clear calculator state
     void clear() { this->cmd_write_offsetB = 0; }
+
+    // Update state
+    void update_write_offset_bytes(uint32_t update_valueB) { this->cmd_write_offsetB += update_valueB; }
 
 private:
     void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -477,8 +477,8 @@ void process_write_host_d(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
 }
 
 void relay_write_h(uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
-    volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
-    uint32_t length = sizeof(CQDispatchCmd) + cmd->write_linear.length;
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
+    uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
     uint32_t data_ptr = cmd_ptr;
 
     relay_to_next_cb<split_dispatch_page_preamble_size>(
@@ -494,7 +494,7 @@ void process_exec_buf_end_d(uint32_t& block_noc_writes_to_clear, uint32_t block_
 // This means each noc_write frees up a page
 void process_write_linear(
     uint32_t num_mcast_dests, uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
-    volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
     bool multicast = num_mcast_dests > 0;
     if (not multicast) {
         num_mcast_dests = 1;
@@ -502,13 +502,13 @@ void process_write_linear(
 
     uint32_t dst_noc = cmd->write_linear.noc_xy_addr;
     uint32_t write_offset_index = cmd->write_linear.write_offset_index;
-    uint32_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
-    uint32_t length = cmd->write_linear.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
+    uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
+    uint64_t length = cmd->write_linear.length;
+    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
     if (multicast) {
-        cq_noc_async_write_init_state<CQ_NOC_sNdl, true>(0, get_noc_addr_helper(dst_noc, dst_addr));
+        cq_noc_async_wwrite_init_state<CQ_NOC_sNDl, true>(0, dst_noc, dst_addr);
     } else {
-        cq_noc_async_write_init_state<CQ_NOC_sNdl, false>(0, get_noc_addr_helper(dst_noc, dst_addr));
+        cq_noc_async_wwrite_init_state<CQ_NOC_sNDl, false>(0, dst_noc, dst_addr);
     }
 
     while (length != 0) {
@@ -563,7 +563,7 @@ void process_write_linear(
 }
 
 void process_write(uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
-    volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
+    volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
     uint32_t num_mcast_dests = cmd->write_linear.num_mcast_dests;
     process_write_linear(num_mcast_dests, block_noc_writes_to_clear, block_next_start_addr);
 }


### PR DESCRIPTION
…date CQ prefetcher process_relay_linear and dispatcher process_write_linear commands to use the new APIs in anticipation of forthcoming usage in PCIE access to pinned Host memory regions that would require 64-bit addressing

### Ticket
Link to Github Issue

### Problem description
Blackhole opens up the possibility for device addressing 64-bit address space on host, via [NOC_TARG/RET_ADDR_LO/MID registers](https://github.com/tenstorrent/tt-isa-documentation/blob/main/BlackholeA0/NoC/MemoryMap.md#niu-request-initiators). A forthcoming PR will enable the device to address pinned user buffers directly via Host IOMMU, foregoing intermediate copy (hugepage), for reads/writes to buffers. This PR is an intermediate commit to that goal. Wormhole also needs > 32-bit addressing to directly access pinned host buffers via the PCIE tile.

### What's changed
Updated and added new NOC APIs
Updated the dispatch commands that we anticipate using for direct access to pinned user buffer on Host to enable their 64-bit addressing. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes