### PR TITLE
avoid race between router and fabric mux setup

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -29,8 +29,7 @@ jobs:
         test-group:
           - name: fabric 1D unit tests
             cmd: |
-              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
-              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DMuxFixture.*"
+              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
             timeout: 15
           - name: fabric 2D fixture unit tests
             cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -106,8 +106,7 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
         echo "Health checks failed, retrying..."
         sleep 5
     done
-    TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DFixture.*"
-    TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1DMuxFixture.*"
+    TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
     TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/unit_tests_eth
 }

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -298,7 +298,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         edm_channel_ack_addr +
         (4 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
     this->edm_local_sync_address = termination_signal_address + field_size;
-    this->edm_status_address = edm_local_sync_address + field_size;
+    this->edm_local_tensix_sync_address = edm_local_sync_address + field_size;
+    this->edm_status_address = edm_local_tensix_sync_address + field_size;
 
     uint32_t buffer_address = edm_status_address + field_size;
 
@@ -1150,6 +1151,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
 
     termination_signal_ptr(config.termination_signal_address),
     edm_local_sync_ptr(config.edm_local_sync_address),
+    edm_local_tensix_sync_ptr(config.edm_local_tensix_sync_address),
     edm_status_ptr(config.edm_status_address),
     build_in_worker_connection_mode(build_in_worker_connection_mode),
     fabric_edm_type(fabric_edm_type),
@@ -1255,6 +1257,9 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     auto ct_args = std::vector<uint32_t>(stream_ids.begin(), stream_ids.end());
     ct_args.push_back(0xFFEE0001);
 
+    // add the downstream tensix connection arg here, num_downstream_tensix_connections
+    ct_args.push_back(this->num_downstream_tensix_connections);
+
     // when have dateline vc (vc1) and with tensix exntension enabled, need to send vc1 to downstream fabric router
     // instead of downstream tensix exntension.
     bool vc1_has_different_downstream_dest =
@@ -1305,6 +1310,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
 
         this->termination_signal_ptr,
         this->edm_local_sync_ptr,
+        this->edm_local_tensix_sync_ptr,
         this->edm_status_ptr,
 
         // fabric counters
@@ -1374,8 +1380,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     ct_args.insert(ct_args.end(), main_args.begin(), main_args.end());
 
     // insert the sender channel num buffers
-    // Index updated to account for 23 stream ID arguments + 1 marker at the beginning
-    const size_t sender_channel_num_buffers_idx = 38;  // 14 + 23 + 1
+    // Index updated to account for 23 stream ID arguments + 1 marker + 1 downstream tensix connections
+    const size_t sender_channel_num_buffers_idx = 39;  // 14 + 23 + 1 + 1
     ct_args.insert(
         ct_args.begin() + sender_channel_num_buffers_idx,
         this->sender_channels_num_buffers.begin(),
@@ -1753,6 +1759,11 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
     eth_chan_directions ds_dir = downstream_builder.get_direction();
 
     auto adapter_spec = downstream_builder.build_connection_to_fabric_channel(channel_id);
+
+    if constexpr (std::is_same_v<BuilderType, FabricTensixDatamoverBuilder>) {
+        this->num_downstream_tensix_connections++;
+        downstream_builder.append_upstream_routers_noc_xy(this->my_noc_x, this->my_noc_y);
+    }
 
     if (is_2D_routing) {
         // TODO: unify vc0 and vc1?

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -292,6 +292,7 @@ struct FabricEriscDatamoverConfig {
     std::size_t edm_channel_ack_addr = 0;
     std::size_t termination_signal_address = 0;  // pad extra bytes to match old EDM so handshake logic will still work
     std::size_t edm_local_sync_address = 0;
+    std::size_t edm_local_tensix_sync_address = 0;
     std::size_t edm_status_address = 0;
 
     // Performance telemetry buffer address (16B aligned)
@@ -608,6 +609,7 @@ public:
 
     size_t termination_signal_ptr = 0;
     size_t edm_local_sync_ptr = 0;
+    size_t edm_local_tensix_sync_ptr = 0;
     size_t edm_status_ptr = 0;
     eth_chan_directions direction = eth_chan_directions::EAST;
     size_t downstream_edms_connected = 0;
@@ -647,6 +649,7 @@ public:
     bool dateline_connection = false;
     bool wait_for_host_signal = false;
     bool has_tensix_extension = false;
+    uint32_t num_downstream_tensix_connections = 0;
 
 private:
     // Shared helper for setting up VC connections

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -304,7 +304,7 @@ chan_id_t FabricContext::get_fabric_master_router_chan(chip_id_t chip_id) const 
 }
 
 std::vector<size_t> FabricContext::get_fabric_router_addresses_to_clear() const {
-    return {this->router_config_->edm_local_sync_address};
+    return {this->router_config_->edm_local_sync_address, this->router_config_->edm_local_tensix_sync_address};
 }
 
 std::pair<uint32_t, uint32_t> FabricContext::get_fabric_router_sync_address_and_status() const {

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -216,6 +216,8 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args() const 
     fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
+    ct_args.push_back(0);  // num_upstream_routers - unused by default
+    ct_args.push_back(0);  // fabric_router_sync_address - unused by default
     append_default_stream_ids_to_ct_args(ct_args);
     append_default_persistent_channel_flags_to_ct_args(ct_args);
     return ct_args;

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -231,6 +231,8 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_compile_time_args_for_rela
     fabric_endpoint_status_address_ = fabric_router_config.edm_status_address;
 
     auto ct_args = get_fabric_mux_compile_time_main_args(fabric_router_config);
+    ct_args.push_back(0);  // num_upstream_routers - unused by default
+    ct_args.push_back(0);  // fabric_router_sync_address - unused by default
     append_default_stream_ids_to_ct_args(ct_args);
     append_default_persistent_channel_flags_to_ct_args(ct_args);
     return ct_args;

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -486,6 +486,10 @@ std::vector<uint32_t> FabricTensixDatamoverBuilder::get_compile_time_args(tt::tt
     fabric_mux_config_->set_fabric_endpoint_status_address(fabric_router_config.edm_status_address);
     auto ct_args = fabric_mux_config_->get_fabric_mux_compile_time_main_args(fabric_router_config);
 
+    // Add number of upstream routers and sync address
+    ct_args.push_back(static_cast<uint32_t>(upstream_routers_noc_x_.size()));
+    ct_args.push_back(fabric_router_config.edm_local_tensix_sync_address);
+
     // Get topology-specific fabric router stream IDs based on topology
     const auto topology = fabric_context.get_fabric_topology();
     const bool is_2d_fabric = fabric_context.is_2D_routing_enabled();
@@ -540,9 +544,21 @@ std::vector<uint32_t> FabricTensixDatamoverBuilder::get_compile_time_args(tt::tt
 }
 
 std::vector<uint32_t> FabricTensixDatamoverBuilder::get_runtime_args(tt::tt_metal::Program& program) const {
-    // Get runtime args from the underlying mux config
-    return fabric_mux_config_->get_fabric_mux_run_time_args(
+    std::vector<uint32_t> runtime_args;
+    runtime_args.insert(runtime_args.end(), upstream_routers_noc_x_.begin(), upstream_routers_noc_x_.end());
+    runtime_args.insert(runtime_args.end(), upstream_routers_noc_y_.begin(), upstream_routers_noc_y_.end());
+
+    // Get base runtime args from the underlying mux config
+    auto mux_runtime_args = fabric_mux_config_->get_fabric_mux_run_time_args(
         local_fabric_node_id_, remote_fabric_node_id_, link_idx_, program, {my_core_logical_});
+
+    runtime_args.insert(runtime_args.end(), mux_runtime_args.begin(), mux_runtime_args.end());
+    return runtime_args;
+}
+
+void FabricTensixDatamoverBuilder::append_upstream_routers_noc_xy(uint32_t noc_x, uint32_t noc_y) {
+    upstream_routers_noc_x_.push_back(noc_x);
+    upstream_routers_noc_y_.push_back(noc_y);
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -152,6 +152,8 @@ public:
     uint32_t get_noc_y() const { return noc_y_; }
     eth_chan_directions get_direction() const { return direction_; }
 
+    void append_upstream_routers_noc_xy(uint32_t noc_x, uint32_t noc_y);
+
 private:
     // Core and fabric configuration
     CoreCoord my_core_logical_;
@@ -174,6 +176,10 @@ private:
     // Channel connection liveness check disable array
     mutable std::array<bool, FabricEriscDatamoverConfig::num_sender_channels>
         channel_connection_liveness_check_disable_array_{};
+
+    // Upstream router coordinates for sync
+    std::vector<uint32_t> upstream_routers_noc_x_;
+    std::vector<uint32_t> upstream_routers_noc_y_;
 
     // Helper methods for kernel compilation
     std::vector<uint32_t> get_compile_time_args(tt::tt_metal::IDevice* device) const;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -64,8 +64,12 @@ static_assert(
     "Stream IDs end marker not found. This implies some arguments were misaligned between host and device. Double "
     "check the CT args.");
 
-// Main configuration arguments (after stream IDs and marker)
-constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = STREAM_IDS_END_MARKER_IDX + 1;
+// Downstream tensix connections argument (after stream IDs and marker)
+constexpr size_t NUM_DOWNSTREAM_TENSIX_CONNECTIONS_IDX = STREAM_IDS_END_MARKER_IDX + 1;
+constexpr uint32_t num_downstream_tensix_connections = get_compile_time_arg_val(NUM_DOWNSTREAM_TENSIX_CONNECTIONS_IDX);
+
+// Main configuration arguments (after stream IDs, marker, and downstream tensix connections)
+constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = NUM_DOWNSTREAM_TENSIX_CONNECTIONS_IDX + 1;
 constexpr size_t NUM_SENDER_CHANNELS = get_compile_time_arg_val(SENDER_CHANNEL_NOC_CONFIG_START_IDX);
 constexpr size_t NUM_RECEIVER_CHANNELS_CT_ARG_IDX = SENDER_CHANNEL_NOC_CONFIG_START_IDX + 1;
 constexpr size_t NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(NUM_RECEIVER_CHANNELS_CT_ARG_IDX);
@@ -85,12 +89,14 @@ static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
 static_assert(
-    wait_for_host_signal_IDX == 27, "wait_for_host_signal_IDX must be 27 (23 stream IDs + 1 marker + 3 config args)");
+    wait_for_host_signal_IDX == 28,
+    "wait_for_host_signal_IDX must be 28 (23 stream IDs + 1 marker + 1 tensix connections + 3 config args)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
 static_assert(
-    MAIN_CT_ARGS_START_IDX == 28, "MAIN_CT_ARGS_START_IDX must be 28 (23 stream IDs + 1 marker + 4 config args)");
+    MAIN_CT_ARGS_START_IDX == 29,
+    "MAIN_CT_ARGS_START_IDX must be 29 (23 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
@@ -184,10 +190,11 @@ constexpr size_t MAIN_CT_ARGS_IDX_2 = MAIN_CT_ARGS_IDX_1 + 19;
 constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2);
 constexpr uint32_t edm_local_sync_ptr_addr =
     wait_for_host_signal ? get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 1) : 0;
-constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 2);
+constexpr uint32_t edm_local_tensix_sync_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 2);
+constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 3);
 
 // Per-channel counters
-constexpr size_t MAIN_CT_ARGS_IDX_3 = MAIN_CT_ARGS_IDX_2 + 3;
+constexpr size_t MAIN_CT_ARGS_IDX_3 = MAIN_CT_ARGS_IDX_2 + 4;
 constexpr bool enable_fabric_counters = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_3 + 0) != 0;
 constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_3 + 1);
 constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_3 + 2);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2874,6 +2874,12 @@ void kernel_main() {
         }
     }
 
