### PR TITLE
#26591: Migrate `AddProgramToMeshWorkload()` to `MeshWorkloadImpl::add_program`

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -399,7 +399,7 @@ Following setting the arguments, the program is added to a `MeshWorkload` and is
 
 ```c++
 MeshWorkload workload;
-AddProgramToMeshWorkload(workload, std::move(program), MeshCoordinateRange(device->shape()));
+workload.add_program(MeshCoordinateRange(device->shape()), std::move(program));
 EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 std::vector<bfloat16> c_data(n_tiles * elements_per_tile, 0.0f);
 EnqueueReadMeshBuffer(cq, c, c_data, /*blocking=*/true);

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
@@ -250,7 +250,7 @@ For mesh execution, we add the program to a mesh workload and enqueue it for exe
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b_data, /*blocking=*/false);
 
     // Add program to mesh workload and execute
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
     distributed::Finish(cq);
 

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -265,7 +265,7 @@ Finally, we add the program to the mesh workload and enqueue it for execution, t
 
     // tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
     // Add the program to the workload for the mesh
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -220,7 +220,7 @@ Running the program
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
     distributed::Finish(cq);
     // Equivalently, we could have done:

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -268,7 +268,7 @@ Then the host program sets the kernel arguments and launches the program. There 
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
@@ -238,7 +238,7 @@ Finally we can run the program. The program is enqueued to the mesh command queu
 
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -448,7 +448,7 @@ See :ref:`Kernel execution and result verification in the single core matrix mul
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
 
     // Add program to mesh workload and execute
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     // Download results from DRAM buffer to host

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -362,7 +362,7 @@ The overall execution flow is managed by enqueuing commands:
     // execute program, and read results
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::EnqueueReadMeshBuffer(cq, output.data(), dst_dram_buffer, true);
 

--- a/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
+++ b/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
@@ -165,7 +165,7 @@ SetRuntimeArgs(program, core1_writer_kernel_id, core1, {dst_dram_buffer->address
 We enqueue the program, finish execution, and verify the output:
 
 ```cpp
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -326,7 +326,7 @@ Once the reader kernel is finished padding the tensor and storing the new data i
 ``` cpp
 distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec.data(), false);
 distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec.data(), false);
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::EnqueueReadMeshBuffer(cq, dst_buffer, dst_vec.data(), false);
 distributed::Finish(cq);

--- a/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
+++ b/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
@@ -168,7 +168,7 @@ KernelHandle compute_kernel_id = CreateKernel(
 After executing the program, we validate the results using Pearson Correlation Coefficient:
 
 ```cpp
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -183,7 +183,7 @@ Once the data is written to the circular buffer, `cb_push_back` is called to mak
 
 ``` cpp
 distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec.data(), false);
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 mesh_device->close();

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -490,8 +490,7 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     uint32_t workload_1_src1_val = 5;
 
     // Uniform values passed to the add operation
-    Ce std::vector<uint32_t> add_src0_vec =
-        create_constant_vector_of_bfloat16(add_src0_buf->size(), workload_0_src0_val);
+    std::vector<uint32_t> add_src0_vec = create_constant_vector_of_bfloat16(add_src0_buf->size(), workload_0_src0_val);
     std::vector<uint32_t> add_src1_vec = create_constant_vector_of_bfloat16(add_src1_buf->size(), workload_0_src1_val);
 
     // Uniform values passed to the multiply and subtract operations (the top row runs multiplication with subtraction

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -153,7 +153,7 @@ TEST_F(MeshEndToEnd2x4Tests, ProgramDispatchTest) {
 
     auto target_devices = MeshCoordinateRange(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(example_program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(example_program));
 
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
@@ -234,7 +234,7 @@ TEST_F(MeshEndToEnd2x4Tests, UntracedEltwiseAddTest) {
     auto mesh_workload = MeshWorkload();
     auto device_range = MeshCoordinateRange(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*program), device_range);
+    mesh_workload.add_program(device_range, std::move(*program));
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
@@ -292,7 +292,7 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseAddTest) {
     auto mesh_workload = MeshWorkload();
     auto device_range = MeshCoordinateRange(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*program), device_range);
+    mesh_workload.add_program(device_range, std::move(*program));
 
     auto& cq = mesh_device_->mesh_command_queue();
 
@@ -356,7 +356,7 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseMulTest) {
     auto mesh_workload = MeshWorkload();
     auto device_range = MeshCoordinateRange(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*program), device_range);
+    mesh_workload.add_program(device_range, std::move(*program));
 
     auto& cq = mesh_device_->mesh_command_queue();
 
@@ -469,16 +469,12 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
 
     auto add_mesh_workload = MeshWorkload();
     auto multiply_and_subtract_mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(
-        add_mesh_workload, std::move(*add_program), all_devices);  // Addition runs on the full grid (sub_device 1)
-    AddProgramToMeshWorkload(
-        multiply_and_subtract_mesh_workload,
-        std::move(*multiply_program),
-        top_row);  // Multiplication runs on the top row (sub_device 2)
-    AddProgramToMeshWorkload(
-        multiply_and_subtract_mesh_workload,
-        std::move(*subtract_program),
-        bottom_row);  // Subtraction runs on the bottom row (sub device 2)
+    add_mesh_workload.add_program(
+        all_devices, std::move(*add_program));  // Addition runs on the full grid (sub_device 1)
+    multiply_and_subtract_mesh_workload.add_program(
+        top_row, std::move(*multiply_program));  // Multiplication runs on the top row (sub_device 2)
+    multiply_and_subtract_mesh_workload.add_program(
+        bottom_row, std::move(*subtract_program));  // Subtraction runs on the bottom row (sub device 2)
 
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), add_mesh_workload, true);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), multiply_and_subtract_mesh_workload, true);
@@ -494,7 +490,8 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     uint32_t workload_1_src1_val = 5;
 
     // Uniform values passed to the add operation
-    std::vector<uint32_t> add_src0_vec = create_constant_vector_of_bfloat16(add_src0_buf->size(), workload_0_src0_val);
+    Ce std::vector<uint32_t> add_src0_vec =
+        create_constant_vector_of_bfloat16(add_src0_buf->size(), workload_0_src0_val);
     std::vector<uint32_t> add_src1_vec = create_constant_vector_of_bfloat16(add_src1_buf->size(), workload_0_src1_val);
 
     // Uniform values passed to the multiply and subtract operations (the top row runs multiplication with subtraction

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -142,8 +142,8 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
             mesh_device_->num_cols() - 1,
         });
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_0);
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_1);
+    mesh_workload.add_program(devices_0, std::move(*programs[0]));
+    mesh_workload.add_program(devices_1, std::move(*programs[1]));
 
     for (int iter = 0; iter < num_iters; iter++) {
         std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), iter + 2);

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -260,7 +260,7 @@ void test_single_connection_single_device_socket(
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(md0->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(send_recv_program), devices);
+    mesh_workload.add_program(devices, std::move(send_recv_program));
     EnqueueMeshWorkload(md0->mesh_command_queue(), mesh_workload, false);
     std::vector<uint32_t> recv_data_readback;
     ReadShard(md0->mesh_command_queue(), recv_data_readback, recv_data_buffer, MeshCoordinate(0, 0));
@@ -551,7 +551,7 @@ void test_single_device_socket_with_workers(
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(md0->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(send_recv_program), devices);
+    mesh_workload.add_program(devices, std::move(send_recv_program));
 
     EnqueueMeshWorkload(md0->mesh_command_queue(), mesh_workload, false);
 
@@ -748,11 +748,11 @@ void test_single_connection_multi_device_socket(
 
     auto sender_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(md0->shape());
-    AddProgramToMeshWorkload(sender_mesh_workload, std::move(sender_program), devices);
+    sender_mesh_workload.add_program(devices, std::move(sender_program));
 
     auto recv_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_recv(md1->shape());
-    AddProgramToMeshWorkload(recv_mesh_workload, std::move(recv_program), devices_recv);
+    recv_mesh_workload.add_program(devices_recv, std::move(recv_program));
 
     EnqueueMeshWorkload(md0->mesh_command_queue(), sender_mesh_workload, false);
     EnqueueMeshWorkload(md1->mesh_command_queue(), recv_mesh_workload, false);
@@ -926,11 +926,11 @@ void test_single_connection_multi_device_socket_with_workers(
 
     auto sender_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(md0->shape());
-    AddProgramToMeshWorkload(sender_mesh_workload, std::move(sender_program), devices);
+    sender_mesh_workload.add_program(devices, std::move(sender_program));
 
     auto recv_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_recv(md1->shape());
-    AddProgramToMeshWorkload(recv_mesh_workload, std::move(recv_program), devices_recv);
+    recv_mesh_workload.add_program(devices_recv, std::move(recv_program));
 
     EnqueueMeshWorkload(md0->mesh_command_queue(), sender_mesh_workload, false);
     EnqueueMeshWorkload(md1->mesh_command_queue(), recv_mesh_workload, false);
@@ -1450,24 +1450,24 @@ void test_multi_sender_single_recv(
 
     auto sender_0_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_0(sender_0->shape());
-    AddProgramToMeshWorkload(sender_0_mesh_workload, std::move(*sender_program_0), devices_0);
+    sender_0_mesh_workload.add_program(devices_0, std::move(*sender_program_0));
 
     auto sender_1_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_1(sender_1->shape());
-    AddProgramToMeshWorkload(sender_1_mesh_workload, std::move(*sender_program_1), devices_1);
+    sender_1_mesh_workload.add_program(devices_1, std::move(*sender_program_1));
 
     auto reduce_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_reduce(reducer->shape());
-    AddProgramToMeshWorkload(reduce_mesh_workload, std::move(*reduce_program), devices_reduce);
+    reduce_mesh_workload.add_program(devices_reduce, std::move(*reduce_program));
     MeshWorkload sender_2_mesh_workload;
     if (split_reducer) {
         sender_2_mesh_workload = MeshWorkload();
-        AddProgramToMeshWorkload(sender_2_mesh_workload, std::move(*sender_program_2), devices_reduce);
+        sender_2_mesh_workload.add_program(devices_reduce, std::move(*sender_program_2));
     }
 
     auto recv_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_recv(receiver->shape());
-    AddProgramToMeshWorkload(recv_mesh_workload, std::move(*recv_program), devices_recv);
+    recv_mesh_workload.add_program(devices_recv, std::move(*recv_program));
 
     for (std::size_t i = 0; i < num_interations; ++i) {
         std::vector<uint32_t> src_vec =
@@ -1585,10 +1585,10 @@ void test_multi_connection_multi_device_data_copy(
             recv_physical_id,
             0);
 
-        AddProgramToMeshWorkload(
-            sender_mesh_workload, std::move(*sender_program), MeshCoordinateRange(connection.sender_core.device_coord));
-        AddProgramToMeshWorkload(
-            recv_mesh_workload, std::move(*recv_program), MeshCoordinateRange(connection.receiver_core.device_coord));
+        sender_mesh_workload.add_program(
+            MeshCoordinateRange(connection.sender_core.device_coord), std::move(*sender_program));
+        recv_mesh_workload.add_program(
+            MeshCoordinateRange(connection.receiver_core.device_coord), std::move(*recv_program));
     }
     EnqueueMeshWorkload(sender_mesh->mesh_command_queue(), sender_mesh_workload, false);
     EnqueueMeshWorkload(recv_mesh->mesh_command_queue(), recv_mesh_workload, false);

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -59,9 +59,9 @@ TEST_F(MeshSubDeviceTestSuite, SyncWorkloadsOnSubDevice) {
     auto waiter_mesh_workload = MeshWorkload();
     auto syncer_mesh_workload = MeshWorkload();
     auto incrementer_mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), devices);
-    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), devices);
-    AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), devices);
+    waiter_mesh_workload.add_program(devices, std::move(waiter_program));
+    syncer_mesh_workload.add_program(devices, std::move(syncer_program));
+    incrementer_mesh_workload.add_program(devices, std::move(incrementer_program));
     for (uint32_t i = 0; i < num_iters; i++) {
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_mesh_workload, false);
         mesh_device_->set_sub_device_stall_group({{SubDeviceId{0}}});
@@ -131,8 +131,8 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
     auto datacopy_mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(sync_and_incr_program), devices);
-    AddProgramToMeshWorkload(datacopy_mesh_workload, std::move(datacopy_program), devices);
+    syncer_mesh_workload.add_program(devices, std::move(sync_and_incr_program));
+    datacopy_mesh_workload.add_program(devices, std::move(datacopy_program));
 
     for (int i = 0; i < 50; i++) {
         mesh_device_->set_sub_device_stall_group({{SubDeviceId{2}}});
@@ -187,16 +187,16 @@ TEST_F(MeshSubDeviceTestSuite, SubDeviceSwitching) {
     auto waiter_mesh_workload = MeshWorkload();
     auto syncer_mesh_workload = MeshWorkload();
     auto incrementer_mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), devices);
-    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), devices);
-    AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), devices);
+    waiter_mesh_workload.add_program(devices, std::move(waiter_program));
+    syncer_mesh_workload.add_program(devices, std::move(syncer_program));
+    incrementer_mesh_workload.add_program(devices, std::move(incrementer_program));
 
     auto waiter_mesh_workload_1 = MeshWorkload();
     auto syncer_mesh_workload_1 = MeshWorkload();
     auto incrementer_mesh_workload_1 = MeshWorkload();
-    AddProgramToMeshWorkload(waiter_mesh_workload_1, std::move(waiter_program_1), devices);
-    AddProgramToMeshWorkload(syncer_mesh_workload_1, std::move(syncer_program_1), devices);
-    AddProgramToMeshWorkload(incrementer_mesh_workload_1, std::move(incrementer_program_1), devices);
+    waiter_mesh_workload_1.add_program(devices, std::move(waiter_program_1));
+    syncer_mesh_workload_1.add_program(devices, std::move(syncer_program_1));
+    incrementer_mesh_workload_1.add_program(devices, std::move(incrementer_program_1));
 
     // Load SubDevice configs, run corresponding workloads, reset ... repeat
     for (uint32_t i = 0; i < num_iters; i++) {
@@ -237,9 +237,9 @@ TEST_F(MeshSubDeviceTestSuite, SubDeviceBasicProgramsReuse) {
     auto waiter_mesh_workload = MeshWorkload();
     auto syncer_mesh_workload = MeshWorkload();
     auto incrementer_mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), devices);
-    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), devices);
-    AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), devices);
+    waiter_mesh_workload.add_program(devices, std::move(waiter_program));
+    syncer_mesh_workload.add_program(devices, std::move(syncer_program));
+    incrementer_mesh_workload.add_program(devices, std::move(incrementer_program));
 
     // Run programs on sub-device manager 1
     for (uint32_t i = 0; i < k_num_iters; i++) {

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -117,7 +117,7 @@ TEST_F(MeshTraceTestSuite, Sanity) {
             auto workload = std::make_shared<MeshWorkload>();
             auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
                 1, mesh_device_->compute_with_storage_grid_size(), seed);
-            AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
+            workload->add_program(all_devices, std::move(*programs[0]));
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
             mesh_workloads.push_back(workload);
         }
@@ -169,23 +169,23 @@ TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
     auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, src0_bufs, src1_bufs, intermed_bufs_0);
     auto mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), row_0);
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), row_1);
+    mesh_workload.add_program(row_0, std::move(*programs[0]));
+    mesh_workload.add_program(row_1, std::move(*programs[1]));
     // Create second workload: running addition on top row (src1 + intermed0) and multiplication on
     // bottom row (src1 * intermed0)
     auto programs_1 = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, intermed_bufs_0, src1_bufs, intermed_bufs_1);
     auto mesh_workload_1 = MeshWorkload();
-    AddProgramToMeshWorkload(mesh_workload_1, std::move(*programs_1[1]), row_0);
-    AddProgramToMeshWorkload(mesh_workload_1, std::move(*programs_1[0]), row_1);
+    mesh_workload_1.add_program(row_0, std::move(*programs_1[1]));
+    mesh_workload_1.add_program(row_1, std::move(*programs_1[0]));
     // Create third workload: running addition on 1st col (src1 + intermed1), multiplication on
     // second col (src1 * intermed1) and subtraction on the third col( src1 - intermed1)
     auto programs_2 = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, intermed_bufs_1, src1_bufs, output_bufs);
     auto mesh_workload_2 = MeshWorkload();
-    AddProgramToMeshWorkload(mesh_workload_2, std::move(*programs_2[0]), col_0);
-    AddProgramToMeshWorkload(mesh_workload_2, std::move(*programs_2[1]), col_1);
-    AddProgramToMeshWorkload(mesh_workload_2, std::move(*programs_2[2]), col_2);
+    mesh_workload_2.add_program(col_0, std::move(*programs_2[0]));
+    mesh_workload_2.add_program(col_1, std::move(*programs_2[1]));
+    mesh_workload_2.add_program(col_2, std::move(*programs_2[2]));
 
     // Initialize inputs
     std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), 2);
@@ -280,17 +280,17 @@ TEST_F(MeshTraceTestSuite, SyncWorkloadsOnSubDeviceTrace) {
     auto syncer_2 = MeshWorkload();
     auto incrementer_2 = MeshWorkload();
 
-    AddProgramToMeshWorkload(waiter_0, std::move(waiter_program_0), left_col);
-    AddProgramToMeshWorkload(syncer_0, std::move(syncer_program_0), left_col);
-    AddProgramToMeshWorkload(incrementer_0, std::move(incrementer_program_0), left_col);
+    waiter_0.add_program(left_col, std::move(waiter_program_0));
+    syncer_0.add_program(left_col, std::move(syncer_program_0));
+    incrementer_0.add_program(left_col, std::move(incrementer_program_0));
 
-    AddProgramToMeshWorkload(waiter_1, std::move(waiter_program_1), right_col);
-    AddProgramToMeshWorkload(syncer_1, std::move(syncer_program_1), right_col);
-    AddProgramToMeshWorkload(incrementer_1, std::move(incrementer_program_1), right_col);
+    waiter_1.add_program(right_col, std::move(waiter_program_1));
+    syncer_1.add_program(right_col, std::move(syncer_program_1));
+    incrementer_1.add_program(right_col, std::move(incrementer_program_1));
 
-    AddProgramToMeshWorkload(waiter_2, std::move(waiter_program_2), all_devices);
-    AddProgramToMeshWorkload(syncer_2, std::move(syncer_program_2), all_devices);
-    AddProgramToMeshWorkload(incrementer_2, std::move(incrementer_program_2), all_devices);
+    waiter_2.add_program(all_devices, std::move(waiter_program_2));
+    syncer_2.add_program(all_devices, std::move(syncer_program_2));
+    incrementer_2.add_program(all_devices, std::move(incrementer_program_2));
 
     // Compile all MeshWorkloads
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_0, false);
@@ -445,13 +445,13 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     auto datacopy_mesh_workload = MeshWorkload();
     auto add_mesh_workload = MeshWorkload();
     // Sync program goes to entire Mesh
-    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(sync_and_incr_program), devices);
+    syncer_mesh_workload.add_program(devices, std::move(sync_and_incr_program));
     // Datacopy goes to top row
-    AddProgramToMeshWorkload(datacopy_mesh_workload, std::move(datacopy_program), left_col);
+    datacopy_mesh_workload.add_program(left_col, std::move(datacopy_program));
     // First addition goes to bottom row
-    AddProgramToMeshWorkload(datacopy_mesh_workload, std::move(add_program), right_col);
+    datacopy_mesh_workload.add_program(right_col, std::move(add_program));
     // Second addition goes to bottom row
-    AddProgramToMeshWorkload(add_mesh_workload, std::move(add_program_2), right_col);
+    add_mesh_workload.add_program(right_col, std::move(add_program_2));
 
     // Compile and load workloads
     mesh_device_->set_sub_device_stall_group({{SubDeviceId{2}}});
@@ -513,7 +513,7 @@ TEST_F(MeshTraceTestSuite, MeshTraceAsserts) {
     auto workload = std::make_shared<MeshWorkload>();
     auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
         1, mesh_device_->compute_with_storage_grid_size(), seed);
-    AddProgramToMeshWorkload(*workload, std::move(*programs[0]), all_devices);
+    workload->add_program(all_devices, std::move(*programs[0]));
     auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
     EXPECT_THROW(EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, true), std::runtime_error);
     EXPECT_THROW(Finish(mesh_device_->mesh_command_queue()), std::runtime_error);
@@ -539,7 +539,7 @@ void run_heterogenous_trace_sweep(
             for (auto& program_grid : workload_grid) {
                 auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
                     1, mesh_device->compute_with_storage_grid_size(), seed);
-                AddProgramToMeshWorkload(*workload, std::move(*programs[0]), program_grid);
+                workload->add_program(program_grid, std::move(*programs[0]));
             }
             EnqueueMeshWorkload(mesh_device->mesh_command_queue(), *workload, false);
             mesh_workloads.push_back(workload);

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -196,8 +196,7 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
                 IDevice* device = mesh_device_->get_device(device_coord);
                 auto programs = utils::create_random_programs(
                     1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
-                AddProgramToMeshWorkload(
-                    *workload, std::move(*programs[0]), MeshCoordinateRange(device_coord, device_coord));
+                workload->add_program(MeshCoordinateRange(device_coord, device_coord), std::move(*programs[0]));
             }
         }
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
@@ -224,9 +223,9 @@ TEST_F(MeshWorkloadTestSuite, OverlappingProgramRanges) {
     MeshCoordinate zero_coord = MeshCoordinate::zero_coordinate(mesh_device_->shape().dims());
     MeshCoordinateRange devices_range = MeshCoordinateRange(zero_coord, zero_coord);
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_range);
+    mesh_workload.add_program(devices_range, std::move(*programs[0]));
     EXPECT_THAT(
-        ([&]() { AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_range); }),
+        ([&]() { mesh_workload.add_program(devices_range, std::move(*programs[1])); }),
         ThrowsMessage<std::runtime_error>(HasSubstr("overlaps with the previously added range")));
 }
 
@@ -251,13 +250,13 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
         if (i % 2) {
             MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{0, 3});
             MeshCoordinateRange devices_1(MeshCoordinate{1, 0}, MeshCoordinate{1, 3});
-            AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-            AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
+            random_workload->add_program(devices_0, std::move(*programs[i]));
+            random_workload->add_program(devices_1, std::move(*programs[i + 1]));
         } else {
             MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{1, 1});
             MeshCoordinateRange devices_1(MeshCoordinate{0, 2}, MeshCoordinate{1, 3});
