### PR TITLE
Analysis : Check exp for fp32

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -665,6 +665,85 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     return (ulp_delta <= ulp_threshold, f"Max ULP Delta: {ulp_delta}")
 
 
+def comp_ulp_check(input, golden, calculated, ulp_threshold, allow_nonfinite=False):
+    """
+    Compute absolute error between two tensors in Units of Least Precision (ULP)
+    """
+
+    # If both tensors are empty, then we can return True
+    if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
+        return True, "Both tensors are empty"
+
+    if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
+        return False, "Calculated tensor contains non-finite values"
+
+    if not _comp_nonfinite(golden, calculated):
+        return False, "Tensors are not finite at the same positions"
+    # nonfinite elments can intefere with ULP error calculation
+    # To avoid this, replace nan, +inf, -inf with 0
+    # (we have already checked that both tensors have the same nonfinite elements)
+    mask_finite = ~torch.isfinite(golden)
+    golden = golden.clone()
+    calculated = calculated.clone()
+    golden[mask_finite] = 0
+    calculated[mask_finite] = 0
+
+    # ULP is measured according to the golden tensor
+    # In most cases, data type of golden tensor should be the same as calculated tensor.
+    # However, in some cases, we may want to measure < 1 ULP differences, which requires golden tensor
+    # to have higher precision than calculated tensor.
+    # If we passed golden tensor to ulp() as is, we would get ULP of higher precision.
+    # e.g. ulp of float32 rather bfloat16 calculation, which would give us a wrong value.
+    ulp_value = ulp(golden.type(calculated.dtype))
+
+    if golden.dtype != calculated.dtype:  # Note: assumes that golden has higher precision than calculated tensor
+        calculated = calculated.type(golden.dtype)
+        ulp_value = ulp_value.type(golden.dtype)  # Convert ULP to higher precision (for sub-1 ULP measurements)
+
+    ULP_Cond = torch.abs(calculated - golden) / ulp_value
+    mask = (ULP_Cond > 1.0) | torch.isnan(ULP_Cond)
+
+    if mask.any():
+        indices = torch.nonzero(mask, as_tuple=False)
+        output_lines = []
+        output_lines.append(f"Found {indices.shape[0]} values with ULP > 1:\n")
+
+        seen_inputs = set()
+        min_input = float("inf")
+        max_input = float("-inf")
+
+        for idx in indices:
+            idx_tuple = tuple(idx.tolist())
+            inp_val = input[idx_tuple].item()
+            # Update min and max
+            if inp_val < min_input:
+                min_input = inp_val
+            if inp_val > max_input:
+                max_input = inp_val
+
+            if inp_val in seen_inputs:
+                continue
+            seen_inputs.add(inp_val)
+
+            calc_val = calculated[idx_tuple].item()
+            golden_val = golden[idx_tuple].item()
+            ulp_val = ULP_Cond[idx_tuple].item()
+
+            line = f"Input: {inp_val}, " f"Calculated: {calc_val}, " f"Golden: {golden_val}, " f"ULP: {ulp_val}"
+            output_lines.append(line)
+
+        file_path = "ulp_mismatches.txt"
+        with open(file_path, "w") as f:
+            f.write("\n".join(output_lines))
+
+        print(f"\nSaved mismatch details to {file_path}")
+        print(f"Failing range : ({min_input}, {max_input} )")
+    else:
+        print("No values with ULP > 1 found.")
+
+    ulp_delta = torch.max(ULP_Cond)
+
+
 def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_fp32.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import math
+from tests.ttnn.utils_for_testing import assert_with_ulp
+import matplotlib.pyplot as plt
+import os
+import pandas as pd
+
+import models.utility_functions as util
+from models.common.utility_functions import comp_ulp_check
+
+
+def plot_graphs_exp_fp32(input_tensor, golden, result, out_dir="plots"):
+    os.makedirs(out_dir, exist_ok=True)
+
+    x_vals = input_tensor.cpu().numpy()
+    # ULP
+    abs_error = torch.abs(golden - result)
+    ulp_spacing = util.ulp(golden)  # <-- FP32 spacing
+    ulp_error = abs_error / ulp_spacing
+
+    y_vals = ulp_error.cpu().numpy()
+
+    plt.figure(figsize=(12, 6))
+    plt.scatter(x_vals, y_vals, s=1, alpha=0.6)
+    plt.xlabel("BF16-->FP32 Input Value")
+    plt.ylabel("ULP Error")
+    # plt.ylim(0, 5)
+    # plt.xlim(0, 5)
+    plt.title("exp FP32 vs Golden: ULP Error per Input Value")
+    plt.grid(True, alpha=0.3)
+
+    out_file = os.path.join(out_dir, "exp_fp32_ulp_errors.png")
+    plt.savefig(out_file, dpi=300)
+    plt.close()
+    print(f"ULP scatter plot saved to: {out_file}")
+
+    golden_vals = golden.to(torch.float32).cpu().numpy()
+    result_vals = result.to(torch.float32).cpu().numpy()
+
+    # TTNN vs Torch
+    plt.figure(figsize=(12, 6))
+
+    plt.scatter(x_vals, golden_vals, s=12, c="blue", label="PyTorch Golden", alpha=0.6, marker="x")
+    plt.scatter(x_vals, result_vals, s=12, c="orange", label="TTNN Result", alpha=0.6, marker="o")
+
+    plt.xlabel("Input")
+    plt.ylabel("exp Output")
+    plt.title("TTNN vs PyTorch")
+    # plt.ylim(0, 5)
+    # plt.xlim(0, 5)
+    plt.legend()
+    save_path = os.path.join(out_dir, "ttnn_vs_torch_exp.png")
+    plt.savefig(save_path, dpi=300)
+    plt.close()
+
+    print(f"Plot saved at: {save_path}")
+
+
+def test_exp_arange_masking(device):
+    # Exp Working range for fp32 - Overflow from 88.7(inf), Underflow till -87.3(<0)
+    low = -87.3
+    high = 88.7
+
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # masking to working range
+    mask = (input_tensor >= low) & (input_tensor <= high)
+    input_tensor = input_tensor[mask]
+
+    # Mask NaN
+    mask = torch.isnan(input_tensor)
+    input_tensor[mask] = 1.0
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.exp)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.exp(tt_in)
+    result = ttnn.to_torch(tt_result)
+    comp_ulp_check(input_tensor, golden, result, 1, allow_nonfinite=True)
+    plot_graphs_exp_fp32(input_tensor, golden, result)
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -40,56 +40,93 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
+        // //---exp 21f algorithm---
+        // // Polynomial coefficients for approximation of exp on [1; 2]
+        // constexpr float POLY_D1 = 0.40196114e-7f;
+        // constexpr int POLY_D2 = 0xf94ee7;
+        // constexpr int POLY_D3 = 0x560e;
+
+        // sfpi::vFloat d1 = sfpi::vFloat(POLY_D1);
+        // sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + zif, 0);
+        // sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + zif, 0);
+        // d2 = d1 * d2;
+        // zif = sfpu::_float_to_int32_(d2 * d3);
+
+        // // Restore exponent
+        // zii = sfpi::reinterpret<sfpi::vInt>(
+        //     sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
+
+        // y = sfpi::reinterpret<sfpi::vFloat>(zii);
+
+        // if constexpr (!is_fp32_dest_acc_en) {
+        //     // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+        //     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+        //     // rather than 81 (which would have been correct).
+        //     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+        //     y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        // }
+
+        // //---exp 61f algorithm---
+
+        // // Normalize mantissa field into a fractional value in [0,1)
+        // sfpi::vFloat frac = sfpi::int32_to_float(zif, 0) * sfpi::vFloat(1.0f / float(1 << 23));
+
+        // // Degree-6 polynomial coefficients
+        // constexpr float C0 = 1.0000000018f;
+        // constexpr float C1 = 0.69314699f;
+        // constexpr float C2 = 0.24022982f;
+        // constexpr float C3 = 0.055483369f;
+        // constexpr float C4 = 0.0096788315f;
+        // constexpr float C5 = 0.001243946f;
+        // constexpr float C6 = 0.0002170391f;
+
+        // // Evaluate polynomial using Horner’s rule
+        // sfpi::vFloat poly =
+        //     ((((((sfpi::vFloat(C6) * frac + sfpi::vFloat(C5)) * frac + sfpi::vFloat(C4)) * frac +
+        //         sfpi::vFloat(C3)) *
+        //             frac +
+        //         sfpi::vFloat(C2)) *
+        //             frac +
+        //         sfpi::vFloat(C1)) *
+        //             frac +
+        //         sfpi::vFloat(C0));
+
+        // // Restore exponent
+        // zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(poly, 127U + zii));
+        // y = sfpi::reinterpret<sfpi::vFloat>(zii);
+        // if constexpr (!is_fp32_dest_acc_en) {
+        //     // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+        //     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+        //     // rather than 81 (which would have been correct).
+        //     // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+        //     y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+        // }
+
+        //---exp 41f algorithm---
+
+        // Normalize mantissa field into a fractional value in [0,1)
+        sfpi::vFloat frac = sfpi::int32_to_float(zif, 0) * sfpi::vFloat(1.0f / float(1 << 23));
+
+        constexpr float C0 = 1.0000026f;
+        constexpr float C1 = 0.69300383f;
+        constexpr float C2 = 0.24144276f;
+        constexpr float C3 = 0.052011463f;
+        constexpr float C4 = 0.013534167f;
+
+        sfpi::vFloat poly =
+            ((((sfpi::vFloat(C4) * frac + sfpi::vFloat(C3)) * frac + sfpi::vFloat(C2)) * frac + sfpi::vFloat(C1)) *
+                 frac +
+             sfpi::vFloat(C0));
+
+        // Restore exponent
+        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(poly, 127U + zii));
+        y = sfpi::reinterpret<sfpi::vFloat>(zii);
         if constexpr (!is_fp32_dest_acc_en) {
-            // Polynomial coefficients for approximation of exp on [1; 2]
-            constexpr float POLY_D1 = 0.40196114e-7f;
-            constexpr int POLY_D2 = 0xf94ee7;
-            constexpr int POLY_D3 = 0x560e;
-
-            sfpi::vFloat d1 = sfpi::vFloat(POLY_D1);
-            sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + zif, 0);
-            sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + zif, 0);
-            d2 = d1 * d2;
-            zif = sfpu::_float_to_int32_(d2 * d3);
-
-            // Restore exponent
-            zii = sfpi::reinterpret<sfpi::vInt>(
-                sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
-
-            y = sfpi::reinterpret<sfpi::vFloat>(zii);
-
             // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
             // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
             // rather than 81 (which would have been correct).
             // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
             y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
-        } else {
-            // Normalize mantissa field into a fractional value in [0,1)
-            sfpi::vFloat frac = sfpi::int32_to_float(zif, 0) * sfpi::vFloat(1.0f / float(1 << 23));
-
-            // Degree-6 polynomial coefficients
-            constexpr float C0 = 1.0000000018f;
-            constexpr float C1 = 0.69314699f;
-            constexpr float C2 = 0.24022982f;
-            constexpr float C3 = 0.055483369f;
-            constexpr float C4 = 0.0096788315f;
-            constexpr float C5 = 0.001243946f;
-            constexpr float C6 = 0.0002170391f;
-
-            // Evaluate polynomial using Horner’s rule
-            sfpi::vFloat poly =
-                ((((((sfpi::vFloat(C6) * frac + sfpi::vFloat(C5)) * frac + sfpi::vFloat(C4)) * frac +
-                    sfpi::vFloat(C3)) *
-                       frac +
-                   sfpi::vFloat(C2)) *
-                      frac +
-                  sfpi::vFloat(C1)) *
-                     frac +
-                 sfpi::vFloat(C0));
-
-            // Restore exponent
-            zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(poly, 127U + zii));
-            y = sfpi::reinterpret<sfpi::vFloat>(zii);
         }
     }
     v_endif;


### PR DESCRIPTION
Improved exp : https://github.com/tenstorrent/tt-metal/pull/25946
Improved exp2 : https://github.com/tenstorrent/tt-metal/pull/25724

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes