### PR TITLE
[skip ci] ci: add L2 nightly to LLK uplift workflow

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -582,4 +582,3 @@ jobs:
 
           echo "✅ Updated PR body with test status"
           echo "✅ PR #$PR_NUMBER ready for review"
-          echo "✅ Auto-merge enabled"

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -236,6 +236,9 @@ jobs:
           - workflow: "blackhole-post-commit.yaml"
             name: "Blackhole Post Commit"
             should-run: ${{ needs.update-submodule.outputs.should-run-blackhole }}
+          - workflow: "tt-metal-l2-nightly.yaml"
+            name: "TT-Metal L2 Nightly APC"
+            should-run: ${{ needs.update-submodule.outputs.should-run-wormhole }}
     steps:
       - name: Checkout
         if: matrix.should-run == 'true'
@@ -313,7 +316,12 @@ jobs:
 
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
-          gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
+          # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
+          if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
+            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" -f run_APC_cpp_tests=true
+          else
+            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
+          fi
 
           # Wait for the new run to appear and ensure it's created after trigger time
           run_id=""
@@ -430,6 +438,13 @@ jobs:
               RESULTS+="- $(check_workflow "all-post-commit-workflows.yaml" "All Post Commit Workflows")"$'\n'
               ALL_PASSED=false
             fi
+
+            if check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC"; then
+              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
+            else
+              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
+              ALL_PASSED=false
+            fi
           fi
 
           if [ "$SHOULD_RUN_BH" = "true" ]; then
@@ -508,6 +523,18 @@ jobs:
               WH_URL=$(echo "$WH_RUNS" | jq -r '.url // ""')
               TEST_STATUS+="- ✅ **All Post Commit Workflows** passed: [View run]($WH_URL)"$'\n'
             fi
+
+            # Get TT-Metal L2 Nightly APC workflow results (filter by PR creation time if not recheck)
+            if [ "${{ inputs.recheck_tests }}" = "true" ]; then
+              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status --jq 'map(select(.status == "completed")) | .[0] // empty' --repo "${{ github.repository }}")
+            else
+              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status,createdAt --jq "map(select(.status == \"completed\" and .createdAt >= \"$PR_CREATED_AT\")) | .[0] // empty" --repo "${{ github.repository }}")
+            fi
+
+            if [ "$L2_RUNS" != "empty" ]; then
+              L2_URL=$(echo "$L2_RUNS" | jq -r '.url // ""')
+              TEST_STATUS+="- ✅ **TT-Metal L2 Nightly APC** passed: [View run]($L2_URL)"$'\n'
+            fi
           fi
 
           if [ "${{ needs.update-submodule.outputs.should-run-blackhole || 'false' }}" = "true" ] || [ "${{ inputs.recheck_tests }}" = "true" ]; then
@@ -555,3 +582,4 @@ jobs:
 
           echo "✅ Updated PR body with test status"
           echo "✅ PR #$PR_NUMBER ready for review"
+          echo "✅ Auto-merge enabled"


### PR DESCRIPTION
### Ticket
None

### Problem description
Similar to https://github.com/tenstorrent/tt-metal/pull/29023.
Recently, some tests were moved from `all-post-commit-workflows.yaml` to `tt-metal-l2-nightly.yaml` and are now only executed when the `run_APC_cpp_tests` parameter is enabled. This migration inadvertently broke the LLK uplift process, as the LLK integration workflow only triggered the original `all-post-commit-workflows.yaml` when Wormhole changes were detected. As a result, critical APC tests that were moved to the nightly workflow were no longer being executed during LLK uplifts, potentially allowing breaking changes to go undetected.

### What's changed
LLK uplift workflow has been updated to run migrated APC tests that currently reside in L2 nightly workflow as part of wormhole tests.
This ensures that LLK uplifts continue to run the complete suite of APC tests, maintaining the same level of validation that existed before the test migration, while supporting the new workflow structure.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes