### PR TITLE
#28062: [skip ci] Add timeouts to multi-user isolation tests and add a couple pipelines to produce data

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -51,6 +51,8 @@ on:
       - "Nightly tt-metal L2 tests"
       - "Package and release"
       - "Build test and publish upstream tests"
+      - "Multi-Host Deployment (Physical)"
+      - "Galaxy Multi-user Isolation Tests"
     types:
       - completed
 

--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       galaxy-multi-user-isolation-tests:
-        description: 'Run Galaxy multi-host job'
+        description: 'Run Galaxy multi-host job (not actually used in logic yet)'
         required: false
         default: true
         type: boolean

--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Create Docker Compose file
         run: python3 .github/scripts/utils/multi-user-create-files.py --image "${{ needs.build-artifact.outputs.dev-docker-image }}"
       - name: Run Docker Compose
+        timeout-minutes: 10
         run: |
           TRAY_PODS_DIR=".multi-user-galaxy-docker-files"
           REQUIRED_PODS=4
@@ -76,6 +77,7 @@ jobs:
           echo "All $REQUIRED_PODS docker containers have created their files (found $count)."
 
       - name: Run the tests
+        timeout-minutes: 15
         run: |
           run_test() {
             testname="$1"


### PR DESCRIPTION
…

### Ticket

#28062

### Problem description

- Always have timeouts for tests
- Let's add the isolation workflow + the multi-host workflow to Superset collection

### What's changed

- Add timeouts
- Add workflows to superset collection
### Checklist
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/17923180968 isolation tests
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes