### PR TITLE
add test infra tests to BH CI

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -49,6 +49,11 @@ jobs:
           - name: ccl nightly tests
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly
             timeout: 30
+          - name: fabric infra unit tests
+            cmd: |
+              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+            timeout: 15
           # - name: t3000 fast fabric tests
           #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -385,6 +385,10 @@ public:
         std::vector<TestConfig> built_tests;
 
         for (const auto& raw_config : raw_configs) {
+            // Skip tests based on topology and device requirements
+            if (should_skip_test(raw_config)) {
+                continue;
+            }
             std::vector<ParsedTestConfig> parametrized_configs = this->expand_parametrizations(raw_config);
 
             // For each newly generated parametrized config, expand its high-level patterns
@@ -405,6 +409,25 @@ public:
     }
 
 private:
+    static constexpr uint32_t MIN_RING_TOPOLOGY_DEVICES = 4;
+
+    // Helper function to check if a test should be skipped based on topology and device count
+    bool should_skip_test(const ParsedTestConfig& test_config) const {
+        if (test_config.fabric_setup.topology == Topology::Ring) {
+            uint32_t num_devices = device_info_provider_.get_local_node_ids().size();
+            if (num_devices < MIN_RING_TOPOLOGY_DEVICES) {
+                log_info(
+                    LogTest,
+                    "Skipping test '{}' - Ring topology requires at least {} devices, but only {} devices available",
+                    test_config.name,
+                    MIN_RING_TOPOLOGY_DEVICES,
+                    num_devices);
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Convert ParsedTestConfig to TestConfig by resolving device identifiers
     TestConfig resolve_test_config(const ParsedTestConfig& parsed_test) {
         TestConfig resolved_test;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -300,7 +300,7 @@ template <
     bool stateful_api,
     bool increment_pointers = true,
     uint8_t NUM_SENDER_BUFFERS>
-#ifndef FABRIC_2D
+#if !defined(FABRIC_2D) && !defined(ARCH_BLACKHOLE)
 FORCE_INLINE
 #endif
     void


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We need to add the infra test to BH CI asap as many commits are breaking fabric right now and we cannot guard it by the basic 1d/2d test.

### What's changed
add group to test in multi card unit test
fix fabric code size

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/17946957672
- [x] [Blackhole Post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/17946951250
- [x] BH nightly https://github.com/tenstorrent/tt-metal/actions/runs/17946963300