### PR TITLE
Do not fail compilation if codegen.sh can't call clang-format properly

### DIFF
--- a/tt_metal/llrt/hal/codegen/codegen.sh
+++ b/tt_metal/llrt/hal/codegen/codegen.sh
@@ -53,6 +53,8 @@ if ! $PYTHON "${SCRIPT_PY}" \
     exit 1
 fi
 
-if which clang-format > /dev/null; then
-    clang-format -i "${OUT_INTF_FILE}" "${OUT_IMPL_FILE}"
+if clang-format -i "${OUT_INTF_FILE}" "${OUT_IMPL_FILE}"; then
+    # some environment does not have a compatible clang-format, in which case we should
+    # ignore the failure
+    :
 fi

--- a/tt_metal/llrt/hal/codegen/codegen.sh
+++ b/tt_metal/llrt/hal/codegen/codegen.sh
@@ -53,8 +53,8 @@ if ! $PYTHON "${SCRIPT_PY}" \
     exit 1
 fi
 
+# some environment does not have a compatible clang-format, in which case we should
+# ignore the failure
 if clang-format -i "${OUT_INTF_FILE}" "${OUT_IMPL_FILE}"; then
-    # some environment does not have a compatible clang-format, in which case we should
-    # ignore the failure
     :
 fi


### PR DESCRIPTION
### Ticket
#29055

### Problem description
Some downstream env has an incompatible version of clang-format, causing failure in codegen.sh

### What's changed
Ignore the failure.  clang-format was called only to satisfy static analyzer and people who poke into the generated code.

### Checklist
Project builds.  Since only a script used by build is modified, this should be sufficient.