### PR TITLE
Update to vector of tensor in Maxpool2D

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools.cpp
@@ -88,8 +88,8 @@ Tensor AdaptiveMaxPool2DOp::invoke(
         false /*return_indices*/);
 
     // Since return_indices=false, the result variant should always contain a Tensor
-    TT_FATAL(std::holds_alternative<Tensor>(result), "Expected Tensor result when return_indices is false");
-    return std::get<Tensor>(result);
+    TT_FATAL(result.size() == 1, "Expected Tensor result when return_indices is false");
+    return result[0];
 }
 
 }  // namespace operations::experimental::adaptive_pool

--- a/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools.cpp
@@ -89,7 +89,7 @@ Tensor AdaptiveMaxPool2DOp::invoke(
 
     // Since return_indices=false, the result variant should always contain a Tensor
     TT_FATAL(result.size() == 1, "Expected Tensor result when return_indices is false");
-    return result[0];
+    return result.at(0);
 }
 
 }  // namespace operations::experimental::adaptive_pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -29,7 +29,7 @@ namespace operations::pool {
 // dilation which is set to (1,1) for avg pool and count_include_pad and divisor_override which have no effect on
 // maxpool.
 
-static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
+static std::vector<Tensor> pool2d_invoke(
     const Tensor& input_tensor,
     Pool2DType pool_type,
     uint32_t batch_size,
@@ -357,14 +357,14 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
             output_tensors.size() == 2,
             "Expected two output tensors when return_indices is true, but got {}.",
             output_tensors.size());
-        return MaxPoolWithIndicesResult{std::move(output_tensors[0]), std::move(output_tensors[1])};
+        return output_tensors;
     } else {
         TT_FATAL(output_tensors.size() == 1, "Expected a single output tensor when return_indices is false.");
-        return std::move(output_tensors[0]);
+        return output_tensors;
     }
 }
 
-std::variant<Tensor, MaxPoolWithIndicesResult> MaxPool2DOp::invoke(
+std::vector<Tensor> MaxPool2DOp::invoke(
     const Tensor& input_tensor,
     uint32_t batch_size,
     uint32_t input_h,
@@ -450,7 +450,8 @@ Tensor AvgPool2DOp::invoke(
         output_layout);
 
     // Average pool always returns just the tensor, never indices
-    return std::get<Tensor>(result);
+    // return std::get<Tensor>(result);
+    return result[0];
 }
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -357,10 +357,10 @@ static std::vector<Tensor> pool2d_invoke(
             output_tensors.size() == 2,
             "Expected two output tensors when return_indices is true, but got {}.",
             output_tensors.size());
-        return std::move(output_tensors);
+        return output_tensors;
     } else {
         TT_FATAL(output_tensors.size() == 1, "Expected a single output tensor when return_indices is false.");
-        return std::move(output_tensors);
+        return output_tensors;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -357,10 +357,10 @@ static std::vector<Tensor> pool2d_invoke(
             output_tensors.size() == 2,
             "Expected two output tensors when return_indices is true, but got {}.",
             output_tensors.size());
-        return output_tensors;
+        return std::move(output_tensors);
     } else {
         TT_FATAL(output_tensors.size() == 1, "Expected a single output tensor when return_indices is false.");
-        return output_tensors;
+        return std::move(output_tensors);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -450,7 +450,6 @@ Tensor AvgPool2DOp::invoke(
         output_layout);
 
     // Average pool always returns just the tensor, never indices
-    // return std::get<Tensor>(result);
     return result.at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -451,7 +451,7 @@ Tensor AvgPool2DOp::invoke(
 
     // Average pool always returns just the tensor, never indices
     // return std::get<Tensor>(result);
-    return result[0];
+    return result.at(0);
 }
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/tensor/host_buffer/functions.hpp"
 
 #include "device/pool_op.hpp"
+#include <vector>
 
 namespace ttnn {
 namespace operations::pool {
@@ -20,7 +21,7 @@ struct MaxPoolWithIndicesResult {
 };
 
 struct MaxPool2DOp {
-    static std::variant<Tensor, MaxPoolWithIndicesResult> invoke(
+    static std::vector<Tensor> invoke(
         const Tensor& input_tensor,
         uint32_t batch_size,
         uint32_t input_h,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -129,11 +129,12 @@ void bind_max_pool2d_operation(py::module& module) {
                     output_layout);
 
                 // Handle variant return type
-                if (std::holds_alternative<MaxPoolWithIndicesResult>(result)) {
-                    auto mpwi_result = std::get<MaxPoolWithIndicesResult>(result);
-                    return py::make_tuple(mpwi_result.output, mpwi_result.indices);
+                if (result.size() > 1) {
+                    // auto mpwi_result = std::get<MaxPoolWithIndicesResult>(result);
+                    // return py::make_tuple(mpwi_result.output, mpwi_result.indices);
+                    return py::make_tuple(result[0], result[1]);
                 } else {
-                    return py::cast(std::get<ttnn::Tensor>(result));
+                    return py::cast(result[0]);
                 }
             },
             py::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -130,9 +130,9 @@ void bind_max_pool2d_operation(py::module& module) {
 
                 // Return single tensor or tuple based on vector size
                 if (result.size() == 1) {
-                    return py::cast(result[0]);
+                    return py::cast(std::move(result[0]));
                 } else {
-                    return py::cast(result);
+                    return py::cast(std::move(result));
                 }
             },
             py::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -107,8 +107,8 @@ void bind_max_pool2d_operation(py::module& module) {
                bool reallocate_halo_output,
                bool return_indices,
                const DataType dtype,
-               const Layout output_layout) {
-                return self(
+               const Layout output_layout) -> py::object {
+                auto result = self(
                     input_tensor,
                     batch_size,
                     input_h,
@@ -127,6 +127,13 @@ void bind_max_pool2d_operation(py::module& module) {
                     return_indices,
                     dtype,
                     output_layout);
+
+                // Return single tensor or tuple based on vector size
+                if (result.size() == 1) {
+                    return py::cast(result[0]);
+                } else {
+                    return py::cast(result);
+                }
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -107,8 +107,8 @@ void bind_max_pool2d_operation(py::module& module) {
                bool reallocate_halo_output,
                bool return_indices,
                const DataType dtype,
-               const Layout output_layout) -> py::object {
-                auto result = self(
+               const Layout output_layout) {
+                return self(
                     input_tensor,
                     batch_size,
                     input_h,
@@ -127,8 +127,6 @@ void bind_max_pool2d_operation(py::module& module) {
                     return_indices,
                     dtype,
                     output_layout);
-
-                return result;
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -128,12 +128,7 @@ void bind_max_pool2d_operation(py::module& module) {
                     dtype,
                     output_layout);
 
-                // Return tuple for return_indices=true, single tensor for return_indices=false
-                if (return_indices) {
-                    return py::make_tuple(result.at(0), result.at(1));
-                } else {
-                    return py::cast(result.at(0));
-                }
+                return result;
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -128,13 +128,11 @@ void bind_max_pool2d_operation(py::module& module) {
                     dtype,
                     output_layout);
 
-                // Handle variant return type
-                if (result.size() > 1) {
-                    // auto mpwi_result = std::get<MaxPoolWithIndicesResult>(result);
-                    // return py::make_tuple(mpwi_result.output, mpwi_result.indices);
-                    return py::make_tuple(result[0], result[1]);
+                // Return tuple for return_indices=true, single tensor for return_indices=false
+                if (return_indices) {
+                    return py::make_tuple(result.at(0), result.at(1));
                 } else {
-                    return py::cast(result[0]);
+                    return py::cast(result.at(0));
                 }
             },
             py::arg("input_tensor"),


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27845)

### Problem description
Look into the use of std::variant as a return type, Artem suggested that this may not be properly supported by TTNN infra. Should use vector of tensors instead, see the implementation in topk.hpp

### What's changed
Update the return type to vector of Tensor.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229861251
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229863651
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229865908
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229867314
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229869685
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229871158
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18229873575
- [x] New/Existing tests provide coverage for changes