### PR TITLE
Ensure Embedding Weights cb is Hardware-Aligned

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_embedding.py
@@ -58,7 +58,6 @@ def test_embedding(
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-@skip_for_blackhole("TODO: Fix on BH #26230")
 @pytest.mark.parametrize("batch_size", [55, 100, 200])
 @pytest.mark.parametrize("sentence_size", [1, 10, 100])
 @pytest.mark.parametrize("hidden_embedding_dim", [1, 128])  # Bert_Num_Cols_768, Llama_Num_Cols

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -442,7 +442,7 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     tt::DataFormat weights_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(weights.dtype());
 
     constexpr uint32_t out_cb_index = tt::CBIndex::c_0;
-    uint32_t rounded_weight_page_size = round_up_to_mul32(weight_page_size);
+    uint32_t rounded_weight_page_size = tt::align(weight_page_size, alignment);
     uint32_t out_cb_size;
     if (output_sharded) {
         out_cb_size = output.buffer()->aligned_size_per_bank();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26230)

### Problem description
[Provide context for the problem.](https://github.com/tenstorrent/tt-metal/issues/26230)

### What's changed
test embeddings had a skip for BH because the weights cb was not 64-byte aligned. Fixed to align it to whatever device it's on.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17958385065) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17867952942) CI with demo tests passes (if applicable)