### PR TITLE
Remove noisy CQ logs and improve UNet test reliability

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -4,6 +4,13 @@
 
 import pytest
 
+from dataclasses import dataclass
+import time
+from typing import List
+
+import numpy as np
+import torch
+
 from loguru import logger
 
 from ttnn.device import is_wormhole_b0
@@ -12,24 +19,95 @@ from models.perf.perf_utils import prep_perf_report
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
 
 from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_SIZE, UNET_L1_SMALL_REGION_SIZE
-from models.experimental.functional_unet.tests.test_unet_model import run_unet_model
 
 UNET_DEVICE_TEST_TOTAL_ITERATIONS = 4
 
 
-@pytest.mark.parametrize("batch", [1])
-@pytest.mark.parametrize("groups", [4])
-@pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
-def test_unet_model(batch, groups, device, iterations, reset_seeds):
-    if (
-        not is_wormhole_b0(device)
-        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
-        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
-    ):
-        pytest.skip(f"Shallow UNet only support 110 or 130 cores on BH (was {device.compute_with_storage_grid_size()})")
-    device.disable_and_clear_program_cache()  # Needed to give consistent device perf between iterations
-    run_unet_model(batch, groups, device, iterations)
+@dataclass
+class PerformanceResults:
+    fps: float
+    fps_std: float
+    inference_time: float
+    compile_time: float
+    batch: int
+    groups: int
+    num_devices: int
+    all_fps: List[float]
+    filtered_fps: List[float]
+
+
+def reset_state():
+    torch.manual_seed(213919)
+
+
+def filter_outliers(measurements: List[float], trim_percentage: float = 0.2) -> List[float]:
+    """Remove outliers using trimmed mean filtering."""
+    if len(measurements) < 3:
+        return measurements
+
+    sorted_measurements = sorted(measurements)
+    n = len(sorted_measurements)
+
+    # Calculate number of elements to trim from each end
+    trim_count = int(n * trim_percentage / 2)
+
+    # If trim_count would leave less than 1 element, don't trim
+    if n - 2 * trim_count < 1:
+        return measurements
+
+    filtered = sorted_measurements[trim_count : n - trim_count]
+
+    logger.info(
+        f"Trimmed {len(measurements) - len(filtered)} outliers from {len(measurements)} measurements (trim_percentage={trim_percentage})"
+    )
+    return filtered
+
+
+def run_multi_iteration_perf_test(test_func, num_runs, *args, **kwargs) -> PerformanceResults:
+    """Run performance test multiple times and apply trimmed mean filtering."""
+    fps_results = []
+    inference_times = []
+    compile_times = []
+    for run_idx in range(num_runs):
+        reset_state()
+
+        logger.info(f"Measurement run {run_idx + 1}/{num_runs}...")
+        result = test_func(*args, **kwargs)
+
+        fps_results.append(result.get_fps())
+        inference_times.append(result.inference_time)
+        compile_times.append(result.inference_and_compile_time - result.inference_time)
+
+        logger.info(f"Run {run_idx + 1} throughput: {result.get_fps():.2f} fps")
+
+        if run_idx < num_runs - 1:
+            time.sleep(1.0)
+
+    filtered_fps = filter_outliers(fps_results)
+    final_fps = np.median(filtered_fps) if len(filtered_fps) >= 2 else np.mean(fps_results)
+    fps_std = np.std(filtered_fps) if len(filtered_fps) >= 2 else np.std(fps_results)
+
+    final_inference_time = np.median(inference_times)
+    final_compile_time = np.median(compile_times)
+
+    logger.info(f"Throughput results: {[f'{x:.1f}' for x in fps_results]}")
+    logger.info(f"Filtered throughput: {[f'{x:.1f}' for x in filtered_fps]}")
+
+    logger.info(f"Median throughput: {final_fps:.2f} +/- {fps_std:.2f} fps")
+    logger.info(f"Median inference time: {final_inference_time:.4f} s")
+    logger.info(f"Median compile time: {final_compile_time:.2f} s")
+
+    return PerformanceResults(
+        fps=final_fps,
+        fps_std=fps_std,
+        inference_time=final_inference_time,
+        compile_time=final_compile_time,
+        batch=result.batch,
+        groups=result.groups,
+        num_devices=result.num_devices,
+        all_fps=fps_results,
+        filtered_fps=filtered_fps,
+    )
 
 
 @pytest.mark.models_device_performance_bare_metal
@@ -73,12 +151,13 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1400.0),),
+    "batch, groups, num_runs, iterations, expected_compile_time, expected_throughput",
+    ((1, 4, 12, 256, 30.0, 1395.0),),
 )
 def test_unet_trace_perf(
     batch: int,
     groups: int,
+    num_runs: int,
     iterations: int,
     expected_compile_time: float,
     expected_throughput: float,
@@ -92,27 +171,40 @@ def test_unet_trace_perf(
     ):
         pytest.skip(f"Shallow UNet only support 110 or 130 cores on BH (was {device.compute_with_storage_grid_size()})")
 
+    model_name = "unet_shallow-trace_2cq_same_io"
+
     from models.experimental.functional_unet.tests.test_unet_trace import (
         test_unet_trace_2cq,
     )
 
-    logger.info(f"Invoking underlying model test for {iterations} iterations...")
-    result = test_unet_trace_2cq(batch, groups, iterations, device, reset_seeds)
+    perf_results = run_multi_iteration_perf_test(
+        test_unet_trace_2cq, num_runs, batch, groups, iterations, device, reset_seeds
+    )
 
-    total_num_samples = result.batch * result.groups * result.num_devices
+    fps = perf_results.fps
+    fps_std = perf_results.fps_std
+    final_inference_time = perf_results.inference_time
+    final_compile_time = perf_results.compile_time
+    total_num_samples = perf_results.batch * perf_results.groups * perf_results.num_devices
     expected_inference_time = total_num_samples / expected_throughput
+
     prep_perf_report(
-        model_name="unet_shallow-trace_2cq_same_io",
+        model_name=model_name,
         batch_size=total_num_samples,
-        inference_and_compile_time=result.inference_and_compile_time,
-        inference_time=result.inference_time,
+        inference_and_compile_time=final_inference_time + final_compile_time,
+        inference_time=final_inference_time,
         expected_compile_time=expected_compile_time,
         expected_inference_time=expected_inference_time,
-        comments=f"batch_{result.batch}-groups_{result.groups}-num_devices_{result.num_devices}",
+        comments=f"batch_{perf_results.batch}-groups_{perf_results.groups}-num_devices_{perf_results.num_devices}",
     )
+
+    confidence_margin = 2 * fps_std  # 95% confidence interval
+    performance_threshold = expected_throughput - confidence_margin
+
     assert (
-        result.get_fps() >= expected_throughput
-    ), f"Expected end-to-end performance to exceed {expected_throughput:.2f} fps but was {result.get_fps():.2f} fps"
+        fps >= performance_threshold
+    ), f"Expected performance {expected_throughput:.2f} ± {confidence_margin:.2f} fps but got {fps:.2f} ± {fps_std:.2f} fps"
+    logger.success(f"Test passed: {fps:.2f} +/- {fps_std:.2f} fps")
 
 
 @pytest.mark.models_performance_bare_metal
@@ -128,11 +220,12 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2660.0),)
+    "batch, groups, num_runs, iterations, expected_compile_time, expected_throughput", ((1, 4, 12, 256, 30.0, 2700.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,
     groups: int,
+    num_runs: int,
     iterations: int,
     expected_compile_time: float,
     expected_throughput: float,
@@ -145,20 +238,31 @@ def test_unet_trace_perf_multi_device(
 
     model_name = "unet_shallow-trace_2cq_same_io-multi_device"
 
-    logger.info(f"Invoking underlying model test for {iterations} iterations...")
-    result = test_unet_trace_2cq_multi_device(batch, groups, iterations, mesh_device, reset_seeds)
+    perf_results = run_multi_iteration_perf_test(
+        test_unet_trace_2cq_multi_device, num_runs, batch, groups, iterations, mesh_device, reset_seeds
+    )
 
-    total_num_samples = result.batch * result.groups * result.num_devices
+    fps = perf_results.fps
+    fps_std = perf_results.fps_std
+    final_inference_time = perf_results.inference_time
+    final_compile_time = perf_results.compile_time
+    total_num_samples = perf_results.batch * perf_results.groups * perf_results.num_devices
     expected_inference_time = total_num_samples / expected_throughput
+
     prep_perf_report(
         model_name=model_name,
         batch_size=total_num_samples,
-        inference_and_compile_time=result.inference_and_compile_time,
-        inference_time=result.inference_time,
+        inference_and_compile_time=final_inference_time + final_compile_time,
+        inference_time=final_inference_time,
         expected_compile_time=expected_compile_time,
         expected_inference_time=expected_inference_time,
-        comments=f"batch_{result.batch}-groups_{result.groups}-num_devices_{result.num_devices}",
+        comments=f"batch_{perf_results.batch}-groups_{perf_results.groups}-num_devices_{perf_results.num_devices}",
     )
+
+    confidence_margin = 2 * fps_std  # 95% confidence interval
+    performance_threshold = expected_throughput - confidence_margin
+
     assert (
-        result.get_fps() >= expected_throughput
-    ), f"Expected end-to-end performance to exceed {expected_throughput:.2f} fps but was {result.get_fps():.2f} fps"
+        fps >= performance_threshold
+    ), f"Expected performance {expected_throughput:.2f} ± {confidence_margin:.2f} fps but got {fps:.2f} ± {fps_std:.2f} fps"
+    logger.success(f"Test passed: {fps:.2f} +/- {fps_std:.2f} fps")

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -74,7 +74,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1405.0),),
+    ((1, 4, 256, 30.0, 1400.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -128,7 +128,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2724.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2660.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -120,7 +120,6 @@ def command_queue(cq_id: int):
         raise ValueError("cq_id cannot be None in command_queue context")
 
     push_current_command_queue_id_for_thread(cq_id)
-    logger.info(f"Pushed command queue id {cq_id} for thread")
     try:
         yield
     finally:
@@ -132,7 +131,6 @@ def command_queue(cq_id: int):
                 f"This might indicate an operation didn't properly restore the command queue state. "
                 f"Restoring to original value {cq_id}."
             )
-        logger.info(f"Popping command queue id {cq_id} for thread")
         pop_current_command_queue_id_for_thread()
 
 


### PR DESCRIPTION
### Summary
This PR makes two improvements to the UNet performance testing:
1. Remove noisy CQ logs: Eliminates verbose command queue logging in ttnn/decorators.py that was cluttering output during performance tests.
2. Reduce measurement variance by running UNet test multiple times: Runs the Shallow UNet performance test for multiple iterations and discards outliers to collect more stable performance metrics.


### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17944366894/job/51028023795, https://github.com/tenstorrent/tt-metal/actions/runs/17944363508, https://github.com/tenstorrent/tt-metal/actions/runs/17944360547