### PR TITLE
Separate BH GLX type. add Cluster::is_ubb_galaxy()

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -151,9 +151,8 @@ private:
 
 protected:
     static void SetUpTestSuite() {
-        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() ==
-                tt::tt_metal::ClusterType::GALAXY ||
-            tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy() ||
+            tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             should_skip_ = true;
             return;
         }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -20,7 +20,7 @@ namespace tt::tt_fabric {
 namespace multi_host_tests {
 
 TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
+    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy()) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
@@ -35,7 +35,7 @@ TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
 }
 
 TEST(MultiHost, TestDualGalaxyFabric2DSanity) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
+    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy()) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
@@ -76,7 +76,7 @@ TEST(MultiHost, TestDualGalaxyFabric2DSanity) {
 }
 
 TEST(MultiHost, TestDualGalaxyFabric1DSanity) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
+    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy()) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -42,7 +42,7 @@ ConnectorType get_connector_type(chip_id_t chip_id, CoreCoord eth_core, uint32_t
     auto arch = cluster.arch();
     auto board_type = cluster.get_board_type(chip_id);
     if (arch == tt::ARCH::WORMHOLE_B0) {
-        if (cluster_type == ClusterType::GALAXY) {
+        if (cluster.is_ubb_galaxy()) {
             if (cluster.is_external_cable(chip_id, eth_core)) {
                 return ConnectorType::QSFP;
             }
@@ -111,7 +111,8 @@ ConnectorType get_connector_type(chip_id_t chip_id, CoreCoord eth_core, uint32_t
 
 bool is_chip_on_edge_of_mesh(chip_id_t physical_chip_id, tt::tt_metal::ClusterType cluster_type) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+        cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
         auto ubb_asic_id = cluster.get_ubb_asic_id(physical_chip_id);
         return (ubb_asic_id >= 2) and (ubb_asic_id <= 5);
     } else if (cluster_type == tt::tt_metal::ClusterType::T3K) {
@@ -128,7 +129,8 @@ bool is_chip_on_edge_of_mesh(chip_id_t physical_chip_id, tt::tt_metal::ClusterTy
 
 bool is_chip_on_corner_of_mesh(chip_id_t physical_chip_id, tt::tt_metal::ClusterType cluster_type) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+        cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
         auto ubb_asic_id = cluster.get_ubb_asic_id(physical_chip_id);
         return (ubb_asic_id == 1);
     } else if (cluster_type == tt::tt_metal::ClusterType::T3K) {
@@ -159,7 +161,8 @@ std::string get_physical_slot_str(chip_id_t chip_id) {
 }
 
 std::string get_physical_loc_str(chip_id_t chip_id, ClusterType cluster_type) {
-    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+    if (cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+        cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
         return get_ubb_id_str(chip_id);
     } else {
         return get_physical_slot_str(chip_id);
@@ -372,7 +375,9 @@ TEST(Cluster, TestMeshFullConnectivity) {
         num_expected_chips = 8;
         num_expected_mmio_chips = 4;
         num_connections_per_side = 2;
-    } else if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+    } else if (
+        cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+        cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
         num_expected_chips = 32;
         num_expected_mmio_chips = 32;
         num_connections_per_side = 4;
@@ -424,6 +429,7 @@ TEST(Cluster, TestMeshFullConnectivity) {
             bool supported_topology = false;
             switch (cluster_type) {
                 case tt::tt_metal::ClusterType::GALAXY:
+                case tt::tt_metal::ClusterType::BLACKHOLE_GALAXY:
                 case tt::tt_metal::ClusterType::T3K:
                     supported_topology = *target_system_topology == FabricType::MESH;
                     break;
@@ -478,7 +484,8 @@ TEST(Cluster, TestMeshFullConnectivity) {
                 validate_num_connections(num_connections_to_chip.size(), num_expected_chip_connections);
             } else {
                 uint32_t num_chip_connections = 0;
-                if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+                if (cluster_type == tt::tt_metal::ClusterType::GALAXY ||
+                    cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
                     num_chip_connections = num_internal_connections_to_chip.size();
                 } else {
                     num_chip_connections = num_connections_to_chip.size();

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -41,6 +41,7 @@ enum class ClusterType : std::uint8_t {
     P150_X8 = 13,                // 8 Blackhole single card, ethernet connected
     P300 = 14,                   // Production P300
     SIMULATOR_QUASAR = 15,       // Simulator Quasar
+    BLACKHOLE_GALAXY = 16,       // Blackhole Galaxy, all chips with mmio
 };
 
 /**

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -335,8 +335,7 @@ void build_tt_fabric_program(
     }
 
     const auto topology = fabric_context.get_fabric_topology();
-    const bool is_galaxy =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::GALAXY;
+    const bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy();
 
     auto build_downstream_connections = [&](tt::tt_fabric::chan_id_t eth_chan_dir1,
                                             tt::tt_fabric::chan_id_t eth_chan_dir2) {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -84,6 +84,7 @@ const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std:
                  "p150_mesh_graph_descriptor.yaml"},  // TODO use quasar mesh
                 {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.yaml"},
+                {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.yaml"},
             });
 
 const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>&
@@ -105,6 +106,7 @@ const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std:
                 {tt::tt_metal::ClusterType::SIMULATOR_QUASAR, "p150_mesh_graph_descriptor.textproto"},
                 {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.textproto"},
                 {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.textproto"},
+                {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.textproto"},
             });
 }  // namespace
 

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
@@ -1,0 +1,12 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 4 policy: STRICT }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.yaml
@@ -1,10 +1,10 @@
 ChipSpec: {
   arch: blackhole,
   ethernet_ports: {
-    N: 4,
-    E: 4,
-    S: 4,
-    W: 4,
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
   }
 }
 
@@ -12,14 +12,14 @@ ChipSpec: {
 Board: [
   { name: Galaxy,
     type: Mesh,
-    topology: [1, 1]}
+    topology: [8, 4]}
  ]
 
 Mesh: [
 {
   id: 0,
   board: Galaxy,
-  device_topology: [1, 1],
+  device_topology: [8, 4],
   host_topology: [1, 1],
 }
 ]

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: blackhole,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+
+Board: [
+  { name: Galaxy,
+    type: Mesh,
+    topology: [1, 1]}
+ ]
+
+Mesh: [
+{
+  id: 0,
+  board: Galaxy,
+  device_topology: [1, 1],
+  host_topology: [1, 1],
+}
+]
+
+Graph: [
+]

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -451,7 +451,7 @@ void MetalContext::set_fabric_config(
     tt_fabric::FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     tt_fabric::FabricTensixConfig fabric_tensix_config) {
-    if (is_2d_fabric_config(fabric_config) && cluster_->get_cluster_type() != tt::tt_metal::ClusterType::GALAXY) {
+    if (is_2d_fabric_config(fabric_config) && !cluster_->is_ubb_galaxy()) {
         const auto fabric_type = get_fabric_type(fabric_config);
         if (fabric_type == tt::tt_fabric::FabricType::TORUS_X || fabric_type == tt::tt_fabric::FabricType::TORUS_Y ||
             fabric_type == tt::tt_fabric::FabricType::TORUS_XY) {
@@ -584,7 +584,7 @@ void MetalContext::initialize_control_plane() {
     std::string suffix = ".textproto";
 
     // If the cluster is a GALAXY and the fabric type is TORUS_XY, override the mesh graph descriptor path
-    if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
+    if (cluster_->is_ubb_galaxy()) {
         std::string mesh_graph_descriptor;
         switch (tt::tt_fabric::get_fabric_type(this->fabric_config_)) {
             case tt::tt_fabric::FabricType::TORUS_XY:

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -169,7 +169,7 @@ tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
         } else if (board_type == BoardType::UBB) {
             cluster_type = tt::tt_metal::ClusterType::GALAXY;
         } else if (board_type == BoardType::UBB_BLACKHOLE) {
-            cluster_type = tt::tt_metal::ClusterType::GALAXY;
+            cluster_type = tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
         }
     }
     return cluster_type;
@@ -228,6 +228,11 @@ void Cluster::detect_arch_and_target() {
 
 // TODO: remove this when we deprecate TG
 bool Cluster::is_galaxy_cluster() const { return this->cluster_type_ == tt::tt_metal::ClusterType::TG; }
+
+bool Cluster::is_ubb_galaxy() const {
+    return this->cluster_type_ == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY ||
+           this->cluster_type_ == tt::tt_metal::ClusterType::GALAXY;
+}
 
 tt::tt_metal::ClusterType Cluster::get_cluster_type() const { return this->cluster_type_; }
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -307,8 +307,11 @@ public:
     void initialize_fabric_config(
         tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode);
 
-    // Returns whether we are running on Galaxy.
+    // Returns whether we are running on Legacy Galaxy.
     bool is_galaxy_cluster() const;
+
+    // Returns whether we are running on UBB Galaxy.
+    bool is_ubb_galaxy() const;
 
     // Returns Wormhole chip board type.
     BoardType get_board_type(chip_id_t chip_id) const;

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -72,7 +72,9 @@ void py_cluster_module_types(py::module& module) {
         .value("SIMULATOR_WORMHOLE_B0", tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "Simulator Wormhole B0")
         .value("SIMULATOR_BLACKHOLE", tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "Simulator Blackhole")
         .value("N300_2x2", tt::tt_metal::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2")
-        .value("P300", tt::tt_metal::ClusterType::P300, "Production P300");
+        .value("P300", tt::tt_metal::ClusterType::P300, "Production P300")
+        .value(
+            "BLACKHOLE_GALAXY", tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "Blackhole Galaxy, all chips with mmio");
 }
 
 void py_cluster_module(py::module& module) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28444

### Problem description
BH GLX

### What's changed
- Add BLACKHOLE_GALAXY (different from existing GALAXY enum)
- Add Cluster::is_ubb_galaxy() function. Returns true for legacy galaxy and new blackhole galaxy
- Add yaml file for BLACKHOLE_GALAXY

### Checklist
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/17924143182
APC
https://github.com/tenstorrent/tt-metal/actions/runs/17924075939
BH
https://github.com/tenstorrent/tt-metal/actions/runs/17924076971