### PR TITLE
Take `unpack_to_dest_mode` into account when computing for Kernel hash.

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -173,15 +173,19 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     auto kernel_handle_fp32 = CreateKernel(program_fp32, kernel_file, CoreCoord(0, 0), config_fp32);
 
     // Get the kernels from programs
-    const auto& kernels_default = program_default.impl().get_kernel(kernel_handle_default);
-    const auto& kernels_fp32 = program_default.impl().get_kernel(kernel_handle_fp32);
+    const auto& kernels_default =
+        program_default.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
+    const auto& kernels_fp32 = program_fp32.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
 
     // Direct hash comparison - this tests the actual Kernel::compute_hash() method
-    auto hash_default = kernels_default->compute_hash();
-    auto hash_fp32 = kernels_fp32->compute_hash();
+    auto hash_default = kernels_default.at(kernel_handle_default)->compute_hash();
+    auto hash_fp32 = kernels_fp32.at(kernel_handle_fp32)->compute_hash();
 
     // The hashes should be different across two kernels due to the difference in unpack_to_dest_mode
-    EXPECT_NE(hash_default, hash_fp32) << "unpack_to_dest_mode is not accounted for in computing kernel hash.";
+    EXPECT_NE(hash_default, hash_fp32)
+        << "Kernels with different unpack_to_dest_mode should have different compute hashes. "
+        << "hash_default: " << hash_default << ", hash_fp32: " << hash_fp32 << ". "
+        << "If this test fails, it indicates that unpack_to_dest_mode is missing from ComputeKernel::config_hash()";
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -12,6 +12,8 @@
 #include <variant>
 #include <vector>
 
+#include "base_types.hpp"
+#include "circular_buffer_constants.h"
 #include "compile_program_with_kernel_path_env_var_fixture.hpp"
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -160,7 +162,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
 
     // Create specially configured unpack_to_dest_mode
     ComputeConfig config_fp32(config_default);
-    config_fp32.unpack_to_dest_mode[0] = UnpackToDestMode::UnpackToDestFp32;  // Change CB 0 to FP32 mode
+    config_fp32.unpack_to_dest_mode.push_back(UnpackToDestMode::UnpackToDestFp32);  // Change CB 0 to FP32 mode
 
     // Create programs (needed for kernel creation context)
     auto program_default = CreateProgram();

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -173,13 +173,12 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     auto kernel_handle_fp32 = CreateKernel(program_fp32, kernel_file, CoreCoord(0, 0), config_fp32);
 
     // Get the kernels from programs
-    const auto& kernels_default =
-        program_default.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-    const auto& kernels_fp32 = program_fp32.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
+    auto kernel_default = program_default.impl().get_kernel(kernel_handle_default);
+    auto kernel_fp32 = program_fp32.impl().get_kernel(kernel_handle_fp32);
 
     // Direct hash comparison - this tests the actual Kernel::compute_hash() method
-    auto hash_default = kernels_default.at(kernel_handle_default)->compute_hash();
-    auto hash_fp32 = kernels_fp32.at(kernel_handle_fp32)->compute_hash();
+    auto hash_default = kernel_default->compute_hash();
+    auto hash_fp32 = kernel_fp32->compute_hash();
 
     // The hashes should be different across two kernels due to the difference in unpack_to_dest_mode
     EXPECT_NE(hash_default, hash_fp32)

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -179,7 +179,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     auto hash_default = kernels_default.at(kernel_handle_default)->compute_hash();
     auto hash_fp32 = kernels_fp32.at(kernel_handle_fp32)->compute_hash();
 
-    // BUG: These should be different but will be the same due to missing unpack_to_dest_mode in config_hash()
+    // The hashes should be different across two kernels due to the difference in unpack_to_dest_mode
     EXPECT_NE(hash_default, hash_fp32)
         << "Kernels with different unpack_to_dest_mode should have different compute hashes. "
         << "hash_default: " << hash_default << ", hash_fp32: " << hash_fp32 << ". "

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -171,19 +171,15 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     auto kernel_handle_fp32 = CreateKernel(program_fp32, kernel_file, CoreCoord(0, 0), config_fp32);
 
     // Get the kernels from programs
-    const auto& kernels_default =
-        program_default.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-    const auto& kernels_fp32 = program_fp32.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
+    const auto& kernels_default = program_default.impl().get_kernel(kernel_handle_default);
+    const auto& kernels_fp32 = program_default.impl().get_kernel(kernel_handle_fp32);
 
     // Direct hash comparison - this tests the actual Kernel::compute_hash() method
-    auto hash_default = kernels_default.at(kernel_handle_default)->compute_hash();
-    auto hash_fp32 = kernels_fp32.at(kernel_handle_fp32)->compute_hash();
+    auto hash_default = kernels_default->compute_hash();
+    auto hash_fp32 = kernels_fp32->compute_hash();
 
     // The hashes should be different across two kernels due to the difference in unpack_to_dest_mode
-    EXPECT_NE(hash_default, hash_fp32)
-        << "Kernels with different unpack_to_dest_mode should have different compute hashes. "
-        << "hash_default: " << hash_default << ", hash_fp32: " << hash_fp32 << ". "
-        << "If this test fails, it indicates that unpack_to_dest_mode is missing from ComputeKernel::config_hash()";
+    EXPECT_NE(hash_default, hash_fp32) << "unpack_to_dest_mode is not accounted for in computing kernel hash.";
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -23,6 +23,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/kernels/kernel_impl.hpp"
 #include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "base_types.hpp"
-#include "circular_buffer_constants.h"
 #include "compile_program_with_kernel_path_env_var_fixture.hpp"
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -24,7 +23,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "impl/kernels/kernel_impl.hpp"
 #include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
@@ -182,9 +180,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
 
     // The hashes should be different across two kernels due to the difference in unpack_to_dest_mode
     EXPECT_NE(hash_default, hash_fp32)
-        << "Kernels with different unpack_to_dest_mode should have different compute hashes. "
-        << "hash_default: " << hash_default << ", hash_fp32: " << hash_fp32 << ". "
-        << "If this test fails, it indicates that unpack_to_dest_mode is missing from ComputeKernel::config_hash()";
+        << "unpack_to_dest_mode is not accounted for in computing ComputeKernel::config_hash()";
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -159,9 +159,8 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     ComputeConfig config_default;
 
     // Create specially configured unpack_to_dest_mode
-    std::vector<UnpackToDestMode> unpack_mode_fp32(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    unpack_mode_fp32[0] = UnpackToDestMode::UnpackToDestFp32;  // Change CB 0 to FP32 mode
-    ComputeConfig config_fp32 = {.unpack_to_dest_mode = unpack_mode_fp32};
+    ComputeConfig config_fp32(config_default);
+    config_fp32.unpack_to_dest_mode[0] = UnpackToDestMode::UnpackToDestFp32;  // Change CB 0 to FP32 mode
 
     // Create programs (needed for kernel creation context)
     auto program_default = CreateProgram();
@@ -172,7 +171,8 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixTestDifferentUnpackToDes
     auto kernel_handle_fp32 = CreateKernel(program_fp32, kernel_file, CoreCoord(0, 0), config_fp32);
 
     // Get the kernels from programs
-    const auto& kernels_default = program_default.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
+    const auto& kernels_default =
+        program_default.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
     const auto& kernels_fp32 = program_fp32.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
 
     // Direct hash comparison - this tests the actual Kernel::compute_hash() method

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
 
 namespace tt::tt_metal {
 
@@ -77,7 +78,9 @@ struct ComputeConfig {
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     bool fp32_dest_acc_en = false;
     bool dst_full_sync_en = false;
-    std::vector<UnpackToDestMode> unpack_to_dest_mode;
+    // This should be a std::array<UnpackToDestMode, NUM_CIRCULAR_BUFFERS>
+    std::vector<UnpackToDestMode> unpack_to_dest_mode =
+        std::vector<UnpackToDestMode>(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     bool bfp8_pack_precise = false;
     bool math_approx_mode = false;
     std::vector<uint32_t> compile_args;

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/circular_buffer_constants.h>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -78,9 +78,7 @@ struct ComputeConfig {
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     bool fp32_dest_acc_en = false;
     bool dst_full_sync_en = false;
-    // This should be a std::array<UnpackToDestMode, NUM_CIRCULAR_BUFFERS>
-    std::vector<UnpackToDestMode> unpack_to_dest_mode =
-        std::vector<UnpackToDestMode>(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode;
     bool bfp8_pack_precise = false;
     bool math_approx_mode = false;
     std::vector<uint32_t> compile_args;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include <tt_stl/assert.hpp>
+#include "base_types.hpp"
 #include "data_types.hpp"
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"
@@ -320,13 +321,23 @@ std::string EthernetKernel::config_hash() const {
 }
 
 std::string ComputeKernel::config_hash() const {
+    // This handles config hashing for unpack_to_dest_mode which can be:
+    // 1. Having specific configuration (e.g. some CBs are set to UnpackToDestFp32)
+    // 2. Having explicit default configuration (vector full of Default)
+    // 3. Having implicit default configuration (vector empty)
+    std::string unpack_mode_descriptor = "default";
+    const auto& unpack_modes = this->config_.unpack_to_dest_mode;
+    if (std::ranges::any_of(this->config_.unpack_to_dest_mode, [](auto v) { return v != UnpackToDestMode::Default; })) {
+        unpack_mode_descriptor = fmt::format("{}", fmt::join(unpack_modes, "."));
+    }
+
     return fmt::format(
         "{}_{}_{}_{}_{}",
         enchantum::to_string(this->config_.math_fidelity),
         this->config_.fp32_dest_acc_en,
         this->config_.math_approx_mode,
         this->config_.dst_full_sync_en,
-        fmt::join(this->config_.unpack_to_dest_mode, "."));
+        unpack_mode_descriptor);
 }
 
 std::string Kernel::compute_hash() const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -321,11 +321,12 @@ std::string EthernetKernel::config_hash() const {
 
 std::string ComputeKernel::config_hash() const {
     return fmt::format(
-        "{}_{}_{}_{}",
+        "{}_{}_{}_{}_{}",
         enchantum::to_string(this->config_.math_fidelity),
         this->config_.fp32_dest_acc_en,
         this->config_.math_approx_mode,
-        this->config_.dst_full_sync_en);
+        this->config_.dst_full_sync_en,
+        fmt::join(this->config_.unpack_to_dest_mode, "."));
 }
 
 std::string Kernel::compute_hash() const {


### PR DESCRIPTION
### Ticket
Closes #22373 

### Problem description
Current kernel hashing does not take into account `unpack_to_dest_mode`, which causes incorrect caching behavior.

### What's changed
Accounted in `unpack_to_dest_mode` in `ComputeKernel::config_hash` also added a new test case that verifies implementation.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18023913141)
- [x] New/Existing tests provide coverage for changes