### PR TITLE
[skip ci] modernize-use-using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -155,7 +155,6 @@ Checks: >
   -modernize-use-std-numbers,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,
-  -modernize-use-using,
   -performance-avoid-endl,
   -performance-enum-size,
   -performance-faster-string-find,


### PR DESCRIPTION
### Ticket
#22758 

### Problem description
We had this check disabled for no apparent reason.
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html

### What's changed
- Enable check