### PR TITLE
[skip ci] Bump t3k unit test pipeline timeout 

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 35, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 40, owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 25, owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 15, owner_id: U013121KDH9}, #Austin Ho


### PR DESCRIPTION
More and more ttnn tests are being added. T3k unit test pipeline started failing deterministically [after this commit.](https://github.com/tenstorrent/tt-metal/commit/964d583539e6be8b5878ea8bb31ff9e964c79f07#diff-fc1194e550bfc15c4f9ae39588d71d3930cf0c4405db44d932bddf3dfcef1110)

The PR had a passing run of t3k unit test pipelines. The original runtime was already close to 35 mins.