### PR TITLE
AG Minimal Higher Dim Bug Fix

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -331,10 +331,12 @@ def test_all_gather_async(
     "ag_output_shape, dim, layout, ag_input_dtype",
     [
         # Gather on dim 0
+        ([24, 3, 128, 96], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 1, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([8, 16, 8, 8], 0, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         # Gather on dim 1
+        ([3, 24, 128, 96], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),
@@ -360,6 +362,8 @@ def test_all_gather_async(
         "tt_training_test_ten",
         "tt_training_test_eleven",
         "tt_training_test_twelve",
+        "tt_training_test_thirteen",
+        "tt_training_test_fourteen",
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -681,14 +681,14 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                         auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
                         worker_reader_sender_runtime_args[0] = input.buffer()->address();
                         worker_reader_sender_runtime_args[1] = output.buffer()->address();
-                        worker_reader_sender_runtime_args[11] = out_ready_semaphore.address();
+                        worker_reader_sender_runtime_args[13] = out_ready_semaphore.address();
                         // sender writer
                         auto& worker_writer_sender_runtime_args = writer_runtime_args[core.x][core.y];
                         worker_writer_sender_runtime_args[0] = output.buffer()->address();
-                        worker_writer_sender_runtime_args[12] = out_ready_semaphore.address();
+                        worker_writer_sender_runtime_args[14] = out_ready_semaphore.address();
 
                         if (barrier_semaphore.has_value()) {
-                            worker_writer_sender_runtime_args[16] = barrier_semaphore.value().address();
+                            worker_writer_sender_runtime_args[18] = barrier_semaphore.value().address();
                         }
 
                         core_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -381,10 +381,14 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
         TT_FATAL(!(input_tensor_shape[3] % TILE_WIDTH), "Input tensor width must be a multiple of TILE_WIDTH");
         TT_FATAL(!(output_tensor_shape[3] % TILE_WIDTH), "Output tensor width must be a multiple of TILE_WIDTH");
         uint32_t TILE_WIDTH = 32;
+
         uint32_t input_tensor_Wt = input_tensor_shape[3] / TILE_WIDTH;
         uint32_t input_tensor_Ht = input_tensor_shape[2] / TILE_WIDTH;
+        uint32_t input_tensor_C = input_tensor_shape[1];
+
         uint32_t output_tensor_Wt = output_tensor_shape[3] / TILE_WIDTH;
         uint32_t output_tensor_Ht = output_tensor_shape[2] / TILE_WIDTH;
+        uint32_t output_tensor_C = output_tensor_shape[1];
 
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             // Fabrix mux kernel
@@ -500,8 +504,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                     output_tensor.buffer()->address(),                        // output_tensor_address
                     input_tensor_Wt,                                          // width in tiles of the output shard
                     input_tensor_Ht,                                          // height in tiles of the output shard
+                    input_tensor_C,                                           // num input channels
                     output_tensor_Wt,                                         // width in tiles of entire output
                     output_tensor_Ht,                                         // height in tiles of entire output
+                    output_tensor_C,                                          // num output channels
                     dim,                                                      // dim to gather on
                     batch_head_size,                                          // product of the first two dims
                     input_tile_id_start,                                      //
@@ -596,8 +602,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
                     output_tensor.buffer()->address(),                           // output_tensor_address
                     input_tensor_Wt,                                             // width in tiles of the output shard
                     input_tensor_Ht,                                             // height in tiles of the output shard
+                    input_tensor_C,                                              // num input channels
                     output_tensor_Wt,                                            // width in tiles of entire output
                     output_tensor_Ht,                                            // height in tiles of entire output
+                    output_tensor_C,                                             // num output channels
                     dim,                                                         // dim to gather on
                     batch_head_size,                                             // product of the first two dims
                     input_tile_id_start,                                         //

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -209,7 +209,7 @@ void kernel_main() {
                     actual_sender_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
             }
 
-            uint32_t num_channels_processed = 0;
+            uint32_t num_channels_processed_in_current_batch = 0;
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
                 chunk_count = 0;
                 while (tiles_read < tiles_to_read) {
@@ -243,16 +243,16 @@ void kernel_main() {
                     noc_async_read_barrier();
                     cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
                 }
-                num_channels_processed++;
-                if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+                num_channels_processed_in_current_batch++;
+                if (gather_dim == 1 && num_channels_processed_in_current_batch == input_tensor_C) {
                     output_tile_id_start +=
                         output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
                 } else {
                     output_tile_id_start += output_tensor_Wt * output_tensor_Ht;
                 }
 
-                if (num_channels_processed == input_tensor_C) {
-                    num_channels_processed = 0;
+                if (num_channels_processed_in_current_batch == input_tensor_C) {
+                    num_channels_processed_in_current_batch = 0;
                 }
 
                 pages_read_in_row = start_pages_read_in_row;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -38,8 +38,10 @@ void kernel_main() {
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     uint32_t input_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t input_tensor_C = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t output_tensor_C = get_arg_val<uint32_t>(arg_idx++);
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_batch_head_count = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -201,11 +203,13 @@ void kernel_main() {
             } else if (gather_dim == 2) {
                 output_tile_id_start = actual_sender_chip_id * input_tensor_Ht * input_tensor_Wt;
             } else if (gather_dim == 1) {
-                // TODO: (GR)
+                output_tile_id_start = actual_sender_chip_id * input_tensor_C * input_tensor_Ht * input_tensor_Wt;
             } else {
                 output_tile_id_start =
                     actual_sender_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
             }
+
+            uint32_t num_channels_processed = 0;
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
                 chunk_count = 0;
                 while (tiles_read < tiles_to_read) {
@@ -239,11 +243,18 @@ void kernel_main() {
                     noc_async_read_barrier();
                     cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
                 }
+                num_channels_processed++;
+                if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+                    output_tile_id_start +=
+                        output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
+                    num_channels_processed = 0;
+                } else {
+                    output_tile_id_start += output_tensor_Wt * output_tensor_Ht;
+                }
                 pages_read_in_row = start_pages_read_in_row;
                 row_offset = start_row_offset;
                 tiles_read = input_tile_id_start;
                 tiles_to_read = input_tile_id_end;
-                output_tile_id_start += output_tensor_Wt * output_tensor_Ht;
             }
         } else {
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -198,8 +198,13 @@ void kernel_main() {
             uint32_t stride_Wt = output_tensor_Wt;
             if (gather_dim == 3) {
                 output_tile_id_start = actual_sender_chip_id * input_tensor_Wt;
-            } else {
+            } else if (gather_dim == 2) {
                 output_tile_id_start = actual_sender_chip_id * input_tensor_Ht * input_tensor_Wt;
+            } else if (gather_dim == 1) {
+                // TODO: (GR)
+            } else {
+                output_tile_id_start =
+                    actual_sender_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
             }
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
                 chunk_count = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -247,10 +247,14 @@ void kernel_main() {
                 if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
                     output_tile_id_start +=
                         output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
-                    num_channels_processed = 0;
                 } else {
                     output_tile_id_start += output_tensor_Wt * output_tensor_Ht;
                 }
+
+                if (num_channels_processed == input_tensor_C) {
+                    num_channels_processed = 0;
+                }
+
                 pages_read_in_row = start_pages_read_in_row;
                 row_offset = start_row_offset;
                 tiles_read = input_tile_id_start;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -237,7 +237,7 @@ void kernel_main() {
         32});
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
 
-    uint32_t num_channels_processed = 0;
+    uint32_t num_channels_processed_in_current_batch = 0;
     uint32_t chunk_count = 0;
     for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
         chunk_count = 0;
@@ -356,15 +356,15 @@ void kernel_main() {
             }
         }
 
-        num_channels_processed++;
-        if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+        num_channels_processed_in_current_batch++;
+        if (gather_dim == 1 && num_channels_processed_in_current_batch == input_tensor_C) {
             tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
         } else {
             tile_id_start += output_tensor_Wt * output_tensor_Ht;
         }
 
-        if (num_channels_processed == input_tensor_C) {
-            num_channels_processed = 0;
+        if (num_channels_processed_in_current_batch == input_tensor_C) {
+            num_channels_processed_in_current_batch = 0;
         }
 
         tiles_read = input_tile_id_start;
@@ -437,7 +437,7 @@ void kernel_main() {
             tile_id_start = actual_slice_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
         }
 
-        num_channels_processed = 0;
+        num_channels_processed_in_current_batch = 0;
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
             chunk_count = 0;
 
@@ -507,15 +507,15 @@ void kernel_main() {
                 tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
             }
 
-            num_channels_processed++;
-            if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+            num_channels_processed_in_current_batch++;
+            if (gather_dim == 1 && num_channels_processed_in_current_batch == input_tensor_C) {
                 tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
             } else {
                 tile_id_start += output_tensor_Wt * output_tensor_Ht;
             }
 
-            if (num_channels_processed == input_tensor_C) {
-                num_channels_processed = 0;
+            if (num_channels_processed_in_current_batch == input_tensor_C) {
+                num_channels_processed_in_current_batch = 0;
             }
 
             tiles_read = input_tile_id_start;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -64,8 +64,10 @@ void kernel_main() {
     address_t output_address = get_arg_val<address_t>(arg_idx++);
     uint32_t input_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t input_tensor_C = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_tensor_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_tensor_Ht = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t output_tensor_C = get_arg_val<uint32_t>(arg_idx++);
     uint32_t gather_dim = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_batch_head_count = get_arg_val<uint32_t>(arg_idx++);
     uint32_t input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -221,7 +223,7 @@ void kernel_main() {
     } else if (gather_dim == 2) {
         tile_id_start = position * input_tensor_Ht * input_tensor_Wt;
     } else if (gather_dim == 1) {
-        // TODO: (GR)
+        tile_id_start = position * input_tensor_C * input_tensor_Ht * input_tensor_Wt;
     } else {
         tile_id_start = position * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
     }
@@ -235,6 +237,7 @@ void kernel_main() {
         32});
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
 
+    uint32_t num_channels_processed = 0;
     uint32_t chunk_count = 0;
     for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
         chunk_count = 0;
@@ -353,7 +356,13 @@ void kernel_main() {
             }
         }
 
-        tile_id_start += output_tensor_Wt * output_tensor_Ht;
+        num_channels_processed++;
+        if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+            tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
+            num_channels_processed = 0;
+        } else {
+            tile_id_start += output_tensor_Wt * output_tensor_Ht;
+        }
         tiles_read = input_tile_id_start;
         tiles_to_read = input_tile_id_end;
         pages_read_in_row = start_pages_read_in_row;
@@ -419,11 +428,12 @@ void kernel_main() {
         } else if (gather_dim == 2) {
             tile_id_start = actual_slice_chip_id * input_tensor_Ht * input_tensor_Wt;
         } else if (gather_dim == 1) {
-            // TODO: (GR)
+            tile_id_start = actual_slice_chip_id * input_tensor_C * input_tensor_Ht * input_tensor_Wt;
         } else {
             tile_id_start = actual_slice_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
         }
 
+        num_channels_processed = 0;
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {
             chunk_count = 0;
 
@@ -493,7 +503,13 @@ void kernel_main() {
                 tt::tt_fabric::fabric_atomic_inc(*mux_connection_handle, pkt_hdr_sem_inc);
             }
 
-            tile_id_start += output_tensor_Wt * output_tensor_Ht;
+            num_channels_processed++;
+            if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
+                tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
+                num_channels_processed = 0;
+            } else {
+                tile_id_start += output_tensor_Wt * output_tensor_Ht;
+            }
             tiles_read = input_tile_id_start;
             tiles_to_read = input_tile_id_end;
             row_offset = start_row_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -218,8 +218,12 @@ void kernel_main() {
 
     if (gather_dim == 3) {
         tile_id_start = position * input_tensor_Wt;
-    } else {
+    } else if (gather_dim == 2) {
         tile_id_start = position * input_tensor_Ht * input_tensor_Wt;
+    } else if (gather_dim == 1) {
+        // TODO: (GR)
+    } else {
+        tile_id_start = position * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
     }
 
     // 2. unicast output ready semaphore
@@ -412,8 +416,12 @@ void kernel_main() {
         uint32_t stride_Wt = output_tensor_Wt;
         if (gather_dim == 3) {
             tile_id_start = actual_slice_chip_id * input_tensor_Wt;
-        } else {
+        } else if (gather_dim == 2) {
             tile_id_start = actual_slice_chip_id * input_tensor_Ht * input_tensor_Wt;
+        } else if (gather_dim == 1) {
+            // TODO: (GR)
+        } else {
+            tile_id_start = actual_slice_chip_id * input_batch_head_count * input_tensor_Ht * input_tensor_Wt;
         }
 
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count; bh_idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -359,10 +359,14 @@ void kernel_main() {
         num_channels_processed++;
         if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
             tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
-            num_channels_processed = 0;
         } else {
             tile_id_start += output_tensor_Wt * output_tensor_Ht;
         }
+
+        if (num_channels_processed == input_tensor_C) {
+            num_channels_processed = 0;
+        }
+
         tiles_read = input_tile_id_start;
         tiles_to_read = input_tile_id_end;
         pages_read_in_row = start_pages_read_in_row;
@@ -506,10 +510,14 @@ void kernel_main() {
             num_channels_processed++;
             if (gather_dim == 1 && num_channels_processed == input_tensor_C) {
                 tile_id_start += output_tensor_Wt * output_tensor_Ht * (output_tensor_C - input_tensor_C + 1);
-                num_channels_processed = 0;
             } else {
                 tile_id_start += output_tensor_Wt * output_tensor_Ht;
             }
+
+            if (num_channels_processed == input_tensor_C) {
+                num_channels_processed = 0;
+            }
+
             tiles_read = input_tile_id_start;
             tiles_to_read = input_tile_id_end;
             row_offset = start_row_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -151,11 +151,6 @@ bool use_composite_all_gather(
         return true;
     }
 
-    // Use composite if gathering on dim 0 or dim 1, and input_shape[0] != 1 or input_shape[1] != 1
-    if ((gather_dim == 0 || gather_dim == 1) && (input_shape[0] != 1 || input_shape[1] != 1)) {
-        return true;
-    }
-
     return false;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -147,11 +147,7 @@ bool use_composite_all_gather(
     bool is_tiled_and_padded_on_gather_dim =
         input_tensor.layout() == ttnn::Layout::TILE && ((gather_dim == 2 && input_shape[2] % tile_height != 0) ||
                                                         (gather_dim == 3 && input_shape[3] % tile_width != 0));
-    if (is_tiled_and_padded_on_gather_dim) {
-        return true;
-    }
-
-    return false;
+    return is_tiled_and_padded_on_gather_dim;
 }
 
 ttnn::Tensor composite_all_gather(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27189)

### Problem description
- minimal AG gave bad PCC for the following config: `(gather_dim == 0 or gather_dim == 1) and (input_shape[0] != 1 or input_shape[1] != 1)`
- as a workaround, we were using the composite-AG to handle these cases

### What's changed
- Updated the `tile_id` logic to properly offset and increment when running with the above config, and update the routing logic to no longer use the composite with this config

### Pipelines
- APC https://github.com/tenstorrent/tt-metal/actions/runs/17921572205
- BH APC https://github.com/tenstorrent/tt-metal/actions/runs/17921562314
- T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/17903698767

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes