### PR TITLE
Revert "Add prefill mode support for MOE decoders (#28879)"

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -37,16 +37,16 @@ from models.demos.deepseek_v3.utils.test_utils import (
     [
         (DecoderBlock, None, 0),
         (MoEDecoderBlock, None, 3),
-        (DecoderBlock, "model.layers.0", None),
-        (MoEDecoderBlock, "model.layers.3", None),
+        # (DecoderBlock, "model.layers.0", None),
+        # (MoEDecoderBlock, "model.layers.3", None), # TODO: Uncomment once PCC is fixed for MoE
     ],
 )
 @pytest.mark.parametrize(
     "mode, seq_len, batch_size",
     [
         ("decode", 1, 32),
-        ("prefill", 128, 1),
-        # ("prefill", 2048, 1),  # Test chunking # TODO: Uncomment once MLA prefill works
+        # ("prefill", 512), # TODO: Uncomment once MLA prefill works
+        # ("prefill", 2048),  # Test chunking # TODO: Uncomment once MLA prefill works
     ],
 )
 def test_forward_pass(

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -98,7 +98,7 @@ def test_forward_pass(
                 (batch_size,), dtype=torch.long
             )  # TODO: investigate the PCC issue with real weights
 
-        logger.info("Running the reference model")
+        logger.info("Running the model")
         reference_output, input_cache, output_cache = run_reference_with_attention(
             reference_model, torch_input, position_ids, None, hf_config_short, mode, False
         )

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -59,7 +59,7 @@ def test_forward_pass(
     set_deterministic_env,
 ):
     # Set less layers and shorter max length for the sake of testing
-    hf_config_short.num_hidden_layers = 8
+    hf_config_short.num_hidden_layers = 3
 
     # CCL workaround (remove once persistent buffers are added)
     mesh_device.disable_and_clear_program_cache()

--- a/models/demos/deepseek_v3/tt/model_1d.py
+++ b/models/demos/deepseek_v3/tt/model_1d.py
@@ -142,28 +142,9 @@ class Model1D(SharedStateAddOn, AbstractModule):
         mesh_device: ttnn.Device,
     ) -> ModelPrefillConfig:
         """Create the model configuration for prefill mode."""
-        mlp_is_padding_layer, _ = cls.get_meta_layer_mapping(mesh_device.shape[0], hf_config.first_k_dense_replace)
-        moe_is_padding_layer, _ = cls.get_meta_layer_mapping(
-            mesh_device.shape[0], hf_config.first_k_dense_replace, hf_config.num_hidden_layers
-        )
         return {
             "embedding": Embedding1D.prefill_model_config(hf_config, mesh_device),
-            "mlp_decoder_block": [
-                DecoderBlock.prefill_model_config(
-                    hf_config,
-                    mesh_device,
-                    is_padding_layer=is_padding_layer,
-                )
-                for is_padding_layer in mlp_is_padding_layer
-            ],
-            "moe_decoder_block": [
-                MoEDecoderBlock.prefill_model_config(
-                    hf_config,
-                    mesh_device,
-                    is_padding_layer=is_padding_layer,
-                )
-                for is_padding_layer in moe_is_padding_layer
-            ],
+            "mlp_decoder_block": [DecoderBlock.prefill_model_config(hf_config, mesh_device)],
             "transfer_row": {"topology": ttnn.Topology.Linear},
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
             "lm_head": LMHead.prefill_model_config(hf_config, mesh_device, input_row_idx=0),
@@ -448,31 +429,6 @@ class Model1D(SharedStateAddOn, AbstractModule):
                     user_id,
                     row_idx,
                     cfg["mlp_decoder_block"][meta_layer_idx],
-                    rope_tensors,
-                    page_tables[layer_idx],
-                )
-
-            # Transfer rows
-            cls.transfer_row(x, row_idx, (row_idx + 1) % cfg["num_rows"], **cfg["transfer_row"])
-
-        # Stage 2: MOE Decoder Block
-        moe_is_padding_layer, moe_meta_layer_indices = cls.get_meta_layer_mapping(
-            cfg["num_rows"], cfg["num_mlp_layers"], cfg["num_mlp_layers"] + cfg["num_moe_layers"]
-        )
-
-        for row_idx, (per_row_is_padding_layer, per_row_meta_layer_indices) in enumerate(
-            zip(moe_is_padding_layer.transpose(0, 1), moe_meta_layer_indices.transpose(0, 1), strict=True)
-        ):
-            for meta_layer_idx, (is_padding_layer, layer_idx) in enumerate(
-                zip(per_row_is_padding_layer, per_row_meta_layer_indices, strict=True)
-            ):
-                if is_padding_layer:
-                    continue
-                x = MoEDecoderBlock.forward_prefill(
-                    x,
-                    user_id,
-                    row_idx,
-                    cfg["moe_decoder_block"][meta_layer_idx],
                     rope_tensors,
                     page_tables[layer_idx],
                 )


### PR DESCRIPTION
This reverts commit e84fdf563aa99f13a6dd145bd8823566b0b30c54.


### Problem description
CI broken.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes