### PR TITLE
Remove all usages of logical sharding from the codebase

### DIFF
--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -202,6 +202,7 @@ void py_module(py::module& module) {
             tensor (ttnn.Tensor): the input tensor to be converted.
             memory_config (ttnn.MemoryConfig): the desired memory configuration for the tensor.
             dtype (ttnn.DataType, optional): the optional `ttnn` data type. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): the optional output tensor. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the converted tensor.
@@ -212,7 +213,11 @@ void py_module(py::module& module) {
             >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
             >>> tensor = ttnn.to_memory_config(tensor, memory_config)
         )doc",
-        ttnn::pybind_arguments_t{py::arg("tensor"), py::arg("memory_config"), py::arg("dtype") = std::nullopt});
+        ttnn::pybind_arguments_t{
+            py::arg("tensor"),
+            py::arg("memory_config"),
+            py::arg("dtype") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -756,8 +756,8 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 ttnn::MemoryConfig input_tensor_sharded_memory_config_to_layout = input_tensor_sharded_memory_config;
                 tt::tt_metal::Alignment alignment = {};
                 if (!input_tensor.is_sharded()) {
-                    // In case we need to run Interleaved2Sharded switch fron physical sharding
-                    // to logical sharding, in order to get smaller allocation size of sharded buffer.
+                    // In case we need to run Interleaved2Sharded, adjust the shard spec,
+                    // in order to get smaller allocation size of sharded buffer.
                     const auto& shard_spec = input_tensor_sharded_memory_config.shard_spec().value();
                     input_tensor_sharded_memory_config_to_layout =
                         input_tensor_sharded_memory_config_to_layout.with_shard_spec(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -754,18 +754,27 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
             }
             if (!auto_shard_mm) {
                 ttnn::MemoryConfig input_tensor_sharded_memory_config_to_layout = input_tensor_sharded_memory_config;
+                tt::tt_metal::Alignment alignment = {};
                 if (!input_tensor.is_sharded()) {
                     // In case we need to run Interleaved2Sharded switch fron physical sharding
                     // to logical sharding, in order to get smaller allocation size of sharded buffer.
+                    const auto& shard_spec = input_tensor_sharded_memory_config.shard_spec().value();
                     input_tensor_sharded_memory_config_to_layout =
-                        input_tensor_sharded_memory_config_to_layout.with_shard_spec(tt::tt_metal::ShardSpec(
-                            input_tensor_sharded_memory_config.shard_spec().value().grid,
-                            input_tensor_sharded_memory_config.shard_spec().value().shape,
-                            input_tensor_sharded_memory_config.shard_spec().value().shape,
-                            input_tensor_sharded_memory_config.shard_spec().value().orientation));
+                        input_tensor_sharded_memory_config_to_layout.with_shard_spec(
+                            tt::tt_metal::ShardSpec(shard_spec.grid, shard_spec.shape, shard_spec.orientation));
+                    alignment = tt::tt_metal::Alignment{shard_spec.shape[0], shard_spec.shape[1]};
                 }
-                Tensor resharded_input_tensor =
-                    ttnn::to_memory_config(input_tensor, input_tensor_sharded_memory_config_to_layout, std::nullopt);
+                Tensor resharded_input_tensor = tt::tt_metal::create_device_tensor(
+                    TensorSpec(
+                        input_tensor.logical_shape(),
+                        tt::tt_metal::TensorLayout(
+                            input_tensor.dtype(),
+                            tt::tt_metal::PageConfig(input_tensor.layout()),
+                            input_tensor_sharded_memory_config_to_layout,
+                            alignment)),
+                    input_tensor.device());
+                ttnn::to_memory_config(
+                    input_tensor, input_tensor_sharded_memory_config_to_layout, std::nullopt, resharded_input_tensor);
                 if (conv_config.deallocate_activation) {
                     input_tensor.deallocate(/*force*/ true);
                     resharded_input_tensor = ttnn::move(resharded_input_tensor);

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -26,12 +26,18 @@ struct ToMemoryConfig {
     static Tensor invoke(
         const ttnn::Tensor& tensor,
         const ttnn::MemoryConfig& memory_config,
-        std::optional<ttnn::DataType> dtype = std::nullopt) {
+        std::optional<ttnn::DataType> dtype = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt) {
         using namespace tt::tt_metal;
         // Temporary until we see why buffer data not being populated
         const auto original_memory_config = ttnn::get_memory_config(tensor);
-        if (original_memory_config.has_value() && original_memory_config.value() == memory_config) {
+        if (original_memory_config.has_value() && original_memory_config.value() == memory_config &&
+            !output_tensor.has_value()) {
             return tensor;
+        }
+        std::vector<std::optional<Tensor>> optional_output_tensors;
+        if (output_tensor.has_value()) {
+            optional_output_tensors.push_back(output_tensor);
         }
 
         if (memory_config.is_sharded()) {
@@ -57,7 +63,7 @@ struct ToMemoryConfig {
                                },
                                {tensor},
                                {},
-                               {std::nullopt})
+                               optional_output_tensors)
                         .at(0);
                 } else {
                     // for row-major tensors where shard-spec[1] is different for input shard and output shard
@@ -72,7 +78,9 @@ struct ToMemoryConfig {
                     return tt::tt_metal::operation::run(
                                data_movement::InterleavedToShardedDeviceOperation{
                                    .output_mem_config = memory_config, .output_dtype = dtype.value_or(temp.dtype())},
-                               {temp})
+                               {temp},
+                               {},
+                               optional_output_tensors)
                         .at(0);
                 }
             } else {
@@ -81,7 +89,9 @@ struct ToMemoryConfig {
                 return tt::tt_metal::operation::run(
                            data_movement::InterleavedToShardedDeviceOperation{
                                .output_mem_config = memory_config, .output_dtype = dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             }
         } else {
@@ -90,14 +100,18 @@ struct ToMemoryConfig {
                 return tt::tt_metal::operation::run(
                            data_movement::ShardedToInterleavedDeviceOperation{
                                .output_mem_config = memory_config, .output_dtype = dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             } else {
                 // L1 to DRAM or DRAM to L1
                 return tt::tt_metal::operation::run(
                            ttnn::operations::data_movement::CopyDeviceOperation{
                                memory_config, dtype.value_or(tensor.dtype())},
-                           {tensor})
+                           {tensor},
+                           {},
+                           optional_output_tensors)
                     .at(0);
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -30,7 +30,7 @@ bool can_deallocate(const Tensor& input_tensor) {
 
 static inline Tensor move(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    auto input_mem_config = input_tensor.memory_config();
+    const auto& input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -12,10 +12,20 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
-void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+void InterleavedToShardedDeviceOperation::validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
+
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        const auto& output_tensor = output_tensors[0].value();
+        TT_FATAL(output_tensor.logical_shape() == input_tensor.logical_shape(), "Mismatched output shape");
+        TT_FATAL(output_tensor.memory_config() == this->output_mem_config, "Mismatched output memory config");
+        TT_FATAL(output_tensor.dtype() == this->output_dtype, "Mismatched output dtype");
+        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
+        TT_FATAL(output_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
+        TT_FATAL(output_tensor.device() == input_tensor.device(), "Operands to shard need to be on the same device!");
+    }
 
     TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(this->output_mem_config.is_sharded(), "Error");
@@ -31,7 +41,10 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 
-std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_output_specs(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_output_specs(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0]->tensor_spec()};
+    }
     const auto& input_tensor = input_tensors.at(0);
     return {TensorSpec(input_tensor.logical_shape(), TensorLayout::fromPaddedShape(
         output_dtype,
@@ -39,6 +52,16 @@ std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_outpu
         output_mem_config,
         input_tensor.logical_shape(),
         input_tensor.padded_shape()))};
+}
+
+std::vector<Tensor> InterleavedToShardedDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+    const auto& input_tensor = input_tensors.at(0);
+    auto spec = compute_output_specs(input_tensors, output_tensors)[0];
+    return {create_device_tensor(spec, input_tensor.device())};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -15,8 +15,12 @@ struct InterleavedToShardedDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
     const bool keep_l1_aligned = false;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
@@ -12,13 +12,22 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
-void ShardedToInterleavedDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+void ShardedToInterleavedDeviceOperation::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto shard_spec = input_tensor.shard_spec().value();
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Input tensor must be sharded");
     TT_FATAL(input_tensor.memory_config().buffer_type() == BufferType::L1, "Input tensor must be in L1");
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        const auto& output_tensor = output_tensors[0].value();
+        TT_FATAL(output_tensor.memory_config() == this->output_mem_config, "Mismatched output memory config");
+        TT_FATAL(output_tensor.dtype() == this->output_dtype, "Mismatched output dtype");
+        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
+        TT_FATAL(output_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
+        TT_FATAL(output_tensor.device() == input_tensor.device(), "Operands to shard need to be on the same device!");
+    }
     TT_FATAL(
         this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Output memory config must be Interleaved");
@@ -35,7 +44,10 @@ void ShardedToInterleavedDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 std::vector<ttnn::TensorSpec> ShardedToInterleavedDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0]->tensor_spec()};
+    }
     const auto& input_tensor = input_tensors.at(0);
     return {TensorSpec(
         input_tensor.logical_shape(),
@@ -45,6 +57,16 @@ std::vector<ttnn::TensorSpec> ShardedToInterleavedDeviceOperation::compute_outpu
             output_mem_config,
             input_tensor.logical_shape(),
             input_tensor.padded_shape()))};
+}
+
+std::vector<Tensor> ShardedToInterleavedDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+    const auto& input_tensor = input_tensors.at(0);
+    auto spec = compute_output_specs(input_tensors, output_tensors)[0];
+    return {create_device_tensor(spec, input_tensor.device())};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
@@ -15,8 +15,12 @@ struct ShardedToInterleavedDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
     const bool is_l1_aligned = false;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(


### PR DESCRIPTION
### Ticket

### Problem description
We're removing support for Logical sharding from the codebase, starting from replacing the only 2 usages in convolutions. In those 2 cases logical sharding was abused, with the sole purpose of trying to add some extra padding to the tensor and preserve it.

### What's changed
Remove usages of logical sharding, converted it to physical.
Explicitly handled the required padding/alignment.
Added output tensor argument to `to_memory_config`, `interleaved_to_sharded`, `sharded_to_interleaved` allowing to manually preserve additional padding.
Fixed a bug in `ttnn::move`, which stripped out padding from a tensor while moving it.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17930672511)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/17930675102)
- [x] [Model regression CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17930677783)
- [x] [Single-card demo tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17930681120)
- [x] [Nightly L2 tests pass for conv and pool](https://github.com/tenstorrent/tt-metal/actions/runs/17930690681)
- [x] New/Existing tests provide coverage for changes
