### PR TITLE
Matmul with optional_output: Fix Bias and Tile Functionality

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -67,6 +67,7 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
     assert_with_pcc(torch_input_tensor, output_tensor, expected_pcc)
 
 
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
 @pytest.mark.parametrize("n", [1])
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("m", [1024])
@@ -76,48 +77,6 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
 @pytest.mark.parametrize("tile_w", [16])
 def test_optional_output_argument_with_tiny_tiles(device, n, c, m, k, n_out, tile_h, tile_w):
     torch.manual_seed(0)
-
-    torch_input_tensor_a = torch.rand((n, c, m, k), dtype=torch.bfloat16)
-    torch_input_tensor_b = torch.rand((n, c, k, n_out), dtype=torch.bfloat16)
-    torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
-    torch_opt_output_tensor = torch.zeros_like(torch_output_tensor)
-
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        layout=ttnn.TILE_LAYOUT,
-        tile=ttnn.Tile((tile_h, 32)),
-        device=device,
-    )
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        layout=ttnn.TILE_LAYOUT,
-        tile=ttnn.Tile((32, tile_w)),
-        device=device,
-    )
-    optional_output_tensor = ttnn.from_torch(
-        torch_opt_output_tensor,
-        layout=ttnn.TILE_LAYOUT,
-        tile=ttnn.Tile((tile_h, tile_w)),
-        device=device,
-    )
-
-    output = ttnn.matmul(input_tensor_a, input_tensor_b)
-    output = ttnn.to_torch(output)
-
-    ttnn.matmul(input_tensor_a, input_tensor_b, optional_output_tensor=optional_output_tensor)
-    optional_output_tensor = ttnn.to_torch(optional_output_tensor)
-
-    assert output.shape == torch_output_tensor.shape == optional_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.999)
-    assert_with_pcc(torch_output_tensor, optional_output_tensor, 0.999)
-    assert_with_pcc(output, optional_output_tensor, 0.999)
-
-
-@pytest.mark.parametrize("tile_h", [8, 16])
-@pytest.mark.parametrize("tile_w", [16])
-def test_optional_output_argument_with_tiny_tiles(device, tile_h, tile_w):
-    torch.manual_seed(0)
-    n, c, m, k, n_out = 1, 1, 1024, 64, 512
 
     torch_input_tensor_a = torch.rand((n, c, m, k), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n, c, k, n_out), dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -68,6 +68,94 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
 
 
 @pytest.mark.parametrize("n", [1])
+@pytest.mark.parametrize("c", [1])
+@pytest.mark.parametrize("m", [1024])
+@pytest.mark.parametrize("k", [64])
+@pytest.mark.parametrize("n_out", [512])
+@pytest.mark.parametrize("tile_h", [8, 16])
+@pytest.mark.parametrize("tile_w", [16])
+def test_optional_output_argument_with_tiny_tiles(device, n, c, m, k, n_out, tile_h, tile_w):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.rand((n, c, m, k), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((n, c, k, n_out), dtype=torch.bfloat16)
+    torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
+    torch_opt_output_tensor = torch.zeros_like(torch_output_tensor)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((tile_h, 32)),
+        device=device,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((32, tile_w)),
+        device=device,
+    )
+    optional_output_tensor = ttnn.from_torch(
+        torch_opt_output_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((tile_h, tile_w)),
+        device=device,
+    )
+
+    output = ttnn.matmul(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    ttnn.matmul(input_tensor_a, input_tensor_b, optional_output_tensor=optional_output_tensor)
+    optional_output_tensor = ttnn.to_torch(optional_output_tensor)
+
+    assert output.shape == torch_output_tensor.shape == optional_output_tensor.shape
+    assert_with_pcc(torch_output_tensor, output, 0.999)
+    assert_with_pcc(torch_output_tensor, optional_output_tensor, 0.999)
+    assert_with_pcc(output, optional_output_tensor, 0.999)
+
+
+@pytest.mark.parametrize("tile_h", [8, 16])
+@pytest.mark.parametrize("tile_w", [16])
+def test_optional_output_argument_with_tiny_tiles(device, tile_h, tile_w):
+    torch.manual_seed(0)
+    n, c, m, k, n_out = 1, 1, 1024, 64, 512
+
+    torch_input_tensor_a = torch.rand((n, c, m, k), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((n, c, k, n_out), dtype=torch.bfloat16)
+    torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
+    torch_opt_output_tensor = torch.zeros_like(torch_output_tensor)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((tile_h, 32)),
+        device=device,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((32, tile_w)),
+        device=device,
+    )
+    optional_output_tensor = ttnn.from_torch(
+        torch_opt_output_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((tile_h, tile_w)),
+        device=device,
+    )
+
+    output = ttnn.matmul(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    ttnn.matmul(input_tensor_a, input_tensor_b, optional_output_tensor=optional_output_tensor)
+    optional_output_tensor = ttnn.to_torch(optional_output_tensor)
+
+    assert output.shape == torch_output_tensor.shape == optional_output_tensor.shape
+    assert_with_pcc(torch_output_tensor, output, 0.999)
+    assert_with_pcc(torch_output_tensor, optional_output_tensor, 0.999)
+    assert_with_pcc(output, optional_output_tensor, 0.999)
+
+
+@pytest.mark.parametrize("n", [1])
 @pytest.mark.parametrize("c", [2])
 @pytest.mark.parametrize("h", [71])
 @pytest.mark.parametrize("w", [35])

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1250,7 +1250,7 @@ tt::tt_metal::Tile get_output_tile(
         if (!output_mem_config.is_sharded()) {
             TT_FATAL(
                 out_tile_shape[1] == in1_tile_w,
-                "the override output tile width ({}) must equal to the in0 tile width ({})",
+                "the override output tile width ({}) must equal the in0 tile width ({})",
                 out_tile_shape[1],
                 in1_tile_w);
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1219,8 +1219,8 @@ tt::tt_metal::Tile get_output_tile(
     if (output_tile.has_value() or optional_output_tensor_tile.has_value()) {
         TT_FATAL(
             !(optional_output_tensor_tile.has_value() && output_tile.has_value()),
-            "Matmul cannot have both an output_tile and an optional_output_tensor_tile. Remove one of them from the "
-            "matmul arguments.");
+            "Matmul cannot have both an output_tile and an optional_output_tensor. Configure the tile type of the "
+            "output tensor instead if both are required.");
         const auto& override_output_tile =
             output_tile.has_value() ? output_tile.value() : optional_output_tensor_tile.value();
         const auto& out_tile_shape = override_output_tile.get_tile_shape();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1229,17 +1229,30 @@ tt::tt_metal::Tile get_output_tile(
         const uint32_t in1_tile_w = in1_tile_shape[1];
 
         TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
-        TT_FATAL(out_tile_shape[1] % in1_tile_w == 0, "the override output tile width be multiple of in1 tile width");
+        TT_FATAL(
+            out_tile_shape[1] % in1_tile_w == 0,
+            "the override output tile width ({}) be multiple of in1 tile width ({})",
+            out_tile_shape[1],
+            in1_tile_w);
         TT_FATAL(out_tile_shape[0] > 0, "the override output tile height needs to be greater than zero");
-        TT_FATAL(out_tile_shape[0] == in0_tile_h, "the override output tile height must equal to the in0 tile height");
+        TT_FATAL(
+            out_tile_shape[0] == in0_tile_h,
+            "the override output tile height ({}) must equal to the in0 tile height ({})",
+            out_tile_shape[0],
+            in0_tile_h);
         if (out_tile_shape[1] != in1_tile_w) {
             TT_FATAL(
                 out_tile_shape[0] <= constants::FACE_HEIGHT,
-                "the override output tile height must equal or less to face height");
+                "the override output tile height ({}) must equal or less to face height ({})",
+                out_tile_shape[0],
+                constants::FACE_HEIGHT);
         }
         if (!output_mem_config.is_sharded()) {
             TT_FATAL(
-                out_tile_shape[1] == in1_tile_w, "the override output tile width must equal to the in0 tile width");
+                out_tile_shape[1] == in1_tile_w,
+                "the override output tile width ({}) must equal to the in0 tile width ({})",
+                out_tile_shape[1],
+                in1_tile_w);
         }
 
         return override_output_tile;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1212,13 +1212,22 @@ tt::tt_metal::Tile get_output_tile(
     const MemoryConfig& output_mem_config,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
-    const std::optional<const tt::tt_metal::Tile> output_tile) {
+    const std::optional<const tt::tt_metal::Tile> output_tile,
+    const std::optional<const tt::tt_metal::Tile> optional_output_tensor_tile) {
     auto in0_tile_shape = in0_tile.get_tile_shape();
     auto in1_tile_shape = in1_tile.get_tile_shape();
-    if (output_tile.has_value()) {
-        uint32_t in0_tile_h = in0_tile_shape[0];
-        uint32_t in1_tile_w = in1_tile_shape[1];
-        const auto& out_tile_shape = output_tile->get_tile_shape();
+    if (output_tile.has_value() or optional_output_tensor_tile.has_value()) {
+        TT_FATAL(
+            !(optional_output_tensor_tile.has_value() && output_tile.has_value()),
+            "Matmul cannot have both an output_tile and an optional_output_tensor_tile. Remove one of them from the "
+            "matmul arguments.");
+        const auto& override_output_tile =
+            output_tile.has_value() ? output_tile.value() : optional_output_tensor_tile.value();
+        const auto& out_tile_shape = override_output_tile.get_tile_shape();
+
+        const uint32_t in0_tile_h = in0_tile_shape[0];
+        const uint32_t in1_tile_w = in1_tile_shape[1];
+
         TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
         TT_FATAL(out_tile_shape[1] % in1_tile_w == 0, "the override output tile width be multiple of in1 tile width");
         TT_FATAL(out_tile_shape[0] > 0, "the override output tile height needs to be greater than zero");
@@ -1233,7 +1242,9 @@ tt::tt_metal::Tile get_output_tile(
                 out_tile_shape[1] == in1_tile_w, "the override output tile width must equal to the in0 tile width");
         }
 
-        return output_tile.value();
+        return override_output_tile;
+    } else if (optional_output_tensor_tile.has_value()) {
+        return optional_output_tensor_tile.value();
     } else {
         return tt::tt_metal::Tile({in0_tile_shape[0], in1_tile_shape[1]});
     }
@@ -1406,7 +1417,13 @@ Matmul create_matmul_struct(
         /*default_l1_acc=*/!is_float_32);
     auto in0_tile = input_tensor_a.tensor_spec().tile();
     auto in1_tile = input_tensor_b.tensor_spec().tile();
-    tt::tt_metal::Tile output_tile = get_output_tile(output_mem_config, in0_tile, in1_tile, parameters.output_tile);
+
+    std::optional<tt::tt_metal::Tile> optional_output_tensor_tile = std::nullopt;
+    if (is_optional_output_tensor) {
+        optional_output_tensor_tile = optional_output_tensors.at(0)->tensor_spec().tile();
+    }
+    tt::tt_metal::Tile output_tile =
+        get_output_tile(output_mem_config, in0_tile, in1_tile, parameters.output_tile, optional_output_tensor_tile);
 
     return Matmul{
         parameters.program_config,
@@ -2843,9 +2860,9 @@ std::vector<ttnn::TensorSpec> SparseMatmul::compute_output_specs(
 
     auto in0_tile = input_tensor_a.tensor_spec().tile();
     auto in1_tile = input_tensor_b.tensor_spec().tile();
-    tt::tt_metal::Tile output_tile = this->output_tile.has_value()
-                                         ? this->output_tile.value()
-                                         : get_output_tile(this->output_mem_config, in0_tile, in1_tile, std::nullopt);
+
+    tt::tt_metal::Tile output_tile = get_output_tile(
+        this->output_mem_config, in0_tile, in1_tile, this->output_tile, /*optional_output_tensor_tile=*/std::nullopt);
 
     return {TensorSpec(
         output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE, output_tile), this->output_mem_config))};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1231,7 +1231,7 @@ tt::tt_metal::Tile get_output_tile(
         TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
         TT_FATAL(
             out_tile_shape[1] % in1_tile_w == 0,
-            "the override output tile width ({}) be multiple of in1 tile width ({})",
+            "the override output tile width ({}) must be a multiple of in1 tile width ({})",
             out_tile_shape[1],
             in1_tile_w);
         TT_FATAL(out_tile_shape[0] > 0, "the override output tile height needs to be greater than zero");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1256,8 +1256,6 @@ tt::tt_metal::Tile get_output_tile(
         }
 
         return override_output_tile;
-    } else if (optional_output_tensor_tile.has_value()) {
-        return optional_output_tensor_tile.value();
     } else {
         return tt::tt_metal::Tile({in0_tile_shape[0], in1_tile_shape[1]});
     }

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -147,17 +147,26 @@ ttnn::Tensor bound_matmul(
     }
 
     if (post_process_bias) {
-        output_tensor = ttnn::add(output_tensor, bias.value(), std::nullopt, parameters.output_mem_config);
+        output_tensor = ttnn::add(
+            ttnn::QueueId{queue_id},
+            output_tensor,
+            bias.value(),
+            /*output_dtype=*/std::nullopt,
+            parameters.output_mem_config,
+            optional_output_tensor);
     }
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
         if (op_type == UnaryOpType::RELU) {
-            output_tensor = ttnn::relu(output_tensor, parameters.output_mem_config);
+            output_tensor = ttnn::relu(
+                ttnn::QueueId{queue_id}, output_tensor, parameters.output_mem_config, optional_output_tensor);
         } else if (op_type == UnaryOpType::GELU) {
-            output_tensor = ttnn::gelu(output_tensor, false, parameters.output_mem_config);
+            output_tensor = ttnn::gelu(
+                ttnn::QueueId{queue_id}, output_tensor, false, parameters.output_mem_config, optional_output_tensor);
         } else if (op_type == UnaryOpType::SILU) {
-            output_tensor = ttnn::silu(output_tensor, parameters.output_mem_config);
+            output_tensor = ttnn::silu(
+                ttnn::QueueId{queue_id}, output_tensor, parameters.output_mem_config, optional_output_tensor);
         } else {
             TT_THROW("ttnn.matmul: Unsupported activation function");
         }

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -148,7 +148,6 @@ ttnn::Tensor bound_matmul(
 
     if (post_process_bias) {
         output_tensor = ttnn::add(
-            ttnn::QueueId{queue_id},
             output_tensor,
             bias.value(),
             /*output_dtype=*/std::nullopt,
@@ -159,14 +158,11 @@ ttnn::Tensor bound_matmul(
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
         if (op_type == UnaryOpType::RELU) {
-            output_tensor = ttnn::relu(
-                ttnn::QueueId{queue_id}, output_tensor, parameters.output_mem_config, optional_output_tensor);
+            output_tensor = ttnn::relu(output_tensor, parameters.output_mem_config, optional_output_tensor);
         } else if (op_type == UnaryOpType::GELU) {
-            output_tensor = ttnn::gelu(
-                ttnn::QueueId{queue_id}, output_tensor, false, parameters.output_mem_config, optional_output_tensor);
+            output_tensor = ttnn::gelu(output_tensor, false, parameters.output_mem_config, optional_output_tensor);
         } else if (op_type == UnaryOpType::SILU) {
-            output_tensor = ttnn::silu(
-                ttnn::QueueId{queue_id}, output_tensor, parameters.output_mem_config, optional_output_tensor);
+            output_tensor = ttnn::silu(output_tensor, parameters.output_mem_config, optional_output_tensor);
         } else {
             TT_THROW("ttnn.matmul: Unsupported activation function");
         }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -70,34 +70,33 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - TILE, ROW_MAJOR
-
+                      - TILE, ROW_MAJOR
 
                 .. list-table:: weight (gamma) and bias (beta)
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 .. list-table:: input_mask
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16, BFLOAT8_B
-                        - TILE
+                      - TILE
 
                 .. list-table:: output_tensor
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - TILE, ROW_MAJOR
+                      - TILE, ROW_MAJOR
 
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device


### PR DESCRIPTION
### Ticket
#24847 
#24870

### Problem description
Calling `ttnn.linear` with the optional output tensor wouldn't apply the bias to the optional output tensor. This was because `bound_matmul` did not properly handle the optional output tensor for the bias or activation function calls.

Matmul also didn't check the tile format of the optional output tensor.

### What's changed
Updated the bias and activation within `bound_matmul` to also use the optional output tensor. Added a testcase with this now-working functionality.

Updated `get_output_tile` to only accept either the tile argument or an optional output tensor, and use the output tensor's tile configuration when provided. Added a testcase using the optional output tensor to specify a tiny tile output.

Minor update to spacing in GN docs.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17920870591)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17920878775)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes