### PR TITLE
Only one run for resnet50 device perf

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10003.0],
-        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13500.0],
+        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10003.0],
+        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13500.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
@@ -21,8 +21,19 @@ from models.demos.ttnn_resnet.tests.resnet50_performant import (
     "act_dtype, weight_dtype, math_fidelity",
     ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-def test_run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator):
-    run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator)
+@pytest.mark.parametrize("skip_compile_run", [True, False])
+def test_run_resnet50_inference(
+    device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator, skip_compile_run
+):
+    run_resnet50_inference(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+        skip_compile_run=skip_compile_run,
+    )
 
 
 @run_for_blackhole()

--- a/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
@@ -7,7 +7,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 
 def run_perf_device(batch_size, test, command, expected_perf):
     subdir = "resnet50"
-    num_iterations = 4
+    num_iterations = 1
     margin = 0.03
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/ttnn_resnet/tests/resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/resnet50_performant.py
@@ -22,6 +22,7 @@ def run_resnet50_pipeline(
     math_fidelity,
     model_location_generator,
     pipeline_config,
+    skip_compile_run=False,
 ):
     test_infra = create_test_infra(
         device,
@@ -49,7 +50,8 @@ def run_resnet50_pipeline(
         l1_input_memory_config=input_mem_config,
     )
 
-    pipeline.compile(tt_inputs_host)
+    if not skip_compile_run:
+        pipeline.compile(tt_inputs_host)
 
     if use_signpost:
         signpost(header="start")
@@ -70,6 +72,7 @@ def run_resnet50_inference(
     weight_dtype,
     math_fidelity,
     model_location_generator,
+    skip_compile_run=False,
 ):
     run_resnet50_pipeline(
         device,
@@ -79,6 +82,7 @@ def run_resnet50_inference(
         math_fidelity,
         model_location_generator,
         PipelineConfig(use_trace=False, num_command_queues=1, all_transfers_on_separate_command_queue=False),
+        skip_compile_run=skip_compile_run,
     )
 
 

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5780.0],
+        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5780.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
@@ -20,8 +20,19 @@ from models.demos.ttnn_resnet.tests.resnet50_performant import (
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-def test_run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator):
-    run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator)
+@pytest.mark.parametrize("skip_compile_run", [True, False])
+def test_run_resnet50_inference(
+    device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator, skip_compile_run
+):
+    run_resnet50_inference(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+        skip_compile_run=skip_compile_run,
+    )
 
 
 @run_for_wormhole_b0()


### PR DESCRIPTION
For device perf we don't need warmup/multiple runs

### Checklist
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/17916987783)