### PR TITLE
[skip ci] cppcoreguidelines-misleading-capture-default-by-value

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -53,7 +53,6 @@ Checks: >
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-macro-to-enum,
   -cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-misleading-capture-default-by-value,
   -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-noexcept-move-operations,

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -19,7 +19,7 @@ class DebugToolsMeshFixture : public MeshDispatchFixture {
        void RunTestOnDevice(
            const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,
            const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-           auto run_function_no_args = [=, this]() { run_function(static_cast<T*>(this), mesh_device); };
+           auto run_function_no_args = [this, run_function, mesh_device]() { run_function(static_cast<T*>(this), mesh_device); };
            MeshDispatchFixture::RunTestOnDevice(run_function_no_args, mesh_device);
        }
 };


### PR DESCRIPTION
### Ticket
#22758 
Closes https://github.com/tenstorrent/tt-metal/issues/22758

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/misleading-capture-default-by-value.html

### What's changed
- Enable check
- Fix the one violation