-            AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-            AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
+            random_workload->add_program(devices_0, std::move(*programs[i]));
+            random_workload->add_program(devices_1, std::move(*programs[i + 1]));
         }
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
@@ -270,10 +269,10 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
         MeshCoordinateRange devices_1(MeshCoordinate{0, 1}, MeshCoordinate{1, 1});
         MeshCoordinateRange devices_2(MeshCoordinate{0, 2}, MeshCoordinate{1, 2});
         MeshCoordinateRange devices_3(MeshCoordinate{0, 3}, MeshCoordinate{1, 3});
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 2]), devices_2);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 3]), devices_3);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
+        random_workload->add_program(devices_2, std::move(*programs[i + 2]));
+        random_workload->add_program(devices_3, std::move(*programs[i + 3]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -290,14 +289,14 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
         MeshCoordinateRange devices_6(MeshCoordinate{1, 2}, MeshCoordinate{1, 2});
         MeshCoordinateRange devices_7(MeshCoordinate{1, 3}, MeshCoordinate{1, 3});
 
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 2]), devices_2);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 3]), devices_3);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 4]), devices_4);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 5]), devices_5);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 6]), devices_6);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 7]), devices_7);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
+        random_workload->add_program(devices_2, std::move(*programs[i + 2]));
+        random_workload->add_program(devices_3, std::move(*programs[i + 3]));
+        random_workload->add_program(devices_4, std::move(*programs[i + 4]));
+        random_workload->add_program(devices_5, std::move(*programs[i + 5]));
+        random_workload->add_program(devices_6, std::move(*programs[i + 6]));
+        random_workload->add_program(devices_7, std::move(*programs[i + 7]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -335,8 +334,8 @@ TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
         MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{1, 7});
         MeshCoordinateRange devices_1(MeshCoordinate{2, 0}, MeshCoordinate{3, 7});
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -348,8 +347,8 @@ TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
         MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{3, 3});
         MeshCoordinateRange devices_1(MeshCoordinate{0, 4}, MeshCoordinate{3, 7});
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -364,10 +363,10 @@ TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
         MeshCoordinateRange devices_2(MeshCoordinate{2, 0}, MeshCoordinate{2, 7});
         MeshCoordinateRange devices_3(MeshCoordinate{3, 0}, MeshCoordinate{3, 7});
 
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 2]), devices_2);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 3]), devices_3);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
+        random_workload->add_program(devices_2, std::move(*programs[i + 2]));
+        random_workload->add_program(devices_3, std::move(*programs[i + 3]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -385,14 +384,14 @@ TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
         MeshCoordinateRange devices_6(MeshCoordinate{0, 6}, MeshCoordinate{3, 6});
         MeshCoordinateRange devices_7(MeshCoordinate{0, 7}, MeshCoordinate{3, 7});
 
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), devices_0);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 1]), devices_1);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 2]), devices_2);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 3]), devices_3);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 4]), devices_4);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 5]), devices_5);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 6]), devices_6);
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i + 7]), devices_7);
+        random_workload->add_program(devices_0, std::move(*programs[i]));
+        random_workload->add_program(devices_1, std::move(*programs[i + 1]));
+        random_workload->add_program(devices_2, std::move(*programs[i + 2]));
+        random_workload->add_program(devices_3, std::move(*programs[i + 3]));
+        random_workload->add_program(devices_4, std::move(*programs[i + 4]));
+        random_workload->add_program(devices_5, std::move(*programs[i + 5]));
+        random_workload->add_program(devices_6, std::move(*programs[i + 6]));
+        random_workload->add_program(devices_7, std::move(*programs[i + 7]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -429,7 +428,7 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
         // Choose a grid of random dimensions and run a MeshWorkload on it
         MeshCoordinateRange device_range(MeshCoordinate{0, 0}, MeshCoordinate{gen_row(rng) - 1, gen_col(rng) - 1});
         auto random_workload = std::make_shared<MeshWorkload>();
-        AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), device_range);
+        random_workload->add_program(device_range, std::move(*programs[i]));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
         mesh_workloads.push_back(random_workload);
     }
@@ -464,8 +463,8 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
     MeshCoordinateRange devices_1(
         MeshCoordinate{0, num_cols_in_workload},
         MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_0);
-    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_1);
+    mesh_workload.add_program(devices_0, std::move(*programs[0]));
+    mesh_workload.add_program(devices_1, std::move(*programs[1]));
     std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), 2);
     std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(src1_bufs[0]->size(), 3);
 
@@ -575,8 +574,8 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
     MeshCoordinateRange devices_1(
         MeshCoordinate{0, mesh_device_->num_cols() - 1},
         MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
-    AddProgramToMeshWorkload(mesh_workload, std::move(program), devices_0);
-    AddProgramToMeshWorkload(mesh_workload, std::move(*program_1), devices_1);
+    mesh_workload.add_program(devices_0, std::move(program));
+    mesh_workload.add_program(devices_1, std::move(*program_1));
 
     std::vector<uint32_t> src_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 1);
 
@@ -637,7 +636,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadCBUpdate) {
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(mesh_device_->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(*program), devices);
+    mesh_workload.add_program(devices, std::move(*program));
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());
     verify_cb_config(mesh_device_, mesh_workload, cb_config_vector, cr_set);
@@ -666,7 +665,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreSanity) {
     }
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices(mesh_device_->shape());
-    AddProgramToMeshWorkload(mesh_workload, std::move(program), devices);
+    mesh_workload.add_program(devices, std::move(program));
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());
 
@@ -699,8 +698,8 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
     MeshCoordinateRange devices_1(
         {0, num_cols_in_workload}, {mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(program0), devices_0);
-    AddProgramToMeshWorkload(mesh_workload, std::move(program1), devices_1);
+    mesh_workload.add_program(devices_0, std::move(program0));
+    mesh_workload.add_program(devices_1, std::move(program1));
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());
 
@@ -748,7 +747,7 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkloadMultiThread) {
                 MeshCoordinateRange device_range(
                     MeshCoordinate{0, 0}, MeshCoordinate{gen_row(rng) - 1, gen_col(rng) - 1});
                 auto random_workload = std::make_shared<MeshWorkload>();
-                AddProgramToMeshWorkload(*random_workload, std::move(*programs[i]), device_range);
+                random_workload->add_program(device_range, std::move(*programs[i]));
                 EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
                 mesh_workloads.push_back(random_workload);
             }

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -165,10 +165,8 @@ bool test_socket_send_recv(
                     sender_fabric_node_id, recv_fabric_node_id, 0, sender_program, {sender_core}, sender_rtas);
 
                 tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_core, sender_rtas);
-                AddProgramToMeshWorkload(
-                    sender_mesh_workload,
-                    std::move(sender_program),
-                    MeshCoordinateRange(connection.sender_core.device_coord));
+                sender_mesh_workload.add_program(
+                    MeshCoordinateRange(connection.sender_core.device_coord), std::move(sender_program));
             }
             // Run workload performing Data Movement over the socket
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), sender_mesh_workload, false);
@@ -216,10 +214,8 @@ bool test_socket_send_recv(
                 tt_fabric::append_fabric_connection_rt_args(
                     recv_fabric_node_id, sender_fabric_node_id, 0, recv_program, {recv_core}, recv_rtas);
                 tt_metal::SetRuntimeArgs(recv_program, recv_kernel, recv_core, recv_rtas);
-                AddProgramToMeshWorkload(
-                    recv_mesh_workload,
-                    std::move(recv_program),
-                    MeshCoordinateRange(connection.receiver_core.device_coord));
+                recv_mesh_workload.add_program(
+                    MeshCoordinateRange(connection.receiver_core.device_coord), std::move(recv_program));
             }
             // Run receiver workload using the created socket
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), recv_mesh_workload, false);

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -117,11 +117,10 @@ public:
             // Create a mesh workload from the program
             auto& program_copy = program;
             auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
-            tt::tt_metal::distributed::AddProgramToMeshWorkload(
-                mesh_workload,
-                std::move(program_copy),
+            mesh_workload.add_program(
                 tt::tt_metal::distributed::MeshCoordinateRange(
-                    tt::tt_metal::distributed::MeshCoordinate(0, 0), tt::tt_metal::distributed::MeshCoordinate(0, 0)));
+                    tt::tt_metal::distributed::MeshCoordinate(0, 0), tt::tt_metal::distributed::MeshCoordinate(0, 0)),
+                std::move(program_copy));
             tt::tt_metal::distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
         }
     }

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -156,8 +156,7 @@ static void build_and_enqueue(
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
-                tt::tt_metal::distributed::AddProgramToMeshWorkload(
-                    mesh_workload, std::move(*programs[i]), device_range);
+                mesh_workload.add_program(device_range, std::move(*programs[i]));
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             } else {
                 if (!enqueue_only) {
@@ -165,8 +164,7 @@ static void build_and_enqueue(
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
-                tt::tt_metal::distributed::AddProgramToMeshWorkload(
-                    mesh_workload, std::move(programs[i]), device_range);
+                mesh_workload.add_program(device_range, std::move(programs[i]));
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             }
         }));

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -471,14 +471,10 @@ void run_test(
 
     tt_metal::distributed::MeshWorkload local_workload;
     tt_metal::distributed::MeshWorkload remote_workload;
-    tt_metal::distributed::AddProgramToMeshWorkload(
-        local_workload,
-        std::move(test_resources.local_device.program),
-        tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}));
-    tt_metal::distributed::AddProgramToMeshWorkload(
-        remote_workload,
-        std::move(test_resources.remote_device.program),
-        tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}));
+    local_workload.add_program(
+        tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}), std::move(test_resources.local_device.program));
+    remote_workload.add_program(
+        tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}), std::move(test_resources.remote_device.program));
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         std::thread th2 = std::thread([&] {

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -83,7 +83,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         CBConfig cb_config;
@@ -115,7 +115,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
 
@@ -167,7 +167,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
 
@@ -217,7 +217,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
 
@@ -257,7 +257,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidUpdateCircularBufferSize) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
         CoreCoord core0(0, 0);
@@ -299,7 +299,7 @@ TEST_F(MeshDeviceFixture, TensixTestInvalidUpdateCircularBufferSize) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
         CoreCoord core0(0, 0);
@@ -336,7 +336,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
         CoreCoord core0(0, 0);
@@ -382,7 +382,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CBConfig cb_config;
         CoreCoord core0(0, 0);
@@ -486,7 +486,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CoreCoord core(0, 0);
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -89,7 +89,7 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferAtValidIndices) {
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program;
     initialize_program(program, cr_set);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t l1_unreserved_base = devices_.at(0)->allocator()->get_base_allocator_addr(HalMemType::L1);

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -88,7 +88,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferNonBlockingAPIs) {
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         const auto master_semaphore = CreateSemaphore(program_, worker_core, 0, CoreType::WORKER);

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
@@ -128,7 +128,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingBlockingToWriter) {
     auto result_buffer = create_result_buffer(mesh_device);
     SetRuntimeArgs(program, reader_kernel, WORKER_CORE, {result_buffer->address()});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -177,7 +177,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingBlockingToCompute) {
 
     SetRuntimeArgs(program, reader_kernel, WORKER_CORE, {result_buffer->address()});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -237,7 +237,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingNonBlockingFront) {
     auto result_buffer = create_result_buffer(mesh_device);
     SetRuntimeArgs(program, reader_kernel, WORKER_CORE, {result_buffer->address(), SUCCESS_TOKEN});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -292,7 +292,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferWrappingNonBlockingBack) {
     auto result_buffer = create_result_buffer(mesh_device);
     SetRuntimeArgs(program, writer_kernel, WORKER_CORE, {result_buffer->address(), SUCCESS_TOKEN});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 

--- a/tests/tt_metal/tt_metal/api/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/api/test_banked.cpp
@@ -70,7 +70,7 @@ bool reader_cb_writer(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     std::string reader_kernel_name = "";
@@ -203,7 +203,7 @@ bool reader_datacopy_writer(const std::shared_ptr<distributed::MeshDevice>& mesh
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     distributed::DeviceLocalBufferConfig in_config{

--- a/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
@@ -41,7 +41,7 @@ TEST_F(MeshDeviceFixture, TensixTestTwentyThousandCompileTimeArgs) {
         auto device_range = distributed::MeshCoordinateRange(zero_coord);
         distributed::MeshWorkload workload;
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         auto device = mesh_device->get_devices()[0];
 
@@ -81,7 +81,7 @@ TEST_F(CompileTimeArgsTest, TensixTestNamedCompileTimeArgs) {
     auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     distributed::MeshWorkload workload;
     Program program;
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -59,7 +59,7 @@ bool reader_only(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 
@@ -128,7 +128,7 @@ bool writer_only(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 
@@ -202,7 +202,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 
@@ -300,7 +300,7 @@ bool reader_datacopy_writer(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
     tt::tt_metal::InterleavedBufferConfig dram_config{

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -73,7 +73,7 @@ bool dram_single_core_db(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core = {0, 0};
@@ -144,7 +144,7 @@ bool dram_single_core(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     distributed::DeviceLocalBufferConfig dram_config{
@@ -196,7 +196,7 @@ bool dram_single_core_pre_allocated(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     distributed::DeviceLocalBufferConfig dram_config{
@@ -350,7 +350,7 @@ TEST_F(MeshDispatchFixture, TensixLoopDRAMReadSingleCoreBothProcessors) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -54,7 +54,7 @@ bool dram_to_l1_multicast(
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     auto& program_ = workload.get_programs().at(device_range);
 

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -37,7 +37,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationDataflow) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
@@ -67,7 +67,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationCompute) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
@@ -106,7 +106,7 @@ TEST_F(MeshDispatchFixture, TensixPassOnNormalKernelCreation) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         std::vector<uint32_t> compute_kernel_args = {};
         EXPECT_NO_THROW({
@@ -141,7 +141,7 @@ TEST_F(MeshDispatchFixture, TensixPassOnMixedOverlapKernelCreation) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
         std::vector<uint32_t> compute_kernel_args = {};

--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -124,7 +124,7 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffersAPI) {
         global_cb_config.remote_index(remote_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         global_cb_config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         EXPECT_THROW(program_.impl().finalize_offsets(mesh_device.get()), std::exception);
     }

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -35,7 +35,7 @@ TEST_F(MeshDispatchFixture, TensixCreateKernelsOnComputeCores) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
@@ -60,7 +60,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixCreateKernelsOnStorageCores) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         const std::set<CoreCoord>& storage_only_cores = mesh_device->storage_only_cores();
@@ -91,7 +91,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         const auto& dispatch_core_config = get_dispatch_core_config();

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -215,7 +215,7 @@ TEST_F(MeshDeviceFixture, TensixDirectedStreamRegWriteRead) {
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         auto device = mesh_device->get_devices()[0];
 
@@ -281,7 +281,7 @@ TEST_F(MeshDeviceFixture, TensixIncrementStreamRegWrite) {
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         CoreCoord logical_grid_size = mesh_device->compute_with_storage_grid_size();
@@ -346,7 +346,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWrite4BAlignment) {
         CoreCoord virtual_receiver_core = mesh_device->worker_core_from_logical_core(receiver_core);
 
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         tt_metal::KernelHandle kernel0 = tt_metal::CreateKernel(
@@ -390,7 +390,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNoc) {
         CoreCoord virtual_receiver_core = mesh_device->worker_core_from_logical_core(receiver_core);
 
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         tt_metal::KernelHandle kernel0 = tt_metal::CreateKernel(
@@ -446,7 +446,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
         CoreCoord virtual_receiver_core = mesh_device->worker_core_from_logical_core(receiver_core);
 
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         tt_metal::KernelHandle kernel0 = tt_metal::CreateKernel(
@@ -502,7 +502,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
         CoreCoord virtual_receiver_core = mesh_device->worker_core_from_logical_core(receiver_core);
 
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         tt_metal::KernelHandle kernel0 = tt_metal::CreateKernel(
@@ -574,7 +574,7 @@ void run_local_noc_stream_reg_inc(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Create the kernel

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -83,7 +83,7 @@ distributed::MeshWorkload initialize_program_data_movement(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     return workload;
 }
 
@@ -119,7 +119,7 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
             .noc = tt_metal::NOC::RISCV_0_default,
             .defines = dm_defines});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     return workload;
 }
 
@@ -170,7 +170,7 @@ std::pair<distributed::MeshWorkload, tt::tt_metal::KernelHandle> initialize_prog
 
     auto kernel_id =
         initialize_program_compute(mesh_device, program, core_range_set, num_unique_rt_args, num_common_rt_args);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     return {std::move(workload), kernel_id};
 }
 
@@ -191,7 +191,7 @@ initialize_program_compute_multi_range_sets(
         kernel_ids.push_back(
             initialize_program_compute(mesh_device, program, core_range_set, num_unique_rt_args, num_common_rt_args));
     }
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     return {std::move(workload), kernel_ids};
 }
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -157,7 +157,7 @@ TEST_F(MeshDeviceFixture, TensixInitializeLegalSemaphores) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         CoreRange core_range({0, 0}, {1, 1});
         unit_tests::initialize_semaphores::create_and_read_max_num_semaphores(devices_.at(id), workload, core_range);
     }
@@ -169,7 +169,7 @@ TEST_F(MeshDeviceFixture, TensixInitializeIllegalSemaphores) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = tt_metal::CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         CoreRange core_range({0, 0}, {1, 1});
         unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
             devices_.at(id), workload, core_range);
@@ -181,7 +181,7 @@ TEST_F(MeshDeviceFixture, TensixCreateMultipleSemaphoresOnSameCore) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core0(0, 0);

--- a/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
@@ -73,7 +73,7 @@ bool SimpleTiledL1WriteCBRead(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     const uint32_t cb_index = 0;

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -169,7 +169,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -178,7 +178,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
@@ -59,7 +59,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const C
 
     // Launch program using slow dispatch
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -165,7 +165,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -60,7 +60,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const D
 
     // Launch program using slow dispatch
     MetalContext::instance().get_cluster().l1_barrier(device->id());
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -123,7 +123,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -167,7 +167,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
@@ -73,7 +73,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;
@@ -127,7 +127,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;
@@ -180,7 +180,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
     auto all_cores = CoreRangeSet({CoreRange(test_config.master_core_coord)});
     tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -235,7 +235,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
     auto all_cores = CoreRangeSet({CoreRange(test_config.master_core_coord)});
     tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;
@@ -289,7 +289,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -344,7 +344,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     distributed::EnqueueMeshWorkload(cq, workload, true);
 

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -118,7 +118,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -138,7 +138,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -113,7 +113,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -120,7 +120,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
         vector<uint32_t> coord_data = {0, 0};
         auto target_devices =
             distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-        distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+        mesh_workload.add_program(target_devices, std::move(program));
 
         auto& cq = mesh_device->mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
@@ -136,7 +136,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
         vector<uint32_t> coord_data = {0, 0};
         auto target_devices =
             distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-        distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+        mesh_workload.add_program(target_devices, std::move(program));
 
         auto& cq = mesh_device->mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -206,7 +206,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -135,7 +135,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
     vector<uint32_t> coord_data = {0, 0};
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -57,7 +57,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const R
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     // Launch program using slow dispatch
     MetalContext::instance().get_cluster().l1_barrier(device->id());

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -73,7 +73,7 @@ void RunTest(
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         Program program = Program();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
         // Create the kernel

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
@@ -44,7 +44,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
     auto device_range =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(0, 0));
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Create a CB for testing TSLICE, dimensions are 32x32 bfloat16s

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
@@ -43,7 +43,7 @@ void RunTest(DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // This tests prints only on a single core

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -194,7 +194,7 @@ void RunTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Create a CB for testing TSLICE, dimensions are 32x32 bfloat16s

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
@@ -34,7 +34,7 @@ static void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distribute
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
@@ -77,7 +77,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     for (const CoreCoord& core : cores) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
@@ -387,7 +387,7 @@ static void print_config_reg(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     // Prepare write kernel
     [[maybe_unused]] auto write_kernel = prepare_writer(workload, config);

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -45,7 +45,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Run a kernel that just waits on a signal that never comes (BRISC only).

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -60,7 +60,7 @@ void RunTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -388,7 +388,7 @@ static bool reader_datacopy_writer(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& cq = mesh_device->mesh_command_queue();
 
     // Prepare reader kernel and get input DRAM buffer

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
@@ -229,7 +229,7 @@ static void RunTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto& cq = mesh_device->mesh_command_queue();
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_raise_wait.cpp
@@ -242,7 +242,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Test runs on a 5x5 grid

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -43,7 +43,7 @@ static void RunTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -35,7 +35,7 @@ static void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distribut
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -109,7 +109,7 @@ void RunTestOnCore(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -65,7 +65,7 @@ void RunDelayTestOnCore(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -40,7 +40,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -47,7 +47,7 @@ void RunTest(
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::AddProgramToMeshWorkload(workload, {}, device_range);
+    workload.add_program(device_range, {});
     auto& program = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -36,7 +36,7 @@ void RunOneTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -42,7 +42,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -236,7 +236,7 @@ TEST_F(MeshDeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
                 .noc = tt_metal::NOC::NOC_0,
                 .compile_args = {l1_address, intermediate_l1_addr, size_bytes}});
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(cq, workload, false);
 
         std::vector<uint32_t> output;
@@ -286,7 +286,7 @@ TEST_F(MeshDeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     EXPECT_TRUE(device->is_mmio_capable());
@@ -349,7 +349,7 @@ TEST_F(BlackholeSingleCardFixture, TensixL1DataCache) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t sem0_id = tt_metal::CreateSemaphore(program_, core, 0);

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -67,8 +67,7 @@ bool load_all_blank_kernels(const std::shared_ptr<distributed::MeshDevice>& mesh
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_0_default});
 
     CreateKernel(program, "tt_metal/kernels/compute/blank.cpp", all_cores, tt::tt_metal::ComputeConfig{});
-    distributed::AddProgramToMeshWorkload(
-        mesh_workload, std::move(program), distributed::MeshCoordinateRange(mesh_device->shape()));
+    mesh_workload.add_program(distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, true);
     return pass;
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -258,7 +258,7 @@ void test_dummy_EnqueueProgram_with_runtime_args(
     tt::tt_metal::SetRuntimeArgs(program, dummy_kernel0, eth_core_coord, dummy_kernel0_args);
 
     auto& cq = mesh_device->mesh_command_queue();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     Finish(cq);
 
@@ -285,7 +285,7 @@ bool test_dummy_EnqueueProgram_with_cbs(
     initialize_dummy_kernels(program, program_config.cr_set);
     const bool is_blocking_op = false;
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, is_blocking_op);
     Finish(cq);
 
@@ -305,7 +305,7 @@ bool test_dummy_EnqueueProgram_with_cbs_update_size(
         initialize_dummy_circular_buffers(program, program_config.cr_set, program_config.cb_config_vector);
     initialize_dummy_kernels(program, program_config.cr_set);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     Finish(cq);
 
@@ -384,7 +384,7 @@ bool test_dummy_EnqueueProgram_with_sems(
     }
 
     initialize_dummy_semaphores(program, program_config.cr_set, expected_semaphore_values);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     return test_dummy_EnqueueProgram_with_sems(device, cq, workload, program_config, {expected_semaphore_values});
 }
@@ -467,7 +467,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(
         }
     }
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     for (uint32_t i = 0; i < num_iterations; i++) {
         distributed::EnqueueMeshWorkload(cq, workload, false);
     }
@@ -574,7 +574,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
 
     uint32_t idx = 0;
     constexpr uint32_t num_common_runtime_args = 13;
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
 
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         auto& program_ = workload.get_programs().at(device_range);
@@ -939,7 +939,7 @@ bool test_increment_runtime_args_sanity(
     }
 
     // Compile and Launch the Program now.
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
     Finish(mesh_device->mesh_command_queue());
 
@@ -1008,7 +1008,7 @@ void test_my_coordinates(
     Program program = tt::tt_metal::CreateProgram();
     create_kernel(processor, program, CoreRangeSet{cr}, compile_args, k_kernel_path);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(cq_id), workload, false);
     Finish(mesh_device->mesh_command_queue(cq_id));
 
@@ -1103,7 +1103,7 @@ TEST_F(UnitMeshCQFixture, TensixTestArbiterDoesNotHang) {
             cr_set,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
         Finish(device->mesh_command_queue());
     }
@@ -1182,7 +1182,7 @@ TEST_F(UnitMeshCQFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
         distributed::MeshWorkload workload;
         Program program;
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
 
         CircularBufferConfig cb_config = CircularBufferConfig(cb_size, intermediate_and_out_data_format_spec)
@@ -1249,7 +1249,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAutoInsertedBlankBriscKernelInDeviceDispatch
         distributed::MeshWorkload workload;
         Program program;
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
         CoreRange cr({0, 0}, {0, 0});
         CoreRangeSet cr_set({cr});
@@ -1587,7 +1587,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllSemaphoreConfigsCorrectlySentMultipleCore
         local_test_functions::initialize_dummy_semaphores(program, second_cr, initial_semaphore_vals);
         expected_semaphore_vals.push_back(initial_semaphore_vals);
         distributed::MeshWorkload workload;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(
             device, device->mesh_command_queue(), workload, config, expected_semaphore_vals));
     }
@@ -1803,7 +1803,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
         distributed::MeshWorkload& workload = workloads.back();
 
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), this->device_range_);
+        workload.add_program(this->device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(this->device_range_);
 
         std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
@@ -2080,7 +2080,7 @@ TEST_F(UnitMeshCQProgramFixture, TensixTestRandomizedProgram) {
         distributed::MeshWorkload& workload = workloads.back();
 
         Program program;
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), this->device_range_);
+        workload.add_program(this->device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(this->device_range_);
 
         std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
@@ -2315,7 +2315,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestSimplePrograms) {
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
         this->create_kernel(program_, CoreType::WORKER, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
@@ -2338,7 +2338,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
 
         bool eth_kernel_added_to_program = false;
@@ -2370,7 +2370,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
         // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
@@ -2398,7 +2398,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
 
         bool eth_kernel_added_to_program = false;
@@ -2431,7 +2431,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms)
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
 
         KernelProperties kernel_properties;
@@ -2456,7 +2456,7 @@ TEST_F(UnitMeshRandomProgramFixture, NIGHTLY_TensixTestLargeProgramFollowedBySma
         distributed::MeshWorkload workload;
         ;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
 
         KernelProperties kernel_properties;
@@ -2480,7 +2480,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPro
         }
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         auto& program_ = workload.get_programs().at(device_range_);
         KernelProperties kernel_properties;
         if (i % 6 == 0) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -123,7 +123,7 @@ static void test_sems_across_core_types(
                 tensix_sem_init_val,
             };
             SetRuntimeArgs(program, tensix_kernel, tensix_core, tensix_rtas);
-            distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+            workload.add_program(device_range, std::move(program));
             fixture->RunProgram(mesh_device, workload);
         }
     }
@@ -153,7 +153,7 @@ TEST_F(MeshDispatchFixture, EthTestBlank) {
                 .eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER,
             });
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     }
 }
@@ -182,7 +182,7 @@ TEST_F(MeshDispatchFixture, TensixTestInitLocalMemory) {
 
     CreateKernel(program, "tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp", core, ComputeConfig{});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     this->RunProgram(mesh_device, workload);
 }
 
@@ -213,7 +213,7 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
             eth_core,
             tt::tt_metal::EthernetConfig{.eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER});
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     }
 }
@@ -290,7 +290,7 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
             core_coord,
             EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = NOC::NOC_0});
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
 
         auto& program_ = workload.get_programs().at(device_range);
@@ -346,7 +346,7 @@ TEST_F(EarlyReturnFixture, TensixKernelEarlyReturn) {
             worker,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     }
 }
@@ -377,7 +377,7 @@ TEST_F(MeshDispatchFixture, TensixCircularBufferInitFunction) {
                 uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
                 std::vector<uint32_t> runtime_args{mask, l1_unreserved_base};
                 SetRuntimeArgs(program, kernel, core, runtime_args);
-                distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+                workload.add_program(device_range, std::move(program));
                 this->RunProgram(mesh_device, workload);
             }
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -42,7 +42,7 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, TensixDataMovementKernel) {
             kernel_src_code,
             cores,
             DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     };
 }
@@ -78,7 +78,7 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, TensixComputeKernel) {
                 .fp32_dest_acc_en = false,
                 .math_approx_mode = false,
                 .compile_args = {}});
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     };
 }
@@ -112,7 +112,7 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, ActiveEthEthernetKernel) {
             kernel_src_code,
             *active_ethernet_cores.begin(),
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
     };
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -82,8 +82,7 @@ void RunTest(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     }
 
     distributed::MeshWorkload workload;
-    distributed::AddProgramToMeshWorkload(
-        workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}));
+    workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange({0, 0}, {0, 0}), std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
     distributed::Finish(mesh_device->mesh_command_queue());
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -41,7 +41,7 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt::tt_metal::Program program = CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t remote_cb_index = 31;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -147,7 +147,7 @@ void test_sub_device_synchronization(distributed::MeshDevice* device) {
     distributed::MeshWorkload mesh_workload;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+    mesh_workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
     device->set_sub_device_stall_group(sub_device_ids_to_block);
 
@@ -210,18 +210,18 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceBasicPrograms) {
             create_basic_sync_program(mesh_device.get(), sub_device_1, sub_device_2);
 
         distributed::MeshWorkload waiter_mesh_workload;
-        distributed::AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), device_range);
+        waiter_mesh_workload.add_program(device_range, std::move(waiter_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_mesh_workload, false);
 
         mesh_device->set_sub_device_stall_group({{SubDeviceId{0}}});
 
         // Test blocking on one sub-device
         distributed::MeshWorkload syncer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), device_range);
+        syncer_mesh_workload.add_program(device_range, std::move(syncer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_mesh_workload, true);
 
         distributed::MeshWorkload incrementer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), device_range);
+        incrementer_mesh_workload.add_program(device_range, std::move(incrementer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_mesh_workload, false);
 
         mesh_device->reset_sub_device_stall_group();
@@ -253,18 +253,18 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceBasicProgramsReuse) {
             create_basic_sync_program(mesh_device.get(), sub_device_1, sub_device_2);
 
         distributed::MeshWorkload waiter_mesh_workload;
-        distributed::AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), device_range);
+        waiter_mesh_workload.add_program(device_range, std::move(waiter_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_mesh_workload, false);
 
         mesh_device->set_sub_device_stall_group({{SubDeviceId{0}}});
 
         // Test blocking on one sub-device
         distributed::MeshWorkload syncer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), device_range);
+        syncer_mesh_workload.add_program(device_range, std::move(syncer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_mesh_workload, true);
 
         distributed::MeshWorkload incrementer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), device_range);
+        incrementer_mesh_workload.add_program(device_range, std::move(incrementer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_mesh_workload, false);
 
         mesh_device->reset_sub_device_stall_group();
@@ -279,18 +279,18 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceBasicProgramsReuse) {
             create_basic_sync_program(mesh_device.get(), sub_device_1, sub_device_2);
 
         distributed::MeshWorkload waiter_mesh_workload;
-        distributed::AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), device_range);
+        waiter_mesh_workload.add_program(device_range, std::move(waiter_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_mesh_workload, false);
 
         mesh_device->set_sub_device_stall_group({{SubDeviceId{1}}});
 
         // Test blocking on one sub-device
         distributed::MeshWorkload syncer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), device_range);
+        syncer_mesh_workload.add_program(device_range, std::move(syncer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_mesh_workload, true);
 
         distributed::MeshWorkload incrementer_mesh_workload;
-        distributed::AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), device_range);
+        incrementer_mesh_workload.add_program(device_range, std::move(incrementer_program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_mesh_workload, false);
 
         mesh_device->reset_sub_device_stall_group();
@@ -339,11 +339,11 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordinat
             .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = compile_args});
 
     distributed::MeshWorkload mesh_workload_1;
-    distributed::AddProgramToMeshWorkload(mesh_workload_1, std::move(program_1), device_range);
+    mesh_workload_1.add_program(device_range, std::move(program_1));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload_1, false);
 
     distributed::MeshWorkload mesh_workload_2;
-    distributed::AddProgramToMeshWorkload(mesh_workload_2, std::move(program_2), device_range);
+    mesh_workload_2.add_program(device_range, std::move(program_2));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload_2, false);
 
     distributed::Finish(mesh_device->mesh_command_queue());
@@ -392,7 +392,7 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordinat
                 .compile_args = compile_args});
 
         distributed::MeshWorkload mesh_workload;
-        distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+        mesh_workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
 
         distributed::Finish(mesh_device->mesh_command_queue());
@@ -454,11 +454,11 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceProgramReuseRtas) {
 
             // Enqueue twice to ensure waits are correct.
             distributed::MeshWorkload mesh_workload_1;
-            distributed::AddProgramToMeshWorkload(mesh_workload_1, create_program_with_args(), device_range);
+            mesh_workload_1.add_program(device_range, create_program_with_args());
             distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload_1, false);
 
             distributed::MeshWorkload mesh_workload_2;
-            distributed::AddProgramToMeshWorkload(mesh_workload_2, create_program_with_args(), device_range);
+            mesh_workload_2.add_program(device_range, create_program_with_args());
             distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload_2, false);
 
             distributed::Synchronize(mesh_device.get(), std::nullopt);
@@ -507,10 +507,10 @@ TEST_F(UnitMeshMultiCQSingleDeviceFixture, TensixTestSubDeviceCQOwnership) {
     };
 
     distributed::MeshWorkload mesh_workload_1;
-    distributed::AddProgramToMeshWorkload(mesh_workload_1, create_program_1(), device_range);
+    mesh_workload_1.add_program(device_range, create_program_1());
 
     distributed::MeshWorkload mesh_workload_2;
-    distributed::AddProgramToMeshWorkload(mesh_workload_2, create_program_2(), device_range);
+    mesh_workload_2.add_program(device_range, create_program_2());
 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), mesh_workload_1, false);
     std::array sub_device_ids_for_event = {SubDeviceId{1}};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -112,7 +112,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceTraceFixture, TensixEnqueueOneProgramTrace) {
     distributed::MeshWorkload workload;
     Program simple_program =
         create_simple_unary_program(*input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+    workload.add_program(device_range_, std::move(simple_program));
 
     vector<uint32_t> input_data(input->get_device_buffer(zero_coord_)->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
@@ -163,7 +163,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceTraceFixture, TensixEnqueueOneProgramTraceLoop
     distributed::MeshWorkload workload;
     Program simple_program =
         create_simple_unary_program(*input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+    workload.add_program(device_range_, std::move(simple_program));
 
     vector<uint32_t> input_data(input->get_device_buffer(zero_coord_)->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
@@ -227,7 +227,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceTraceFixture, TensixEnqueueOneProgramTraceBenc
     distributed::MeshWorkload workload;
     Program simple_program =
         create_simple_unary_program(*input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+    workload.add_program(device_range_, std::move(simple_program));
 
     vector<uint32_t> input_data(input->get_device_buffer(zero_coord_)->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
@@ -313,7 +313,7 @@ TEST_F(UnitMeshCQTraceFixture, TensixInstantiateTraceSanity) {
     distributed::MeshWorkload workload;
     Program simple_program =
         create_simple_unary_program(*input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+    workload.add_program(device_range_, std::move(simple_program));
 
     distributed::EnqueueMeshWorkload(mesh_command_queue, workload, true);
     auto tid = distributed::BeginTraceCapture(mesh_device.get(), mesh_command_queue.id());
@@ -352,7 +352,7 @@ TEST_F(UnitMeshCQTraceFixture, TensixEnqueueProgramTraceCapture) {
     distributed::MeshWorkload workload;
     Program simple_program =
         create_simple_unary_program(*input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+    workload.add_program(device_range_, std::move(simple_program));
 
     vector<uint32_t> input_data(input->get_device_buffer(zero_coord_)->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
@@ -380,7 +380,7 @@ TEST_F(UnitMeshCQTraceFixture, TensixEnqueueProgramTraceCapture) {
     distributed::MeshWorkload temp_workload;
     Program simple_program_temp = create_simple_unary_program(
         *input_temp->get_device_buffer(zero_coord_), *output_temp->get_device_buffer(zero_coord_));
-    distributed::AddProgramToMeshWorkload(temp_workload, std::move(simple_program_temp), device_range_);
+    temp_workload.add_program(device_range_, std::move(simple_program_temp));
     distributed::EnqueueMeshWorkload(mesh_command_queue, temp_workload, true);
 
     // Run trace that can clobber the temporary buffers created above
@@ -421,7 +421,7 @@ TEST_F(UnitMeshCQTraceFixture, TensixEnqueueProgramDeviceCapture) {
     if (has_eager) {
         Program simple_program = create_simple_unary_program(
             *input->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
-        distributed::AddProgramToMeshWorkload(workload, std::move(simple_program), device_range_);
+        workload.add_program(device_range_, std::move(simple_program));
 
         distributed::EnqueueWriteMeshBuffer(mesh_command_queue, input, input_data, true);
         distributed::EnqueueMeshWorkload(mesh_command_queue, workload, true);
@@ -474,8 +474,8 @@ TEST_F(UnitMeshCQTraceFixture, TensixEnqueueTwoProgramTrace) {
     Program op1 =
         create_simple_unary_program(*interm->get_device_buffer(zero_coord_), *output->get_device_buffer(zero_coord_));
 
-    distributed::AddProgramToMeshWorkload(workload0, std::move(op0), device_range_);
-    distributed::AddProgramToMeshWorkload(workload1, std::move(op1), device_range_);
+    workload0.add_program(device_range_, std::move(op0));
+    workload1.add_program(device_range_, std::move(op1));
 
     vector<uint32_t> input_data(input->get_device_buffer(zero_coord_)->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
@@ -581,7 +581,7 @@ TEST_F(UnitMeshCQTraceFixture, TensixEnqueueMultiProgramTraceBenchmark) {
                 *interm_buffers[i - 1]->get_device_buffer(zero_coord_),
                 *interm_buffers[i]->get_device_buffer(zero_coord_));
         }
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range_);
+        workload.add_program(device_range_, std::move(program));
         workloads.push_back(std::move(workload));
     }
 
@@ -645,7 +645,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestSimpleProgramsTrace) {
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::WORKER, true);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -669,7 +669,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::ETH, true);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -702,7 +702,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestSimpleProgramsTrace
             this->create_kernel(program, CoreType::WORKER, true);
         }
 
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -721,7 +721,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, NIGHTLY_TensixTestProgramsTrace) {
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::WORKER);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -750,7 +750,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -792,7 +792,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
         }
         program.set_runtime_id(i);
 
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -819,7 +819,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, NIGHTLY_TensixTestAlternatingLargeAndS
         }
 
         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -846,7 +846,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, NIGHTLY_TensixTestLargeProgramFollowed
         }
 
         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -873,7 +873,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestLargeProgramInBetweenFiveSma
         }
 
         this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
     }
 
@@ -895,7 +895,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestProgramsTraceAndNoTrace) {
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::WORKER);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
         const bool use_trace = (rand() % 2) == 0;
         if (use_trace) {
@@ -948,7 +948,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
         kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
 
         const bool use_trace = (rand() % 2) == 0;
@@ -1015,7 +1015,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoT
             this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
         }
 
-        distributed::AddProgramToMeshWorkload(this->workloads[i], std::move(program), device_range_);
+        this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
 
         const bool use_trace = (rand() % 2) == 0;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -39,9 +39,9 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms) 
     distributed::MeshWorkload waiter_workload, syncer_workload, incrementer_workload;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::AddProgramToMeshWorkload(waiter_workload, std::move(waiter_program), device_range);
-    distributed::AddProgramToMeshWorkload(syncer_workload, std::move(syncer_program), device_range);
-    distributed::AddProgramToMeshWorkload(incrementer_workload, std::move(incrementer_program), device_range);
+    waiter_workload.add_program(device_range, std::move(waiter_program));
+    syncer_workload.add_program(device_range, std::move(syncer_program));
+    incrementer_workload.add_program(device_range, std::move(incrementer_program));
 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload, false);
     mesh_device->set_sub_device_stall_group({{SubDeviceId{0}}});
@@ -119,9 +119,9 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations) {
     distributed::MeshWorkload waiter_workload_1, syncer_workload_1, incrementer_workload_1;
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::AddProgramToMeshWorkload(waiter_workload_1, std::move(waiter_program_1), device_range);
-    distributed::AddProgramToMeshWorkload(syncer_workload_1, std::move(syncer_program_1), device_range);
-    distributed::AddProgramToMeshWorkload(incrementer_workload_1, std::move(incrementer_program_1), device_range);
+    waiter_workload_1.add_program(device_range, std::move(waiter_program_1));
+    syncer_workload_1.add_program(device_range, std::move(syncer_program_1));
+    incrementer_workload_1.add_program(device_range, std::move(incrementer_program_1));
 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload_1, false);
     mesh_device->set_sub_device_stall_group({{SubDeviceId{0}}});
@@ -145,9 +145,9 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations) {
         create_basic_sync_program(mesh_device.get(), sub_device_2, sub_device_1);
 
     distributed::MeshWorkload waiter_workload_2, syncer_workload_2, incrementer_workload_2;
-    distributed::AddProgramToMeshWorkload(waiter_workload_2, std::move(waiter_program_2), device_range);
-    distributed::AddProgramToMeshWorkload(syncer_workload_2, std::move(syncer_program_2), device_range);
-    distributed::AddProgramToMeshWorkload(incrementer_workload_2, std::move(incrementer_program_2), device_range);
+    waiter_workload_2.add_program(device_range, std::move(waiter_program_2));
+    syncer_workload_2.add_program(device_range, std::move(syncer_program_2));
+    incrementer_workload_2.add_program(device_range, std::move(incrementer_program_2));
 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload_2, false);
     mesh_device->set_sub_device_stall_group({{SubDeviceId{0}}});

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -119,7 +119,7 @@ bool reader_kernel_no_send(
             (uint32_t)eth_l1_byte_address,
         });
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     fixture->RunProgram(mesh_device, workload);
 
     auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
@@ -193,7 +193,7 @@ bool writer_kernel_no_receive(
             (uint32_t)eth_l1_byte_address,
         });
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     fixture->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> readback_vec;
@@ -294,7 +294,7 @@ bool noc_reader_and_writer_kernels(
         device->id(), eth_noc_xy, all_zeros, eth_dst_l1_address);
     distributed::WriteShard(cq, writer_dram_buffer, all_zeros, zero_coord);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     auto eth_readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -173,13 +173,13 @@ bool chip_to_chip_dram_buffer_transfer(
     std::thread t1;
     std::thread t2;
     if (fixture->IsSlowDispatch()) {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
         t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
     } else {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         fixture->RunProgram(sender_mesh_device, sender_workload, true);
         fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
     }
@@ -311,13 +311,13 @@ bool chip_to_chip_interleaved_buffer_transfer(
     std::thread t1;
     std::thread t2;
     if (fixture->IsSlowDispatch()) {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
         t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
     } else {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         fixture->RunProgram(sender_mesh_device, sender_workload, true);
         fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
     }

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -163,13 +163,13 @@ bool eth_direct_sender_receiver_kernels(
     std::thread t1;
     std::thread t2;
     if (fixture->IsSlowDispatch()) {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
         t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
     } else {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         fixture->RunProgram(sender_mesh_device, sender_workload, true);
         fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
     }

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -98,13 +98,13 @@ static void eth_direct_send_multi_txq_rxq(
     std::thread t1;
     std::thread t2;
     if (fixture->IsSlowDispatch()) {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
         t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
     } else {
-        distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program), device_range);
-        distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program), device_range);
+        sender_workload.add_program(device_range, std::move(sender_program));
+        receiver_workload.add_program(device_range, std::move(receiver_program));
         fixture->RunProgram(sender_mesh_device, sender_workload, true);
         fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
     }

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -341,10 +341,8 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
         const auto& device = std::get<0>(sender_receivers[i]);
