### PR TITLE
Fix watcher link status up

### DIFF
--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -262,7 +262,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while (risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK == MEM_SYSENG_ETH_MSG_CALL);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;
@@ -274,7 +274,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_DONE);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
 
     auto link_status = (volatile eth_live_status_t*)(MEM_SYSENG_ETH_LIVE_STATUS);
     return link_status->rx_link_up == 1;

--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -262,7 +262,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE && risc1_mailbox_val != 0);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;
@@ -274,7 +274,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
 
     auto link_status = (volatile eth_live_status_t*)(MEM_SYSENG_ETH_LIVE_STATUS);
     return link_status->rx_link_up == 1;

--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -262,7 +262,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;
@@ -274,7 +274,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) == MEM_SYSENG_ETH_MSG_CALL);
+    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE);
 
     auto link_status = (volatile eth_live_status_t*)(MEM_SYSENG_ETH_LIVE_STATUS);
     return link_status->rx_link_up == 1;

--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -262,7 +262,7 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while ((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE && risc1_mailbox_val != 0);
+    } while (((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE) && risc1_mailbox_val != 0);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;

--- a/tt_metal/hw/inc/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/blackhole/eth_fw_api.h
@@ -262,7 +262,8 @@ FORCE_INLINE bool is_link_up() {
     do {
         invalidate_l1_cache();
         risc1_mailbox_val = *risc1_mailbox_msg_ptr;
-    } while (((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE) && risc1_mailbox_val != 0);
+    } while (((risc1_mailbox_val & MEM_SYSENG_ETH_MSG_STATUS_MASK) != MEM_SYSENG_ETH_MSG_DONE) &&
+             risc1_mailbox_val != 0);
 
     // This tells link status check to avoid copying results into another location in L1
     *risc1_mailbox_arg0_ptr = 0xFFFFFFFF;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29070

### Problem description
- Incorrect while loop causing ND hang
- Problem showed up with putting the correct brackets for operator precedence

### What's changed
- Fix issues

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes