### PR TITLE
[skip ci] ci: run APC tests that were moved to L2 nightly when performing LLK uplift

### DIFF
--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -50,6 +50,9 @@ on:
       blackhole-result:
         description: 'Result of blackhole tests (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.blackhole-result }}
+      tt-metal-l2-nightly-result:
+        description: 'Result of TT-Metal L2 Nightly APC tests (status:url format)'
+        value: ${{ jobs.setup-and-test.outputs.tt-metal-l2-nightly-result }}
 
 concurrency:
   group: llk-integration-${{ inputs.mirrored_branch }}
@@ -82,8 +85,10 @@ jobs:
       parent-branch-name: ${{ env.PARENT_BRANCH_NAME }}
       all-post-commit-run-id: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
       blackhole-run-id: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
+      tt-metal-l2-nightly-run-id: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
       all-post-commit-result: ${{ steps.monitor-workflows.outputs.all-post-commit-result }}
       blackhole-result: ${{ steps.monitor-workflows.outputs.blackhole-result }}
+      tt-metal-l2-nightly-result: ${{ steps.monitor-workflows.outputs.tt-metal-l2-nightly-result }}
     steps:
       - name: Setup
         uses: actions/checkout@v4
@@ -173,6 +178,7 @@ jobs:
           declare -A workflows
           workflows["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
           workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
+          workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit }}"
 
           declare -A run_ids
 
@@ -181,7 +187,12 @@ jobs:
             local workflow_file="$1"
             local display_name="$2"
 
-            gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
+            # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
+            if [ "$workflow_file" = "tt-metal-l2-nightly.yaml" ]; then
+              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" -f run_APC_cpp_tests=true
+            else
+              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
+            fi
 
             # Poll for run ID
             local run_id=""
@@ -208,6 +219,10 @@ jobs:
                   run_ids["blackhole"]=$(trigger_and_get_id "$workflow" "Blackhole")
                   [ -n "${run_ids[blackhole]}" ] && echo "✅ Blackhole run ID: ${run_ids[blackhole]}"
                   ;;
+                "tt-metal-l2-nightly.yaml")
+                  run_ids["tt-metal-l2-nightly"]=$(trigger_and_get_id "$workflow" "TT-Metal L2 Nightly APC")
+                  [ -n "${run_ids[tt-metal-l2-nightly]}" ] && echo "✅ TT-Metal L2 Nightly APC run ID: ${run_ids[tt-metal-l2-nightly]}"
+                  ;;
               esac
             fi
           done
@@ -215,6 +230,7 @@ jobs:
           # Output run IDs for monitoring steps
           echo "all-post-commit-run-id=${run_ids[all-post-commit]}" >> $GITHUB_OUTPUT
           echo "blackhole-run-id=${run_ids[blackhole]}" >> $GITHUB_OUTPUT
+          echo "tt-metal-l2-nightly-run-id=${run_ids[tt-metal-l2-nightly]}" >> $GITHUB_OUTPUT
       - name: Monitor triggered workflows
         id: monitor-workflows
         if: |
@@ -227,6 +243,7 @@ jobs:
           POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
           ALL_POST_COMMIT_RUN_ID: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
           BLACKHOLE_RUN_ID: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
+          TT_METAL_L2_NIGHTLY_RUN_ID: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
         run: |
           # Helper function for workflow monitoring
           monitor_workflow() {
@@ -295,6 +312,7 @@ jobs:
           declare -A workflow_configs
           workflow_configs["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}:$ALL_POST_COMMIT_RUN_ID:all-post-commit-result"
           workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
+          workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
           exit_code=0
           for workflow_file in "${!workflow_configs[@]}"; do
             IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"
@@ -314,7 +332,7 @@ jobs:
         run: |
           echo "🔄 Parent workflow cancelled - cleaning up spawned workflows..."
           # Workflows spawned by this job
-          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml")
+          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml")
           # Consider both queued and in_progress runs
           STATUSES=("queued" "in_progress")
           for workflow in "${SPAWNED_WORKFLOWS[@]}"; do
@@ -387,6 +405,7 @@ jobs:
             declare -A test_configs
             test_configs["All Post-Commit Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.all-post-commit-result }}"
             test_configs["Blackhole Post-Commit Tests"]="${{ inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.blackhole-result }}"
+            test_configs["TT-Metal L2 Nightly APC Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
 
             # Function to display test result
             display_test_result() {


### PR DESCRIPTION
### Ticket
None

### Problem description
Recently, some tests were moved from `all-post-commit-workflows.yaml` to `tt-metal-l2-nightly.yaml` and are now only executed when the `run_APC_cpp_tests` parameter is enabled. This migration inadvertently broke the LLK uplift process, as the LLK integration workflow only triggered the original `all-post-commit-workflows.yaml` when Wormhole changes were detected. As a result, critical APC tests that were moved to the nightly workflow were no longer being executed during LLK uplifts, potentially allowing breaking changes to go undetected.

### What's changed
LLK uplift workflow has been updated to run migrated APC tests that currently reside in L2 nightly workflow as part of wormhole tests.
This ensures that LLK uplifts continue to run the complete suite of APC tests, maintaining the same level of validation that existed before the test migration, while supporting the new workflow structure.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes