### PR TITLE
Fix ResNet50 perf on BH

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 8700.0],
-        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 10200.0],
+        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10003.0],
+        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13500.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -106,7 +106,7 @@ def test_perf_2cqs(
 )
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
-    ((16, 0.0022, 30), (32, 0.0035, 30)),
+    ((16, 0.0018, 30), (32, 0.0026, 30)),
 )
 def test_perf_trace_2cqs(
     device,

--- a/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
@@ -7,7 +7,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 
 def run_perf_device(batch_size, test, command, expected_perf):
     subdir = "resnet50"
-    num_iterations = 4
+    num_iterations = 1
     margin = 0.03
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
@@ -7,7 +7,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 
 def run_perf_device(batch_size, test, command, expected_perf):
     subdir = "resnet50"
-    num_iterations = 1
+    num_iterations = 4
     margin = 0.03
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/ttnn_resnet/tests/resnet50_test_infra.py
+++ b/models/demos/ttnn_resnet/tests/resnet50_test_infra.py
@@ -332,23 +332,9 @@ class ResNet50TestInfra:
 
         batch_size = output_tensor.shape[0]
 
-        valid_pcc = 1.0
-        if self.batch_size >= 8:
-            valid_pcc = golden_pcc[self.device.arch()][self.batch_size][
-                (self.math_fidelity, self.weight_dtype, self.act_dtype)
-            ]
-        else:
-            if self.act_dtype == ttnn.bfloat8_b:
-                if self.math_fidelity == ttnn.MathFidelity.LoFi:
-                    valid_pcc = 0.87
-                else:
-                    valid_pcc = 0.94
-            else:
-                if self.math_fidelity == ttnn.MathFidelity.LoFi:
-                    valid_pcc = 0.93
-                else:
-                    valid_pcc = 0.982
+        valid_pcc = 0.98
         self.pcc_passed, self.pcc_message = check_with_pcc(self.torch_output_tensor, output_tensor, pcc=valid_pcc)
+        assert self.pcc_passed, self.pcc_message
 
         logger.info(
             f"ResNet50 batch_size={batch_size}, act_dtype={self.act_dtype}, weight_dtype={self.weight_dtype}, math_fidelity={self.math_fidelity}, PCC={self.pcc_message}"

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -61,10 +61,6 @@ hardcoded_matmul_config_linear = {
     ),
 }
 
-ops_parallel_config = {
-    "layer1_module1_input": None,
-}
-
 
 def ResnetLinear(
     in_features: int,
@@ -171,7 +167,7 @@ class resnet50Bottleneck:
                 "conv_config": ttnn.Conv2dConfig(
                     weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                     shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-                    if height_sharding
+                    if height_sharding and input_height != 28
                     else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                     deallocate_activation=True,
                     reallocate_halo_output=True,
@@ -215,10 +211,8 @@ class resnet50Bottleneck:
         input_width,
         reshard_if_not_optimal=False,
         height_sharding=None,
-        eltwise_binary_out_in_place=True,
         packer_l1_acc=True,
         enable_act_double_buffer=False,
-        ops_parallel_config=None,
         layer_module=None,
     ):
         logger.debug(
@@ -273,8 +267,7 @@ class resnet50Bottleneck:
         run_downsample_before_conv2 = True
         ds_out = None
 
-        if is_wormhole_b0():
-            run_downsample_before_conv2 = False
+        run_downsample_before_conv2 = False
 
         if run_downsample_before_conv2:
             ds_out = self.run_downsample_if_req(
@@ -288,23 +281,8 @@ class resnet50Bottleneck:
                 packer_l1_accum_enabled=packer_l1_acc,
                 enable_act_double_buffer=False,
             )
-            if layer_module and layer_module == "layer4_module1":
-                if ops_parallel_config and "layer4_module1_downsample" not in ops_parallel_config:
-                    x_memory_config = ttnn.get_memory_config(ds_out)
-                    sharded_config = ttnn.create_sharded_memory_config_(
-                        ttnn.Shape([batch_size, ds_input_height, ds_input_width, self.conv1_input_channels]),
-                        x_memory_config.shard_spec.grid,
-                        x_memory_config.memory_layout,
-                        x_memory_config.shard_spec.orientation,
-                        tile_layout=True,
-                    )
-                    ops_parallel_config["layer4_module1_downsample"] = sharded_config
 
         logger.debug(f"Running conv2")
-
-        if layer_module and layer_module == "layer4_module1":
-            if ops_parallel_config and "layer4_module1_input" in ops_parallel_config:
-                out = ttnn.to_memory_config(out, ops_parallel_config["layer4_module1_input"])
 
         conv_kwargs_2 = {
             "in_channels": self.conv2_input_channels,
@@ -335,34 +313,11 @@ class resnet50Bottleneck:
         }
 
         if is_blackhole():
-            conv_kwargs_2["conv_config"].act_block_h_override = 2 * 32
-            if (
-                batch_size == 32
-                and layer_module
-                and (
-                    layer_module == "layer1_module2"
-                    or layer_module == "layer1_module3"
-                    or layer_module == "layer2_module2"
-                    or layer_module == "layer2_module3"
-                    or layer_module == "layer2_module4"
-                )
-            ):
-                conv_kwargs_2["conv_config"].act_block_h_override = 0
-            elif (
-                batch_size == 20
-                and layer_module
-                and (layer_module == "layer4_module2" or layer_module == "layer4_module3")
-            ):
-                conv_kwargs_2["conv_config"].act_block_h_override = 0
-            elif (
-                batch_size == 16
-                and layer_module
-                and (layer_module == "layer1_module2" or layer_module == "layer1_module3")
-            ):
-                conv_kwargs_2["conv_config"].act_block_h_override = 0
-            # p100 case
-            if is_blackhole_p100(device) and batch_size == 32 and layer_module and (layer_module == "layer1_module2"):
-                conv_kwargs_2["conv_config"].act_block_h_override = 32
+            if layer_module == "layer1_module2":
+                conv_kwargs_2["conv_config"].act_block_h_override = 16 * 32
+            if batch_size == 32 and is_blackhole_p100(device):
+                if layer_module == "layer1_module3" or layer_module == "layer2_module1":
+                    conv_kwargs_2["conv_config"].act_block_h_override = 32
 
         out, [input_height, input_width], [self.conv2_weight_tensor, self.conv2_bias_tensor] = ttnn.conv2d(
             input_tensor=out,
@@ -378,18 +333,6 @@ class resnet50Bottleneck:
             return_weights_and_bias=True,
             dtype=self.model_config["ACTIVATIONS_DTYPE"],
         )
-
-        if layer_module and layer_module == "layer4_module1":
-            if ops_parallel_config and "layer4_module1_input" not in ops_parallel_config:
-                x_memory_config = ttnn.get_memory_config(out)
-                sharded_config = ttnn.create_sharded_memory_config_(
-                    ttnn.Shape([batch_size, module_input_height, module_input_width, self.conv2_input_channels]),
-                    x_memory_config.shard_spec.grid,
-                    x_memory_config.memory_layout,
-                    x_memory_config.shard_spec.orientation,
-                    tile_layout=True,
-                )
-                ops_parallel_config["layer4_module1_input"] = sharded_config
 
         # conv3 is 1x1 conv
         logger.debug(f"Running conv3")
@@ -447,20 +390,12 @@ class resnet50Bottleneck:
         if ds_out.memory_config() != out.memory_config():
             ds_out = ttnn.to_memory_config(ds_out, out.memory_config())
 
-        if eltwise_binary_out_in_place:
-            # underscore version is in_place = True
-            out = ttnn.add_(
-                out,
-                ds_out,
-                activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)],
-            )
-        else:
-            out = ttnn.add(
-                out,
-                ds_out,
-                activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)],
-                memory_config=ttnn.L1_MEMORY_CONFIG,
-            )
+        # underscore version is in_place = True
+        out = ttnn.add_(
+            out,
+            ds_out,
+            activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)],
+        )
         ttnn.deallocate(ds_out)
         return out, input_height, input_width
 
@@ -577,7 +512,7 @@ class resnet50:
             activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
             deallocate_activation=dealloc_input,
             act_block_h_override=act_block_h_override,
-            enable_act_double_buffer=is_wormhole_b0() or is_blackhole(),
+            enable_act_double_buffer=True,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,
             # otherwise act block h is not big enough for the reuse
@@ -708,18 +643,10 @@ class resnet50:
         return self.run(
             input_tensor,
             device,
-            ops_parallel_config,
         )
 
     ## merged runs (first and optimized)
-    def run(self, input_tensor, device, ops_parallel_config) -> ttnn.Tensor:
-        is_first_run = False
-        if not ops_parallel_config:
-            is_first_run = True
-            logger.debug(f"==== First run")
-        else:
-            logger.debug(f"==== Optimized run")
-
+    def run(self, input_tensor, device) -> ttnn.Tensor:
         logger.debug(f"==== fold on device")
 
         # run fold
@@ -815,17 +742,8 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             enable_act_double_buffer=True,
+            layer_module="layer1_module1",
         )
-
-        if is_first_run:
-            x_memory_config = ttnn.get_memory_config(x)
-            ops_parallel_config["layer1_module1_input"] = ttnn.create_sharded_memory_config_(
-                layer1_module1_input_shape,
-                x_memory_config.shard_spec.grid,
-                x_memory_config.memory_layout,
-                x_memory_config.shard_spec.orientation,
-                tile_layout=True,
-            )
 
         logger.debug(f"==== Running layer 1 module 2")
         x, x_height, x_width = self.layer1_module2(
@@ -849,9 +767,7 @@ class resnet50:
             layer_module="layer1_module3",
         )
 
-        layer2_module1_input_shape = ttnn.Shape(x.padded_shape)
-
-        reshard = is_blackhole() or not is_wormhole_b0()
+        reshard = is_blackhole()
         height_shard = True
 
         logger.debug(f"==== Running layer 2 module 1")
@@ -866,16 +782,6 @@ class resnet50:
             enable_act_double_buffer=True,
             layer_module="layer2_module1",
         )
-
-        if is_first_run:
-            x_memory_config = ttnn.get_memory_config(x)
-            ops_parallel_config["layer2_module1_input"] = ttnn.create_sharded_memory_config_(
-                layer2_module1_input_shape,
-                x_memory_config.shard_spec.grid,
-                x_memory_config.memory_layout,
-                x_memory_config.shard_spec.orientation,
-                tile_layout=True,
-            )
 
         logger.debug(f"==== Running layer 2 module 2")
         x, x_height, x_width = self.layer2_module2(
@@ -910,12 +816,8 @@ class resnet50:
             layer_module="layer2_module4",
         )
 
-        layer3_module1_input_shape = ttnn.Shape(x.padded_shape)
-
-        reshard = is_wormhole_b0()
-        height_shard = False
-        if is_blackhole():
-            x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG)
+        reshard = True
+        height_shard = is_blackhole()
 
         logger.debug(f"==== Running layer 3 module 1")
         x, x_height, x_width = self.layer3_module1(
@@ -927,17 +829,8 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             enable_act_double_buffer=True,
+            layer_module="layer3_module1",
         )
-
-        if is_first_run:
-            x_memory_config = ttnn.get_memory_config(x)
-            ops_parallel_config["layer3_module1_input"] = ttnn.create_sharded_memory_config_(
-                layer3_module1_input_shape,
-                x_memory_config.shard_spec.grid,
-                x_memory_config.memory_layout,
-                x_memory_config.shard_spec.orientation,
-                tile_layout=True,
-            )
 
         logger.debug(f"==== Running layer 3 module 2")
         x, x_height, x_width = self.layer3_module2(
@@ -947,6 +840,7 @@ class resnet50:
             x_height,
             x_width,
             enable_act_double_buffer=True,
+            layer_module="layer3_module2",
         )
 
         logger.debug(f"==== Running layer 3 module 3")
@@ -989,27 +883,12 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            eltwise_binary_out_in_place=True,
             enable_act_double_buffer=True,
+            layer_module="layer3_module6",
         )
 
-        reshard = is_blackhole() and self.batch_size == 20
+        reshard = is_blackhole()
         height_shard = False
-
-        layer4_module1_input_shape = ttnn.Shape(x.padded_shape)
-        if is_blackhole():
-            x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG)
-            x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)
-        else:
-            core_range_set = ttnn.CoreGrid(x=8, y=7)
-            shard_config = ttnn.create_sharded_memory_config_(
-                layer4_module1_input_shape,
-                core_range_set,
-                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.ShardOrientation.ROW_MAJOR,
-                tile_layout=True,
-            )
-            x = ttnn.to_memory_config(x, shard_config)
 
         logger.debug(f"==== Running layer 4 module 1")
         x, x_height, x_width = self.layer4_module1(
@@ -1021,7 +900,6 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             enable_act_double_buffer=True,
-            ops_parallel_config=ops_parallel_config,
             layer_module="layer4_module1",
         )
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -264,23 +264,7 @@ class resnet50Bottleneck:
         )
 
         act_block_h_override = 0
-        run_downsample_before_conv2 = True
         ds_out = None
-
-        run_downsample_before_conv2 = False
-
-        if run_downsample_before_conv2:
-            ds_out = self.run_downsample_if_req(
-                x,
-                device,
-                batch_size,
-                ds_input_height,
-                ds_input_width,
-                reshard_if_not_optimal,
-                height_sharding,
-                packer_l1_accum_enabled=packer_l1_acc,
-                enable_act_double_buffer=False,
-            )
 
         logger.debug(f"Running conv2")
 
@@ -372,20 +356,17 @@ class resnet50Bottleneck:
             dtype=self.model_config["ACTIVATIONS_DTYPE"],
         )
 
-        if not run_downsample_before_conv2:
-            ds_out = self.run_downsample_if_req(
-                x,
-                device,
-                batch_size,
-                ds_input_height,
-                ds_input_width,
-                reshard_if_not_optimal,
-                height_sharding,
-                packer_l1_accum_enabled=packer_l1_acc,
-                enable_act_double_buffer=enable_act_double_buffer,
-            )
-
-        assert ds_out is not None, "ds_out is None"
+        ds_out = self.run_downsample_if_req(
+            x,
+            device,
+            batch_size,
+            ds_input_height,
+            ds_input_width,
+            reshard_if_not_optimal,
+            height_sharding,
+            packer_l1_accum_enabled=packer_l1_acc,
+            enable_act_double_buffer=enable_act_double_buffer,
+        )
 
         if ds_out.memory_config() != out.memory_config():
             ds_out = ttnn.to_memory_config(ds_out, out.memory_config())


### PR DESCRIPTION
Issue #28606

Removing spilling tensors to interleaved on BH.
Switch layer3 to be HS (instead of BS).
Optimise act_block_h_override usage.
Disable run_downsample_before_conv2 for BH.
Cleanup ops_parallel_config as it was unused.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28606)

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/17910626366)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17910618411)