### PR TITLE
feat(ops): Add tanh activation function with autograd support

### DIFF
--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -11,6 +11,7 @@ namespace ttml::ops {
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor);
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor);
 autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_bw = false);
+autograd::TensorPtr tanh(const autograd::TensorPtr& tensor);
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor);
 autograd::TensorPtr sum(const autograd::TensorPtr& tensor);
 autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t new_batch_dim);


### PR DESCRIPTION
### Ticket
Fixes #36409

### Problem description
The hyperbolic tangent (tanh) activation function is needed for the BERT pooler layer and other transformer components. This PR implements tanh activation for tt-train with autograd support.

### What's changed
Implements hyperbolic tangent (tanh) activation function for neural network layers, following the established pattern for unary operations in the TTML framework.

Changes:
- Add tanh forward pass using ttnn::tanh
- Implement backward pass using ttnn::tanh_bw with gradient computation (1 - tanh²(x)) * grad_output
- Register gradient function in autograd computation graph for automatic differentiation
- Extract tensor value from optional return type in backward pass

Tests:
- Add forward pass correctness test with expected values for range [-2, 3]
- Add backward pass gradient verification using MSE loss
- Add saturation region behavior test for extreme values (±10, ±5)
- Verify near-zero gradients in saturation regions where tanh approaches ±1

The implementation enables tanh activation for use in transformer models (e.g., BERT pooler) and other architectures requiring bounded activation functions with range (-1, 1).

Tested on Wormhole B0 architecture with all tests passing.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ivoitovych/tanh-for-ttml)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ivoitovych/tanh-for-ttml)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ivoitovych/tanh-for-ttml)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ivoitovych/tanh-for-ttml)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ivoitovych/tanh-for-ttml)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ivoitovych/tanh-for-ttml)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ivoitovych/tanh-for-ttml)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs