### PR TITLE
fix DM test suite bug when no stats is present

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -24,9 +24,10 @@ class StatsCollector:
             "riscv_0": {"analysis": "riscv_0_analysis", "events": "riscv_0_events"},
         }
 
-    def gather_analysis_stats(self):
+    def gather_analysis_stats(self, stats=None):
         # Gather stats from csv and set up analysis
-        stats = self.gather_stats_from_csv()
+        if stats is None:
+            stats = self.gather_stats_from_csv()
         cores = [
             key
             for key in stats["devices"][0]["cores"].keys()

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -46,6 +46,9 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 
     # Gather analysis stats
     stats_collector = StatsCollector(log_file_path, test_id_to_name, test_type_attributes, verbose=verbose)
+    if not stats_collector.gather_stats_from_csv().get("devices"):
+        logger.info("No profiling data available.")
+        return
     dm_stats, aggregate_stats = stats_collector.gather_analysis_stats()
 
     # Print stats if explicitly requested

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -46,10 +46,11 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 
     # Gather analysis stats
     stats_collector = StatsCollector(log_file_path, test_id_to_name, test_type_attributes, verbose=verbose)
-    if not stats_collector.gather_stats_from_csv().get("devices"):
+    stats = stats_collector.gather_stats_from_csv()
+    if not stats.get("devices"):
         logger.info("No profiling data available.")
         return
-    dm_stats, aggregate_stats = stats_collector.gather_analysis_stats()
+    dm_stats, aggregate_stats = stats_collector.gather_analysis_stats(stats)
 
     # Print stats if explicitly requested
     stats_reporter = StatsReporter(


### PR DESCRIPTION
### Ticket
[Github issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=130048207&issue=tenstorrent%7Ctt-metal%7C29014)

### Problem description
In the Data movement test suite python script, we have a bug where if you run only a test which has GTEST_SKIP(), the test fails because of KeyError in stats_collector.

### What's changed
Added a simple check to see if there is any data available before using it.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [results](https://github.com/tenstorrent/tt-metal/actions/runs/18100386337)
