### PR TITLE
Replace MeshDevice with IDevice is_mmio_capable

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -254,9 +254,9 @@ int main(int argc, char** argv) {
         }
         eth_sender_core_iter++;
     } while (device_id == std::numeric_limits<chip_id_t>::max() ||
-             !test_fixture.devices_.at(device_id)->is_mmio_capable());
+             !test_fixture.devices_.at(device_id)->get_devices()[0]->is_mmio_capable());
     TT_FATAL(device_id != std::numeric_limits<chip_id_t>::max(), "No valid receiver device found to connect to");
-    TT_FATAL(test_fixture.devices_.at(device_id)->is_mmio_capable(), "Receiver device is not mmio capable");
+    TT_FATAL(test_fixture.devices_.at(device_id)->get_devices()[0]->is_mmio_capable(), "Receiver device is not mmio capable");
     const auto& device_1 = test_fixture.devices_.at(device_id);
 
     // Add more configurations here until proper argc parsing added

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -256,7 +256,8 @@ int main(int argc, char** argv) {
     } while (device_id == std::numeric_limits<chip_id_t>::max() ||
              !test_fixture.devices_.at(device_id)->get_devices()[0]->is_mmio_capable());
     TT_FATAL(device_id != std::numeric_limits<chip_id_t>::max(), "No valid receiver device found to connect to");
-    TT_FATAL(test_fixture.devices_.at(device_id)->get_devices()[0]->is_mmio_capable(), "Receiver device is not mmio capable");
+    auto* receiver_device = test_fixture.devices_.at(device_id)->get_devices()[0];
+    TT_FATAL(receiver_device->is_mmio_capable(), "Receiver device is not mmio capable");
     const auto& device_1 = test_fixture.devices_.at(device_id);
 
     // Add more configurations here until proper argc parsing added

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -474,7 +474,11 @@ IDevice* MeshDevice::get_device(chip_id_t physical_device_id) const {
     TT_THROW("Physical Device ID: {} not found in assigned devices", physical_device_id);
 }
 
-std::vector<IDevice*> MeshDevice::get_devices() const { return view_->get_devices(); }
+std::vector<IDevice*> MeshDevice::get_devices() const {
+    auto devices = view_->get_devices();
+    TT_ASSERT(!devices.empty(), "Mesh Device should have at least 1 IDevice");
+    return devices;
+}
 
 // TODO: Remove this function once we have a proper view interface
 IDevice* MeshDevice::get_device(size_t row_idx, size_t col_idx) const {


### PR DESCRIPTION
### Ticket
NA

### Problem description
T3K Frequent pipeline failure introduced by mesh device migration

### What's changed
use idevice

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/17869127597