### PR TITLE
[skip ci] Wheels can't be uploaded from reusable workflow

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -50,13 +50,20 @@ jobs:
           echo "is-release-candidate=$isReleaseCandidate" >> "$GITHUB_OUTPUT"
 
           # Set tag-type
-          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]] || [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          echo "Determining tag-type for GITHUB_REF: ${GITHUB_REF}"
+          echo "isReleaseCandidate: $isReleaseCandidate"
+
+          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]] || [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            echo "Matched stable branch or RC tag pattern"
             if [[ "$isReleaseCandidate" == "true" ]]; then
+              echo "Setting tag-type=rc (release candidate)"
               echo "tag-type=rc" >> "$GITHUB_OUTPUT"
             else
+              echo "Setting tag-type= (production release)"
               echo "tag-type=" >> "$GITHUB_OUTPUT"
             fi
           else
+            echo "No stable/RC match - setting tag-type=dev (development build)"
             echo "tag-type=dev" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -107,7 +107,7 @@ jobs:
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) || inputs.dry-run }}
+    if: ${{ github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run }}
     environment:
       name: pypi
       url: https://pypi.org/project/ttnn/
@@ -198,7 +198,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) || inputs.dry-run }}
+    if: ${{ github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "is-release-candidate=$isReleaseCandidate" >> "$GITHUB_OUTPUT"
 
           # Set tag-type
-          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]] || [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             if [[ "$isReleaseCandidate" == "true" ]]; then
               echo "tag-type=rc" >> "$GITHUB_OUTPUT"
             else
@@ -100,7 +100,7 @@ jobs:
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/') && contains(github.event.base_ref || '', 'refs/heads/stable'))) || inputs.dry-run }}
+    if: ${{ (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/')) || inputs.dry-run }}
     environment:
       name: pypi
       url: https://pypi.org/project/ttnn/
@@ -191,7 +191,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/') && contains(github.event.base_ref || '', 'refs/heads/stable'))) || inputs.dry-run }}
+    if: ${{ (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/')) || inputs.dry-run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -97,6 +97,41 @@ jobs:
       tag-version: ${{ needs.create-tag.outputs.version }}
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
 
+  publish-to-pypi:
+    needs: [build-test-publish, create-tag]
+    runs-on: ubuntu-latest
+    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/') && contains(github.event.base_ref || '', 'refs/heads/stable'))) || inputs.dry-run }}
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ttnn/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download ALL wheels (separate folders)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eager-dist-*
+          path: artifacts
+          merge-multiple: false
+
+      - name: Remove profiler artifacts
+        run: |
+          find artifacts -maxdepth 1 -type d -name '*profiler*' -print -exec rm -rf {} +
+
+      - name: Flatten into dist/
+        run: |
+          mkdir -p dist
+          # copy wheel/sdist files from remaining artifact dirs
+          find artifacts -type f -name '*.whl' -exec cp {} dist/ \;
+          find artifacts -type f -name '*.tar.gz' -exec cp {} dist/ \;
+          ls -l dist
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: ${{ !inputs.dry-run }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+
 
   create-changelog:
     needs: [create-tag, build-test-publish]

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -107,7 +107,7 @@ jobs:
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/')) || inputs.dry-run }}
+    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) || inputs.dry-run }}
     environment:
       name: pypi
       url: https://pypi.org/project/ttnn/
@@ -198,7 +198,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/')) || inputs.dry-run }}
+    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) || inputs.dry-run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       version:
-        required: true
+        required: false
         type: string
       os:
         required: false
         type: string
         default: ubuntu-22.04
       tag-latest:
-        required: true
+        required: false
         type: boolean
         default: false
       timeout:

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -232,32 +232,3 @@ jobs:
             echo "Publishing wheel: $wheel"
             s3pypi upload "$wheel" --put-root-index --bucket ${{ secrets.PYPI_BUCKET }}
           done
-
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    needs:
-      - build-artifact
-      - single-card-demos
-      - t3000-demos
-      - t3000-model-perf
-      - galaxy-demos
-      - blackhole-single-card-demos
-      - blackhole-multi-card-demos
-
-    runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/') && contains(github.event.base_ref || '', 'refs/heads/stable'))) || inputs.dry-run }}
-    environment:
-      name: pypi
-      url: https://pypi.org/project/ttnn/
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-        path: dist/
-    - name: Publish distribution 📦 to PyPI (skipped for dry run)
-      if: ${{ !inputs.dry-run }}
-      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -145,7 +145,7 @@ jobs:
       - build-artifact
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || inputs.dry-run }}
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run }}
     with:
       os: ${{ inputs.distro || 'ubuntu' }}-${{ inputs.version || '22.04' }}
       version: ${{ inputs.tag-version }}


### PR DESCRIPTION
This is because of https://github.com/pypi/warehouse/issues/11096.

### Problem description
PyPi doesn't support uploading wheels from reusable workflow

### What's changed
Put upload of wheels from package-and-release workflow