+    // if enable the tensix extension, then before open downstream connection, need to wait for downstream tensix ready
+    // for connection.
+    if constexpr (num_downstream_tensix_connections) {
+        wait_for_notification((uint32_t)edm_local_tensix_sync_ptr_addr, num_downstream_tensix_connections);
+    }
+
     if constexpr (is_2d_fabric) {
         uint32_t has_downstream_edm = has_downstream_edm_vc0_buffer_connection & 0xF;
         uint32_t edm_index = 0;

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -144,8 +144,8 @@ void forward_data(
 void kernel_main() {
     size_t rt_args_idx = 0;
 
-    uint8_t upstream_noc_x[num_upstream_routers];
-    uint8_t upstream_noc_y[num_upstream_routers];
+    std::array<uint8_t, num_upstream_routers> upstream_noc_x;
+    std::array<uint8_t, num_upstream_routers> upstream_noc_y;
     if constexpr (num_upstream_routers > 0) {
         for (uint32_t i = 0; i < num_upstream_routers; i++) {
             upstream_noc_x[i] = (uint8_t)get_arg_val<uint32_t>(rt_args_idx++);

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -38,8 +38,10 @@ constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(15
 
 constexpr ProgrammableCoreType CORE_TYPE = static_cast<ProgrammableCoreType>(get_compile_time_arg_val(16));
 constexpr bool wait_for_fabric_endpoint = get_compile_time_arg_val(17) == 1;
+constexpr size_t num_upstream_routers = get_compile_time_arg_val(18);
+constexpr size_t fabric_router_sync_address = get_compile_time_arg_val(19);
 
-constexpr size_t CHANNEL_STREAM_IDS_START_IDX = 18;
+constexpr size_t CHANNEL_STREAM_IDS_START_IDX = 20;
 
 constexpr size_t NOC_ALIGN_PADDING_BYTES = 12;
 
@@ -142,6 +144,17 @@ void forward_data(
 void kernel_main() {
     size_t rt_args_idx = 0;
 
+    uint8_t upstream_noc_x[num_upstream_routers];
+    uint8_t upstream_noc_y[num_upstream_routers];
+    if constexpr (num_upstream_routers > 0) {
+        for (uint32_t i = 0; i < num_upstream_routers; i++) {
+            upstream_noc_x[i] = (uint8_t)get_arg_val<uint32_t>(rt_args_idx++);
+        }
+        for (uint32_t i = 0; i < num_upstream_routers; i++) {
+            upstream_noc_y[i] = (uint8_t)get_arg_val<uint32_t>(rt_args_idx++);
+        }
+    }
+
     auto status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(status_address);
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::STARTED;
 
@@ -215,6 +228,14 @@ void kernel_main() {
 
     volatile auto termination_signal_ptr =
         reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(termination_signal_address);
+
+    // signal the upstream routers the mux is ready
+    if constexpr (num_upstream_routers > 0) {
+        for (uint32_t i = 0; i < num_upstream_routers; i++) {
+            auto noc_addr = get_noc_addr(upstream_noc_x[i], upstream_noc_y[i], fabric_router_sync_address);
+            noc_semaphore_inc(noc_addr, 1);
+        }
+    }
 
     // wait for fabric router to be ready before setting up the connection
     if constexpr (wait_for_fabric_endpoint) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
there is a chance that race can happen (could be unlikely given the time that fabric routers need to setup and sync with local and remote routers), where fabric router calls open and updates mux kernel l1 info before mux kernel local data structure setup are done (ex, the sender worker interface), which could cause the overwrite of some values being transferred from fabric router.

### What's changed
Add a sync point in fabric router, which waits for mux to finish all the local setup, and mux send the credit to the upstream fabric router.

### Checklist
- [ ] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17956483131
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17952810850/job/51057220827
- [x] BH nightly  https://github.com/tenstorrent/tt-metal/actions/runs/17956489986/job/51070224454