### PR TITLE
[tt-train] Cross Entropy Operation Fix: Avoid Unnecessary Host Tensor Creation

### DIFF
--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -37,32 +37,36 @@ autograd::TensorPtr cross_entropy_loss(
     auto target_shape = target->get_shape();
 
     if (prediction_shape.rank() != 4U || target_shape.rank() != 2U) {
-        throw std::logic_error(fmt::format(
-            "Cross entropy loss expects: prediction rank = 4, target rank = 2.\n"
-            "Got: prediction shape {}, target shape {}",
-            prediction_shape,
-            target_shape));
+        throw std::logic_error(
+            fmt::format(
+                "Cross entropy loss expects: prediction rank = 4, target rank = 2.\n"
+                "Got: prediction shape {}, target shape {}",
+                prediction_shape,
+                target_shape));
     }
 
     if (prediction_shape[0] != target_shape[0]) {
-        throw std::logic_error(fmt::format(
-            "Cross entropy loss: batch dimension (dim 0) must match.\n"
-            "Got: prediction shape {}, target shape {}",
-            prediction_shape,
-            target_shape));
+        throw std::logic_error(
+            fmt::format(
+                "Cross entropy loss: batch dimension (dim 0) must match.\n"
+                "Got: prediction shape {}, target shape {}",
+                prediction_shape,
+                target_shape));
     }
 
     if (prediction_shape[-2] != target_shape[-1]) {
-        throw std::logic_error(fmt::format(
-            "Cross entropy loss: prediction dim -2 must equal target dim -1.\n"
-            "Got: prediction shape {}, target shape {}",
-            prediction_shape,
-            target_shape));
+        throw std::logic_error(
+            fmt::format(
+                "Cross entropy loss: prediction dim -2 must equal target dim -1.\n"
+                "Got: prediction shape {}, target shape {}",
+                prediction_shape,
+                target_shape));
     }
 
     auto loss = ttml::metal::cross_entropy_fw(prediction->get_value(), target->get_value());
     auto shape = ttnn::Shape({1, 1, 1, 1});
-    autograd::TensorPtr out = autograd::create_tensor(core::from_vector({0.F}, shape, &autograd::ctx().get_device()));
+    autograd::TensorPtr out =
+        autograd::create_tensor(core::empty(shape, &autograd::ctx().get_device(), loss.memory_config()));
     ttnn::moreh_mean(
         loss,
         std::nullopt,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The current implementation of the cross entropy operation involves creating a host tensor, which introduces unnecessary overhead. Since the tensor is only used on the device, creating it on the host is redundant and inefficient.

### What's changed
- Updated the cross entropy operation to create the tensor directly on the device.
- Eliminated unnecessary host tensor creation, reducing overhead and improving efficiency.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes
