### PR TITLE
#29061: Add additional verification for Fabric 2D Dynamic CCLs

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1537,6 +1537,22 @@ std::vector<Shape4D<uint32_t>> GenericWrappedTensorSlicerV2::create_worker_slice
     return worker_slice_shapes;
 }
 
+void validate_fabric_2d_dynamic_config(Topology topology) {
+    TT_FATAL(topology != Topology::Ring, "Fabric 2D dynamic is not supported for ring topology");
+    auto physical_mesh_shapes = tt::tt_fabric::get_physical_mesh_shapes();
+    TT_FATAL(
+        physical_mesh_shapes.size() == 1,
+        "Fabric 2D dynamic CCLs expected a single Physical Mesh to be instantiated, but got {} meshes",
+        physical_mesh_shapes.size());
+    const auto& physical_mesh_shape = physical_mesh_shapes.begin()->second;
+    TT_FATAL(
+        physical_mesh_shape.dims() == 2,
+        "Fabric 2D dynamic CCLs are not supported for mesh shape with more than 2 dimensions");
+    TT_FATAL(
+        physical_mesh_shape[0] == 1 || physical_mesh_shape[1] == 1,
+        "Fabric 2D dynamic CCLs are only supported for 1D physical meshes");
+}
+
 std::tuple<size_t, size_t, bool> get_forward_backward_configuration(
     size_t ring_size, size_t ring_index, Topology topology) {
     // Used for experimentation for optimal perf
@@ -1577,7 +1593,7 @@ std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_forward_backwar
 
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
     if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC) {
-        TT_FATAL(topology != Topology::Ring, "Fabric 2D dynamic is not supported for ring topology");
+        validate_fabric_2d_dynamic_config(topology);
         if (forward_device) {
             auto forward_device_fabric_node_id =
                 tt::tt_fabric::get_fabric_node_id_from_physical_chip_id((*forward_device)->id());
@@ -1640,7 +1656,7 @@ std::tuple<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_forward_backwar
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
 
     if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC) {
-        TT_FATAL(topology != Topology::Ring, "Fabric 2D dynamic is not supported for ring topology");
+        validate_fabric_2d_dynamic_config(topology);
         auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(src_device->id());
         auto set_mcast_args = [&src_fabric_node_id](std::array<uint32_t, 6>& args, std::optional<IDevice*> device, uint32_t num_targets) {
             if (device) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29061

### Problem description
- CCLs supporting Fabric 2D Dynamic are missing asserts constraining the Physical Mesh Shape (Fabric must be initialized as a 1D Mesh)
- This leads to workloads hanging without a clear error message 

### What's changed
- Add asserts to helper APIs used by CCLs enabled for 2D Dynamic

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes