### PR TITLE
[skip ci] Bumped trace region size on SD on BH

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -7,4 +7,4 @@ from models.common.utility_functions import is_blackhole
 # L1 Small Size Constants
 SD_L1_SMALL_SIZE = 20928
 # Trace Region Size Constants
-SD_TRACE_REGION_SIZE = 814510080 if is_blackhole() else 789835776
+SD_TRACE_REGION_SIZE = 814600080 if is_blackhole() else 789835776


### PR DESCRIPTION
### Problem description
Model perf stable_diffusion [test failing](https://github.com/tenstorrent/tt-metal/actions/runs/17911708434/job/50925267315#step:10:1488) due to trace region size 

### What's changed
- bumped trace region size