### PR TITLE
[skip ci] Add template for Sanity pipelines

### DIFF
--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -1,0 +1,105 @@
+import yaml
+import json
+import sys
+import os
+from collections import defaultdict
+
+
+def verify_timeouts(tests_file, time_budget_file):
+    """
+    Verifies that the SUM of all test timeouts for each SKU in tests_file
+    is within the total time budget defined in time_budget_file.
+    """
+    # These could be passed in from the workflow
+    TEAM = "ops"
+    WORKFLOW = "sanity"
+
+    print(f"Loading time budgets from: {time_budget_file}")
+    with open(time_budget_file, "r") as f:
+        budgets = yaml.safe_load(f)
+
+    print(f"Loading tests from: {tests_file}")
+    with open(tests_file, "r") as f:
+        tests = yaml.safe_load(f)
+
+    errors_found = False
+
+    # Navigate to the relevant part of the config
+    try:
+        workflow_budgets = budgets[TEAM][WORKFLOW]
+    except KeyError:
+        print(f"Error: Could not find time budgets for team '{TEAM}' and workflow '{WORKFLOW}' in {time_budget_file}.")
+        sys.exit(1)
+
+    # --- Part 1: Validate test file format and sum timeouts per SKU ---
+    print("\n--- Summing Test Timeouts per SKU ---")
+
+    sku_timeout_totals = defaultdict(int)
+
+    for test in tests:
+        test_name = test.get("name", "Unnamed Test")
+
+        # Validate that mandatory keys exist
+        if "timeout" not in test:
+            print(f"  [ERROR] Validation FAILED! Test '{test_name}' is missing the mandatory 'timeout' key.")
+            errors_found = True
+            continue
+        if "sku" not in test:
+            print(f"  [ERROR] Validation FAILED! Test '{test_name}' is missing the mandatory 'sku' key.")
+            errors_found = True
+            continue
+
+        test_timeout = test["timeout"]
+        test_sku = test["sku"]
+
+        # Add this test's timeout to the total for its SKU
+        sku_timeout_totals[test_sku] += test_timeout
+        print(f"  Test '{test_name}' (SKU: {test_sku}) adds {test_timeout} min.")
+
+    # If there were any validation errors (missing keys), fail now.
+    if errors_found:
+        print(f"\nMissing keys in {tests_file}. Please fix the entries above.")
+        sys.exit(1)
+
+    # --- Part 2: Verify Total Time Budget for each SKU ---
+    print("\n--- Verifying Total Time Budgets ---")
+
+    for sku, total_time_requested in sku_timeout_totals.items():
+        try:
+            # Directly access the total budget for the SKU
+            total_time_budget = workflow_budgets["skus"][sku]["time_budget"]
+
+            print(
+                f"Checking total for SKU '{sku}': Requested = {total_time_requested} min, Budget = {total_time_budget} min"
+            )
+
+            if total_time_requested > total_time_budget:
+                print(
+                    f"  [ERROR] Total Time Budget FAILED for SKU '{sku}'! The sum of all test timeouts ({total_time_requested} min) exceeds the allocated budget of {total_time_budget} min."
+                )
+                errors_found = True
+            else:
+                print(f"  [OK] Total time for SKU '{sku}' is within the budget.")
+
+        except (KeyError, TypeError):
+            print(
+                f"  [ERROR] Configuration FAILED! Could not find a 'time_budget' key for SKU '{sku}' in {time_budget_file}."
+            )
+            errors_found = True
+            continue
+
+    # --- Final Verdict ---
+    if errors_found:
+        print("\nVerification failed.")
+        sys.exit(1)
+    else:
+        print("\nVerification successful.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python verify_time_budget.py <path_to_tests.yaml> <path_to_machine_time_allocation.yaml>")
+        sys.exit(1)
+
+    verify_timeouts(sys.argv[1], sys.argv[2])

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -1,0 +1,15 @@
+# This file defines the maximum allowed timeout (in minutes) for tests
+# belonging to a given team and workflow.
+
+# This is part of an effort to reorganize the pipelines for clearer resource allocation and ownership.
+# For more information please refer to https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1396506680/Proposed+pipeline+and+test+organization+changes
+
+# Team: ops
+ops:
+  # Workflow: sanity
+  sanity:
+    skus:
+      N300:
+        time_budget: 540
+      P150b:
+        time_budget: 540

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -228,3 +228,12 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Enable ops-sanity workflow after issue:30675 resolved
+  # ops-sanity:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/ops-sanity.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/ops-sanity.yaml
+++ b/.github/workflows/ops-sanity.yaml
@@ -1,0 +1,141 @@
+# This is a template workflow for running Ops Sanity pipeline tests.
+# These tests are meant to run after every commit and are meant to replace the existing APC pipeline.
+
+
+# The following parameters can be controlled in the tests.yaml file by the developer:
+
+# name: The name of the test
+# cmd: The command to run the test
+# sku: the sku of the test (N150, N300, P100, P150b, llmbox, galaxy, etc)
+# owner_id: The owner of the test
+
+
+name: "[testing] Ops Sanity pipeline"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+  push:
+    branches:
+      ["roseli/28975-pipeline-reorg-apc-ops"]
+
+jobs:
+  load-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.load-test-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ./tests/pipeline_reorg/ops/sanity/tests.yaml \
+            ./.github/time_budget.yaml
+
+      - name: Load test matrix
+        id: load-test-matrix
+        # the tests.yaml file is currently hardcoded
+        # Install yq to parse the tests.yaml file
+        # TODO: move yq install out to install dependencies step.
+        env:
+          TESTS_YAML_PATH: ./tests/pipeline_reorg/ops/sanity/tests.yaml
+        run: |
+          set -e
+          # Install yq
+          YQ_VERSION="v4.44.1"
+          wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          # Check if the file exists
+          if [ ! -f "$TESTS_YAML_PATH" ]; then
+            echo "::error::Test matrix file not found at: $TESTS_YAML_PATH"
+            exit 1
+          fi
+          # Sanitize line endings
+          sanitized_yaml=$(sed 's/\r$//' $TESTS_YAML_PATH)
+          # Convert to JSON
+          json_output=$(echo "${sanitized_yaml}" | yq '. | to_json(0)')
+          # Print the JSON output
+          echo "Read contents of $TESTS_YAML_PATH and converted to JSON:"
+          echo "${json_output}"
+          echo "matrix=${json_output}" >> $GITHUB_OUTPUT
+
+  build-artifact:
+    # This job will ONLY run if the build-artifact-name input is NOT provided.
+    if: ${{ inputs.build-artifact-name == '' }}
+    needs: load-test-matrix
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      version: 22.04
+      build-wheel: true
+
+  tests:
+    # If the build-artifact-name input is NOT provided, we need to run the build-artifact job first.
+    needs: [load-test-matrix, build-artifact]
+    # Always run this job even if build-artifact job is not run.
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: >-
+      ${{
+        (matrix.test-group.sku == 'P100') && fromJSON(format('["in-service", "cloud-virtual-machine", "{0}"]', matrix.test-group.sku))
+        || ((matrix.test-group.sku == 'P150b') && format('tt-ubuntu-2204-{0}-metal', matrix.test-group.sku))
+        || format('tt-ubuntu-2204-{0}-viommu-metal', matrix.test-group.sku)
+      }}
+    container:
+      image: ${{ inputs.docker-image || needs.build-artifact.outputs.dev-docker-image || 'docker-image-unresolved!' }}
+      env:
+        LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: Mark repository as safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name || needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          echo ${{ matrix.test-group.cmd }}
+          ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/ops-sanity.yaml
+++ b/.github/workflows/ops-sanity.yaml
@@ -25,9 +25,6 @@ on:
       docker-image:
         required: true
         type: string
-  push:
-    branches:
-      ["roseli/28975-pipeline-reorg-apc-ops"]
 
 jobs:
   load-test-matrix:

--- a/tests/pipeline_reorg/ops/sanity/tests.yaml
+++ b/tests/pipeline_reorg/ops/sanity/tests.yaml
@@ -1,0 +1,208 @@
+# This file defines the test matrix for the Ops Sanity pipeline.
+
+# Each entry represents a parallel job with the following keys:
+#   name: The display name for the job in GitHub Actions.
+#   cmd: The exact command to run for the test.
+#   sku: Machine type to target (e.g. N300, P150b).
+#   owner_id: The Slack user ID to notify on failure.
+#   timeout: The maximum allowed runtime for this job in minutes.
+
+# The following two tests are examples. They should be removed before this workflow is enabled in APC.
+- name: example_test
+  cmd: ./tests/scripts/run_ttnn_examples.sh
+  owner_id: U08DEGUJY3H # Rose Li
+  sku: N300
+  timeout: 5
+
+- name: example_test_BH
+  cmd: ./tests/scripts/run_ttnn_examples.sh
+  owner_id: U08DEGUJY3H # Rose Li
+  sku: P150b
+  timeout: 5
+
+# The following tests should be uncommented after removing the same tests from APC and BHPC.
+# The timeouts are approximate and should be adjusted to the actual runtime of the tests before enabling.
+# Moreh and Transformers group assigned to Chris Maryan by default due to lack of owner.
+
+#- name: ttnn eltwise group 1
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 1 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 2
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 2 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 3
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 3 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 4
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 4 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 5
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 5 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 6
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 6 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 7
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 7 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn eltwise group 8
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 8 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 1
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: N300
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 2
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: N300
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 3
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: N300
+#  timeout: 40
+#- name: ttnn conv group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U085GDCAZTN # Pavle Josipovic
+#  sku: N300
+#  timeout: 40
+#- name: ttnn pool group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U085GDCAZTN # Pavle Josipovic
+#  sku: N300
+#  timeout: 40
+#- name: ttnn matmul group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: N300
+#  timeout: 40
+#- name: ttnn fused group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: N300
+#  timeout: 40
+#- name: ttnn moreh group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn transformers group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: N300
+#  timeout: 40
+#- name: ttnn reduce and misc ops group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/rand tests/ttnn/unit_tests/operations/debug
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: N300
+#  timeout: 40
+
+# BH section. TODO: combine skus into one test block to avoid duplication.
+#- name: ttnn eltwise group 1
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 1 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 2
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 2 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 3
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 3 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 4
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 4 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 5
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 5 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 6
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 6 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 7
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 7 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn eltwise group 8
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 8 -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 1
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 2
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn data_movement/ccl group 3
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"
+#  owner_id: U05ACKAJTHS # Naif Tarafdar
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn conv group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U085GDCAZTN # Pavle Josipovic
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn pool group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U085GDCAZTN # Pavle Josipovic
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn matmul group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn fused group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn moreh group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn transformers group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"
+#  owner_id: U08411R54Q2 # Chris Maryan
+#  sku: P150b
+#  timeout: 40
+#- name: ttnn reduce and misc ops group
+#  cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/rand tests/ttnn/unit_tests/operations/debug
+#  owner_id: U084B1CES7M # Borys Bradel
+#  sku: P150b
+#  timeout: 40


### PR DESCRIPTION
This PR does not affect APC or any existing pipeline.

This PR is the first of a series of refactoring PRs for pipeline reorganization. Please refer to https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1396506680/Proposed+pipeline+and+test+organization+changes for more details.

Todo list beyond this PR is currently tracked at https://github.com/tenstorrent/tt-metal/issues/30675

Goals of this refactoring:

- create simplified interface for devs adding tests 
- clearly communicate machine time allocation via time_budget.yaml
- auto verify time budgets at the beginning of workflows
- clearer ownership of tests
- less pipelines to get a PR merged

Using the `tests.yaml` file to adjust timeouts:

- each test must specify timeout and sku (currently only N300 and P150b supported for specifically ops tests)
- the sum of the timeout per sku must be less than or equal to the specified budget in `time_budget.yaml`

Testing:

- [x] APC calling Ops Sanity https://github.com/tenstorrent/tt-metal/actions/runs/18585877776 (failure on one job expected)
- [x] Ops Sanity workflow dispatch https://github.com/tenstorrent/tt-metal/actions/runs/18585828695