### PR TITLE
MPWI Kernel Based Index Tensor Creation

### DIFF
--- a/tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py
@@ -10,8 +10,106 @@ import math
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.common.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def validate_indices(input_tensor, torch_indices, ttnn_indices, kernel_size, stride, padding, dilation, dtype):
+    """
+    Validate indices using logic from test_mpwi.py
+    Note input tensors should be in [N, H, W, C] format
+    Returns (indices_valid, tie_breaking_differences, actual_errors, value_differences, window_violations)
+    """
+    batch_size, input_h, input_w, channels = input_tensor.shape
+    kernel_h, kernel_w = kernel_size
+    stride_h, stride_w = stride
+    pad_tb, pad_lr = padding
+    dilation_h, dilation_w = dilation
+
+    # Check if indices are exactly equal first
+    indices_match = torch.equal(torch_indices, ttnn_indices)
+    if indices_match:
+        return True, 0, 0, 0, 0
+
+    # Find positions where indices don't match
+    diff = torch.abs(torch_indices - ttnn_indices)
+    mismatch_positions = torch.nonzero(diff, as_tuple=False)
+    num_mismatches = len(mismatch_positions)
+
+    tie_breaking_differences = 0
+    actual_errors = 0
+    value_differences = 0
+    window_violations = 0
+    for pos in mismatch_positions:
+        n, h, w, c = pos
+        torch_idx = torch_indices[n, h, w, c]
+        ttnn_idx = ttnn_indices[n, h, w, c]
+
+        # Convert linear indices to spatial coordinates
+        torch_h = torch_idx // input_w
+        torch_w = torch_idx % input_w
+        ttnn_h = ttnn_idx // input_w
+        ttnn_w = ttnn_idx % input_w
+
+        # Get input values at these positions
+        if ttnn_h >= 0 and ttnn_w >= 0 and ttnn_h < input_h and ttnn_w < input_w:
+            torch_input_val = input_tensor[n, torch_h, torch_w, c]
+            ttnn_input_val = input_tensor[n, ttnn_h, ttnn_w, c]
+        else:
+            actual_errors += 1
+            window_violations += 1
+            continue
+
+        # Check if this is a valid tie-breaking difference
+        # Two conditions must be satisfied:
+        # 1. The values must be the same
+        # 2. Both indices must be within the same kernel window
+
+        # Check if values are the same
+        atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
+        if dtype == ttnn.bfloat8_b:
+            atol = 0.35
+            values_same = math.isclose(torch_input_val, ttnn_input_val, abs_tol=atol, rel_tol=rtol)
+        else:
+            values_same = torch_input_val == ttnn_input_val
+
+        # Check if both indices are within the same kernel window
+        def is_in_dilated_kernel_window(
+            input_h, input_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
+        ):
+            for kh in range(kernel_h):
+                for kw in range(kernel_w):
+                    kernel_pos_h = kernel_top_left_h + kh * dilation_h
+                    kernel_pos_w = kernel_top_left_w + kw * dilation_w
+                    if kernel_pos_h == input_h and kernel_pos_w == input_w:
+                        return True
+            return False
+
+        kernel_top_left_h = h * stride_h - pad_tb
+        kernel_top_left_w = w * stride_w - pad_lr
+        ttnn_in_window = is_in_dilated_kernel_window(
+            ttnn_h, ttnn_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
+        )
+
+        if values_same and ttnn_in_window:
+            tie_breaking_differences += 1
+        elif not ttnn_in_window:
+            actual_errors += 1
+            window_violations += 1
+        else:
+            actual_errors += 1
+            value_differences += 1
+
+    # Indices are valid if there are no actual errors
+    assert num_mismatches == (
+        tie_breaking_differences + actual_errors
+    ), "Total mismatches should equal sum of tie-breaking differences and actual errors"
+    if actual_errors > 0:
+        assert actual_errors == (
+            value_differences + window_violations
+        ), "Actual errors should equal sum of value differences and window violations"
+    else:
+        assert actual_errors == 0 and value_differences == 0 and window_violations == 0, "No errors should be present"
+    return (actual_errors == 0), tie_breaking_differences, actual_errors, value_differences, window_violations
 
 
 def run_max_pool2d_with_indices(
@@ -23,11 +121,11 @@ def run_max_pool2d_with_indices(
     kernel_w,
     stride_h,
     stride_w,
-    pad_h,
-    pad_w,
+    pad_tb,
+    pad_lr,
     dilation_h,
     dilation_w,
-    dtype,
+    ttnn_dtype,
     device,
     sharding=None,
     ceil_mode=False,
@@ -36,196 +134,118 @@ def run_max_pool2d_with_indices(
 ):
     kernel_size = [kernel_h, kernel_w]
     stride = [stride_h, stride_w]
-    padding = [pad_h, pad_w]
+    padding = [pad_tb, pad_lr]
     dilation = [dilation_h, dilation_w]
+    pad_h = pad_tb * 2  # total padding
+    pad_w = pad_lr * 2  # total padding
+
+    if ceil_mode:
+        out_h = math.ceil((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.ceil((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
+        if ((out_h - 1) * stride_h) >= (in_h + pad_tb):
+            ceil_mode_out_shape_adj = True
+            out_h -= 1
+        if ((out_w - 1) * stride_w) >= (in_w + pad_lr):
+            ceil_mode_out_shape_adj = True
+            out_w -= 1
+    else:
+        out_h = math.floor((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
+        out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
 
     torch.manual_seed(0)
     torch.set_printoptions(precision=3, sci_mode=False, linewidth=500, threshold=10000, edgeitems=32)
 
-    activation_shape = [in_n, in_c, in_h, in_w]
-    activation = torch.randn(activation_shape, dtype=torch.bfloat16)
-    activation_permuted = torch.permute(activation, (0, 2, 3, 1))
+    tensor_shape = (in_n, in_c, in_h, in_w)
+    ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
+    torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    # torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
+    # for n in range(in_n):
+    #     for c in range(in_c):
+    #         for h in range(in_h):
+    #             for w in range(in_w):
+    #                 torch_input[n, c, h, w] = h * in_w + w
+    torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
+    torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
+    ttnn_layout = ttnn.ROW_MAJOR_LAYOUT
+    if ttnn_dtype == ttnn.bfloat8_b:
+        ttnn_layout = ttnn.TILE_LAYOUT
 
-    if dtype == ttnn.bfloat8_b:
-        activation_shape = (1, 1, in_n * in_h * in_w, in_c)
-        activation_reshaped = activation_permuted.reshape(activation_shape)
-        ttnn_activation = ttnn.from_torch(activation_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
-    else:
-        ttnn_activation = ttnn.from_torch(activation_permuted, dtype)
+    ttnn_input = ttnn.from_torch(
+        torch_input_reshaped, ttnn_dtype, layout=ttnn_layout, memory_config=memory_config, device=device
+    )
 
-    ttnn_activation_device = ttnn.to_device(ttnn_activation, device)
-    start_time = start_measuring_time()
-
-    # Use auto sharding as recommended by colleague for sweep tests
-    # Let TTNN automatically select the best sharding scheme
-    # sharding remains None for auto sharding
-
-    # Call max_pool2d with return_indices=True
-    output, indices = ttnn.max_pool2d(
-        input_tensor=ttnn_activation_device,
+    ttnn_output, ttnn_indices = ttnn.max_pool2d(
+        input_tensor=ttnn_input,
         batch_size=in_n,
         input_h=in_h,
         input_w=in_w,
         channels=in_c,
-        kernel_size=[kernel_h, kernel_w],
-        stride=[stride_h, stride_w],
-        padding=[pad_h, pad_w],
-        dilation=[dilation_h, dilation_w],
-        memory_config=memory_config,
-        applied_shard_scheme=sharding,
-        in_place_halo=in_place,
-        return_indices=True,  # This is the key difference
-        ceil_mode=ceil_mode,
-    )
-
-    output_host = output.cpu()
-    indices_host = indices.cpu()
-    output_pytorch = torch.Tensor(ttnn.to_torch(output_host))
-    indices_pytorch = torch.Tensor(ttnn.to_torch(indices_host))
-    e2e_perf = stop_measuring_time(start_time)
-
-    ## reference
-    golden_pytorch, golden_indices = torch.nn.functional.max_pool2d(
-        activation,
-        kernel_size,
+        kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         dilation=dilation,
-        return_indices=True,
+        applied_shard_scheme=sharding,
         ceil_mode=ceil_mode,
+        in_place_halo=in_place,
+        deallocate_input=False,
+        reallocate_halo_output=True,
+        return_indices=True,
     )
 
-    golden_shape = golden_pytorch.shape
-    output_pytorch = output_pytorch.reshape(golden_shape[0], golden_shape[2], golden_shape[3], golden_shape[1])
-    output_pytorch = torch.permute(output_pytorch, (0, 3, 1, 2))  ## N, C, H, W
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+    # convert indexes to int64 for compatability with torch
+    ttnn_indices_torch = ttnn.to_torch(ttnn_indices, dtype=torch.int64)
+    # manually fix the wrapping since TTNN uint16 tensors get converted to int16 torch tensors, even when data type is specified as int64
+    ttnn_indices_torch = torch.where(ttnn_indices_torch < 0, ttnn_indices_torch + 65536, ttnn_indices_torch)
 
-    # Handle indices reshaping
-    indices_pytorch = indices_pytorch.reshape(golden_shape[0], golden_shape[2], golden_shape[3], golden_shape[1])
-    indices_pytorch = torch.permute(indices_pytorch, (0, 3, 1, 2))  ## N, C, H, W
+    torch_output, torch_indices = torch.nn.functional.max_pool2d(
+        torch_input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=True,
+    )
+
+    # Reshape torch output to match TTNN format (NCHW -> NHWC)
+    torch_output_reshaped = torch_output.permute(0, 2, 3, 1)  # N, H, W, C
+    torch_indices_reshaped = torch_indices.permute(0, 2, 3, 1)  # N, H, W, C
+
+    # Reshape TTNN outputs to match PyTorch shape for comparison
+    # TTNN output is in shape (1, 1, in_n * out_h * out_w, channels)
+    ttnn_output_reshaped = ttnn_output_torch.reshape(in_n, out_h, out_w, in_c)
+    ttnn_indices_reshaped = ttnn_indices_torch.reshape(in_n, out_h, out_w, in_c)
 
     atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
-    if dtype == ttnn.bfloat8_b:
+    if ttnn_dtype == ttnn.bfloat8_b:
         atol = 0.35
+    output_match = torch.allclose(ttnn_output_reshaped, torch_output_reshaped, atol=atol, rtol=rtol)
 
-    ## test for equivalence of outputs
-    output_allclose = torch.allclose(output_pytorch, golden_pytorch, atol=atol)
-    output_isequal = torch.equal(output_pytorch, golden_pytorch)
-
-    def validate_indices(input_tensor, torch_indices, ttnn_indices, kernel_size, stride, padding, dilation, dtype):
-        """
-        Validate indices using logic from test_mpwi.py
-        Returns (indices_valid, tie_breaking_differences, actual_errors)
-        """
-        try:
-            batch_size, channels, input_h, input_w = input_tensor.shape
-            kernel_h, kernel_w = kernel_size
-            stride_h, stride_w = stride
-            dilation_h, dilation_w = dilation
-
-            # Check if indices are exactly equal first
-            indices_match = torch.equal(torch_indices, ttnn_indices)
-            if indices_match:
-                return True, 0, 0
-
-            # Analyze mismatches - keep indices as integers
-            diff = torch.abs(torch_indices - ttnn_indices)
-
-            # Find positions where indices don't match
-            mismatch_mask = diff > 0
-            mismatch_positions = torch.nonzero(mismatch_mask, as_tuple=False)
-
-            tie_breaking_differences = 0
-            actual_errors = 0
-
-            atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
-            if dtype == ttnn.bfloat8_b:
-                atol = 0.35
-
-            for pos in mismatch_positions:
-                n, c, h, w = pos
-                torch_idx = int(torch_indices[n, c, h, w].item())
-                ttnn_idx = int(ttnn_indices[n, c, h, w].item())
-
-                # Convert linear indices to spatial coordinates
-                torch_h = torch_idx // input_w
-                torch_w = torch_idx % input_w
-                ttnn_h = ttnn_idx // input_w
-                ttnn_w = ttnn_idx % input_w
-
-                # Get input values at these positions
-                if torch_h >= 0 and torch_w >= 0 and torch_h < input_h and torch_w < input_w:
-                    torch_input_val = input_tensor[n, c, torch_h, torch_w]
-                else:
-                    actual_errors += 1
-                    continue
-
-                if ttnn_h >= 0 and ttnn_w >= 0 and ttnn_h < input_h and ttnn_w < input_w:
-                    ttnn_input_val = input_tensor[n, c, ttnn_h, ttnn_w]
-                else:
-                    actual_errors += 1
-                    continue
-
-                # Check if values are the same
-                if dtype == ttnn.bfloat8_b:
-                    values_same = math.isclose(torch_input_val, ttnn_input_val, abs_tol=atol, rel_tol=rtol)
-                else:
-                    values_same = torch_input_val == ttnn_input_val
-
-                # Calculate kernel window for this output position
-                kernel_top_left_h = h * stride_h - padding[0]
-                kernel_top_left_w = w * stride_w - padding[1]
-
-                def is_in_dilated_kernel_window(
-                    input_h, input_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                ):
-                    """Check if a position is within the dilated kernel window"""
-                    for kh in range(kernel_h):
-                        for kw in range(kernel_w):
-                            kernel_pos_h = kernel_top_left_h + kh * dilation_h
-                            kernel_pos_w = kernel_top_left_w + kw * dilation_w
-                            if kernel_pos_h == input_h and kernel_pos_w == input_w:
-                                return True
-                    return False
-
-                torch_in_window = is_in_dilated_kernel_window(
-                    torch_h, torch_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                )
-                ttnn_in_window = is_in_dilated_kernel_window(
-                    ttnn_h, ttnn_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                )
-
-                same_kernel_window = torch_in_window and ttnn_in_window
-
-                if values_same and same_kernel_window:
-                    # Valid tie-breaking difference
-                    tie_breaking_differences += 1
-                else:
-                    # Actual error
-                    actual_errors += 1
-
-            # Indices are valid if there are no actual errors
-            return actual_errors == 0, tie_breaking_differences, actual_errors
-
-        except Exception:
-            return False, 0, 1
-
-    indices_valid, tie_breaking_diffs, actual_errors = validate_indices(
-        activation, golden_indices, indices_pytorch, kernel_size, stride, padding, dilation, dtype
+    indices_valid, tie_breaking_differences, actual_errors, value_differences, window_violations = validate_indices(
+        torch_input_permuted,
+        torch_indices_reshaped,
+        ttnn_indices_reshaped,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ttnn_dtype,
     )
 
-    # Assert all validations as requested by colleague:
+    test_passed = output_match and indices_valid
 
-    # 1. Output validation: allclose for bfloat8, equal for bfloat16
-    if dtype == ttnn.bfloat8_b:
-        assert output_allclose, "Reference and output tensor are not close"
-    else:  # bfloat16
-        assert output_isequal, "Reference and output tensor are not equal"
+    print(
+        "Results: ",
+        {
+            "test_passed": test_passed,
+            "output_match": output_match,
+            "indices_valid": indices_valid,
+            "tie_breaking_differences": tie_breaking_differences,
+            "actual_errors": actual_errors,
+            "value_differences": value_differences,
+            "window_violations": window_violations,
+        },
+    )
 
-    # 2. PCC check (do for both dtypes, even though bfloat16 should always be 1)
-    pcc_result = check_with_pcc(output_pytorch, golden_pytorch, pcc=0.998)
-    assert pcc_result[0], f"PCC check failed: {pcc_result[1]}"
-
-    # 3. Indices validation
-    assert (
-        indices_valid
-    ), f"Indices validation failed with {actual_errors} actual errors (tie-breaking differences: {tie_breaking_diffs})"
+    assert test_passed

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_max_pool2d_sweeps_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_max_pool2d_sweeps_mpwi.py
@@ -13,56 +13,52 @@ import ttnn
     [
         # Contains following parameters
         # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
-        # PASSING CASES - Verified working MPWI test cases from GitHub issue traces using AUTO SHARDING
-        # Sources: https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/docs/operations/aten.max_pool2d_with_indices.default.md
-        #          https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/tests/autogen_op/ALL/test_ALL_aten_max_pool2d_with_indices_default.py
-        # NOTE: All sweep tests now use auto sharding as per colleague's requirement
-        [1, 64, 112, 112, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 64, 147, 147, 3, 3, 2, 2, 0, 0, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 96, 56, 56, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 96, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 192, 28, 28, 3, 3, 1, 1, 1, 1, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 192, 56, 56, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 192, 71, 71, 3, 3, 2, 2, 0, 0, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 256, 28, 28, 3, 3, 1, 1, 1, 1, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 256, 56, 56, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 384, 35, 35, 3, 3, 2, 2, 0, 0, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 480, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 480, 28, 28, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 512, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 512, 19, 19, 3, 3, 1, 1, 1, 1, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [1, 512, 28, 28, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        [4, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],  # ✓ VERIFIED WORKING (AUTO SHARDING)
-        # FAILING CASES - Documented with specific error reasons from GitHub issue traces (AUTO SHARDING):
-        # [1, 4, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 16, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 32, 112, 112, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 32, 256, 256, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): input size exceeds uint16 limit
-        # [1, 64, 24, 24, 2, 2, 1, 1, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 64, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 64, 112, 112, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 64, 128, 128, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 64, 224, 224, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 64, 300, 300, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): input size exceeds uint16 limit
-        # [1, 64, 360, 640, 3, 3, 2, 2, 1, 1, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): memory allocation failure (address.has_value())
-        # [1, 128, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 128, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 128, 64, 64, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 128, 112, 112, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 256, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 256, 32, 32, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 256, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 256, 75, 75, 2, 2, 2, 2, 0, 0, 1, 1, True],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 320, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 512, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 512, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 640, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 832, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, True],  # ✗ FAILED (AUTO SHARDING): only kernel sizes equal to 9 are supported
-        # [1, 768, 14, 14, 3, 3, 2, 2, 0, 0, 1, 1, True],  # ✗ FAILED (AUTO SHARDING): Fails with BFLOAT8_B dtype
-        # [1, 832, 7, 7, 3, 3, 1, 1, 1, 1, 1, 1, True],  # ✗ FAILED (AUTO SHARDING): Fails with BFLOAT8_B dtype
-        # [1, 1024, 17, 17, 3, 3, 2, 2, 0, 0, 1, 1, False],  # ✗ FAILED (AUTO SHARDING): Fails with BFLOAT8_B dtype
+        [1, 64, 112, 112, 3, 3, 2, 2, 0, 0, 1, 1, True],
+        [1, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],
+        [1, 64, 147, 147, 3, 3, 2, 2, 0, 0, 1, 1, False],
+        [1, 96, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],
+        [1, 192, 28, 28, 3, 3, 1, 1, 1, 1, 1, 1, True],
+        [1, 192, 56, 56, 3, 3, 2, 2, 0, 0, 1, 1, True],
+        [1, 192, 71, 71, 3, 3, 2, 2, 0, 0, 1, 1, False],
+        [1, 256, 28, 28, 3, 3, 1, 1, 1, 1, 1, 1, True],
+        [1, 256, 56, 56, 3, 3, 2, 2, 0, 0, 1, 1, True],
+        [1, 384, 35, 35, 3, 3, 2, 2, 0, 0, 1, 1, False],
+        [1, 480, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],
+        [1, 480, 28, 28, 3, 3, 2, 2, 0, 0, 1, 1, True],
+        [1, 512, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],
+        [1, 512, 19, 19, 3, 3, 1, 1, 1, 1, 1, 1, False],
+        [1, 512, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 512, 28, 28, 3, 3, 2, 2, 0, 0, 1, 1, True],
+        [1, 4, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 16, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 32, 112, 112, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 64, 24, 24, 2, 2, 1, 1, 0, 0, 1, 1, False],
+        [1, 64, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 64, 128, 128, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 128, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 128, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 128, 64, 64, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 128, 112, 112, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 128, 150, 150, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 256, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 256, 32, 32, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 256, 56, 56, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 256, 75, 75, 2, 2, 2, 2, 0, 0, 1, 1, True],
+        [1, 320, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 512, 38, 38, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [4, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],
+        [1, 64, 224, 224, 2, 2, 2, 2, 0, 0, 1, 1, False],
+        [1, 528, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],
+        # FAILING CASES
+        # [1, 512, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 640, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 832, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, True], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 768, 14, 14, 3, 3, 2, 2, 0, 0, 1, 1, True], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 832, 7, 7, 3, 3, 1, 1, 1, 1, 1, 1, True], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 1024, 17, 17, 3, 3, 2, 2, 0, 0, 1, 1, False], # BFLOAT8 shard height must match physical height for width sharding
+        # [1, 32, 256, 256, 2, 2, 2, 2, 0, 0, 1, 1, False], # input size exceeds uint16 limit
+        # [1, 64, 300, 300, 2, 2, 2, 2, 0, 0, 1, 1, False], # input size exceeds uint16 limit
+        # [1, 64, 360, 640, 3, 3, 2, 2, 1, 1, 1, 1, False], # OOM
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -84,9 +80,6 @@ def test_max_pool2d_with_indices_sweep(device, dtype, input_spec):
         ceil_mode,
     ) = input_spec
 
-    # All included test cases are verified to work with AUTO SHARDING
-    # Based on comprehensive testing of GitHub issue traces using auto sharding
-    # All validation (output, PCC, indices) is handled inside run_max_pool2d_with_indices function
     run_max_pool2d_with_indices(
         in_n,
         in_c,
@@ -105,5 +98,3 @@ def test_max_pool2d_with_indices_sweep(device, dtype, input_spec):
         None,  # None means auto sharding
         ceil_mode,
     )
-
-    # If we reach here, all assertions in run_max_pool2d_with_indices passed successfully

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -7,10 +7,12 @@ import ttnn
 import math
 import pytest
 
+from tests.sweep_framework.sweep_utils.max_pool2d_with_indices_common import run_max_pool2d_with_indices
+
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize("in_c", [1, 16, 24, 32, 40, 48, 56, 64])
-def test_max_pool2d_with_indices(device, in_c):
+def test_mpwi_20_core_C_dims(device, in_c):
     in_n = 1
     in_h = 159
     in_w = 159
@@ -23,52 +25,12 @@ def test_max_pool2d_with_indices(device, in_c):
     ttnn_dtype = ttnn.bfloat16
     # ttnn_dtype = ttnn.bfloat8_b
 
-    tensor_shape = (in_n, in_c, in_h, in_w)  # NCHW format
+    kernel_h, kernel_w = kernel_size
+    stride_h, stride_w = stride
+    pad_h, pad_w = padding
+    dilation_h, dilation_w = dilation
 
-    pad_h = padding[0] * 2  # padding is [top/bottom, left/right] but we need total padding
-    pad_w = padding[1] * 2
-    dilation_h = dilation[0]
-    dilation_w = dilation[1]
-    kernel_h = kernel_size[0]
-    kernel_w = kernel_size[1]
-    stride_h = stride[0]
-    stride_w = stride[1]
-
-    if ceil_mode:
-        out_h = math.ceil((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.ceil((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
-        if ((out_h - 1) * stride_h) >= (in_h + padding[0]):
-            ceil_mode_out_shape_adj = True
-            out_h -= 1
-        if ((out_w - 1) * stride_w) >= (in_w + padding[1]):
-            ceil_mode_out_shape_adj = True
-            out_w -= 1
-    else:
-        out_h = math.floor((in_h + pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h) + 1
-        out_w = math.floor((in_w + pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w) + 1
-
-    # Create tensor filled with height and width coordinates
-    torch.manual_seed(0)
-    # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
-
-    # Create tensor where each element equals its HW coordinate (h * in_w + w)
-    torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
-    # torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-    # for n in range(in_n):
-    #     for c in range(in_c):
-    #         for h in range(in_h):
-    #             for w in range(in_w):
-    #                 torch_input[n, c, h, w] = h * in_w + w
-
-    ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
-    torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
-    torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
-    ttnn_layout = ttnn.ROW_MAJOR_LAYOUT
-    if ttnn_dtype == ttnn.bfloat8_b:
-        ttnn_layout = ttnn.TILE_LAYOUT
-
-    # Memory configuration for ttnn_input
-    # Calculate shard width as the nearest multiple of 32 that is >= in_c
+    # shield team memory config
     shard_width = math.ceil(in_c / 32) * 32
     memory_config = ttnn.MemoryConfig(
         memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -79,253 +41,76 @@ def test_max_pool2d_with_indices(device, in_c):
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
-    ttnn_input = ttnn.from_torch(
-        torch_input_reshaped, ttnn_dtype, layout=ttnn_layout, memory_config=memory_config, device=device
+
+    run_max_pool2d_with_indices(
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ttnn_dtype,
+        device,
+        None,  # None means auto sharding
+        ceil_mode,
+        memory_config,
+        False,  # not in place
     )
 
-    ttnn_output, indices = ttnn.max_pool2d(
-        input_tensor=ttnn_input,
-        batch_size=in_n,
-        input_h=in_h,
-        input_w=in_w,
-        channels=in_c,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        # applied_shard_scheme=shard_scheme,
-        ceil_mode=ceil_mode,
-        in_place_halo=False,
-        deallocate_input=False,
-        reallocate_halo_output=True,
-        return_indices=True,
+
+@pytest.mark.parametrize(
+    "input_spec",
+    [
+        # Contains following parameters
+        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
+        # DILATION / MULTI-BATCH CASES
+        [2, 40, 100, 100, 3, 3, 2, 2, 0, 1, 2, 2, True],
+        [3, 56, 85, 85, 3, 3, 3, 3, 1, 0, 2, 2, False],
+        [4, 24, 56, 64, 3, 3, 2, 1, 1, 1, 3, 2, True],
+    ],
+)
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_mpwi_general(device, ttnn_dtype, input_spec):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ceil_mode,
+    ) = input_spec
+
+    run_max_pool2d_with_indices(
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ttnn_dtype,
+        device,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode,
+        None,  # no memory_config
+        False,  # not in place
     )
-    ttnn_outputs_exactly_equal = True
-
-    print("\nTTNN max pool results:")
-    print("Output shape:", ttnn.to_torch(ttnn_output).shape)
-    # print("Output:\n", ttnn.to_torch(ttnn_output))
-    print("Indices shape:", ttnn.to_torch(indices).shape)
-    # print("Indices:\n", ttnn.to_torch(indices))
-
-    # Check that ttnn_output_base is exactly equal to ttnn_output
-    # ttnn_output_base = ttnn.max_pool2d(
-    #     input_tensor=ttnn_input,
-    #     batch_size=in_n,
-    #     input_h=in_h,
-    #     input_w=in_w,
-    #     channels=in_c,
-    #     kernel_size=kernel_size,
-    #     stride=stride,
-    #     padding=padding,
-    #     dilation=dilation,
-    #     # applied_shard_scheme=shard_scheme,
-    #     ceil_mode=ceil_mode,
-    #     in_place_halo=True,  # test the base with IPH for a little more IPH coverage
-    #     deallocate_input=False,
-    #     reallocate_halo_output=True,
-    #     return_indices=False,
-    # )
-    # ttnn_outputs_exactly_equal = torch.equal(ttnn.to_torch(ttnn_output_base), ttnn.to_torch(ttnn_output))
-    print(f"ttnn_output_base exactly equals ttnn_output: {ttnn_outputs_exactly_equal}")
-
-    # Run PyTorch max pool for reference
-    torch_output, torch_indices = torch.nn.functional.max_pool2d(
-        torch_input,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        ceil_mode=ceil_mode,
-        return_indices=True,
-    )
-
-    print("Torch result:")
-    print(torch_output.flatten())
-    print("TTNNresult:")
-    print(ttnn.to_torch(ttnn_output).flatten())
-
-    # Reshape torch output to match TTNN format (NCHW -> NHWC)
-    torch_output_reshaped = torch_output.permute(0, 2, 3, 1)  # N, H, W, C
-    torch_indices_reshaped = torch_indices.permute(0, 2, 3, 1)  # N, H, W, C
-
-    print("PyTorch max pool results:")
-    print("Output shape:", torch_output_reshaped.shape)
-    # print("Output:\n", torch_output_reshaped)
-    print("Indices shape:", torch_indices_reshaped.shape)
-    # print("Indices:\n", torch_indices_reshaped)
-
-    # Compare outputs using allclose
-    ttnn_output_torch = ttnn.to_torch(ttnn_output)
-    ttnn_indices_torch = ttnn.to_torch(indices)
-
-    # Reshape TTNN outputs to match PyTorch shape for comparison
-    # TTNN output is in shape (1, 1, out_h*out_w, channels)
-    # Calculate output dimensions using the pooling formula
-    ttnn_output_reshaped = ttnn_output_torch.reshape(in_n, out_h, out_w, in_c)
-    ttnn_indices_reshaped = ttnn_indices_torch.reshape(in_n, out_h, out_w, in_c)
-
-    atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
-    if ttnn_dtype == ttnn.bfloat8_b:
-        atol = 0.35
-    output_match = torch.allclose(torch_output_reshaped, ttnn_output_reshaped, atol=atol, rtol=rtol)
-    indices_match = torch.equal(torch_indices_reshaped, ttnn_indices_reshaped)
-
-    print(f"Output values match (allclose): {output_match}")
-    print(f"Indices values match (allclose): {indices_match}")
-
-    # Print detailed mismatch information if outputs don't match
-    if not output_match:
-        print("\n=== OUTPUT MISMATCHES ===")
-        diff = torch.abs(torch_output_reshaped - ttnn_output_reshaped)
-        max_diff = torch.max(diff)
-        print(f"Maximum absolute difference: {max_diff}")
-
-        # Find positions where values don't match (with a small tolerance)
-        mismatch_mask = diff > 1e-5
-        mismatch_positions = torch.nonzero(mismatch_mask, as_tuple=False)
-
-        if len(mismatch_positions) > 0:
-            print(f"Number of mismatched elements: {len(mismatch_positions)}")
-            print("All mismatches (n, h, w, c): torch_val vs ttnn_val (diff):")
-            for i, pos in enumerate(mismatch_positions):
-                n, h, w, c = pos
-                torch_val = torch_output_reshaped[n, h, w, c]
-                ttnn_val = ttnn_output_reshaped[n, h, w, c]
-                diff_val = diff[n, h, w, c]
-                print(f"  [{n}, {h}, {w}, {c}]: {torch_val:.6f} vs {ttnn_val:.6f} (diff: {diff_val:.6f})")
-
-    # Count total output elements
-    total_output_elements = torch_output_reshaped.numel()
-    print(f"\nTotal output elements: {total_output_elements}")
-
-    # Analyze indices mismatches
-    tie_breaking_differences = 0
-    value_differences = 0
-    has_actual_errors = False
-
-    if not indices_match:
-        print("\n=== INDICES MISMATCHES ===")
-        torch_indices_float = torch_indices_reshaped.float()
-        ttnn_indices_float = ttnn_indices_reshaped.float()
-        diff = torch.abs(torch_indices_float - ttnn_indices_float)
-        max_diff = torch.max(diff)
-        print(f"Maximum absolute difference: {max_diff}")
-
-        # Find positions where indices don't match
-        mismatch_mask = diff > 1e-5
-        mismatch_positions = torch.nonzero(mismatch_mask, as_tuple=False)
-
-        if len(mismatch_positions) > 0:
-            print(f"Number of mismatched elements: {len(mismatch_positions)}")
-            print("All mismatches (n, h, w, c): torch_idx vs ttnn_idx (diff):")
-            for i, pos in enumerate(mismatch_positions):
-                n, h, w, c = pos
-                torch_idx = torch_indices_float[n, h, w, c]
-                ttnn_idx = ttnn_indices_float[n, h, w, c]
-                diff_val = diff[n, h, w, c]
-
-                # Convert linear indices back to spatial coordinates in the input tensor
-                # PyTorch uses NCHW format for indexing in max_pool2d
-                torch_idx_int = int(torch_idx.item())
-                ttnn_idx_int = int(ttnn_idx.item())
-
-                # Convert linear index to (h, w) coordinates within the pooling window
-                # For PyTorch indices, they are relative to the flattened spatial dimensions (H*W)
-                torch_h = torch_idx_int // in_w
-                torch_w = torch_idx_int % in_w
-                ttnn_h = ttnn_idx_int // in_w
-                ttnn_w = ttnn_idx_int % in_w
-
-                # Get the actual input values at these positions
-                torch_input_val = (
-                    torch_input[n, c, torch_h, torch_w] if torch_h < in_h and torch_w < in_w else float("nan")
-                )
-                ttnn_input_val = torch_input[n, c, ttnn_h, ttnn_w] if ttnn_h < in_h and ttnn_w < in_w else float("nan")
-
-                print(
-                    f"  output [{n}, {h}, {w}, {c}]: torch_idx={torch_idx:.0f} vs ttnn_idx={ttnn_idx:.0f} (diff: {diff_val:.0f})"
-                )
-                print(f"    Torch chose input[{n},{c},{torch_h},{torch_w}] = {torch_input_val:.6f}")
-                print(f"    TTNN chose input[{n},{c},{ttnn_h},{ttnn_w}] = {ttnn_input_val:.6f}")
-
-                # Check if this is a valid tie-breaking difference
-                # Two conditions must be satisfied:
-                # 1. The values must be the same
-                # 2. Both indices must be within the same kernel window
-
-                if ttnn_dtype == ttnn.bfloat8_b:
-                    values_same = math.isclose(torch_input_val, ttnn_input_val, abs_tol=atol, rel_tol=rtol)
-                else:
-                    values_same = torch_input_val == ttnn_input_val
-
-                # Calculate the top-left corner of the kernel window for this output position
-                # Given output position (h, w), the top-left of the kernel window is:
-                kernel_top_left_h = h * stride_h - padding[0]  # padding[0] is top padding
-                kernel_top_left_w = w * stride_w - padding[1]  # padding[1] is left padding
-
-                # Check if both indices are within the same dilated kernel window
-                # With dilation, the kernel doesn't cover a contiguous rectangle but specific positions
-                def is_in_dilated_kernel_window(
-                    input_h, input_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                ):
-                    """Check if a position (input_h, input_w) is within the dilated kernel window"""
-                    # Check if the position aligns with the dilated kernel pattern
-                    for kh in range(kernel_h):
-                        for kw in range(kernel_w):
-                            kernel_pos_h = kernel_top_left_h + kh * dilation_h
-                            kernel_pos_w = kernel_top_left_w + kw * dilation_w
-                            if kernel_pos_h == input_h and kernel_pos_w == input_w:
-                                return True
-                    return False
-
-                torch_in_window = is_in_dilated_kernel_window(
-                    torch_h, torch_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                )
-                ttnn_in_window = is_in_dilated_kernel_window(
-                    ttnn_h, ttnn_w, kernel_top_left_h, kernel_top_left_w, kernel_h, kernel_w, dilation_h, dilation_w
-                )
-
-                same_kernel_window = torch_in_window and ttnn_in_window
-
-                print(
-                    f"    Dilated kernel window: top_left=({kernel_top_left_h},{kernel_top_left_w}), kernel_size=({kernel_h},{kernel_w}), dilation=({dilation_h},{dilation_w})"
-                )
-                print(f"    Torch index in window: {torch_in_window}, TTNN index in window: {ttnn_in_window}")
-
-                if values_same and same_kernel_window:
-                    print(f"    -> Same input values AND same kernel window! This is a valid tie-breaking difference.")
-                    tie_breaking_differences += 1
-                elif values_same and not same_kernel_window:
-                    print(f"    -> Same input values but DIFFERENT kernel windows! This is an error.")
-                    value_differences += 1
-                    has_actual_errors = True
-                else:
-                    print(
-                        f"    -> Different input values! Value difference: {abs(torch_input_val - ttnn_input_val):.6f}"
-                    )
-                    value_differences += 1
-                    has_actual_errors = True
-                print()
-
-    print(f"\n=== SUMMARY ===")
-    print(f"Total output elements: {total_output_elements}")
-    print(f"Tie-breaking differences: {tie_breaking_differences}")
-    print(f"Value or window differences(actual errors): {value_differences}")
-
-    # Updated test result logic - only fail if there are actual value differences or output mismatches
-    test_passed = output_match and (not has_actual_errors) and ttnn_outputs_exactly_equal
-
-    if test_passed:
-        print("\n✓ Test PASSED: TTNN and PyTorch outputs match!")
-        if tie_breaking_differences > 0:
-            print(f"  Note: {tie_breaking_differences} tie-breaking differences in indices are acceptable.")
-    else:
-        print("\n✗ Test FAILED:")
-        if not output_match:
-            print("  - Output values do not match")
-        if has_actual_errors:
-            print(f"  - {value_differences} actual value differences found in indices")
-
-    # Ensure the test actually passes/fails based on the results
-    assert test_passed, "Test failed - see output above for details"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -14,15 +14,20 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS = 8>
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS = 8,
+    DataLayout layout = DataLayout::TILE>
 inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
-    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS>(
+    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>(
         values_tile_idx, indices_tile_idx, tile_idx);
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, DataLayout layout = DataLayout::TILE>
 inline void init_max_pool_with_indices() {
-    _init_max_pool_with_indices_();
+    _init_max_pool_with_indices_<layout>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -10,17 +10,22 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
-        sfpu::init_max_pool_with_indices<APPROXIMATE>);
+        sfpu::init_max_pool_with_indices<APPROXIMATE, layout>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int num_rows>
+template <
+    bool APPROXIMATE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS = 8,
+    ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(
     uint dst_index, uint32_t idx_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows>,
+        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>,
         dst_index,
         idx_index,
         vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -14,15 +14,20 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int num_rows, int ITERATIONS = 8>
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS = 8,
+    DataLayout layout = DataLayout::TILE>
 inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
-    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS>(
+    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>(
         values_tile_idx, indices_tile_idx, tile_idx);
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, DataLayout layout = DataLayout::TILE>
 inline void init_max_pool_with_indices() {
-    _init_max_pool_with_indices_();
+    _init_max_pool_with_indices_<layout>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -10,17 +10,22 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::max_pool_with_indices, APPROXIMATE>(
-        sfpu::init_max_pool_with_indices<APPROXIMATE>);
+        sfpu::init_max_pool_with_indices<APPROXIMATE, layout>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int num_rows>
+template <
+    bool APPROXIMATE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS = 8,
+    ckernel::DataLayout layout = ckernel::DataLayout::TILE>
 inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(
     uint dst_index, uint32_t idx_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows>,
+        ckernel::sfpu::calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>,
         dst_index,
         idx_index,
         vector_mode);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -10,7 +10,7 @@
 #include "compute_kernel_api/pack.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/tile_move_copy.h"
-#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/add_int_sfpu.h"
 
 #define DEBUG_PRINT 0
 
@@ -18,6 +18,7 @@
 #include "debug/dprint.h"
 #include "debug/dprint_pages.h"
 #include "debug/dprint_tensix.h"
+#include "tools/profiler/kernel_profiler.hpp"
 #endif
 
 #define ALWI inline __attribute__((always_inline))
@@ -28,72 +29,6 @@
 #define TILE_WIDTH 32
 
 namespace NAMESPACE {
-
-template <uint32_t topk_output_tiles, uint32_t data_dst_idx, uint32_t index_dst_idx, uint32_t topk_cb_tile_idx>
-ALWI void tilize_dest_function(uint32_t curr_in_cb_id, uint32_t curr_in_idx_cb_id) {
-    tilize_init_short_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles);
-    tilize_block_no_pack(curr_in_idx_cb_id, topk_output_tiles, index_dst_idx, topk_cb_tile_idx);
-    tilize_uninit_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id);
-    tilize_init_short_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id, topk_output_tiles);
-    tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
-    tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
-}
-
-template <
-    uint32_t topk_output_tiles,
-    uint32_t data_dst_idx,
-    uint32_t index_dst_idx,
-    uint32_t topk_cb_tile_idx,
-    uint32_t tile_tmp_cb_id,
-    uint32_t tile_idx_tmp_cb_id,
-    uint32_t out_cb_id,
-    uint32_t num_out_sticks,
-    bool pack_untilize_reinit>
-ALWI void tilize_copy_function(uint32_t curr_in_cb_id, uint32_t curr_in_idx_cb_id, uint32_t output_faces) {
-    // tensix syncs are necessary here until https://github.com/tenstorrent/tt-metal/issues/30399 is resolved
-    tensix_sync();
-    unary_op_init_common(curr_in_cb_id, tile_tmp_cb_id);
-    tensix_sync();
-    tilize_init(curr_in_cb_id, topk_output_tiles, tile_tmp_cb_id);
-
-    cb_reserve_back(tile_tmp_cb_id, topk_output_tiles);
-
-    tilize_block(curr_in_cb_id, topk_output_tiles, tile_tmp_cb_id, topk_cb_tile_idx, topk_cb_tile_idx);
-
-    cb_push_back(tile_tmp_cb_id, topk_output_tiles);
-    cb_wait_front(tile_tmp_cb_id, topk_output_tiles);
-    cb_reserve_back(tile_idx_tmp_cb_id, topk_output_tiles);
-
-    tilize_uninit_with_dt(curr_in_cb_id, curr_in_idx_cb_id, tile_idx_tmp_cb_id);
-    tilize_init_short_with_dt(curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles, tile_idx_tmp_cb_id);
-    tilize_block(curr_in_idx_cb_id, topk_output_tiles, tile_idx_tmp_cb_id, topk_cb_tile_idx, topk_cb_tile_idx);
-
-    cb_push_back(tile_idx_tmp_cb_id, topk_output_tiles);
-    cb_wait_front(tile_idx_tmp_cb_id, topk_output_tiles);
-
-    tilize_uninit(curr_in_idx_cb_id, tile_idx_tmp_cb_id);
-
-    copy_tile_init(tile_tmp_cb_id);
-    if constexpr (pack_untilize_reinit) {
-// note pack_untilize_dest_init must be called immediately after copy_tile_init see issue
-// https://github.com/tenstorrent/tt-metal/issues/#27314
-// also note we don't actually call pack_untilize_dest_init here, but instead call all it
-// contents without the llk_pack_untilize_hw_configure_disaggregated call so that
-// we can avoid tensix_syncs
-#ifdef ARCH_BLACKHOLE
-        // Needed for setting swizzle_32b:
-        MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
-#endif
-        PACK((llk_pack_untilize_init<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM>(
-            out_cb_id, num_out_sticks, output_faces)));
-        PACK((llk_init_packer_dest_offset_registers<true, false>()));
-    }
-    copy_tile(tile_tmp_cb_id, 0, data_dst_idx);
-    copy_tile(tile_idx_tmp_cb_id, 0, index_dst_idx);
-
-    cb_pop_front(tile_tmp_cb_id, topk_output_tiles);
-    cb_pop_front(tile_idx_tmp_cb_id, topk_output_tiles);
-}
 
 void MAIN {
     // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
@@ -110,24 +45,37 @@ void MAIN {
 
     constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
     constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);  // for split reader
-    constexpr uint32_t in_idx_cb_id_0 = get_compile_time_arg_val(9);
-    constexpr uint32_t in_idx_cb_id_1 = get_compile_time_arg_val(10);  // for split reader
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(11);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(12);
-    constexpr uint32_t tile_tmp_cb_id = get_compile_time_arg_val(13);
-    constexpr uint32_t tile_idx_tmp_cb_id = get_compile_time_arg_val(14);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(15);
-    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(16);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(17);
-    constexpr bool return_indices = (bool)get_compile_time_arg_val(18);
-    constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(19);
-    constexpr bool is_output_tiled = get_compile_time_arg_val(20);  // 1 = TILED, 0 = ROW_MAJOR
-    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(21);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
+    constexpr uint32_t in_idx_cb_id = get_compile_time_arg_val(11);
+    constexpr uint32_t pack_tmp_cb_id = get_compile_time_arg_val(12);
+    constexpr uint32_t pack_idx_tmp_cb_id = get_compile_time_arg_val(13);
+    constexpr uint32_t right_inc_cb_id = get_compile_time_arg_val(14);
+    constexpr uint32_t down_left_wrap_inc_cb_id = get_compile_time_arg_val(15);
+    constexpr uint32_t up_left_wrap_inc_cb_id = get_compile_time_arg_val(16);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(18);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(19);
+    constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(20);
+    constexpr bool is_output_tiled = get_compile_time_arg_val(21);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(22);
+    constexpr bool return_indices = (bool)get_compile_time_arg_val(23);
+    constexpr uint32_t stride_h = get_compile_time_arg_val(24);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(25);
+    constexpr uint32_t in_h_padded = get_compile_time_arg_val(26);
+    constexpr uint32_t in_w_padded = get_compile_time_arg_val(27);
+    constexpr uint32_t eff_kernel_h = get_compile_time_arg_val(28);
+    constexpr uint32_t eff_kernel_w = get_compile_time_arg_val(29);
+    constexpr uint32_t pad_l = get_compile_time_arg_val(30);
 
-    constexpr uint32_t topk_output_tiles = 1;
-    constexpr uint32_t topk_cb_tile_idx = 0;
+    constexpr bool use_split_reader = split_reader && !return_indices;
+
+    constexpr uint32_t mpwi_cb_tile_idx = 0;
     constexpr uint32_t data_dst_idx = 0;
     constexpr uint32_t index_dst_idx = 2;
+    constexpr uint32_t inc_dst_idx = 4;
+    constexpr uint32_t index_scratch_in_dst_idx = 5;
+    constexpr uint32_t index_scratch_out_dst_idx = 6;
 
     constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT && !return_indices ? window_size_hw : FACE_HEIGHT;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
@@ -157,32 +105,15 @@ void MAIN {
     // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
-#ifdef ARCH_BLACKHOLE
-    constexpr bool use_tilize_dest = in_c <= FACE_WIDTH;
-    constexpr bool pack_untilize_reinit = !use_tilize_dest;
-#else
-    constexpr bool use_tilize_dest = true;
-    constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
-#endif
+
     if constexpr (!return_indices) {
         constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
         tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
             in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb, num_faces_in_input_tile, face_r_dim);
         pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb, num_out_sticks, num_faces_in_output_tile);
     } else {
-        if constexpr (use_tilize_dest) {
-            unary_op_init_common(in_cb_id_0, in_cb_id_0);
-            tilize_init_no_pack(in_cb_id_0, topk_output_tiles);
-            if constexpr (!pack_untilize_reinit) {
-                const uint32_t output_faces =
-                    last_tile_is_partial ? num_faces_in_last_output_tile : num_faces_in_output_tile;
-                pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
-            }
-        }
-
-        // this can be done here because we do not use the SFPU for anything else so it does not get reprogrammed
-        // if you use the sfpu for other operations, you need to call this to reprogram the sfpu
-        max_reduce_with_indices_init();
+        unary_op_init_common(in_cb_id_0, in_cb_id_0);
+        copy_tile_to_dst_init_short(in_cb_id_0);
     }
 
     constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
@@ -193,13 +124,28 @@ void MAIN {
     if constexpr (one_scalar_per_core) {
         cb_wait_front(in_scalar_cb_id_0, 1);
     }
+    uint32_t current_idx_col;
+    uint32_t current_idx_row;
+    if constexpr (return_indices) {
+        const uint16_t start_row = (uint16_t)get_arg_val<uint32_t>(0);
+        const uint16_t start_col = (uint16_t)get_arg_val<uint32_t>(1);
+        current_idx_col = start_col;
+        current_idx_row = start_row;
+
+        cb_wait_front(right_inc_cb_id, 1);
+        cb_wait_front(down_left_wrap_inc_cb_id, 1);
+        cb_wait_front(up_left_wrap_inc_cb_id, 1);
+        // in_idx_cb_id is populated by the reader, but this happens after the inc CBs are populated
+        // so idx_tmp is protected here, and we intend to have PACK act as the sole producer, hence
+        // why the reader cannot push_back here
+        cb_push_back(in_idx_cb_id, 1);
+    }
 
     uint32_t tilize_stick_counter = 0;
     for (uint32_t n = 0; n < nsticks_per_core_by_nblocks; ++n) {
-        const bool reader0 = !(split_reader && (n & 0x1));
+        const bool reader0 = !(use_split_reader && (n & 0x1));
         const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
         const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
-        const uint32_t curr_in_idx_cb_id = !reader0 ? in_idx_cb_id_1 : in_idx_cb_id_0;
         if constexpr (!one_scalar_per_core) {
             cb_wait_front(curr_scalar_cb_id, 1);
         }
@@ -216,7 +162,7 @@ void MAIN {
                 (last_tile_is_partial && last_c_block)
                     ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
                     : number_of_tiles * num_faces_in_output_tile;
-            if constexpr (!is_output_tiled) {
+            if constexpr (!is_output_tiled && !return_indices) {
                 cb_reserve_back(out_cb_id, output_faces);
             }
             if constexpr (tilize_reconfig) {
@@ -229,33 +175,54 @@ void MAIN {
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 cb_wait_front(curr_in_cb_id, 1);
                 if constexpr (return_indices) {
-                    cb_wait_front(curr_in_idx_cb_id, 1);
+                    reconfig_data_format_srca(curr_in_cb_id);
+                    copy_tile(curr_in_cb_id, mpwi_cb_tile_idx, data_dst_idx);
 
-                    if constexpr (use_tilize_dest) {
-                        tilize_dest_function<topk_output_tiles, data_dst_idx, index_dst_idx, topk_cb_tile_idx>(
-                            curr_in_cb_id, curr_in_idx_cb_id);
-                    } else {
-                        tilize_copy_function<
-                            topk_output_tiles,
-                            data_dst_idx,
-                            index_dst_idx,
-                            topk_cb_tile_idx,
-                            tile_tmp_cb_id,
-                            tile_idx_tmp_cb_id,
-                            out_cb_id,
-                            num_out_sticks,
-                            pack_untilize_reinit>(curr_in_cb_id, curr_in_idx_cb_id, output_faces);
+                    if (first_c_block) {
+                        cb_wait_front(in_idx_cb_id, 1);
+                    }
+                    reconfig_data_format_srca(in_idx_cb_id);
+                    copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
+                    copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_scratch_in_dst_idx);
+                    if (last_c_block) {
+                        cb_pop_front(in_idx_cb_id, 1);
                     }
 
+                    if (first_c_block) {
+                        max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
+                    }
                     // the max_reduce_with_indices LLK function only supports kernel_size=9, pending
                     // https://github.com/tenstorrent/tt-metal/issues/28141 but, since for return_indices the in_cb is
                     // oversized (equal to 1 tile), and since this CB is filled with padding values in the beginning of
                     // the data movement kernel, it is possible to still use max_reduce_with_indices with kernel sizes
                     // smaller than 9 as the excess sticks are just filled with padding values
                     constexpr uint32_t max_mpwi_kernel_size = 9;
-                    max_reduce_with_indices<max_mpwi_kernel_size>(data_dst_idx, index_dst_idx);
+                    max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR>(
+                        data_dst_idx, index_dst_idx);
 
-                    cb_pop_front(curr_in_idx_cb_id, 1);
+                    // update the current index column
+                    if (last_c_block) {
+                        if (current_idx_col + stride_w + eff_kernel_w > in_w_padded) {
+                            // we reached the right edge, wrap down and to the left
+                            current_idx_col = 0;
+                            if (current_idx_row + stride_h + eff_kernel_h > in_h_padded) {
+                                // we reached the bottom right corner, wrap to the top and to the left
+                                current_idx_row = 0;
+                                copy_tile(up_left_wrap_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                            } else {
+                                current_idx_row += stride_h;
+                                copy_tile(down_left_wrap_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                            }
+                        } else {
+                            // we are still in the same row, move to the right
+                            current_idx_col += stride_w;
+                            copy_tile(right_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
+                        }
+
+                        // we allow overflow here for negative values as this only occurs in padding regions
+                        add_int_tile_init();
+                        add_uint16_tile(index_scratch_in_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
+                    }
                 } else {
                     unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         curr_in_cb_id,
@@ -336,31 +303,20 @@ void MAIN {
                     tile_regs_release();
                 }
             } else {
-                if constexpr (use_tilize_dest) {
-                    if constexpr (pack_untilize_reinit) {
-#ifdef ARCH_BLACKHOLE
-                        // Needed for setting swizzle_32b:
-                        MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
-#endif
-                        PACK((llk_pack_untilize_init<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM>(
-                            out_cb_id, num_out_sticks, output_faces)));
-                        PACK((llk_init_packer_dest_offset_registers<true, false>()));
-                    }
-                }
+                cb_reserve_back(pack_tmp_cb_id, 1);
+                pack_reconfig_data_format(pack_tmp_cb_id);
+                pack_tile<true>(data_dst_idx, pack_tmp_cb_id, mpwi_cb_tile_idx);
+                cb_push_back(pack_tmp_cb_id, 1);
 
-                pack_reconfig_data_format(out_cb_id);
-                pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, data_dst_idx>(
-                    out_cb_id, 1, 0, num_out_sticks, output_faces);
-                pack_reconfig_data_format(out_idx_cb_id);
-                pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, index_dst_idx>(
-                    out_idx_cb_id, 1, 0, num_out_sticks, output_faces);
+                cb_reserve_back(pack_idx_tmp_cb_id, 1);
+                pack_reconfig_data_format(pack_idx_tmp_cb_id);
+                pack_tile<true>(index_dst_idx, pack_idx_tmp_cb_id, mpwi_cb_tile_idx);
+                cb_push_back(pack_idx_tmp_cb_id, 1);
 
-                if constexpr (pack_untilize_reinit) {
-                    pack_untilize_uninit(out_cb_id);
-                }
-                cb_push_back(out_cb_id, output_faces);
-                if constexpr (return_indices) {
-                    cb_push_back(out_idx_cb_id, output_faces);
+                if (last_c_block) {
+                    cb_reserve_back(in_idx_cb_id, 1);
+                    pack_tile<true>(index_scratch_out_dst_idx, in_idx_cb_id, mpwi_cb_tile_idx);
+                    cb_push_back(in_idx_cb_id, 1);
                 }
                 tile_regs_release();
             }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -19,6 +19,8 @@
 #define TILE_WIDTH 32
 #define FACE_WIDTH 16
 #define FACE_HEIGHT 16
+#define FACE_SIZE (FACE_WIDTH * FACE_HEIGHT)
+#define FACES_PER_TILE_WIDTH (TILE_WIDTH / FACE_WIDTH)
 
 // Zero out a single page (where wr ptr points) for a given circular buffer.
 template <uint32_t cb_id>
@@ -77,16 +79,106 @@ ALWI void clear_out_tiles(uint64_t write_addr, uint64_t clear_value_addr) {
     noc_async_read_barrier();
 }
 
+// Initialize indices and increment tiles for return_indices functionality
+template <
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t in_w,
+    uint32_t in_c,
+    uint32_t pad_t,
+    uint32_t pad_l,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    uint16_t right_inc,
+    uint16_t down_left_wrap_inc,
+    uint16_t up_left_wrap_inc,
+    uint32_t in_idx_cb_id,
+    uint32_t right_inc_cb_id,
+    uint32_t down_left_wrap_inc_cb_id,
+    uint32_t up_left_wrap_inc_cb_id>
+ALWI void initialize_return_indices_data() {
+    // since kernels can start in padded regions we need to have "indexes" in these regions
+    // we choose a paradigm where we padding indexes must satisfy the following conditions:
+    //   1. they are 1 less than the index to the right (whether it's padding or not)
+    //   2. they are in_w less than the index below (whether it's padding or not)
+    // this results in repeat indexes, negative indexes and other such effects, but since
+    // padding is never chosen as a max index, validity of the padding index is unimportant
+    // we only care that when they are incremented they result in the correct index which
+    // this paradigm guarantees
+    // Note we also use unsigned integers and allow wrapping for negatives to preserve range
+    // and since all negative values correspond to padding indexes which will never be a max
+
+    // Calculate initial index based on padding conditions
+    uint16_t init_index = 0;
+    constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
+    const uint16_t start_row = (uint16_t)get_arg_val<uint32_t>(0);
+    const uint16_t start_col = (uint16_t)get_arg_val<uint32_t>(1);
+
+    if (start_row <= pad_t) {
+        // top left is in top padding, we increment from the padding index in the top left
+        // of the padded tensor
+        uint16_t global_top_left_pad_idx = -(uint16_t)pad_l - (uint16_t)pad_t * (uint16_t)in_w;
+        init_index = global_top_left_pad_idx + start_col + start_row * in_w;
+    } else if (start_col <= pad_l) {
+        // top left is in left padding, we increment from the padding index in the leftmost
+        // column of the starting row of the padded tensor
+        uint16_t leftmost_valid_index = (start_row - (uint16_t)pad_t) * (uint16_t)in_w;
+        uint16_t start_row_left_pad_idx = leftmost_valid_index - (uint16_t)pad_l;
+        init_index = start_row_left_pad_idx + start_col;
+    } else {
+        // top left is in valid region, we choose the valid index
+        init_index = (start_row - (uint16_t)pad_t) * (uint16_t)in_w + (start_col - (uint16_t)pad_l);
+    }
+
+    constexpr uint32_t fill_c = in_c <= TILE_WIDTH ? in_c : TILE_WIDTH;
+
+    // initialize the index CB - TODO for c > 1 we could optimize by storing two values per write
+    volatile tt_l1_ptr uint16_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(in_idx_cb_id));
+    uint16_t kernel_idx = 0;
+    for (uint32_t h = 0; h < kernel_h; ++h) {
+        for (uint32_t w = 0; w < kernel_w; ++w) {
+            uint16_t hw = h * kernel_w + w;
+            for (uint32_t c = 0; c < fill_c; ++c) {
+                uint16_t index = init_index + kernel_idx;
+                idx_ptr[hw * TILE_WIDTH + c] = index;
+            }
+            kernel_idx += dilation_w;
+        }
+        kernel_idx += dilation_h * in_w - eff_kernel_w - (dilation_w - 1);
+    }
+
+    // initialize the increment CBs
+    auto fill_inc = [&](uint32_t cb_id, uint16_t inc) __attribute__((always_inline)) {
+        uint32_t inc_32_bit = (uint32_t)inc | ((uint32_t)inc << 16);
+        volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+        for (uint32_t k = 0; k < kernel_h * kernel_w; ++k) {
+            constexpr uint32_t fill_c_32_bit = fill_c % 2 == 0 ? fill_c / 2 : (fill_c / 2) + 1;
+            for (uint32_t c = 0; c <= fill_c_32_bit; ++c) {
+                ptr[k * TILE_WIDTH / 2 + c] = inc_32_bit;
+            }
+        }
+    };
+
+    cb_reserve_back(right_inc_cb_id, 1);
+    fill_inc(right_inc_cb_id, right_inc);
+    cb_push_back(right_inc_cb_id, 1);
+
+    cb_reserve_back(down_left_wrap_inc_cb_id, 1);
+    fill_inc(down_left_wrap_inc_cb_id, down_left_wrap_inc);
+    cb_push_back(down_left_wrap_inc_cb_id, 1);
+
+    cb_reserve_back(up_left_wrap_inc_cb_id, 1);
+    fill_inc(up_left_wrap_inc_cb_id, up_left_wrap_inc);
+    cb_push_back(up_left_wrap_inc_cb_id, 1);
+}
+
 // Fill an L1 buffer with the given val
 // WARNING: Use with caution as there's no memory protection. Make sure size is within limits
 template <
     uint32_t in_nblocks_c,
     uint32_t in_cb_id,
-    uint32_t in_idx_cb_id,
-    uint32_t tile_tmp_cb_id,
-    uint32_t tile_idx_tmp_cb_id,
-    uint32_t window_h,
-    uint32_t window_w,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
     uint32_t in_w_padded,
     uint32_t in_nbytes_leftover,
     uint32_t in_c,
@@ -103,9 +195,13 @@ template <
     uint32_t dilation_h,
     uint32_t dilation_w,
     bool return_indices,
-    bool zero_pages>
-ALWI void read_window_with_top_left_index(
-    uint32_t ind, uint32_t in_l1_read_base_addr, uint32_t in_idx_l1_read_base_addr) {
+    bool zero_pages,
+    uint32_t out_cb_id,
+    uint32_t out_idx_cb_id,
+    uint32_t reader_id,
+    uint32_t pack_tmp_cb_id,
+    uint32_t pack_idx_tmp_cb_id>
+ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
     constexpr uint32_t BYTES_PER_ELEM = 2;
     // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
     // return_indices requires 1 tile at a time, otherwise we can reduce 8 tiles at a time.
@@ -113,116 +209,121 @@ ALWI void read_window_with_top_left_index(
     constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
     constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
-                                     (window_h * window_w) <= 16 && !last_tile_is_partial;
+                                     (kernel_h * kernel_w) <= 16 && !last_tile_is_partial;
     uint32_t max_write_inc = wide_reduction ? MAX_BYTES_PER_REDUCTION : in_nbytes_leftover;
     if constexpr (return_indices) {
         static_assert(MAX_TILES_PER_REDUCTION == 1, "MAX_TILES_PER_REDUCTION must be 1 for return indices");
+        max_write_inc = TILE_WIDTH * BYTES_PER_ELEM;
     }
-#ifdef ARCH_BLACKHOLE
-    if constexpr (return_indices) {
-        if (in_c <= FACE_WIDTH) {
-            max_write_inc = FACE_WIDTH * BYTES_PER_ELEM;
-        }
-    }
-#endif
     for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
-        uint32_t read_bytes = in_nbytes_c;
-        if constexpr (wide_reduction) {
-            read_bytes =
-                (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
-        }
-
-        uint32_t in_l1_write_addr = get_write_ptr(in_cb_id);
-        cb_reserve_back(in_cb_id, 1);
-        uint32_t in_idx_l1_write_addr = 0;
-        if constexpr (return_indices) {
-            in_idx_l1_write_addr = get_write_ptr(in_idx_cb_id);
-            cb_reserve_back(in_idx_cb_id, 1);
-        }
-        uint32_t processed_sticks = 0;
-        // page zeroing is only necessary for tiled block output format so that scale is not affected by junk/padding
-        // data
-        if constexpr (zero_pages) {
-            if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page<in_cb_id>();
+        if constexpr (reader_id == 0 || !return_indices) {
+            uint32_t read_bytes = in_nbytes_c;
+            if constexpr (wide_reduction) {
+                read_bytes =
+                    (c_i == in_nblocks_c - 1) ? in_nbytes_c - c_i * MAX_BYTES_PER_REDUCTION : MAX_BYTES_PER_REDUCTION;
             }
-        }
-        for (uint32_t h = 0; h < window_h; ++h) {
-            auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
-                const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
-                const uint32_t read_offset =
-                    in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
-                noc_async_read_one_packet(get_noc_addr(read_offset), in_l1_write_addr, read_bytes * w_multiple);
-                // if compute is using tilize_reconfig we will only untilize the needed number of tiles rather
-                // than the entire MAX_TILES_PER_REDUCTION, thus we use a different offset for the write address
-                if constexpr (tilize_reconfig) {
-                    in_l1_write_addr += read_bytes * w_multiple;
-                } else {
-                    in_l1_write_addr += max_write_inc * w_multiple;
+
+            uint32_t in_l1_write_addr = get_write_ptr(in_cb_id);
+            cb_reserve_back(in_cb_id, 1);
+            uint32_t processed_sticks = 0;
+            // page zeroing is only necessary for tiled block output format so that scale is not affected by
+            // junk/padding data
+            if constexpr (zero_pages) {
+                if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
+                    zero_out_page<in_cb_id>();
                 }
-                if constexpr (return_indices) {
-                    const uint32_t idx_read_offset =
-                        in_idx_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
-                    noc_async_read_one_packet(
-                        get_noc_addr(idx_read_offset), in_idx_l1_write_addr, read_bytes * w_multiple);
+            }
+            for (uint32_t h = 0; h < kernel_h; ++h) {
+                auto process_h = [&](uint32_t w_offset, uint32_t w_multiple) __attribute__((always_inline)) {
+                    const uint32_t stick_offset = ind + w_offset + h * dilation_h * in_w_padded;
+                    const uint32_t read_offset =
+                        in_l1_read_base_addr + (stick_offset * shard_width_bytes + c_i * MAX_BYTES_PER_REDUCTION);
+                    noc_async_read_one_packet(get_noc_addr(read_offset), in_l1_write_addr, read_bytes * w_multiple);
+                    // if compute is using tilize_reconfig we will only untilize the needed number of tiles rather
+                    // than the entire MAX_TILES_PER_REDUCTION, thus we use a different offset for the write address
                     if constexpr (tilize_reconfig) {
-                        in_idx_l1_write_addr += read_bytes * w_multiple;
+                        in_l1_write_addr += read_bytes * w_multiple;
                     } else {
-                        in_idx_l1_write_addr += max_write_inc * w_multiple;
+                        in_l1_write_addr += max_write_inc * w_multiple;
                     }
-                }
-                processed_sticks += w_multiple;
-                if constexpr (is_large_kernel) {
-                    if ((processed_sticks % max_sticks_for_reduction) == 0 ||
-                        processed_sticks == total_elems_to_reduce) {
-                        noc_async_read_barrier();
-                        cb_push_back(in_cb_id, 1);
-                        cb_reserve_back(in_cb_id, 1);
-                        in_l1_write_addr = get_write_ptr(in_cb_id);
-                        // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
-                        // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
-                        // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
-                        // cannot contain values greater than the max value, and if we have N=1 chunks we already
-                        // initialized the entire CB with the init value, but for avg pool we need to fill the
-                        // entire CB with the init value since the junk data will contribute to the average.
-                        if constexpr (is_avg_pool) {
-                            // clear the in CB
-                            if ((total_elems_to_reduce - processed_sticks) < max_sticks_for_reduction &&
-                                processed_sticks != total_elems_to_reduce) {
-                                clear_out_tiles<clear_value_cb_id, in_cb_ntiles>(
-                                    get_noc_addr(in_l1_write_addr), get_noc_addr(get_read_ptr(clear_value_cb_id)));
+                    processed_sticks += w_multiple;
+                    if constexpr (is_large_kernel) {
+                        if ((processed_sticks % max_sticks_for_reduction) == 0 ||
+                            processed_sticks == total_elems_to_reduce) {
+                            noc_async_read_barrier();
+                            cb_push_back(in_cb_id, 1);
+                            cb_reserve_back(in_cb_id, 1);
+                            in_l1_write_addr = get_write_ptr(in_cb_id);
+                            // If next is last chunk, fill whole buffer with the init_value. note for max pool we do
+                            // not need to fill the CB for the partial chunk since as long as we have N>1 chunks we
+                            // are guaranteed that the junk data remaining from chunk N-1 will fill the entire CB and
+                            // cannot contain values greater than the max value, and if we have N=1 chunks we already
+                            // initialized the entire CB with the init value, but for avg pool we need to fill the
+                            // entire CB with the init value since the junk data will contribute to the average.
+                            if constexpr (is_avg_pool) {
+                                // clear the in CB
+                                if ((total_elems_to_reduce - processed_sticks) < max_sticks_for_reduction &&
+                                    processed_sticks != total_elems_to_reduce) {
+                                    clear_out_tiles<clear_value_cb_id, in_cb_ntiles>(
+                                        get_noc_addr(in_l1_write_addr), get_noc_addr(get_read_ptr(clear_value_cb_id)));
+                                }
                             }
                         }
                     }
+                };
+
+                // Case where in_nbytes_leftover and in_nbytes_c is different is when we are dealing with
+                // tesnors that have last tile as partial. Cb page size is multiple of tile but when the last
+                // tile is partial we have to read the smaller stick width. Therefore we need to write out the next
+                // stick right bellow the previous one and this is when increment of the write pointer and the read
+                // stick size is not compliant.
+                bool use_contiguous_read = !wide_reduction && in_nbytes_leftover == in_nbytes_c &&
+                                           dilation_w == 1;  // read entire row as one chunk (only if no width dilation)
+                if constexpr (is_large_kernel) {
+                    bool whole_row_remaining =
+                        kernel_w <= max_sticks_for_reduction - (processed_sticks % max_sticks_for_reduction);
+                    use_contiguous_read &= whole_row_remaining;
                 }
-            };
 
-            // Case where in_nbytes_leftover and in_nbytes_c is different is when we are dealing with
-            // tesnors that have last tile as partial. Cb page size is multiple of tile but when the last
-            // tile is partial we have to read the smaller stick width. Therefore we need to write out the next stick
-            // right bellow the previous one and this is when increment of the write pointer and the read stick size is
-            // not compliant.
-            bool use_contiguous_read = !wide_reduction && in_nbytes_leftover == in_nbytes_c &&
-                                       dilation_w == 1;  // read entire row as one chunk (only if no width dilation)
-            if constexpr (is_large_kernel) {
-                bool whole_row_remaining =
-                    window_w <= max_sticks_for_reduction - (processed_sticks % max_sticks_for_reduction);
-                use_contiguous_read &= whole_row_remaining;
-            }
-
-            if (use_contiguous_read) {
-                process_h(0, window_w);
-            } else {  // read rows stick by stick with dilation
-                for (uint32_t w = 0; w < window_w; ++w) {
-                    process_h(w * dilation_w, 1);
+                if (use_contiguous_read) {
+                    process_h(0, kernel_w);
+                } else {  // read rows stick by stick with dilation
+                    for (uint32_t w = 0; w < kernel_w; ++w) {
+                        process_h(w * dilation_w, 1);
+                    }
                 }
             }
         }
         if constexpr (!is_large_kernel) {
-            noc_async_read_barrier();
-            cb_push_back(in_cb_id, 1);
-            if constexpr (return_indices) {
-                cb_push_back(in_idx_cb_id, 1);
+            if (reader_id == 0 || !return_indices) {
+                noc_async_read_barrier();
+                cb_push_back(in_cb_id, 1);
+            }
+            if constexpr (reader_id == 1 && return_indices) {
+                constexpr uint32_t num_faces_in_output_tile = 2;
+                constexpr uint32_t num_faces_in_last_output_tile =
+                    last_tile_is_partial && in_c % TILE_WIDTH <= FACE_WIDTH ? 1 : 2;
+                uint32_t output_faces =
+                    c_i == in_nblocks_c - 1 ? num_faces_in_last_output_tile : num_faces_in_output_tile;
+
+                cb_wait_front(pack_tmp_cb_id, 1);
+                noc_async_read_one_packet(
+                    get_noc_addr(get_read_ptr(pack_tmp_cb_id)),
+                    get_write_ptr(out_cb_id),
+                    output_faces * FACE_WIDTH * BYTES_PER_ELEM);
+                cb_wait_front(pack_idx_tmp_cb_id, 1);
+                noc_async_read_one_packet(
+                    get_noc_addr(get_read_ptr(pack_idx_tmp_cb_id)),
+                    get_write_ptr(out_idx_cb_id),
+                    output_faces * FACE_WIDTH * BYTES_PER_ELEM);
+                noc_async_read_barrier();
+                cb_pop_front(pack_tmp_cb_id, 1);
+                cb_pop_front(pack_idx_tmp_cb_id, 1);
+
+                cb_push_back(out_cb_id, output_faces);
+                if constexpr (return_indices) {
+                    cb_push_back(out_idx_cb_id, output_faces);
+                }
             }
         }
     }
@@ -268,8 +369,8 @@ ALWI void fill_scalar(
  */
 void kernel_main() {
     constexpr uint32_t reader_nindices = get_compile_time_arg_val(0);
-    constexpr uint32_t window_h = get_compile_time_arg_val(1);
-    constexpr uint32_t window_w = get_compile_time_arg_val(2);
+    constexpr uint32_t kernel_h = get_compile_time_arg_val(1);
+    constexpr uint32_t kernel_w = get_compile_time_arg_val(2);
 
     constexpr int32_t pad_w = get_compile_time_arg_val(3);
 
@@ -294,36 +395,49 @@ void kernel_main() {
 
     constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
-    constexpr uint32_t in_idx_cb_id = (reader_id == 1) ? get_compile_time_arg_val(19) : get_compile_time_arg_val(18);
-    constexpr uint32_t in_shard_idx_cb_id = get_compile_time_arg_val(20);
-    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(21);
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(22);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(23);
-    constexpr uint32_t tile_tmp_cb_id = get_compile_time_arg_val(24);
-    constexpr uint32_t tile_idx_tmp_cb_id = get_compile_time_arg_val(25);
-    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(26);
-    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(27);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(28);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(29);
-    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(30);
-    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(31);
-    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(32);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(33);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(34);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(35);
-    constexpr bool return_indices = (bool)get_compile_time_arg_val(36);
-    constexpr bool zero_pages = (bool)get_compile_time_arg_val(37);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
+    constexpr uint32_t in_idx_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t pack_tmp_cb_id = get_compile_time_arg_val(22);
+    constexpr uint32_t pack_idx_tmp_cb_id = get_compile_time_arg_val(23);
+    constexpr uint32_t right_inc_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t down_left_wrap_inc_cb_id = get_compile_time_arg_val(25);
+    constexpr uint32_t up_left_wrap_inc_cb_id = get_compile_time_arg_val(26);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(27);
+    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(28);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(29);
+    constexpr uint32_t config_cb_id = get_compile_time_arg_val(30);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(31);
+    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(32);
+    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(33);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(34);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(35);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(36);
+    constexpr bool return_indices = (bool)get_compile_time_arg_val(37);
+    constexpr uint32_t pad_t = get_compile_time_arg_val(38);
+    constexpr uint32_t pad_l = get_compile_time_arg_val(39);
+    constexpr uint16_t right_inc = get_compile_time_arg_val(40);
+    constexpr uint16_t down_left_wrap_inc = get_compile_time_arg_val(41);
+    constexpr uint16_t up_left_wrap_inc = get_compile_time_arg_val(42);
+    constexpr bool zero_pages = (bool)get_compile_time_arg_val(43);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(44);
+    constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(45);
 
+    constexpr bool use_split_reader = split_reader && !return_indices;
+    constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
+
+    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
     constexpr uint32_t in_scalar_cb_id =
-        split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+        use_split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
 
     uint32_t scalar_index = 0;
     uint32_t scalar_start = 0;
     uint32_t scalar_end = 1;
     uint32_t scalar_value = 0;
 
-    constexpr uint32_t window_size_hw = window_h * window_w;
+    constexpr uint32_t window_size_hw = kernel_h * kernel_w;
     constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT && !return_indices ? window_size_hw : FACE_HEIGHT;
     constexpr uint32_t num_faces_in_input_tile =
         (max_sticks_for_reduction < TILE_WIDTH || window_size_hw <= FACE_HEIGHT) && !return_indices ? 2 : 4;
@@ -348,13 +462,30 @@ void kernel_main() {
             cb_wait_front(clear_value_cb_id, 1);
         }
         // for average pool clear out tiles runs in loop, no need to initialize here
+        // TODO do we really need to init the in CB for return indices?
+        // - yes until LLK is updated for arbitrary kernel sizes, for now we rely on init
         if constexpr (!is_avg_pool || !is_large_kernel || return_indices) {
             clear_out_tiles<in_cb_id, clear_value_cb_id>();
-            if constexpr (return_indices) {
-                clear_out_tiles<in_idx_cb_id, clear_value_cb_id>();
-            }
         }
-        // we don't need to clear the idx CB since the data CB is the one being sorted
+    }
+
+    if constexpr (reader_id == 0 && return_indices) {
+        initialize_return_indices_data<
+            kernel_h,
+            kernel_w,
+            in_w,
+            in_c,
+            pad_t,
+            pad_l,
+            dilation_h,
+            dilation_w,
+            right_inc,
+            down_left_wrap_inc,
+            up_left_wrap_inc,
+            in_idx_cb_id,
+            right_inc_cb_id,
+            down_left_wrap_inc_cb_id,
+            up_left_wrap_inc_cb_id>();
     }
 
     // initialize the scalar CB
@@ -367,21 +498,15 @@ void kernel_main() {
     }
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
-    uint32_t in_idx_l1_read_base_addr = 0;
-    if constexpr (return_indices) {
-        in_idx_l1_read_base_addr = get_read_ptr(in_shard_idx_cb_id);
-    }
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
     uint32_t config_l1_addr;
     volatile tt_l1_ptr uint16_t* config_ptr;
 
-    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
-
     uint32_t segments_counter = 1;
     uint32_t counter = reader_id;
-    constexpr uint32_t total_elems_to_reduce = window_h * window_w;
+    constexpr uint32_t total_elems_to_reduce = kernel_h * kernel_w;
     constexpr bool wide_reduction = in_nblocks_c > 1;
 
     if constexpr (!one_scalar_per_core) {
@@ -398,7 +523,7 @@ void kernel_main() {
 
     uint32_t reader_indices_on_core = 0;
 
-    if (split_reader) {
+    if (use_split_reader) {
         if (reader_id == 0) {
             reader_indices_on_core = (reader_nindices + 1) / 2;
         } else {
@@ -418,21 +543,18 @@ void kernel_main() {
             first_row_value = true;
         }
 
-        constexpr uint32_t stride_multiple = split_reader ? 2 : 1;
+        constexpr uint32_t stride_multiple = use_split_reader ? 2 : 1;
         for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
             if constexpr (!one_scalar_per_core) {
-                fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader>(
+                fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, use_split_reader>(
                     scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
             reader_indices_on_core--;
-            read_window_with_top_left_index<
+            read_kernel_with_top_left_index<
                 in_nblocks_c,
                 in_cb_id,
-                in_idx_cb_id,
-                tile_tmp_cb_id,
-                tile_idx_tmp_cb_id,
-                window_h,
-                window_w,
+                kernel_h,
+                kernel_w,
                 in_w_padded,
                 in_nbytes_leftover,
                 in_c,
@@ -449,8 +571,13 @@ void kernel_main() {
                 dilation_h,
                 dilation_w,
                 return_indices,
-                zero_pages>(ind, in_l1_read_base_addr, in_idx_l1_read_base_addr);
-            if (split_reader && ind == end) {
+                zero_pages,
+                out_cb_id,
+                out_idx_cb_id,
+                reader_id,
+                pack_tmp_cb_id,
+                pack_idx_tmp_cb_id>(ind, in_l1_read_base_addr);
+            if (use_split_reader && ind == end) {
                 first_row_value = false;
             }
         }
@@ -458,17 +585,14 @@ void kernel_main() {
 
     while (reader_indices_on_core--) {
         if constexpr (!one_scalar_per_core) {
-            fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, split_reader>(
+            fill_scalar<one_scalar_per_core, in_scalar_cb_id, reader_nindices, use_split_reader>(
                 scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
         }
-        read_window_with_top_left_index<
+        read_kernel_with_top_left_index<
             in_nblocks_c,
             in_cb_id,
-            in_idx_cb_id,
-            tile_tmp_cb_id,
-            tile_idx_tmp_cb_id,
-            window_h,
-            window_w,
+            kernel_h,
+            kernel_w,
             in_w_padded,
             in_nbytes_leftover,
             in_c,
@@ -485,6 +609,11 @@ void kernel_main() {
             dilation_h,
             dilation_w,
             return_indices,
-            zero_pages>(0, in_l1_read_base_addr, in_idx_l1_read_base_addr);
+            zero_pages,
+            out_cb_id,
+            out_idx_cb_id,
+            reader_id,
+            pack_tmp_cb_id,
+            pack_idx_tmp_cb_id>(0, in_l1_read_base_addr);
     }
 }  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -208,9 +208,40 @@ static Tensor create_scalar_config_tensor(
     return Tensor(std::move(buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
 
+std::vector<uint16_t> generate_core_starting_indices(
+    const std::vector<uint32_t>& op_trace_metadata,
+    const std::vector<sliding_window::ShardBoundary>& shard_boundaries,
+    const tt::tt_metal::TensorMemoryLayout shard_scheme,
+    const uint32_t num_cores_x,
+    const uint32_t ncores) {
+    std::vector<uint16_t> starting_indices;
+    uint32_t repeat_factor = 0;
+    switch (shard_scheme) {
+        case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED: repeat_factor = 1; break;
+        case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED: repeat_factor = ncores; break;
+        case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED: repeat_factor = num_cores_x; break;
+        default: TT_FATAL(false, "Unsupported shard scheme");
+    };
+    for (const auto& item : shard_boundaries) {
+        const auto& [output_shard_start, output_shard_end] = item.output_range;
+        const auto& [input_shard_start, input_shard_end] = item.input_range;
+        if (output_shard_start >= op_trace_metadata.size()) {
+            // this core has no output
+            starting_indices.push_back(0);
+            continue;
+        }
+        TT_ASSERT(input_shard_start == op_trace_metadata[output_shard_start]);
+        for (uint32_t r = 0; r < repeat_factor; r++) {
+            starting_indices.push_back(op_trace_metadata[output_shard_start]);
+        }
+    }
+
+    return starting_indices;
+}
+
 Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_new(
     Program& program,
-    const std::vector<Tensor>& inputs,
+    const Tensor& input,
     const Tensor& reader_indices,
     uint32_t reader_indices_size,
     std::vector<Tensor>& outputs,
@@ -234,6 +265,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t ceil_pad_w,
     bool ceil_mode,
     bool return_indices,
+    std::vector<uint16_t> core_starting_indices,
     bool count_include_pad,
     uint32_t dilation_h,
     uint32_t dilation_w,
@@ -243,26 +275,41 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     std::optional<int32_t> divisor_override,
     uint32_t memory_used,
     const Layout& output_layout) {
-    distributed::MeshDevice* device = inputs[0].device();
+    distributed::MeshDevice* device = input.device();
 
     const tt::tt_metal::DeviceStorage& reader_indices_storage = reader_indices.device_storage();
+    const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     // distributing out_hw across the grid
-    const auto all_cores = inputs[0].shard_spec().value().grid;
+    const auto all_cores = input.shard_spec().value().grid;
     const uint32_t ncores = all_cores.num_cores();
+    const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+    const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
     const uint32_t out_nhw_per_core = outputs[0].shard_spec()->shape[0];
 
     const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
     const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
     FactoryParameters params = get_factory_parameters(
-        num_shards_c, inputs[0].dtype(), outputs[0].dtype(), kernel_h, kernel_w, in_c, pool_type, return_indices, output_layout);
+        num_shards_c,
+        input.dtype(),
+        outputs[0].dtype(),
+        kernel_h,
+        kernel_w,
+        in_c,
+        pool_type,
+        return_indices,
+        output_layout);
+    uint32_t eff_kernel_h = ((kernel_h - 1) * dilation_h) + 1;
+    uint32_t eff_kernel_w = ((kernel_w - 1) * dilation_w) + 1;
     uint32_t pad_h = pad_t + pad_b;
     uint32_t pad_w = pad_l + pad_r;
+    const uint32_t in_h_padded = in_h + pad_h + ceil_pad_h;
+    const uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
-    const auto& input_shape = inputs[0].padded_shape();
-    const uint32_t shard_width = inputs[0].shard_spec()->shape[1];
+    const auto& input_shape = input.padded_shape();
+    const uint32_t shard_width = input.shard_spec()->shape[1];
     const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
                                              ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
                                              : in_c / num_shards_c;
@@ -309,32 +356,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     // incoming data is the input cb instead of raw l1/dram addr
     // this input shard has halo and padding inserted.
-    const uint32_t raw_in_cb_npages = inputs[0].shard_spec().value().shape[0];
+    const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
     const uint32_t raw_in_cb_pagesize = in_nbytes_c;
     const auto [raw_in_cb_id, raw_in_cb] = tt::tt_metal::create_cb(
-        next_cb_index++,
-        program,
-        all_cores,
-        raw_in_cb_pagesize,
-        raw_in_cb_npages,
-        params.data_format,
-        inputs[0].buffer());
-    uint32_t raw_in_idx_cb_id = 32;
-    tt::tt_metal::CBHandle raw_in_idx_cb = 0;
-    if (return_indices) {
-        TT_FATAL(inputs.size() == 2, "Index tensor must be provided if return_indices is true");
-        uint32_t raw_in_idx_cb_npages = raw_in_cb_npages;
-        uint32_t raw_in_idx_cb_pagesize = input_shape[3] / num_shards_c * params.index_nbytes;
-        raw_in_idx_cb_id = next_cb_index++;
-        std::tie(raw_in_idx_cb_id, raw_in_idx_cb) = tt::tt_metal::create_cb(
-            next_cb_index++,
-            program,
-            all_cores,
-            raw_in_idx_cb_pagesize,
-            raw_in_idx_cb_npages,
-            params.index_format,
-            inputs[1].buffer());
-    }
+        next_cb_index++, program, all_cores, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input.buffer());
 
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
 
@@ -392,33 +417,46 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
     }
 
-    uint32_t in_idx_cb_id_0 = 32;
-    uint32_t in_idx_cb_id_1 = 32;
-    uint32_t tile_tmp_cb_id = 32;
-    uint32_t tile_idx_tmp_cb_id = 32;
+    uint32_t in_idx_cb_id = 32;
+    uint32_t pack_tmp_cb_id = 32;
+    uint32_t pack_idx_tmp_cb_id = 32;
+    uint32_t right_inc_cb_id = 32;
+    uint32_t down_left_wrap_inc_cb_id = 32;
+    uint32_t up_left_wrap_inc_cb_id = 32;
+    uint16_t right_inc = 0;
+    uint16_t down_left_wrap_inc = 0;
+    uint16_t up_left_wrap_inc = 0;
     if (return_indices) {
-        const uint32_t in_idx_cb_pagesize = params.index_nbytes * in_cb_page_padded;
-        const uint32_t in_idx_cb_npages = params.multi_buffering_factor;
-
-        in_idx_cb_id_0 = next_cb_index++;
-        tt::tt_metal::create_cb(
-            in_idx_cb_id_0, program, all_cores, in_idx_cb_pagesize, in_idx_cb_npages, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id_0, in_idx_cb_pagesize, in_idx_cb_npages);
-        if (params.split_reader) {
-            in_idx_cb_id_1 = next_cb_index++;
-            tt::tt_metal::create_cb(
-                in_idx_cb_id_1, program, all_cores, in_idx_cb_pagesize, in_idx_cb_npages, params.index_format);
-            log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id_1, in_idx_cb_pagesize, in_idx_cb_npages);
-        }
-
         uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        tile_tmp_cb_id = next_cb_index++;
-        tt::tt_metal::create_cb(tile_tmp_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", tile_tmp_cb_id, params.nbytes * tile_elems, 1);
-        tile_idx_tmp_cb_id = next_cb_index++;
+        in_idx_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(in_idx_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id, params.nbytes * tile_elems, 1);
+        pack_tmp_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(pack_tmp_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.data_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_tmp_cb_id, params.nbytes * tile_elems, 1);
+        pack_idx_tmp_cb_id = next_cb_index++;
         tt::tt_metal::create_cb(
-            tile_idx_tmp_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", tile_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
+            pack_idx_tmp_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
+        right_inc_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(
+            right_inc_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", right_inc_cb_id, params.index_nbytes * tile_elems, 1);
+        down_left_wrap_inc_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(
+            down_left_wrap_inc_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(
+            tt::LogOp, "CB {} :: PS = {}, NP = {}", down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
+        up_left_wrap_inc_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(
+            up_left_wrap_inc_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", up_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
+
+        // compute increments for index tile population
+        right_inc = stride_w;
+        down_left_wrap_inc = in_w * stride_h + (1 - out_w) * stride_w;
+        up_left_wrap_inc =
+            (1 - out_h) * stride_h * in_w + (1 - out_w) * stride_w;  // allow overflow for negative values
     }
 
     const bool is_output_tiled = output_layout == Layout::TILE;
@@ -520,14 +558,13 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             .out_nhw_per_core = out_nhw_per_core,
             .divisor_override = divisor_override};
         config_tensor = create_scalar_config_tensor(
-            avg_pool_config, inputs[0].memory_config().memory_layout(), in_n, num_shards_c, ncores);
+            avg_pool_config, input.memory_config().memory_layout(), in_n, num_shards_c, ncores);
 
         const std::array<uint32_t, 2> shard_shape =
             std::array<uint32_t, 2>({1, static_cast<uint32_t>(config_tensor.logical_shape()[-1])});
-        const tt::tt_metal::ShardOrientation config_tensor_shard_orientation =
-            inputs[0].shard_spec().value().orientation;
+        const tt::tt_metal::ShardOrientation config_tensor_shard_orientation = input.shard_spec().value().orientation;
         const tt::tt_metal::ShardSpec config_shard_spec(
-            inputs[0].shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
+            input.shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
         const MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
         const Tensor config_tensor_device = config_tensor.to_device(device, memory_config);
 
@@ -558,26 +595,34 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_cb_id_0,                     // 15
         in_cb_id_1,                     // 16
         raw_in_cb_id,                   // 17
-        in_idx_cb_id_0,                 // 18
-        in_idx_cb_id_1,                 // 19
-        raw_in_idx_cb_id,               // 20
-        in_reader_indices_cb_id,        // 21
-        in_scalar_cb_id_0,              // 22
-        in_scalar_cb_id_1,              // 23
-        tile_tmp_cb_id,                 // 24
-        tile_idx_tmp_cb_id,             // 25
-        clear_value_cb_id,              // 26
-        (uint32_t)pool_type,            // 27
-        one_scalar_per_core,            // 28
-        config_cb_id,                   // 29
-        in_nbytes_c,                    // 30
-        shard_width_bytes,              // 31
-        params.multi_buffering_factor,  // 32
-        stride_w,                       // 33
-        dilation_h,                     // 34
-        dilation_w,                     // 35
-        (uint32_t)return_indices,       // 36
-        (uint32_t)zero_pages};          // 37
+        in_reader_indices_cb_id,        // 18
+        in_scalar_cb_id_0,              // 19
+        in_scalar_cb_id_1,              // 20
+        in_idx_cb_id,                   // 21
+        pack_tmp_cb_id,                 // 22
+        pack_idx_tmp_cb_id,             // 23
+        right_inc_cb_id,                // 24
+        down_left_wrap_inc_cb_id,       // 25
+        up_left_wrap_inc_cb_id,         // 26
+        clear_value_cb_id,              // 27
+        (uint32_t)pool_type,            // 28
+        one_scalar_per_core,            // 29
+        config_cb_id,                   // 30
+        in_nbytes_c,                    // 31
+        shard_width_bytes,              // 32
+        params.multi_buffering_factor,  // 33
+        stride_w,                       // 34
+        dilation_h,                     // 35
+        dilation_w,                     // 36
+        (uint32_t)return_indices,       // 37
+        pad_t,                          // 38
+        pad_l,                          // 39
+        right_inc,                      // 40
+        down_left_wrap_inc,             // 41
+        up_left_wrap_inc,               // 42
+        (uint32_t)zero_pages,           // 43
+        out_cb_id,                      // 44
+        out_idx_cb_id};                 // 45
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 
@@ -613,22 +658,31 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         params.max_rows_for_reduction,  // 6
         in_cb_id_0,                     // 7
         in_cb_id_1,                     // 8
-        in_idx_cb_id_0,                 // 9
-        in_idx_cb_id_1,                 // 10
-        in_scalar_cb_id_0,              // 11
-        in_scalar_cb_id_1,              // 12
-        tile_tmp_cb_id,                 // 13
-        tile_idx_tmp_cb_id,             // 14
-        out_cb_id,                      // 15
-        out_idx_cb_id,                  // 16
-        one_scalar_per_core,            // 17
-        (uint32_t)return_indices,       // 18
-        pre_tilize_cb_id,               // 19
-        is_output_tiled,                // 20
-        is_output_block_format};        // 21
+        in_scalar_cb_id_0,              // 9
+        in_scalar_cb_id_1,              // 10
+        in_idx_cb_id,                   // 11
+        pack_tmp_cb_id,                 // 12
+        pack_idx_tmp_cb_id,             // 13
+        right_inc_cb_id,                // 14
+        down_left_wrap_inc_cb_id,       // 15
+        up_left_wrap_inc_cb_id,         // 16
+        out_cb_id,                      // 17
+        out_idx_cb_id,                  // 18
+        one_scalar_per_core,            // 19
+        pre_tilize_cb_id,               // 20
+        is_output_tiled,                // 21
+        is_output_block_format,         // 22
+        (uint32_t)return_indices,       // 23
+        stride_h,                       // 24
+        stride_w,                       // 25
+        in_h_padded,                    // 26
+        in_w_padded,                    // 27
+        eff_kernel_h,                   // 28
+        eff_kernel_w,                   // 29
+        pad_l};                         // 30
 
     // Get device arch for compute kernel config initialization
-    auto device_arch = inputs[0].device()->arch();
+    auto device_arch = input.device()->arch();
 
     // Initialize device compute kernel config with user-provided config or defaults
     auto device_compute_kernel_config = init_device_compute_kernel_config(
@@ -653,12 +707,31 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     auto compute_kernel = CreateKernel(program, compute_kernel_fname, all_cores, compute_config);
 
+    // set the starting indices for each core as runtime args
+    if (return_indices) {
+        TT_FATAL(core_starting_indices.size() == ncores, "core starting indices size should match number of cores");
+        for (uint32_t core_i = 0; core_i < ncores; core_i++) {
+            const uint32_t core_x_i = core_i % rectangular_x;
+            const uint32_t core_y_i = core_i / rectangular_x;
+            const CoreRange core(CoreCoord(core_x_i, core_y_i), CoreCoord(core_x_i, core_y_i));
+
+            const uint32_t start_index = core_starting_indices[core_i];
+            const uint32_t start_mod_batch = start_index % (in_w_padded * in_h_padded);
+            const uint32_t start_row = start_mod_batch / in_w_padded;
+            const uint32_t start_col = start_mod_batch % in_w_padded;
+
+            std::vector<uint32_t> args = {(uint32_t)(start_row), (uint32_t)(start_col)};
+            SetRuntimeArgs(program, reader0_kernel, core, args);
+            SetRuntimeArgs(program, compute_kernel, core, args);
+        }
+    }
+
     auto temporary_size = calculate_total_cb_size(program);
 
     uint32_t post_allocate_size =
-        inputs[0].device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
     uint32_t l1_usage = calculate_L1_usage(
-        inputs[0],
+        input,
         in_c,
         pad_h,
         pad_w,
@@ -670,7 +743,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         kernel_w,
         out_h,
         out_w,
-        inputs[0].memory_config(),
+        input.memory_config(),
         outputs[0].memory_config(),
         pool_type,
         count_include_pad,
@@ -726,7 +799,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "split_reader: {}", params.split_reader);
         log_debug(tt::LogOp, "multi_buffering_factor: {}", params.multi_buffering_factor);
         log_debug(tt::LogOp, "is_wide_reduction: {}", params.is_wide_reduction);
-        log_debug(tt::LogOp, "is_in_sharded: {}", inputs[0].memory_config().is_sharded());
+        log_debug(tt::LogOp, "is_in_sharded: {}", input.memory_config().is_sharded());
         log_debug(tt::LogOp, "is_out_sharded: {}", outputs[0].memory_config().is_sharded());
     }
 
@@ -737,7 +810,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
          .reader1_kernel = reader1_kernel,
          .compute_kernel = compute_kernel,
          .raw_in_cb = raw_in_cb,
-         .raw_in_idx_cb = raw_in_idx_cb,
          .out_cb = out_cb,
          .out_idx_cb = out_idx_cb,
          .ncores = ncores,
@@ -747,7 +819,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
 Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     const operation_attributes_t& op_attr, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
-    const auto& input = tensor_args.input_tensors_[0];
+    const auto& input = tensor_args.input_tensor_;
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     const auto& pool_type = op_attr.pool_type_;
     const auto& out_mem_config = op_attr.memory_config_;
@@ -796,6 +868,14 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
     std::vector<std::vector<uint16_t>> top_left_indices =
         sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, stride_w);
+    std::vector<uint16_t> core_starting_indices;
+    if (return_indices) {
+        const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+        const uint32_t ncores = input.shard_spec().value().grid.num_cores();
+        const TensorMemoryLayout shard_scheme = input.memory_config().memory_layout();
+        core_starting_indices =
+            generate_core_starting_indices(op_trace_metadata, shard_boundaries, shard_scheme, num_cores_x, ncores);
+    }
 
     Tensor reader_indices = sliding_window::construct_on_host_config_tensor(top_left_indices, parallel_config);
     Tensor reader_indices_on_device =
@@ -803,7 +883,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
 
     return pool2d_multi_core_sharded_with_halo_v2_impl_new(
         program,
-        tensor_args.input_tensors_,
+        tensor_args.input_tensor_,
         reader_indices_on_device,
         top_left_indices[0].size(),
         output_tensors,
@@ -827,6 +907,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         ceil_pad_w,
         ceil_mode,
         return_indices,
+        core_starting_indices,
         count_include_pad,
         dilation_h,
         dilation_w,
@@ -847,7 +928,7 @@ void Pool2D::MultiCore::override_runtime_arguments(
     auto& raw_in_cb = cached_program.shared_variables.raw_in_cb;
     auto& out_cb = cached_program.shared_variables.out_cb;
 
-    const auto& input_tensor = tensor_args.input_tensors_[0];
+    const auto& input_tensor = tensor_args.input_tensor_;
     auto src_buffer = input_tensor.buffer();
     auto dst_buffer = output_tensors[0].buffer();
 
@@ -861,17 +942,8 @@ void Pool2D::MultiCore::override_runtime_arguments(
     }
 
     if (operation_attributes.return_indices_) {
-        TT_FATAL(tensor_args.input_tensors_.size() == 2, "Index tensor is required when return_indices is true");
-        auto& raw_in_idx_cb = cached_program.shared_variables.raw_in_idx_cb;
         auto& out_idx_cb = cached_program.shared_variables.out_cb;
-
-        const auto& index_tensor = tensor_args.input_tensors_[1];
-        auto src_idx_buffer = index_tensor.buffer();
         auto dst_idx_buffer = output_tensors.size() > 1 ? output_tensors[1].buffer() : nullptr;
-
-        if (input_sharded) {
-            UpdateDynamicCircularBufferAddress(program, raw_in_idx_cb, *src_idx_buffer);
-        }
         if (out_sharded && dst_idx_buffer) {
             UpdateDynamicCircularBufferAddress(program, out_idx_cb, *dst_idx_buffer);
         }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -18,7 +18,7 @@ Pool2D::program_factory_t Pool2D::select_program_factory(const operation_attribu
 }
 
 void validate_pool2d(
-    const std::vector<Tensor>& input_tensors,
+    const Tensor& input,
     const Pool2DType pool_type,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     const MemoryConfig& out_mem_config,
@@ -26,7 +26,6 @@ void validate_pool2d(
     const bool return_indices,
     const Layout& output_layout) {
     // check the input tensor
-    const Tensor& input = input_tensors[0];
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input.buffer() != nullptr, "Operands to reshape need to be allocated in buffers on device!");
     TT_FATAL(input.dtype() == DataType::BFLOAT16, "Only BFLOAT16 supported for now");
@@ -35,23 +34,7 @@ void validate_pool2d(
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
 
     if (return_indices) {
-        // check the index tensor
-        TT_FATAL(input_tensors.size() == 2, "Indices tensor must be provided if return_indices is true");
-        const auto& index = input_tensors[1];
-        TT_FATAL(index.storage_type() == StorageType::DEVICE, "Indices tensor to pool needs to be on device!");
-        TT_FATAL(index.buffer() != nullptr, "Indices tensor to pool needs to be allocated in buffers on device!");
-        TT_FATAL(index.dtype() == DataType::UINT16, "Only UINT16 supported for indices tensor");
-        TT_FATAL(
-            index.layout() == Layout::ROW_MAJOR,
-            "Only ROW_MAJOR supported for indices tensor. Tracked by issue #23338");
-        TT_FATAL(index.memory_config().is_sharded(), "Indices tensor needs to be sharded");
-        TT_FATAL(
-            index.logical_shape() == input.logical_shape() && index.padded_shape() == input.padded_shape(),
-            "Indices tensor shape ({}, {}) must match input tensor shape ({}, {})",
-            index.logical_shape(),
-            index.padded_shape(),
-            input.logical_shape(),
-            input.padded_shape());
+        TT_FATAL(pool_type == Pool2DType::MAX_POOL2D, "Return_indices is only supported for MAX pool type");
 
         // generality constraints, see https://github.com/tenstorrent/tt-metal/issues/27845
         auto input_h = sliding_window_config.input_hw.first;
@@ -88,9 +71,9 @@ void validate_pool2d(
     }
 }
 
-void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
+void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
     validate_pool2d(
-        tensors.input_tensors_,
+        tensor.input_tensor_,
         op_attr.pool_type_,
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
@@ -99,9 +82,9 @@ void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_att
         op_attr.output_layout_);
 }
 
-void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
+void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
     validate_pool2d(
-        tensors.input_tensors_,
+        tensor.input_tensor_,
         op_attr.pool_type_,
         op_attr.sliding_window_config_,
         op_attr.memory_config_,
@@ -111,7 +94,7 @@ void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr
 }
 
 Pool2D::spec_return_value_t Pool2D::compute_output_specs(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
     auto& sliding_window_config = op_attr.sliding_window_config_;
     auto& out_mem_config = op_attr.memory_config_;
     auto& output_dtype = op_attr.output_dtype_;
@@ -156,8 +139,8 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 }
 
 Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto output_spec_data = compute_output_specs(op_attr, tensors);
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    auto output_spec_data = compute_output_specs(op_attr, tensor);
     if (op_attr.return_indices_) {
         // the index output spec is the same as the input spec just with a different data type
         tt::tt_metal::TensorLayout output_layout_ind(
@@ -167,17 +150,16 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
             output_spec_data.tensor_layout().get_alignment());
         auto output_spec_ind = TensorSpec(output_spec_data.logical_shape(), output_layout_ind);
         return {
-            create_device_tensor(output_spec_data, tensors.input_tensors_[0].device()),
-            create_device_tensor(output_spec_ind, tensors.input_tensors_[0].device())};
+            create_device_tensor(output_spec_data, tensor.input_tensor_.device()),
+            create_device_tensor(output_spec_ind, tensor.input_tensor_.device())};
     } else {
-        return {create_device_tensor(output_spec_data, tensors.input_tensors_[0].device())};
+        return {create_device_tensor(output_spec_data, tensor.input_tensor_.device())};
     }
 }
 
-tt::stl::hash::hash_t Pool2D::compute_program_hash(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto input_mem_config = tensors.input_tensors_[0].memory_config();
-    auto in_dtype = tensors.input_tensors_[0].dtype();
+tt::stl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op_attr, const tensor_args_t& tensor) {
+    auto input_mem_config = tensor.input_tensor_.memory_config();
+    auto in_dtype = tensor.input_tensor_.dtype();
     auto out_dtype = op_attr.output_dtype_;
     return tt::tt_metal::operation::hash_operation<Pool2D>(
         op_attr.sliding_window_config_.get_hash(),
@@ -192,8 +174,8 @@ tt::stl::hash::hash_t Pool2D::compute_program_hash(
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
-    const operation_attributes_t& op_attr, const tensor_args_t& inputs, const tensor_return_value_t& outputs) {
-    const auto& input = inputs.input_tensors_[0];
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor, const tensor_return_value_t& outputs) {
+    const auto& input = tensor.input_tensor_;
     const auto& input_shape = input.logical_shape();
     auto sliding_window_config = op_attr.sliding_window_config_;
     uint32_t batch_size = sliding_window_config.batch_size;
@@ -229,7 +211,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t
 }
 
 std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke(
-    const std::vector<Tensor>& input_tensors,
+    const Tensor& input_tensor,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     Pool2DType pool_type,
     DataType output_dtype,
@@ -252,7 +234,7 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
             .divisor_override_ = divisor_override,
             .return_indices_ = return_indices,
             .memory_used = memory_used},
-        tensor_args_t{input_tensors}};
+        tensor_args_t{input_tensor}};
 }
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -36,7 +36,7 @@ struct Pool2D {
     };
 
     struct tensor_args_t {
-        const std::vector<Tensor>& input_tensors_;
+        const Tensor& input_tensor_;
     };
 
     using spec_return_value_t = TensorSpec;
@@ -48,7 +48,6 @@ struct Pool2D {
             tt::tt_metal::KernelHandle reader1_kernel{};
             tt::tt_metal::KernelHandle compute_kernel{};
             tt::tt_metal::CBHandle raw_in_cb{};
-            tt::tt_metal::CBHandle raw_in_idx_cb{};
             tt::tt_metal::CBHandle out_cb{};
             tt::tt_metal::CBHandle out_idx_cb{};
             uint32_t ncores{};
@@ -81,7 +80,7 @@ struct Pool2D {
         const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::vector<Tensor>& input_tensors,
+        const Tensor& input_tensor,
         const sliding_window::SlidingWindowConfig& sliding_window_config,
         Pool2DType pool_type,
         DataType output_dtype,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_program_factory.cpp
@@ -279,19 +279,28 @@ tt::tt_metal::operation::ProgramWithCallbacks grid_sample_program_factory(
             MAX_ROWS_FOR_REDUCTION,            // ct_arg[6]: MAX_ROWS_FOR_REDUCTION
             input_cb_index_0,                  // ct_arg[7]: input_cb_index_0
             input_cb_index_1,                  // ct_arg[8]: input_cb_index_1
-            DUMMY_CB_ID,                       // ct_arg[9]: unused
-            DUMMY_CB_ID,                       // ct_arg[10]: unused
-            scalar_cb_index_0,                 // ct_arg[11]: scalar_cb_index_0
-            scalar_cb_index_1,                 // ct_arg[12]: scalar_cb_index_1
+            scalar_cb_index_0,                 // ct_arg[9]: scalar_cb_index_0
+            scalar_cb_index_1,                 // ct_arg[10]: scalar_cb_index_1
+            DUMMY_CB_ID,                       // ct_arg[11]: unused
+            DUMMY_CB_ID,                       // ct_arg[12]: unused
             DUMMY_CB_ID,                       // ct_arg[13]: unused
             DUMMY_CB_ID,                       // ct_arg[14]: unused
-            output_cb_index,                   // ct_arg[15]: output_cb_index
+            DUMMY_CB_ID,                       // ct_arg[15]: unused
             DUMMY_CB_ID,                       // ct_arg[16]: unused
-            ONE_SCALAR_PER_CORE,               // ct_arg[17]: ONE_SCALAR_PER_CORE
-            false,                             // ct_arg[18]: unused
-            pre_tilize_cb_id,                  // ct_arg[19]: pre_tilize_cb_id
-            is_output_tiled ? 1U : 0U,         // ct_arg[20]: is_output_tiled
-            is_output_block_format ? 1U : 0U,  // ct_arg[21]: is_output_block_format
+            output_cb_index,                   // ct_arg[17]: output_cb_index
+            DUMMY_CB_ID,                       // ct_arg[18]: unused
+            ONE_SCALAR_PER_CORE,               // ct_arg[19]: ONE_SCALAR_PER_CORE
+            pre_tilize_cb_id,                  // ct_arg[20]: pre_tilize_cb_id
+            is_output_tiled ? 1U : 0U,         // ct_arg[21]: is_output_tiled
+            is_output_block_format ? 1U : 0U,  // ct_arg[22]: is_output_block_format
+            false,                             // ct_arg[23]: return_indices (unused)
+            1,                                 // ct_arg[24]: stride_h (unused)
+            1,                                 // ct_arg[25]: stride_w (unused)
+            1,                                 // ct_arg[26]: in_h_padded (unused)
+            1,                                 // ct_arg[27]: in_w_padded (unused)
+            1,                                 // ct_arg[28]: eff_kernel_h (unused)
+            1,                                 // ct_arg[29]: eff_kernel_w (unused)
+            1,                                 // ct_arg[30]: pad_l (unused)
         };
 
         return tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -118,6 +118,7 @@ FactoryParameters get_factory_parameters(
     const Layout& output_layout) {
     uint32_t multi_buffering_factor = 2;
     bool split_reader = true;
+    TT_FATAL((split_reader && return_indices) || !return_indices, "split_reader must be true for MPWI");
 
     auto dtype = input_dtype == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_dtype;
     tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
@@ -251,21 +252,15 @@ uint32_t calculate_L1_usage(
         in_cb_config_1_size = in_cb_npages * in_cb_pagesize;
     }
 
-    uint32_t in_idx_cb_config_0_size = 0;
-    uint32_t in_idx_cb_config_1_size = 0;
-    uint32_t tile_tmp_cb_size = 0;
-    uint32_t tile_idx_tmp_cb_size = 0;
+    uint32_t total_mpwi_cb_size = 0;
     if (return_indices) {
-        uint32_t in_idx_cb_pagesize = params.index_nbytes * in_cb_page_padded;
-        in_idx_cb_config_0_size = in_cb_npages * in_idx_cb_pagesize;
-        if (params.split_reader) {
-            in_idx_cb_config_1_size = in_cb_npages * in_idx_cb_pagesize;
-        }
-
         // Add tile temporary CBs for return_indices
         uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        tile_tmp_cb_size = params.nbytes * tile_elems * 1;            // 1 page
-        tile_idx_tmp_cb_size = params.index_nbytes * tile_elems * 1;  // 1 page
+        uint32_t idx_tile_size = params.index_nbytes * tile_elems * 1;  // 1 page
+        uint32_t data_tile_size = params.nbytes * tile_elems * 1;       // 1 page
+        // 1 data sized tile (pack_tmp_cb) and 5 index sized tiles (in_idx, pack_idx_tmp, right_inc, down_left_wrap_inc,
+        // up_left_wrap_inc)
+        total_mpwi_cb_size = (5 * idx_tile_size) + data_tile_size;
     }
 
     uint32_t out_cb_pagesize;
@@ -301,8 +296,7 @@ uint32_t calculate_L1_usage(
     }
 
     return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           in_idx_cb_config_0_size + in_idx_cb_config_1_size + tile_tmp_cb_size + tile_idx_tmp_cb_size +
-           pre_tilize_cb_size + sliding_window::align_buffer(out_cb_config_size) +
+           total_mpwi_cb_size + pre_tilize_cb_size + sliding_window::align_buffer(out_cb_config_size) +
            sliding_window::align_buffer(out_idx_cb_config_size);
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27845 (#5)

### Problem description
The initial implementation of MPWI included creation of an index input tensor which needed to be passed through the entire processing chain along side the data input tensor. This was very non-performant. Additionally, MPWI worked on tilized data which required expensive re-initializations of LLK functions in a loop.

### What's changed
The index input tensor has been eliminated. Instead, the reader populates a CB with the initial indexes as well as three other CBs with right, down left wrap, and up left wrap increments. For each kernel position the compute kernel simply increments the indexes by the required amount. Additionally MPWI has been updated to operate on row major data eliminating the need for the tilize/untilize steps and associated re-initializations. This improves the perf of the max pool kernel, but this gain is offset by the new overhead of generating indexes on the fly.

### Perf Comparison
| Micro Op | Main (us) | This PR (us) |
| :------- | :------: | -------: |
| Repeat | 196 | 0 |
| I2S | 521 | 0 |
| Idx Halo | 2 | 0 |
| Data Halo | 7 | 7 |
| Pool2D | 433 | 699 |
| -- | | |
| **Total:** | **1159** | **706** |
| **Relative:** | **100%** | **60.9%** |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852351875
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852356665
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18858443164
Failing on main, this PR hits same unrelated error
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852397005
Failing on main, this PR hits same unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852364772
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852388116
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18852409894
Failing on main, this PR hits same unrelated error
- [x] New/Existing tests provide coverage for changes