### PR TITLE
Revert "Blackhole test cleanup and rack box setup (#28275)"

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -964,36 +964,28 @@ def is_grayskull():
     return "grayskull" in ARCH_NAME
 
 
-def skip_for_blackhole(reason_str="Test_Infrastructure_Skip: not working for Blackhole"):
+def skip_for_blackhole(reason_str="not working for Blackhole"):
     return pytest.mark.skipif(is_blackhole(), reason=reason_str)
 
 
-def skip_for_wormhole_b0(reason_str="Test_Infrastructure_Skip: not working for Wormhole B0"):
+def skip_for_wormhole_b0(reason_str="not working for Wormhole B0"):
     return pytest.mark.skipif(is_wormhole_b0(), reason=reason_str)
 
 
-def skip_for_grayskull(reason_str="Test_Infrastructure_Skip: not working for Grayskull"):
+def skip_for_grayskull(reason_str="not working for Grayskull"):
     return pytest.mark.skipif(is_grayskull(), reason=reason_str)
 
 
-def run_for_blackhole(reason_str="Test_Infrastructure_Skip: only runs for Blackhole"):
+def run_for_blackhole(reason_str="only runs for Blackhole"):
     return pytest.mark.skipif(not is_blackhole(), reason=reason_str)
 
 
-def run_for_wormhole_b0(reason_str="Test_Infrastructure_Skip: only runs for Wormhole B0"):
+def run_for_wormhole_b0(reason_str="only runs for Wormhole B0"):
     return pytest.mark.skipif(not is_wormhole_b0(), reason=reason_str)
 
 
-def run_for_grayskull(reason_str="Test_Infrastructure_Skip: only runs for Grayskull"):
+def run_for_grayskull(reason_str="only runs for Grayskull"):
     return pytest.mark.skipif(not is_grayskull(), reason=reason_str)
-
-
-def skip_for_n_dev(n, reason_str="Test_Infrastructure_Skip: Test is not meant for this number of devices"):
-    return pytest.mark.skipif(ttnn.get_num_devices() == n, reason=reason_str)
-
-
-def skip_for_n_or_less_dev(n, reason_str="Test_Infrastructure_Skip: Test is not meant for this number of devices"):
-    return pytest.mark.skipif(ttnn.get_num_devices() <= n, reason=reason_str)
 
 
 def get_devices_for_t3000(all_devices, num_devices):

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -56,8 +56,6 @@ from models.common.utility_functions import (
     run_for_wormhole_b0,
     skip_for_blackhole,
     skip_for_grayskull,
-    skip_for_n_dev,
-    skip_for_n_or_less_dev,
     skip_for_wormhole_b0,
     tilize,
     tilize_to_list,

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -42,7 +42,6 @@ def run_all_gather_impl(
     num_buffers_per_channel=None,
     allowed_pcc=1,
     skip_check=False,
-    num_l1_banks=64,
     all_gather_function=ttnn.experimental.all_gather_async,
 ):
     torch.manual_seed(0)
@@ -51,16 +50,7 @@ def run_all_gather_impl(
 
     # Skip unsupported cases
     (is_known_failure, message) = is_unsupported_case(
-        ag_output_shape,
-        dim,
-        mem_config_ag,
-        num_devices,
-        num_links,
-        ag_input_dtype,
-        layout,
-        tile,
-        num_l1_banks,
-        mem_config_input,
+        ag_output_shape, dim, mem_config_ag, num_devices, num_links, ag_input_dtype, layout, tile
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -98,7 +98,7 @@ def test_all_gather_async(
     ttnn.ReadDeviceProfiler(submesh_device)
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1links"])
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, ag_input_dtype",

--- a/tests/ttnn/stress_tests/test_ccl.py
+++ b/tests/ttnn/stress_tests/test_ccl.py
@@ -7,129 +7,16 @@ import ttnn
 
 from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl
 from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
-from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@pytest.mark.parametrize("num_links", [4])  # Check over all four links
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, all_gather_topology",
     [
-        (4, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-        (4, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
-        (2, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-    ],
-)
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_ag",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-    ],
-    ids=[
-        "DRAM_ONLY",
-    ],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (False, 1),
-    ],
-    ids=["non-trace"],
-)
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}),
-    ],
-    indirect=["device_params"],
-    ids=["fabric"],
-)
-@pytest.mark.parametrize(
-    "cluster_axis",
-    [
-        0,
-        1,
-    ],
-    ids=["row", "column"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [20])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_ccl_ddr_smoke_test(
-    bh_2d_mesh_device,
-    num_devices,
-    ag_output_shape,
-    cluster_axis,
-    dim,
-    num_links,
-    ag_input_dtype,
-    layout,
-    mem_config_input,
-    mem_config_ag,
-    enable_trace,
-    all_gather_topology,
-    num_iters,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, cluster_axis)
-    for i in range(bh_2d_mesh_device.shape[(cluster_axis - 1) % 2]):
-        # Check all the rows and columns independantly within the device
-        if cluster_axis == 0:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((num_devices, 1)), offset=ttnn.MeshCoordinate(0, i)
-            )
-        else:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((1, num_devices)), offset=ttnn.MeshCoordinate(i, 0)
-            )
-        run_all_gather_impl(
-            submesh_device,
-            num_devices,
-            ag_output_shape,
-            dim,
-            num_links,
-            ag_input_dtype,
-            layout,
-            mem_config_input,
-            mem_config_ag,
-            all_gather_topology=all_gather_topology,
-            enable_trace=enable_trace,
-            num_iters=num_iters,
-            cluster_axis=cluster_axis,
-            chunks_per_sync=chunks_per_sync,
-            num_workers_per_link=num_workers_per_link,
-            num_buffers_per_channel=num_buffers_per_channel,
-            allowed_pcc=0.9999,
-        )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@pytest.mark.parametrize("num_links", [4])
-@pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, all_gather_topology",
-    [
-        (4, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-        (4, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
-        (2, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
+        (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
+        (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
+        (2, [1, 1, 2048, 2048], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
     ],
     ids=["4 device line", "4_device_ring", "2_device_line"],
 )
@@ -150,6 +37,10 @@ def test_ccl_ddr_smoke_test(
     "mem_config_input, mem_config_ag",
     [
         (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ),
+        (
             ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
             ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
         ),
@@ -163,6 +54,7 @@ def test_ccl_ddr_smoke_test(
         ),
     ],
     ids=[
+        "DRAM_ONLY",
         "L1_TO_DRAM",
         "DRAM_TO_L1",
         "L1_ONLY",
@@ -171,9 +63,10 @@ def test_ccl_ddr_smoke_test(
 @pytest.mark.parametrize(
     "enable_trace, num_iters",
     [
-        (False, 1),
+        (True, 10),
+        (False, 10),
     ],
-    ids=["non-trace"],
+    ids=["trace", "non-trace"],
 )
 @pytest.mark.parametrize(
     "device_params",
@@ -194,7 +87,7 @@ def test_ccl_ddr_smoke_test(
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_ccl_other_smoke_test(
+def test_ccl_smoke_test(
     bh_2d_mesh_device,
     num_devices,
     ag_output_shape,
@@ -212,7 +105,12 @@ def test_ccl_other_smoke_test(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, cluster_axis)
+    if (8 == ttnn.get_num_devices()) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Rackbox is a mesh not a torus so ring wouldn't work")
+    if bh_2d_mesh_device.shape[cluster_axis] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform in this axis")
+    if (bh_2d_mesh_device.shape[cluster_axis] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires the entire row or column so it loops around")
     for i in range(bh_2d_mesh_device.shape[(cluster_axis - 1) % 2]):
         if cluster_axis == 0:
             submesh_device = bh_2d_mesh_device.create_submesh(
@@ -240,6 +138,5 @@ def test_ccl_other_smoke_test(
             num_workers_per_link=num_workers_per_link,
             num_buffers_per_channel=num_buffers_per_channel,
             allowed_pcc=0.9999,
-            num_l1_banks=120,
         )
     ttnn.ReadDeviceProfiler(submesh_device)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test.py
@@ -10,15 +10,15 @@ from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@pytest.mark.parametrize("num_links", [4])  # Check over all four links
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout, all_gather_topology",
     [
-        (4, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-        (4, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
-        (2, [1, 1, 16384, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
+        (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
+        (2, [1, 1, 256, 256], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
     ],
+    ids=["4_device_ring", "2_device_line"],
 )
 @pytest.mark.parametrize(
     "ag_input_dtype",
@@ -39,130 +39,22 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_n
         (
             ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
             ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ),
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ),
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+        ),
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
         ),
     ],
     ids=[
         "DRAM_ONLY",
-    ],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (False, 1),
-    ],
-    ids=["non-trace"],
-)
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}),
-    ],
-    indirect=["device_params"],
-    ids=["fabric"],
-)
-@pytest.mark.parametrize(
-    "cluster_axis",
-    [
-        0,
-        1,
-    ],
-    ids=["row", "column"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [20])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_ccl_ddr_smoke_test(
-    bh_2d_mesh_device,
-    num_devices,
-    ag_output_shape,
-    cluster_axis,
-    dim,
-    num_links,
-    ag_input_dtype,
-    layout,
-    mem_config_input,
-    mem_config_ag,
-    enable_trace,
-    all_gather_topology,
-    num_iters,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, cluster_axis)
-    for i in range(bh_2d_mesh_device.shape[(cluster_axis - 1) % 2]):
-        # Check all the rows and columns independantly within the device
-        if cluster_axis == 0:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((num_devices, 1)), offset=ttnn.MeshCoordinate(0, i)
-            )
-        else:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((1, num_devices)), offset=ttnn.MeshCoordinate(i, 0)
-            )
-        run_all_gather_impl(
-            submesh_device,
-            num_devices,
-            ag_output_shape,
-            dim,
-            num_links,
-            ag_input_dtype,
-            layout,
-            mem_config_input,
-            mem_config_ag,
-            all_gather_topology=all_gather_topology,
-            enable_trace=enable_trace,
-            num_iters=num_iters,
-            cluster_axis=cluster_axis,
-            chunks_per_sync=chunks_per_sync,
-            num_workers_per_link=num_workers_per_link,
-            num_buffers_per_channel=num_buffers_per_channel,
-            allowed_pcc=0.9999,
-        )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@pytest.mark.parametrize("num_links", [4])
-@pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, all_gather_topology",
-    [
-        (4, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-        (4, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
-        (2, [1, 1, 4096, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-    ],
-    ids=["4 device line", "4_device_ring", "2_device_line"],
-)
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_ag",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=[
         "L1_TO_DRAM",
         "DRAM_TO_L1",
         "L1_ONLY",
@@ -171,9 +63,10 @@ def test_ccl_ddr_smoke_test(
 @pytest.mark.parametrize(
     "enable_trace, num_iters",
     [
-        (False, 1),
+        (True, 10),
+        (False, 10),
     ],
-    ids=["non-trace"],
+    ids=["trace", "non-trace"],
 )
 @pytest.mark.parametrize(
     "device_params",
@@ -194,8 +87,8 @@ def test_ccl_ddr_smoke_test(
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_ccl_other_smoke_test(
-    bh_2d_mesh_device,
+def test_ccl_smoke_test(
+    bh_1d_mesh_device,
     num_devices,
     ag_output_shape,
     cluster_axis,
@@ -212,34 +105,28 @@ def test_ccl_other_smoke_test(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, cluster_axis)
-    for i in range(bh_2d_mesh_device.shape[(cluster_axis - 1) % 2]):
-        if cluster_axis == 0:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((num_devices, 1)), offset=ttnn.MeshCoordinate(0, i)
-            )
-        else:
-            submesh_device = bh_2d_mesh_device.create_submesh(
-                ttnn.MeshShape((1, num_devices)), offset=ttnn.MeshCoordinate(i, 0)
-            )
-        run_all_gather_impl(
-            submesh_device,
-            num_devices,
-            ag_output_shape,
-            dim,
-            num_links,
-            ag_input_dtype,
-            layout,
-            mem_config_input,
-            mem_config_ag,
-            all_gather_topology=all_gather_topology,
-            enable_trace=enable_trace,
-            num_iters=num_iters,
-            cluster_axis=cluster_axis,
-            chunks_per_sync=chunks_per_sync,
-            num_workers_per_link=num_workers_per_link,
-            num_buffers_per_channel=num_buffers_per_channel,
-            allowed_pcc=0.9999,
-            num_l1_banks=120,
-        )
+    validate_test(num_devices, all_gather_topology, bh_1d_mesh_device.shape, cluster_axis)
+    if cluster_axis == 0:
+        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    else:
+        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
+    run_all_gather_impl(
+        submesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        cluster_axis=cluster_axis,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
+        allowed_pcc=0.9999,
+    )
     ttnn.ReadDeviceProfiler(submesh_device)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
@@ -7,116 +7,19 @@ import pytest
 import ttnn
 
 from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl
-from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0, skip_for_n_dev, skip_for_n_or_less_dev
-from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(1)
-@pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout",
-    [
-        (2, [1, 1, 128, 128], 3, ttnn.TILE_LAYOUT),
-    ],
-)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_ag",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=["trace", "non-trace"],
-)
-@pytest.mark.parametrize(
-    "device_params, all_gather_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [20])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_2D_line(
-    bh_2d_mesh_device,
-    num_devices,
-    ag_output_shape,
-    dim,
-    num_links,
-    ag_input_dtype,
-    layout,
-    mem_config_input,
-    mem_config_ag,
-    enable_trace,
-    all_gather_topology,
-    num_iters,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, 0)
-
-    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_all_gather_impl(
-        submesh_device,
-        num_devices,
-        ag_output_shape,
-        dim,
-        num_links,
-        ag_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_ag,
-        all_gather_topology=all_gather_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-        allowed_pcc=0.9999,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(2)
 @pytest.mark.parametrize(
     "num_devices, ag_output_shape, dim, layout",
     [
         (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
+        (2, [1, 1, 128, 128], 3, ttnn.TILE_LAYOUT),
     ],
+    ids=["4_device_test", "2_device_test"],
 )
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
@@ -156,206 +59,15 @@ def test_all_gather_2D_line(
     "device_params, all_gather_topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [20])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_4D_line(
-    bh_2d_mesh_device,
-    num_devices,
-    ag_output_shape,
-    dim,
-    num_links,
-    ag_input_dtype,
-    layout,
-    mem_config_input,
-    mem_config_ag,
-    enable_trace,
-    all_gather_topology,
-    num_iters,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, 0)
-    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_all_gather_impl(
-        submesh_device,
-        num_devices,
-        ag_output_shape,
-        dim,
-        num_links,
-        ag_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_ag,
-        all_gather_topology=all_gather_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-        allowed_pcc=0.9999,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(2)
-@pytest.mark.parametrize(
-    "ag_output_shape, dim, layout",
-    [
-        ([1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_ag",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=["trace", "non-trace"],
-)
-@pytest.mark.parametrize(
-    "device_params, all_gather_topology",
-    [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
     ],
     indirect=["device_params"],
+    ids=["fabric_linear", "fabric_ring"],
 )
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_ring(
-    bh_1d_mesh_device,
-    ag_output_shape,
-    dim,
-    num_links,
-    ag_input_dtype,
-    layout,
-    mem_config_input,
-    mem_config_ag,
-    enable_trace,
-    all_gather_topology,
-    num_iters,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    num_devices = bh_1d_mesh_device.shape[0]
-    validate_test(num_devices, all_gather_topology, bh_1d_mesh_device.shape, 0)
-
-    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_all_gather_impl(
-        submesh_device,
-        num_devices,
-        ag_output_shape,
-        dim,
-        num_links,
-        ag_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_ag,
-        all_gather_topology=all_gather_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-        allowed_pcc=0.9999,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(7)
-@pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout",
-    [
-        (2, [1, 1, 128, 128], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_ag",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=["trace", "non-trace"],
-)
-@pytest.mark.parametrize(
-    "device_params, all_gather_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [20])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_8D_vertical(
+def test_all_gather_nightly(
     bh_2d_mesh_device,
     num_devices,
     ag_output_shape,
@@ -372,9 +84,14 @@ def test_all_gather_8D_vertical(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, 1)
-    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
-    cluster_axis = 1
+    if (2 == num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires more than 2 devices")
+    if (bh_2d_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    if bh_2d_mesh_device.shape[0] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    cluster_axis = 0
     run_all_gather_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_reduce_scatter_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_reduce_scatter_apc.py
@@ -5,116 +5,18 @@
 import pytest
 import ttnn
 from tests.nightly.t3000.ccl.test_minimal_reduce_scatter_async import run_reduce_scatter_impl
-from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0, skip_for_n_dev, skip_for_n_or_less_dev
-from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(1)
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout",
-    [
-        (2, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_2D_nightly_linear(
-    bh_1d_mesh_device,
-    num_devices,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [2], ids=["2_links"])
 @pytest.mark.parametrize(
     "num_devices, rs_input_shape, dim, layout",
     [
         (4, [1, 1, 128, 256], 3, ttnn.TILE_LAYOUT),
+        (2, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
     ],
+    ids=["4_device", "2_device"],
 )
 @pytest.mark.parametrize(
     "rs_input_dtype",
@@ -158,210 +60,18 @@ def test_rs_row_2D_nightly_linear(
     "device_params, rs_topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_4D_nightly_linear(
-    bh_1d_mesh_device,
-    num_devices,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(2)
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "rs_input_shape, dim, layout",
-    [
-        ([1, 1, 128, 256], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 128, 512], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
     ],
     indirect=["device_params"],
+    ids=[
+        "fabric_linear",
+        "fabric_ring",
+    ],
 )
 @pytest.mark.parametrize("chunks_per_sync", [2])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_nightly_ring(
-    bh_1d_mesh_device,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    num_devices = bh_1d_mesh_device.shape[0]
-    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    cluster_axis = 0
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(7)
-@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
-@pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout",
-    [
-        (2, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-)
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_2D_nightly_linear(
+def test_rs_row_nightly(
     bh_2d_mesh_device,
     num_devices,
     num_links,
@@ -378,9 +88,14 @@ def test_rs_row_2D_nightly_linear(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    cluster_axis = 1
-    validate_test(num_devices, rs_topology, bh_2d_mesh_device.shape, cluster_axis)
-    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
+    if (2 == num_devices) and (rs_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires more than 2 devices")
+    if (bh_2d_mesh_device.shape[0] != num_devices) and (rs_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    if bh_2d_mesh_device.shape[0] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    cluster_axis = 0
     run_reduce_scatter_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/perf_tests.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/perf_tests.py
@@ -9,16 +9,12 @@ from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
 THRESHOLD = 0.4
-from models.utility_functions import skip_for_n_dev, skip_for_wormhole_b0, skip_for_n_or_less_dev
 
 
-@skip_for_wormhole_b0()
-@skip_for_n_or_less_dev(2)
-@skip_for_n_dev(8)
 @pytest.mark.parametrize(
     "warmup_iters, perf_target_us",
     [
-        (10, 310),
+        (10, 8.1),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
-from models.utility_functions import skip_for_n_dev, skip_for_wormhole_b0, skip_for_n_or_less_dev
 
 
 def run_with_trace(
@@ -283,13 +282,11 @@ def run_all_to_all_impl(
         assert eq, f"{i} FAILED: {output}"
 
 
-@skip_for_wormhole_b0()
-@skip_for_n_or_less_dev(2)
 @pytest.mark.parametrize(
-    "num_links, logical_shape, in_dim, out_dim, layout",
+    "num_devices, num_links, logical_shape, in_dim, out_dim, layout",
     [
-        (1, [1, 1, 44544, 3072 * 3], 2, 3, ttnn.TILE_LAYOUT),  # Pre-attn all-to-all
-        (1, [1, 1, 44544, 3072], 3, 2, ttnn.TILE_LAYOUT),  # Post-attn all-to-all
+        (4, 1, [1, 1, 44544, 3072 * 3], 2, 3, ttnn.TILE_LAYOUT),  # Pre-attn all-to-all
+        (4, 1, [1, 1, 44544, 3072], 3, 2, ttnn.TILE_LAYOUT),  # Post-attn all-to-all
     ],
     ids=["pre-attn", "post-attn"],
 )
@@ -320,6 +317,7 @@ def run_all_to_all_impl(
 )
 def test_all_to_all(
     bh_1d_mesh_device,
+    num_devices,
     logical_shape,
     in_dim,
     out_dim,
@@ -334,7 +332,6 @@ def test_all_to_all(
     enable_trace,
     is_ci_env,
 ):
-    num_devices = bh_1d_mesh_device.shape[0]
     topology = ttnn.Topology.Ring
     validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
     run_all_to_all_impl(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -8,7 +8,7 @@ import math
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal
-from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0, skip_for_n_dev, skip_for_n_or_less_dev
+from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
@@ -234,9 +234,7 @@ def run_reduce_scatter_impl(
     bh_1d_mesh_device.clear_loaded_sub_device_manager()
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
-@skip_for_n_dev(8)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
@@ -306,121 +304,12 @@ def run_reduce_scatter_impl(
     "device_params, rs_topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
-    ],
-    indirect=["device_params"],
-)
-def test_reduce_scatter_async_4dev_ring(
-    bh_1d_mesh_device,
-    num_devices,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    ones_tensor,
-    use_barrier,
-    use_persistent_buffers,
-    rs_topology,
-):
-    validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-    run_reduce_scatter_impl(
-        bh_1d_mesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        ones_tensor=ones_tensor,
-        use_barrier=use_barrier,
-        use_persistent_buffers=use_persistent_buffers,
-    )
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
-@pytest.mark.parametrize("num_links", [1], ids=["1link"])
-@pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout, rs_input_dtype, is_training_shape",
-    [
-        (4, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        (4, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False),  # use batching when fused
-        # Composite-RS tests
-        (4, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, True),
-        (4, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b, True),
-        # (4, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True), #Issue 27619
-    ],
-    ids=[
-        "padded_dim_2_test_one",
-        "padded_dim_2_test_two",
-        "batch_8",
-        "batch_4",
-        "batch_1_sd35_spatial",
-        "batch_1_sd35_prompt",
-        "batch_2",
-        "batch_1",
-        "composite_rs_test_one",
-        "composite_rs_test_two",
-        # "composite_rs_test_three",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        )
-    ],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 1),
-    ],
-    ids=["perf", "check"],
-)
-@pytest.mark.parametrize(
-    "ones_tensor",
-    [
-        True,
-        False,
-    ],
-    ids=["ones", "random"],
-)
-@pytest.mark.parametrize(
-    "use_barrier, use_persistent_buffers",
-    [
-        (True, True),
-        (True, False),
-        (False, True),
-    ],
-    ids=["barrier_with_persistent_buffers", "barrier_without_persistent_buffers", "no_barrier_with_persistent_buffers"],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
 )
-def test_reduce_scatter_async_line(
+def test_reduce_scatter_async(
     bh_1d_mesh_device,
     num_devices,
     num_links,
@@ -428,7 +317,6 @@ def test_reduce_scatter_async_line(
     dim,
     layout,
     rs_input_dtype,
-    is_training_shape,
     mem_config_input,
     mem_config_rs,
     enable_trace,
@@ -439,10 +327,6 @@ def test_reduce_scatter_async_line(
     rs_topology,
 ):
     validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
-
-    if is_training_shape and enable_trace:
-        pytest.skip("We've seen ND PCC when running the composite-RS with trace")
-
     run_reduce_scatter_impl(
         bh_1d_mesh_device,
         num_devices,
@@ -462,24 +346,23 @@ def test_reduce_scatter_async_line(
     )
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "num_devices, rs_input_shape, dim, layout, rs_input_dtype",
     [
         # Scatter on dim 0
-        (4, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 128, 128], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 1
-        (4, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Scatter on dim 2
-        (4, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        (4, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        # (4, [16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # # Scatter on dim 3
         (4, [1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         (4, [16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
@@ -514,9 +397,11 @@ def test_reduce_scatter_async_line(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_training_shapes(
     bh_1d_mesh_device,
@@ -533,8 +418,6 @@ def test_reduce_scatter_async_training_shapes(
     num_iters,
     ones_tensor,
 ):
-    if dim != 3:
-        pytest.skip("#26572: Can only operate on dim 3")
     validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, 0)
     run_reduce_scatter_impl(
         bh_1d_mesh_device,
@@ -555,8 +438,7 @@ def test_reduce_scatter_async_training_shapes(
     )
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "num_devices, layout, rs_input_dtype",
@@ -631,6 +513,7 @@ def test_reduce_scatter_async_training_shapes(
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 113664}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_sharded_to_sharded(
     bh_1d_mesh_device,
@@ -701,8 +584,7 @@ def test_reduce_scatter_async_sharded_to_sharded(
     )
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "num_devices, layout, rs_input_dtype",
@@ -758,6 +640,7 @@ def test_reduce_scatter_async_sharded_to_sharded(
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 113664}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_interleaved_to_sharded(
     bh_1d_mesh_device,
@@ -818,8 +701,7 @@ def test_reduce_scatter_async_interleaved_to_sharded(
     )
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
     "num_devices, layout, rs_input_dtype",
@@ -869,6 +751,7 @@ def test_reduce_scatter_async_interleaved_to_sharded(
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 113664}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
+    ids=["fabric_ring", "fabric_linear"],
 )
 def test_reduce_scatter_async_sharded_to_interleaved(
     bh_1d_mesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_new_all_broadcast.py
@@ -9,7 +9,7 @@ import pytest
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
-from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0, skip_for_n_dev
+from models.utility_functions import skip_for_grayskull
 
 
 def run_with_trace(
@@ -233,7 +233,7 @@ def run_all_broadcast_impl(
 
 
 # Enumerate the post-commit cases explicitly
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: Test_Infrastructure_Skip: test is for blackhole only")
+@skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, output_shape, layout, input_dtype",
     [
@@ -284,7 +284,6 @@ def test_all_broadcast(
 
 
 # Enumerate the post-commit cases explicitly
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: Test_Infrastructure_Skip: test is for blackhole only")
 @pytest.mark.parametrize(
     "num_devices, num_links, output_shape, layout, input_dtype",
     [
@@ -335,7 +334,6 @@ def test_all_broadcast_trace(
     )
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: Test_Infrastructure_Skip: test is for blackhole only")
 @pytest.mark.parametrize(
     "num_devices, output_shape, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
     [
@@ -383,6 +381,7 @@ def test_all_broadcast_sharded(
 ):
     topology = ttnn.Topology.Linear
     validate_test(num_devices, topology, bh_1d_mesh_device.shape, 0)
+    pytest.skip("This is currently not functional")
     if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
         pytest.skip("bfloat8_b not supported for row-major")
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_reduce_scatter_nightly.py
@@ -5,250 +5,21 @@
 import pytest
 import ttnn
 from tests.nightly.t3000.ccl.test_minimal_reduce_scatter_async import run_reduce_scatter_impl
-from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0, skip_for_n_dev, skip_for_n_or_less_dev
+from models.utility_functions import skip_for_blackhole, skip_for_wormhole_b0
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
 
 
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(1)
-@pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
-@pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout",
-    [
-        (2, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
-        (2, [1, 1, 32, 768], 3, ttnn.TILE_LAYOUT),
-    ],
-    ids=["2_device_32_1024", "2_device_32_768"],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_to_dram", "dram_to_l1", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-    ids=[
-        "fabric_linear",
-    ],
-)
-@pytest.mark.parametrize("cluster_axis", [0])
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_2D_nightly(
-    bh_2d_mesh_device,
-    num_devices,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-    cluster_axis,
-):
-    validate_test(num_devices, rs_topology, bh_2d_mesh_device.shape, cluster_axis)
-    if cluster_axis == 0:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    else:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(7)
-@pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
-@pytest.mark.parametrize(
-    "num_devices, rs_input_shape, dim, layout",
-    [
-        (2, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
-        (2, [1, 1, 32, 768], 3, ttnn.TILE_LAYOUT),
-    ],
-    ids=["2_device_32_1024", "2_device_32_768"],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_to_dram", "dram_to_l1", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
-    ],
-    indirect=["device_params"],
-    ids=[
-        "fabric_linear",
-    ],
-)
-@pytest.mark.parametrize("cluster_axis", [1])
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_vertical_nightly(
-    bh_2d_mesh_device,
-    num_devices,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-    cluster_axis,
-):
-    validate_test(num_devices, rs_topology, bh_2d_mesh_device.shape, cluster_axis)
-    if cluster_axis == 0:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    else:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
+@skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
 @pytest.mark.parametrize(
     "num_devices, rs_input_shape, dim, layout",
     [
         (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
         (4, [1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
+        (2, [1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
+        (2, [1, 1, 32, 768], 3, ttnn.TILE_LAYOUT),
     ],
-    ids=["4_device_128_2048", "4_device_32_4096"],
+    ids=["4_device_128_2048", "4_device_32_4096", "2_device_32_1024", "2_device_32_768"],
 )
 @pytest.mark.parametrize(
     "rs_input_dtype",
@@ -305,13 +76,14 @@ def test_rs_row_vertical_nightly(
     indirect=["device_params"],
     ids=[
         "fabric_linear",
+        "fabric_ring",
     ],
 )
 @pytest.mark.parametrize("chunks_per_sync", [2])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_4D_nightly(
-    bh_2d_mesh_device,
+def test_rs_row_nightly(
+    bh_1d_mesh_device,
     num_devices,
     num_links,
     rs_input_shape,
@@ -328,124 +100,8 @@ def test_rs_row_4D_nightly(
     num_buffers_per_channel,
 ):
     cluster_axis = 0
-    validate_test(num_devices, rs_topology, bh_2d_mesh_device.shape, cluster_axis)
-    if cluster_axis == 0:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    else:
-        submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
-    run_reduce_scatter_impl(
-        submesh_device,
-        num_devices,
-        rs_input_shape,
-        dim,
-        num_links,
-        rs_input_dtype,
-        layout,
-        mem_config_input,
-        mem_config_rs,
-        rs_topology=rs_topology,
-        enable_trace=enable_trace,
-        num_iters=num_iters,
-        cluster_axis=cluster_axis,
-        chunks_per_sync=chunks_per_sync,
-        num_workers_per_link=num_workers_per_link,
-        num_buffers_per_channel=num_buffers_per_channel,
-    )
-    ttnn.ReadDeviceProfiler(submesh_device)
-
-
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This test is for blackhole")
-@skip_for_n_or_less_dev(3)
-@pytest.mark.parametrize("num_links", [1, 2], ids=["1_link", "2_links"])
-@pytest.mark.parametrize(
-    "rs_input_shape, dim, layout",
-    [
-        ([1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "rs_input_dtype",
-    [
-        ttnn.bfloat16,
-        # ttnn.uint32, #Bad PCC
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        # "uint_32", #Bad PCC
-        "bfloat_8",
-    ],
-)
-@pytest.mark.parametrize(
-    "mem_config_input, mem_config_rs",
-    [
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-        (
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
-        ),
-    ],
-    ids=["dram_only", "l1_to_dram", "dram_to_l1", "l1_only"],
-)
-@pytest.mark.parametrize(
-    "enable_trace, num_iters",
-    [
-        (True, 10),
-        (False, 10),
-    ],
-    ids=[
-        "trace",
-        "non-trace",
-    ],
-)
-@pytest.mark.parametrize(
-    "device_params, rs_topology",
-    [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
-    ],
-    indirect=["device_params"],
-    ids=[
-        "fabric_ring",
-    ],
-)
-@pytest.mark.parametrize("chunks_per_sync", [2])
-@pytest.mark.parametrize("num_workers_per_link", [2])
-@pytest.mark.parametrize("num_buffers_per_channel", [8])
-def test_rs_row_ring_nightly(
-    bh_1d_mesh_device,
-    num_links,
-    rs_input_shape,
-    dim,
-    layout,
-    rs_input_dtype,
-    mem_config_input,
-    mem_config_rs,
-    enable_trace,
-    num_iters,
-    rs_topology,
-    chunks_per_sync,
-    num_workers_per_link,
-    num_buffers_per_channel,
-):
-    cluster_axis = 0
-    num_devices = bh_1d_mesh_device.shape[0]
     validate_test(num_devices, rs_topology, bh_1d_mesh_device.shape, cluster_axis)
-    if cluster_axis == 0:
-        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
-    else:
-        submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
+    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     run_reduce_scatter_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -51,7 +51,7 @@ def run_allgather_only_with_trace(
     tt_out_tensor = ttnn.experimental.all_gather_async(
         input_tensor_mesh,
         dim,
-        multi_device_global_semaphore=[ccl_semaphore_handles[0], ccl_semaphore_handles[1]],
+        multi_device_global_semaphore=ccl_semaphore_handles[0],
         num_links=num_links,
         memory_config=output_mem_config,
         topology=all_gather_topology,
@@ -68,12 +68,11 @@ def run_allgather_only_with_trace(
             tt_out_tensor = ttnn.experimental.all_gather_async(
                 input_tensor_mesh,
                 dim,
-                multi_device_global_semaphore=[ccl_semaphore_handles[2 * i], ccl_semaphore_handles[2 * i + 1]],
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
                 num_links=num_links,
                 memory_config=output_mem_config,
                 topology=all_gather_topology,
                 subdevice_id=subdevice_id,
-                barrier_semaphore=barrier_semaphore_handles[i % 2] if use_barrier else None,
             )
             tt_out_tensor.deallocate(True)
         ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
@@ -83,7 +82,7 @@ def run_allgather_only_with_trace(
         tt_out_tensor = ttnn.experimental.all_gather_async(
             input_tensor_mesh,
             dim,
-            multi_device_global_semaphore=[ccl_semaphore_handles[2 * i], ccl_semaphore_handles[2 * i + 1]],
+            multi_device_global_semaphore=ccl_semaphore_handles[i],
             num_links=num_links,
             memory_config=output_mem_config,
             topology=all_gather_topology,
@@ -131,7 +130,7 @@ def run_all_gather_impl(
     output_shard_shape=None,
     output_shard_grid=None,
     tensor_mem_layout=None,
-    warmup_iters=2,
+    warmup_iters=20,
     use_barrier=False,
 ):
     if num_iters < 1:
@@ -153,13 +152,9 @@ def run_all_gather_impl(
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [
-        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters * 2)
-    ]
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
     if use_barrier:
         barrier_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(2)]
-    else:
-        barrier_semaphore_handles = None
 
     ### For sharded all gather only
     if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
@@ -254,8 +249,8 @@ def run_all_gather_impl(
             dim,
             num_links,
             output_mem_config,
-            ccl_semaphore_handles=ccl_semaphore_handles,
-            barrier_semaphore_handles=barrier_semaphore_handles,
+            multi_device_global_semaphore=ccl_semaphore_handles,
+            barrier_semaphore=barrier_semaphore_handles,
             use_barrier=use_barrier,
             num_iter=num_iters,
             warmup_iters=warmup_iters,
@@ -267,7 +262,7 @@ def run_all_gather_impl(
             tt_out_tensor = ttnn.experimental.all_gather_async(
                 input_tensor_mesh_list[i],
                 dim,
-                multi_device_global_semaphore=[ccl_semaphore_handles[2 * i], ccl_semaphore_handles[2 * i + 1]],
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
                 num_links=num_links,
                 memory_config=output_mem_config,
                 topology=all_gather_topology,
@@ -411,19 +406,19 @@ def test_all_gather_only(
 
 
 # Enumerate the post-commit cases explicitly
-@skip_for_wormhole_b0("Test_Infrastructure_Skip: This is a blackhole test")
+@skip_for_wormhole_b0("This is a blackhole test")
 @pytest.mark.parametrize(
     "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
     [
         (
             4,
-            [1, 1, 4096, 2048],
-            3,
+            [1, 32, 32, 128],
+            1,
             ttnn.TILE_LAYOUT,
-            (64, 512),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
-            (64, 2048),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 7))}),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
     ],
@@ -435,7 +430,7 @@ def test_all_gather_only(
         ttnn.uint32,
     ],
 )
-@pytest.mark.parametrize("warmup_iters, num_iters", [(10, 20)])
+@pytest.mark.parametrize("warmup_iters, num_iters", [(1000, 10)])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -448,7 +443,7 @@ def test_all_gather_only(
     indirect=True,
 )
 def test_bh_trace_ag(
-    bh_1d_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     output_shape,
     dim,
@@ -465,11 +460,13 @@ def test_bh_trace_ag(
     output_shard_grid,
     tensor_mem_layout,
 ):
-    if bh_1d_mesh_device.shape[0] != num_devices:
+    if bh_2d_mesh_device.shape[0] != num_devices:
         pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    if ttnn.get_num_devices() == 8:
+        pytest.skip("Test requires a torus but rackbox is a mesh")
     profiler = BenchmarkProfiler()
     run_all_gather_impl(
-        bh_1d_mesh_device,
+        bh_2d_mesh_device,
         num_devices,
         output_shape,
         dim,
@@ -479,7 +476,6 @@ def test_bh_trace_ag(
         function_level_defaults,
         input_shard_shape,
         input_shard_grid,
-        use_barrier=True,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
         output_shard_shape=output_shard_shape,


### PR DESCRIPTION
This reverts commit a7ce66c29d48051c5316af115b2cead4deec8370.

This broke ttnn unit tests on APC.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
