### PR TITLE
padding error fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -2347,9 +2347,10 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
             pack_two_bfloat16_into_uint32({bfloat_winv_value_group_2, bfloat_winv_value_group_2});
     }
     float cinv = std::sqrt(
-        pad_correction_factor / num_cores_per_batch *
-        num_cores_per_group);  // bcast-cores scaler. Pad correction factor=(padded_size/logical_size) to account for
-                               // scaling error from padding.
+        pad_correction_factor /
+        (num_cores_per_batch *
+         num_cores_per_group));  // bcast-cores scaler. Pad correction factor=(padded_size/logical_size) to account for
+                                 // scaling error from padding.
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
     union {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -1954,6 +1954,11 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         eltwise_binary_defines["UNTILIZE_OUT"] = "1";
     }
     // compute kernel compile time args
+    float pad_correction_factor = shape[1] * shape[2] * (1.0 / (a.logical_shape()[1] * a.logical_shape()[2]));
+    union {
+        float f;
+        uint32_t u;
+    } one_minus_pad_correction_factor = {1.0 - pad_correction_factor};
     std::vector<uint32_t> mcast_sender_compute_compile_time_args_group_1 = {
         (std::uint32_t)1,
         (std::uint32_t)gamma.has_value(),
@@ -1961,18 +1966,14 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_cores_per_mcast_group,
         (std::uint32_t)num_batches_per_core_group_1,
         (std::uint32_t)num_groups_per_core,
-
         (std::uint32_t)block_ht_group_1,
         (std::uint32_t)block_wt,
         (std::uint32_t)block_ht_group_1 * block_wt,
-
         (std::uint32_t)subblock_wt,
         (std::uint32_t)num_subblocks_w,
-
         (std::uint32_t)per_core_Mt_group_1,
         (std::uint32_t)per_core_Nt,
         (std::uint32_t)per_core_Mt_group_1 * per_core_Nt,
-
         (std::uint32_t)per_core_Nt * TILE_HW * datum_size_bytes,  // per_core_N_tile_bytes
         (std::uint32_t)num_groups_per_reset,
         (std::uint32_t)single_tile_size,
@@ -1986,8 +1987,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_out_blocks,
         (std::uint32_t)num_channels_per_group,
         (std::uint32_t)num_rows_per_batch_per_core_group_1,
-
-        (std::uint32_t)num_reciprocals};
+        (std::uint32_t)num_reciprocals,
+        (std::uint32_t)one_minus_pad_correction_factor.u};
     std::vector<uint32_t> mcast_sender_compute_compile_time_args_group_2 = {
         (std::uint32_t)1,
         (std::uint32_t)gamma.has_value(),
@@ -1995,18 +1996,14 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_cores_per_mcast_group,
         (std::uint32_t)num_batches_per_core_group_2,
         (std::uint32_t)num_groups_per_core,
-
         (std::uint32_t)block_ht_group_2,
         (std::uint32_t)block_wt,
         (std::uint32_t)block_ht_group_2 * block_wt,
-
         (std::uint32_t)subblock_wt,
         (std::uint32_t)num_subblocks_w,
-
         (std::uint32_t)per_core_Mt_group_2,
         (std::uint32_t)per_core_Nt,
         (std::uint32_t)per_core_Mt_group_2 * per_core_Nt,
-
         (std::uint32_t)per_core_Nt * TILE_HW * datum_size_bytes,  // per_core_N_tile_bytes
         (std::uint32_t)num_groups_per_reset,
         (std::uint32_t)single_tile_size,
@@ -2020,9 +2017,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_out_blocks,
         (std::uint32_t)num_channels_per_group,
         (std::uint32_t)num_rows_per_batch_per_core_group_2,
-
-        (std::uint32_t)num_reciprocals};
-
+        (std::uint32_t)num_reciprocals,
+        (std::uint32_t)one_minus_pad_correction_factor.u};
     std::vector<uint32_t> mcast_receiver_compute_compile_time_args_group_1 = {
         (std::uint32_t)0,
         (std::uint32_t)gamma.has_value(),
@@ -2030,18 +2026,14 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_cores_per_mcast_group,
         (std::uint32_t)num_batches_per_core_group_1,
         (std::uint32_t)num_groups_per_core,
-
         (std::uint32_t)block_ht_group_1,
         (std::uint32_t)block_wt,
         (std::uint32_t)block_ht_group_1 * block_wt,
-
         (std::uint32_t)subblock_wt,
         (std::uint32_t)num_subblocks_w,
-
         (std::uint32_t)per_core_Mt_group_1,
         (std::uint32_t)per_core_Nt,
         (std::uint32_t)per_core_Mt_group_1 * per_core_Nt,
-
         (std::uint32_t)per_core_Nt * TILE_HW * datum_size_bytes,  // per_core_N_tile_bytes
         (std::uint32_t)num_groups_per_reset,
         (std::uint32_t)single_tile_size,
@@ -2055,8 +2047,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_out_blocks,
         (std::uint32_t)num_channels_per_group,
         (std::uint32_t)num_rows_per_batch_per_core_group_1,
-
-        (std::uint32_t)num_reciprocals};
+        (std::uint32_t)num_reciprocals,
+        (std::uint32_t)one_minus_pad_correction_factor.u};
     std::vector<uint32_t> mcast_receiver_compute_compile_time_args_group_2 = {
         (std::uint32_t)0,
         (std::uint32_t)gamma.has_value(),
@@ -2064,18 +2056,14 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_cores_per_mcast_group,
         (std::uint32_t)num_batches_per_core_group_2,
         (std::uint32_t)num_groups_per_core,
-
         (std::uint32_t)block_ht_group_2,
         (std::uint32_t)block_wt,
         (std::uint32_t)block_ht_group_2 * block_wt,
-
         (std::uint32_t)subblock_wt,
         (std::uint32_t)num_subblocks_w,
-
         (std::uint32_t)per_core_Mt_group_2,
         (std::uint32_t)per_core_Nt,
         (std::uint32_t)per_core_Mt_group_2 * per_core_Nt,
-
         (std::uint32_t)per_core_Nt * TILE_HW * datum_size_bytes,  // per_core_N_tile_bytes
         (std::uint32_t)num_groups_per_reset,
         (std::uint32_t)single_tile_size,
@@ -2089,8 +2077,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         (std::uint32_t)num_out_blocks,
         (std::uint32_t)num_channels_per_group,
         (std::uint32_t)num_rows_per_batch_per_core_group_2,
-
-        (std::uint32_t)num_reciprocals};
+        (std::uint32_t)num_reciprocals,
+        (std::uint32_t)one_minus_pad_correction_factor.u};
     // compute kernel
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -2358,7 +2346,10 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
         packed_winv_value_group_2 =
             pack_two_bfloat16_into_uint32({bfloat_winv_value_group_2, bfloat_winv_value_group_2});
     }
-    float cinv = 1.0f / std::sqrt(num_cores_per_batch * num_cores_per_group);  // bcast-cores scaler
+    float cinv = std::sqrt(
+        pad_correction_factor / num_cores_per_batch *
+        num_cores_per_group);  // bcast-cores scaler. Pad correction factor=(padded_size/logical_size) to account for
+                               // scaling error from padding.
     bfloat16 bfloat_cinv_value = bfloat16::truncate(cinv);
     uint32_t packed_cinv_value = pack_two_bfloat16_into_uint32({bfloat_cinv_value, bfloat_cinv_value});
     union {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Current DRAM implementation of group norm uses the padded shape resulting in some slight errors in computation. The error is dependent on the difference between the logical shape and the padded shape.

### What's changed
Most part of the current code heavily depend on the padded shape. As a result, the easiest fix was to do the following:
- Update the scalar multiplier used in the reduce call to ensure the correct normalizing factor is used for computing the expectations.
- Add padding error correction after computing the global variance by subtracting the error contribution from the padded values.

Examples (see corresponding PCC below for each test)
Before
```
[welford_mode=legacy-N=8-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9984171091383687
[welford_mode=legacy-N=9-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9983684139080529
[welford_mode=legacy-N=1-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9986941903361634
[welford_mode=legacy-N=1-C=480-H=1-W=65-num_groups=8-num_out_blocks=1-cores_y=1-cores_x=1-device_params={'l1_small_size': 0}] - PCC: 0.970402830880845
welford_mode=legacy-N=1-C=2560-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9983462264826012
```

After
```
[welford_mode=legacy-N=8-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9999588086218497
[welford_mode=legacy-N=9-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9999598882026742
[welford_mode=legacy-N=1-C=768-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9999653689687459
[welford_mode=legacy-N=1-C=480-H=1-W=65-num_groups=8-num_out_blocks=1-cores_y=1-cores_x=1-device_params={'l1_small_size': 0}] - PCC: 0.999881945848959
[welford_mode=legacy-N=1-C=2560-H=1-W=481-num_groups=32-num_out_blocks=2-cores_y=8-cores_x=8-device_params={'l1_small_size': 0}] - PCC: 0.9999319746334209
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [T3K pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17951406274)