-        distributed::AddProgramToMeshWorkload(
-            workloads[device->get_devices()[0]->id()],
-            std::move(programs[device->get_devices()[0]->id()]),
-            device_range);
+        workloads[device->get_devices()[0]->id()].add_program(
+            device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
                 device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
@@ -500,10 +498,8 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
         const auto& device = std::get<0>(sender_receivers[i]);
-        distributed::AddProgramToMeshWorkload(
-            workloads[device->get_devices()[0]->id()],
-            std::move(programs[device->get_devices()[0]->id()]),
-            device_range);
+        workloads[device->get_devices()[0]->id()].add_program(
+            device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
                 device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -127,7 +127,7 @@ void matmul_tile(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -221,7 +221,7 @@ bool matmul_large_block(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -75,7 +75,7 @@ std::tuple<distributed::MeshWorkload, tt_metal::KernelHandle, tt_metal::KernelHa
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -79,7 +79,7 @@ create_program(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -77,7 +77,7 @@ create_program(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -65,7 +65,7 @@ bool matmul_single_core(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -242,8 +242,7 @@ void create_and_run_row_pipeline(
                  (uint32_t)num_repetitions});
         }
     }
-    distributed::AddProgramToMeshWorkload(
-        mesh_workload, std::move(program), distributed::MeshCoordinateRange(mesh_device->shape()));
+    mesh_workload.add_program(distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -174,7 +174,7 @@ bool flatten(
 
     tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles * 32});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     fixture->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> result_vec;
@@ -261,7 +261,7 @@ bool flatten_stress(
         core,
         tt_metal::ComputeConfig{.compile_args = compute_kernel_args});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_on_workload = workload.get_programs().at(device_range);
     // Inside the loop, run async runtime functions
     for (int i = 0; i < 1000; i++) {

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -238,8 +238,7 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
         }
     }
 
-    distributed::AddProgramToMeshWorkload(
-        mesh_workload, std::move(program), distributed::MeshCoordinateRange(cq.device()->shape()));
+    mesh_workload.add_program(distributed::MeshCoordinateRange(cq.device()->shape()), std::move(program));
 
     std::vector<uint32_t> dest_buffer_data;
     distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, false);

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -150,7 +150,7 @@ bool vecadd_multi_core(
     distributed::WriteShard(cq, a, a_data, zero_coord);
     distributed::WriteShard(cq, b, b_data, zero_coord);
     // Enqueue the program
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     log_debug(LogTest, "Kernel execution finished");

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -358,7 +358,7 @@ void run_single_core_broadcast(
     distributed::WriteShard(cq, src_a_dram_buffer, tilized_input0, zero_coord);
     distributed::WriteShard(cq, src_b_dram_buffer, tilized_input1, zero_coord);
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     std::vector<uint32_t> dest_buffer_data;

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -70,7 +70,7 @@ void run_single_core_copy_block_matmul_partials(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -88,7 +88,7 @@ void run_single_core_cumsum(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -116,7 +116,7 @@ bool test_dropout_standalone(
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload;
         Program program = CreateProgram();
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
         const auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -111,7 +111,7 @@ bool single_core_reconfig(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -280,7 +280,7 @@ void run_single_core_reduce_program(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     CoreCoord core = {0, 0};

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -153,7 +153,7 @@ bool run_sfpu_all_same_buffer(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -123,7 +123,7 @@ bool single_core_binary(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt::tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     distributed::DeviceLocalBufferConfig dram_config{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -213,7 +213,7 @@ bool single_tile_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_dev
         .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     auto input0_dram_buffer = CreateBuffer(dram_config);
@@ -361,7 +361,7 @@ bool single_block_matmul(
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     auto input0_dram_buffer = CreateBuffer(dram_config_0);
@@ -523,7 +523,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt_metal::Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     auto input0_dram_buffer = CreateBuffer(dram_config_0);

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -105,7 +105,7 @@ void run_single_core_transpose(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -248,7 +248,7 @@ void run_single_core_unary_broadcast(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
     Program program = tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     CoreCoord core = {0, 0};
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -100,7 +100,7 @@ void run_single_core_tilize_program(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt::tt_metal::CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto device = mesh_device->get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -136,10 +136,8 @@ void build_and_run_program(
     }
     distributed::MeshWorkload workload1;
     distributed::MeshWorkload workload2;
-    distributed::AddProgramToMeshWorkload(
-        workload1, std::move(program1), distributed::MeshCoordinateRange(device->shape()));
-    distributed::AddProgramToMeshWorkload(
-        workload2, std::move(program2), distributed::MeshCoordinateRange(device->shape()));
+    workload1.add_program(distributed::MeshCoordinateRange(device->shape()), std::move(program1));
+    workload2.add_program(distributed::MeshCoordinateRange(device->shape()), std::move(program2));
 
     // This loop caches program1 and runs
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -336,8 +336,8 @@ create_mesh_workloads(
     std::vector<tt_metal::distributed::MeshWorkload> mesh_workloads;
     for (auto& program : programs) {
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(
+            tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
         mesh_workloads.push_back(std::move(mesh_workload));
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -887,8 +887,8 @@ int main(int argc, char** argv) {
         std::vector<tt_metal::distributed::MeshWorkload> mesh_workloads;
         for (auto& program : programs) {
             auto mesh_workload = tt_metal::distributed::MeshWorkload();
-            tt_metal::distributed::AddProgramToMeshWorkload(
-                mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+            mesh_workload.add_program(
+                tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
             mesh_workloads.push_back(std::move(mesh_workload));
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -603,8 +603,7 @@ int main(int argc, char** argv) {
         log_info(LogTest, "Num tests {}", num_tests);
         // Create MeshWorkload
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (!fast_dispatch_mode) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -240,8 +240,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Num tests {}", num_tests);
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -22,7 +22,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt-metalium/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -22,7 +22,7 @@
 #include <variant>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
+#include <tt-metalium/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -208,8 +208,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Num tests {}", num_tests);
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -313,8 +313,7 @@ int main(int argc, char** argv) {
 
         // Create MeshWorkload for kernel execution
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         for (uint32_t i = 0; i < num_tests; ++i) {
             // Execute application

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -276,8 +276,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Num tests {}", num_tests);
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
@@ -202,8 +202,7 @@ int main(int argc, char** argv) {
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -455,8 +455,7 @@ int main(int argc, char** argv) {
         //                      Execution Application
         ////////////////////////////////////////////////////////////////////////////
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -639,8 +639,7 @@ int main(int argc, char** argv) {
         //                      Execution Application
         ////////////////////////////////////////////////////////////////////////////
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
-        tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}});
+        mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange{{0, 0}, {0, 0}}, std::move(program));
 
         log_info(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -338,8 +338,8 @@ int main(int argc, char** argv) {
         if (page_size_as_runtime_arg_g) {
             tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_coord, {page_size_g});
         }
-        tt::tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload, std::move(program), tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()));
+        mesh_workload.add_program(
+            tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
 
         CoreCoord w = mesh_device->worker_core_from_logical_core(worker_g.start_coord);
         log_info(LogTest, "Master core: {}", w.str());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -422,8 +422,8 @@ ProgramExecutor create_standard_executor(
     // Create mesh workloads
     mesh_workloads.resize(programs.size());
     for (auto i = 0; i < programs.size(); i++) {
-        AddProgramToMeshWorkload(
-            mesh_workloads[i], std::move(programs[i]), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+        mesh_workloads[i].add_program(
+            MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)), std::move(programs[i]));
     }
     std::function warmup_func{[&info, &mesh_cq, &mesh_workloads]() {
         for (int i = 0; i < info.warmup_iterations; i++) {
@@ -455,8 +455,8 @@ ProgramExecutor create_load_prefetcher_executor(
     // Create mesh workload
     mesh_workloads.resize(programs.size());
     for (auto i = 0; i < programs.size(); i++) {
-        AddProgramToMeshWorkload(
-            mesh_workloads[i], std::move(programs[i]), MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)));
+        mesh_workloads[i].add_program(
+            MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 0)), std::move(programs[i]));
     }
 
     std::function warmup_func{[&info, &mesh_cq, &mesh_workloads]() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -606,11 +606,10 @@ void run(
                 auto& device = device_helper.devices[i];
                 auto& program = programs[i];
                 tt_metal::distributed::MeshWorkload mesh_workload;
-                tt_metal::distributed::AddProgramToMeshWorkload(
-                    mesh_workload,
-                    std::move(program),
+                mesh_workload.add_program(
                     tt_metal::distributed::MeshCoordinateRange(
-                        tt_metal::distributed::MeshCoordinate(0, 0), tt_metal::distributed::MeshCoordinate(0, 0)));
+                        tt_metal::distributed::MeshCoordinate(0, 0), tt_metal::distributed::MeshCoordinate(0, 0)),
+                    std::move(program));
                 threads.emplace_back([&]() {
                     // Use distributed::EnqueueMeshWorkload instead of LaunchProgram
                     tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
@@ -625,11 +624,10 @@ void run(
                 auto& program = programs[i];
                 program.set_runtime_id(0);
                 tt_metal::distributed::MeshWorkload mesh_workload;
-                tt_metal::distributed::AddProgramToMeshWorkload(
-                    mesh_workload,
-                    std::move(program),
+                mesh_workload.add_program(
                     tt_metal::distributed::MeshCoordinateRange(
-                        tt_metal::distributed::MeshCoordinate(0, 0), tt_metal::distributed::MeshCoordinate(0, 0)));
+                        tt_metal::distributed::MeshCoordinate(0, 0), tt_metal::distributed::MeshCoordinate(0, 0)),
+                    std::move(program));
                 tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
             }
             log_info(tt::LogTest, "Iteration {} Calling Finish", iteration);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -154,9 +154,9 @@ void run(
     tt::tt_metal::distributed::MeshCoordinateRange device_range1 =
         tt::tt_metal::distributed::MeshCoordinateRange(zero_coord1, zero_coord1);
     tt::tt_metal::distributed::MeshWorkload mesh_workload0;
-    tt::tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload0, std::move(program0), device_range0);
+    mesh_workload0.add_program(device_range0, std::move(program0));
     tt::tt_metal::distributed::MeshWorkload mesh_workload1;
-    tt::tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload1, std::move(program1), device_range1);
+    mesh_workload1.add_program(device_range1, std::move(program1));
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         // For slow dispatch mode, use threads with mesh workloads

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -366,7 +366,7 @@ void build_and_run_roundtrip_latency_test(
             tt::tt_metal::distributed::MeshCoordinateRange(zero_coord, zero_coord);
 
         tt::tt_metal::distributed::MeshWorkload mesh_workload;
-        tt::tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload, std::move(*program_ptr), device_range);
+        mesh_workload.add_program(device_range, std::move(*program_ptr));
         tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device_ptr->mesh_command_queue(), mesh_workload, false);
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -163,10 +163,10 @@ void run(
         tt::tt_metal::distributed::MeshCoordinateRange(zero_coord1, zero_coord1);
 
     tt::tt_metal::distributed::MeshWorkload mesh_workload0;
-    tt::tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload0, std::move(program0), device_range0);
+    mesh_workload0.add_program(device_range0, std::move(program0));
 
     tt::tt_metal::distributed::MeshWorkload mesh_workload1;
-    tt::tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload1, std::move(program1), device_range1);
+    mesh_workload1.add_program(device_range1, std::move(program1));
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         // For slow dispatch mode, use threads with mesh workloads

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1112,7 +1112,7 @@ int main(int argc, char** argv) {
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+        mesh_workload.add_program(device_range, std::move(program));
         auto start = std::chrono::high_resolution_clock::now();
         tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
         tt_metal::distributed::Finish(device->mesh_command_queue());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -319,7 +319,7 @@ int main(int argc, char** argv) {
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+        mesh_workload.add_program(device_range, std::move(program));
         auto start = std::chrono::high_resolution_clock::now();
         tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);
         tt_metal::distributed::Finish(device->mesh_command_queue());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -308,7 +308,7 @@ int main(int argc, char** argv) {
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+        mesh_workload.add_program(device_range, std::move(program));
         log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
         auto begin = std::chrono::steady_clock::now();
         tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -228,7 +228,7 @@ int main(int argc, char** argv) {
         auto mesh_workload = tt_metal::distributed::MeshWorkload();
         distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(device->shape().dims());
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        tt_metal::distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+        mesh_workload.add_program(device_range, std::move(program));
         log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
         auto begin = std::chrono::steady_clock::now();
         tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), mesh_workload, false);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -489,7 +489,7 @@ int main(int argc, char** argv) {
 
     log_info(tt::LogTest, "Launching programs");
     auto& cq = mesh_device->mesh_command_queue();
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+    mesh_workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
 
     log_info(tt::LogTest, "Waiting for workers to complete");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -151,7 +151,7 @@ public:
 
     void enqueue_program(const MeshCoordinate& mesh_coord, tt::tt_metal::Program program) {
         MeshCoordinateRange device(mesh_coord, mesh_coord);
-        tt::tt_metal::distributed::AddProgramToMeshWorkload(*mesh_workload_, std::move(program), device);
+        mesh_workload_->add_program(device, std::move(program));
     }
 
     void run_programs() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -40,8 +40,7 @@ int main(int argc, char** argv) {
         });
 
     tt_metal::distributed::MeshWorkload workload;
-    tt_metal::distributed::AddProgramToMeshWorkload(
-        workload, std::move(program), tt_metal::distributed::MeshCoordinateRange(device->shape()));
+    workload.add_program(tt_metal::distributed::MeshCoordinateRange(device->shape()), std::move(program));
     tt_metal::distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, true);
     tt_metal::ReadMeshDeviceProfilerResults(*device);
     device->close();

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -45,8 +45,7 @@ bool runTest(
         tt::tt_metal::ComputeConfig{
             .compile_args = compile_args,
         });
-    distributed::AddProgramToMeshWorkload(
-        workload, std::move(program), distributed::MeshCoordinateRange(mesh_device->shape()));
+    workload.add_program(distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 
     distributed::Finish(mesh_device->mesh_command_queue());

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -138,8 +138,7 @@ int main(int argc, char** argv) {
                 core,
                 runtime_args
             );
-            distributed::AddProgramToMeshWorkload(
-                mesh_workload, std::move(program), distributed::MeshCoordinateRange(device->shape()));
+            mesh_workload.add_program(distributed::MeshCoordinateRange(device->shape()), std::move(program));
             distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
             log_info(tt::LogTest, "Started program");
             distributed::Finish(cq);

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -178,8 +178,7 @@ int main(int argc, char** argv) {
             SetRuntimeArgs(program, unary_writer_kernel, core, writer_args);
             SetRuntimeArgs(program, binary_reader_kernel, core, reader_args);
 
-            distributed::AddProgramToMeshWorkload(
-                mesh_workload, std::move(program), distributed::MeshCoordinateRange(mesh_device->shape()));
+            mesh_workload.add_program(distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
             ////////////////////////////////////////////////////////////////////////////
             //                      Compile Application
             ////////////////////////////////////////////////////////////////////////////

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -144,8 +144,7 @@ void benchmark_args_combinations_single_core(
 
         // Launch program
         auto mesh_work_load = tt::tt_metal::distributed::MeshWorkload();
-        AddProgramToMeshWorkload(
-            mesh_work_load, std::move(program), (tt::tt_metal::distributed::MeshCoordinateRange)mesh_coordinate);
+        mesh_work_load.add_program((tt::tt_metal::distributed::MeshCoordinateRange)mesh_coordinate, std::move(program));
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_work_load, false);
 
         // Wait for program to finish

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -331,12 +331,12 @@ bool RunWriteBWTest(
 
     distributed::MeshWorkload sender_workload;
     tt_metal::Program sender_program_{};
-    distributed::AddProgramToMeshWorkload(sender_workload, std::move(sender_program_), device_range);
+    sender_workload.add_program(device_range, std::move(sender_program_));
     auto& sender_program = sender_workload.get_programs().at(device_range);
 
     distributed::MeshWorkload receiver_workload;
     tt_metal::Program receiver_program_{};
-    distributed::AddProgramToMeshWorkload(receiver_workload, std::move(receiver_program_), device_range);
+    receiver_workload.add_program(device_range, std::move(receiver_program_));
     auto& receiver_program = receiver_workload.get_programs().at(device_range);
 
     auto& sender_cq = sender_mesh_device->mesh_command_queue();

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -625,8 +625,7 @@ bool RunPipelinedWorkersTest(
         }
     }
     std::vector<tt::tt_metal::distributed::MeshWorkload> mesh_workloads(1);
-    tt::tt_metal::distributed::AddProgramToMeshWorkload(
-        mesh_workloads[0], std::move(program), tt::tt_fabric::MeshCoordinateRange({0, 0}, {0, 0}));
+    mesh_workloads[0].add_program(tt::tt_fabric::MeshCoordinateRange({0, 0}, {0, 0}), std::move(program));
 
     run_workloads(mesh_workloads, {mesh_device});
 

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -36,8 +36,6 @@ class IDevice;
 
 namespace distributed {
 
-void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range);
-
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
 
 template <typename DType>

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -14,10 +14,6 @@
 
 namespace tt::tt_metal::distributed {
 
-void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range) {
-    mesh_workload.add_program(device_range, std::move(program));
-}
-
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking) {
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         mesh_workload.impl().compile(mesh_cq.device());

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -110,7 +110,7 @@ int main() {
     SetRuntimeArgs(program, core1_writer_kernel_id, core1, {dst_dram_buffer->address()});
 
     // Program enqueue (non-blocking). Wait for completion before reading back.
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -143,7 +143,7 @@ int main() {
     SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address()});
 
     // Add the program to the workload and execute it.
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -115,7 +115,7 @@ SetRuntimeArgs(program, binary_reader_kernel_id, core, {src0_dram_buffer->addres
 SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
 SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address()});
 
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 ```

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -111,7 +111,7 @@ int main() {
 
     // Add the program to the workload and enqueue it for execution on the MeshDevice.
     // Setting blocking=false returns immediately; commands on the queue execute in FIFO order.
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
 
     // Read a shard of the destination MeshBuffer back to host.

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -95,7 +95,7 @@ SetRuntimeArgs(
         dst_l1_buffer->address(),
     });
 
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
 ```
 

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
             sender_core_logical.x,
             sender_core_logical.y,
             device_id);
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(cq, workload, false);
         fmt::print("Waiting until program finishes\n");
         distributed::Finish(cq);

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
     // `Finish(cq)` to wait for all programs to finish.
     // But it shouldn't matter in this case since we block on reading the output
     // buffer.
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
     // distributed::Finish(cq);
     std::cout << "Kernel execution finished" << std::endl;

--- a/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
@@ -155,7 +155,7 @@ int main() {
         SetRuntimeArgs(program, compute, core, {n_tiles});
 
         // Add the program to the workload for the mesh.
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
         distributed::Finish(cq);

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
         distributed::MeshWorkload workload;
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
         // Add the program to the workload for the mesh.
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
         distributed::Finish(cq);

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -37,7 +37,7 @@ int main() {
     auto mesh_workload = MeshWorkload();
     auto target_devices = MeshCoordinateRange(mesh_device->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(example_program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(example_program));
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
     // Synchronize the mesh command queue to ensure the workload has completed.

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -139,7 +139,7 @@ int main() {
     auto mesh_workload = MeshWorkload();
     auto device_range = MeshCoordinateRange(mesh_device->shape());
 
-    AddProgramToMeshWorkload(mesh_workload, std::move(program), device_range);
+    mesh_workload.add_program(device_range, std::move(program));
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
     // Read back results

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -211,16 +211,14 @@ int main() {
     // multiple Physical Devices in the Virtual Mesh.
     auto add_mesh_workload = MeshWorkload();
     auto multiply_and_subtract_mesh_workload = MeshWorkload();
-    AddProgramToMeshWorkload(
-        add_mesh_workload, std::move(*add_program), all_devices);  // Addition runs on the full grid (sub_device 1)
-    AddProgramToMeshWorkload(
-        multiply_and_subtract_mesh_workload,
-        std::move(*multiply_program),
-        top_row);  // Multiplication runs on the top row (sub_device 2)
-    AddProgramToMeshWorkload(
-        multiply_and_subtract_mesh_workload,
-        std::move(*subtract_program),
-        bottom_row);  // Subtraction runs on the bottom row (sub device 2)
+    add_mesh_workload.add_program(
+        all_devices, std::move(*add_program));  // Addition runs on the full grid (sub_device 1)
+    multiply_and_subtract_mesh_workload.add_program(
+        top_row,
+        std::move(*multiply_program));  // Multiplication runs on the top row (sub_device 2)
+    multiply_and_subtract_mesh_workload.add_program(
+        bottom_row,
+        std::move(*subtract_program));  // Subtraction runs on the bottom row (sub device 2)
 
     // =========== Step 4: Compile and Load Workloads on the Mesh ===========
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), add_mesh_workload, true);

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -150,7 +150,7 @@ int main(int argc, char** argv) {
         // ensure that the kernel is finished before we read the output buffer. This is done by calling distributed::Finish(cq) which waits until
         // all operations in the command queue are finished. This is equivalent to calling EnqueueMeshWorkload(cq, program, true); telling
         // Metalium to wait until the program is finished before returning.
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
         // Equivalently:

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.md
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.md
@@ -128,7 +128,7 @@ In this program, we have a second source tensor. We will be adding this to the f
 Enqueue the program as a mesh workload. Use non-blocking enqueue and explicitly wait with `Finish(cq)` before reading results.
 
 ```cpp
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 ```

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -132,7 +132,7 @@ int main() {
         SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address(), n_tiles});
 
         // Enqueue the program as a mesh workload (non-blocking) and wait for completion before reading results.
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.md
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.md
@@ -114,7 +114,7 @@ SetRuntimeArgs(program, unary_writer_kernel_id, core, { dst_dram_buffer->address
 Enqueue the program in a mesh workload (non-blocking), then wait for completion and read back results from shard `{0, 0}`.
 
 ```cpp
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute.md
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute.md
@@ -45,7 +45,7 @@ Set runtime args, enqueue the program in a mesh workload (non-blocking), print a
 
 ```cpp
 SetRuntimeArgs(program, void_compute_kernel_id, core, {});
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 fmt::print("Hello, Core (0, 0) on Device 0, I am sending you a compute kernel. Standby awaiting communication.\n");
 

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -48,7 +48,7 @@ int main() {
 
     // Configure program and enqueue it as a mesh workload (non-blocking)
     SetRuntimeArgs(program, void_compute_kernel_id, core, {});
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     fmt::print("Hello, Core (0, 0) on Device 0, I am sending you a compute kernel. Standby awaiting communication.\n");
 

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_data_movement.md
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_data_movement.md
@@ -52,7 +52,7 @@ SetRuntimeArgs(program, void_dataflow_kernel_noc0_id, core, {});
 SetRuntimeArgs(program, void_dataflow_kernel_noc1_id, core, {});
 std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication." << std::endl;
 
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::Finish(cq);
 ```

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -55,7 +55,7 @@ int main() {
     std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
               << std::endl;
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
     // Wait Until MeshWorkload Finishes. The program should print the following (NC and BR is Data movement core 1 and 0

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -66,7 +66,7 @@ int main() {
 
     // Set runtime args, add program to mesh workload, and enqueue (non-blocking)
     SetRuntimeArgs(program, data_reader_kernel_id, core, {dram_buffer->address()});
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     fmt::print("Hello, Core {{0, 0}} on Device 0, please handle the data.\n");

--- a/tt_metal/programming_examples/loopback/dram_loopback.md
+++ b/tt_metal/programming_examples/loopback/dram_loopback.md
@@ -84,7 +84,7 @@ SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 Enqueue the program as a mesh workload (non-blocking), then wait for completion.
 
 ```cpp
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
 distributed::Finish(cq);
 ```

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -112,7 +112,7 @@ int main() {
         SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 
         // Add the program to the workload for the mesh.
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
         distributed::Finish(cq);

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
@@ -259,7 +259,7 @@ void matmul_multi_core(
     // returns, the output vector is fully populated).
     distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     // Blocking read waits for completion before returning and resizes 'output' as needed
     distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -334,7 +334,7 @@ void matmul_multicore_reuse(
     // Non-blocking uploads allow overlapping host setup with device transfers
     distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     // Blocking read from shard {0,0} waits for completion and populates 'output'
     distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -459,7 +459,7 @@ void matmul_multicore_reuse_mcast(
 
     distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
 }

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -176,7 +176,7 @@ void matmul_single_core(
     // buffer
     distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
     distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
 }

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.md
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.md
@@ -136,7 +136,7 @@ Launch program, enqueue & read in output buffer result into the host vector.
 ``` cpp
 distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
 distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+workload.add_program(device_range, std::move(program));
 distributed::EnqueueMeshWorkload(cq, workload, false);
 distributed::ReadShard(cq, output, dst_dram_buffer, distributed::MeshCoordinate(0, 0), true);
 ```

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -196,7 +196,7 @@ int main() {
     // Upload inputs (non-blocking), enqueue mesh workload (non-blocking), read back result, then wait for completion
     distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
     distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec, false);
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::EnqueueReadMeshBuffer(cq, dst_vec, dst_buffer, true);
     distributed::Finish(cq);

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -59,7 +59,7 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     // Enqueue mesh workload (non-blocking) then read profiler results from the mesh device
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
     ReadMeshDeviceProfilerResults(*mesh_device);
 

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -61,7 +61,7 @@ bool RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     // Enqueue mesh workload (non-blocking)
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 
     return pass;

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -57,7 +57,7 @@ void RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
 
     // Enqueue mesh workload (non-blocking) and read profiler results
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
     ReadMeshDeviceProfilerResults(*mesh_device);
 }

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -67,7 +67,7 @@ void RunFillUpAllBuffers(
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0, .defines = kernel_defines});
     }
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     if (fast_dispatch) {
         for (int i = 0;
              i < PROFILER_OP_SUPPORT_COUNT * kernel_profiler::PROFILER_L1_GUARANTEED_MARKER_COUNT / loop_count;

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -44,7 +44,7 @@ void RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         all_cores,
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args});
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     for (int i = 0; i < fastDispatch; i++) {
         // Enqueue the same mesh workload multiple times to generate profiler traffic
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -72,7 +72,7 @@ int main() {
             l1_buffer->size()};
         SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 
-        distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+        workload.add_program(device_range, std::move(program));
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -67,7 +67,7 @@ void RunFillUpAllBuffers(
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0, .defines = kernel_defines});
     }
 
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     if (fast_dispatch) {
         for (int i = 0; i < enqueue_times; i++) {
             // Enqueue the same mesh workload multiple times to generate profiler events

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -193,7 +193,7 @@ int main() {
     SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer->address()});
 
     // Program enqueue
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -139,7 +139,7 @@ int main() {
     fmt::print("\n");
 
     // start/finish program and close device
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
     // Kernel prints to console. No need to print the output here.
     //

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
     EnqueueWriteMeshBuffer(cq, a, a_data, false);
     EnqueueWriteMeshBuffer(cq, b, b_data, false);
     // Enqueue the program
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     std::cout << "Kernel execution finished" << std::endl;

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -225,7 +225,7 @@ int main(int argc, char** argv) {
 
     // Setup arguments and run the program.
     SetRuntimeArgs(program, compute, cores, {num_tiles_per_core});
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
     fmt::print("Kernel execution finished. Reading results...\n");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2605,7 +2605,7 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> create_homogenous_mesh_wor
     std::unordered_map<MeshCoordinateRange, MatmulCallback> callbacks = {};
 
     auto workload_device_range = get_range_from_mesh_coords(tensor_coords);
-    AddProgramToMeshWorkload(matmul_workload, std::move(matmul_program.program), workload_device_range);
+    matmul_workload.add_program(workload_device_range, std::move(matmul_program.program));
     callbacks[workload_device_range] = std::move(matmul_program.override_runtime_arguments_callback.value());
     return {.workload = std::move(matmul_workload), .per_program_callbacks = std::move(callbacks)};
 }
@@ -2740,10 +2740,8 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> Matmul::create_mesh_worklo
                         false,
                         false,
                         false);
-                    AddProgramToMeshWorkload(
-                        dram_sharded_mm_workload,
-                        std::move(dram_sharded_mm_program.program),
-                        MeshCoordinateRange(coord, coord));
+                    dram_sharded_mm_workload.add_program(
+                        MeshCoordinateRange(coord, coord), std::move(dram_sharded_mm_program.program));
                     callbacks[MeshCoordinateRange(coord, coord)] =
                         std::move(dram_sharded_mm_program.override_runtime_arguments_callback.value());
                 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26591)

### Problem description
N/A

### What's changed

- Migration of `AddProgramToMeshWorkload` API, contributing to the effort to deprecate/remove `tt_metal/api/tt-metalium/distributed.hpp`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18046002293))
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18100214073))