### PR TITLE
[skip ci] Bumped vovnet perf

### DIFF
--- a/models/experimental/vovnet/tests/perf/test_perf.py
+++ b/models/experimental/vovnet/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 143.94],
+        [1, 159.00],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
Device perf regressions CI is failing because vovnet is [faster than expected ](https://github.com/tenstorrent/tt-metal/actions/runs/17907362954/job/50911456061#step:32:181)
### What's changed
- bumped vovnet expected perf