### PR TITLE
#28756: Disable bh l1 data cache by default. Keep it selectively enabled on dispatch & fabric kernels

### DIFF
--- a/tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md
+++ b/tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md
@@ -68,13 +68,15 @@ Information relevant to programming Blackhole while it is being brought up.
 
 Blackhole added a small (4 x 16B cachelines) write-through data cache in L1. Writing an address on one core and reading it from another only requires the reader to invalidate if the address was previously read.
 
-Invalidating the cache can be done via calls to `invalidate_l1_cache()`. Hardware can clear the cache at some randomized time interval but this is slower than explicitly invalidating the cache. By default the hardware timeout is disabled but can be enabled by setting env var `TT_METAL_ENABLE_HW_CACHE_INVALIDATION`
+The data cache is disabled by default but can be enabled globally through an env var:
+```
+export TT_METAL_ENABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
+```
+where the values specify which riscs to enable cache on.
 
-The cache can be disabled through an env var:
-```
-export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
-```
-where the values specify which riscs to disable cache on.
+Alternatively, the data cache can be enabled on kernel by kernel basis by calling `set_l1_data_cache<true>()`. This needs to be accompanied with a `set_l1_data_cache<false>()` call before kernel exits.
+
+Invalidating the cache can be done via calls to `invalidate_l1_cache()`. Hardware can clear the cache at some randomized time interval but this is slower than explicitly invalidating the cache. By default the hardware timeout is disabled but can be enabled by setting env var `TT_METAL_ENABLE_HW_CACHE_INVALIDATION`
 
 ### Ethernet Cores
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/poll_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/poll_l1.cpp
@@ -6,6 +6,7 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
+    set_l1_data_cache<true>();
     uint32_t poll_addr = get_arg_val<uint32_t>(0);
     uint32_t expected_value = get_arg_val<uint32_t>(1);
     auto sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(2)));
@@ -22,4 +23,5 @@ void kernel_main() {
             invalidate_l1_cache();
         }
     }
+    set_l1_data_cache<false>();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/write_to_break_poll.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/write_to_break_poll.cpp
@@ -6,6 +6,7 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
+    set_l1_data_cache<true>();
     uint32_t poll_addr = get_arg_val<uint32_t>(0);
     uint32_t value_to_write = get_arg_val<uint32_t>(1);
     auto sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(2)));
@@ -19,4 +20,5 @@ void kernel_main() {
     }
 
     poll_addr_ptr[0] = value_to_write;
+    set_l1_data_cache<false>();
 }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2348,6 +2348,7 @@ void initialize_state_for_txq1_active_mode_sender_side() {
 }
 
 void kernel_main() {
+    set_l1_data_cache<true>();
     eth_txq_reg_write(sender_txq_id, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD);
     static_assert(
         receiver_txq_id == sender_txq_id || receiver_txq_id == 1,
@@ -3012,5 +3013,6 @@ void kernel_main() {
     // make sure all the noc transactions are acked before re-init the noc counters
     teardown(termination_signal_ptr, edm_status_ptr, receiver_channel_0_trid_tracker, receiver_channel_1_trid_tracker);
 
+    set_l1_data_cache<false>();
     WAYPOINT("DONE");
 }

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -133,6 +133,7 @@ void forward_data(
 }
 
 void kernel_main() {
+    set_l1_data_cache<true>();
     size_t rt_args_idx = 0;
 
     auto status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(status_address);
@@ -269,4 +270,5 @@ void kernel_main() {
     noc_async_atomic_barrier();
 
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::TERMINATED;
+    set_l1_data_cache<false>();
 }

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -155,26 +155,14 @@ inline __attribute__((always_inline)) void configure_gathering() {
 
 inline __attribute__((always_inline)) void configure_l1_data_cache() {
 #if defined(ARCH_BLACKHOLE)
-#if defined(DISABLE_L1_DATA_CACHE)
-    // Flush and Disables Blackhole's L1 cache by setting bit 3. Grayskull and Wormhole do not have L1 cache
-    // L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
-    // export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR*,ER*>
-    asm(R"ASM(
-            fence
-            li t1, 0x8
-            csrrs zero, 0x7c0, t1
-             )ASM" ::
-            : "t1");
-#elif !defined(ENABLE_HW_CACHE_INVALIDATION)
-    // Disable gathering to stop HW from invalidating the data cache after 128 transactions by setting bit 24
-    // This is default enabled
-    asm(R"ASM(
-            li   t1, 0x1
-            slli t1, t1, 24
-            fence
-            csrrs zero, 0x7c0, t1
-             )ASM" ::
-            : "t1");
+    // Blackhole's L1 cache can be disabled by setting bit 3 and enabled by clearing it. Grayskull and Wormhole do not have L1 cache
+    // The cache is default disabled. When hw APIs better hide L1 cache, we can keep it enabled
+    // L1 cache can be enabled by setting `TT_METAL_ENABLE_L1_DATA_CACHE_RISCVS` env var. It can be enabled risc by risc
+    // export TT_METAL_ENABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR*,ER*>
+#if defined(ENABLE_L1_DATA_CACHE)
+    set_l1_data_cache<true>();
+#else
+    set_l1_data_cache<false>();
 #endif
 #endif
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1336,6 +1336,7 @@ static inline bool process_cmd_h(
 }
 
 void kernel_main() {
+    set_l1_data_cache<true>();
 #if defined(FABRIC_RELAY)
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": start (fabric relay. 2d = " << (uint32_t)is_2d_fabric
            << ")" << ENDL();
@@ -1497,4 +1498,5 @@ void kernel_main() {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
     }
     // DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": out" << ENDL();
+    set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -328,6 +328,7 @@ void set_go_signal_noc_data() {
 }
 
 void kernel_main() {
+    set_l1_data_cache<true>();
     DPRINT << "dispatch_s : start" << ENDL();
     // Initialize customized command buffers.
     dispatch_s_wr_reg_cmd_buf_init();
@@ -384,4 +385,5 @@ void kernel_main() {
     noc_async_full_barrier();
 #endif
     DPRINT << "dispatch_s : done" << ENDL();
+    set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1964,6 +1964,7 @@ void kernel_main_hd() {
 }
 
 void kernel_main() {
+    set_l1_data_cache<true>();
 #if defined(FABRIC_RELAY)
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start (fabric relay. 2d = " << (uint32_t)is_2d_fabric
            << ")" << ENDL();
@@ -1988,4 +1989,5 @@ void kernel_main() {
     noc_async_full_barrier();
 
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": out" << ENDL();
+    set_l1_data_cache<false>();
 }

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -10,13 +10,13 @@ namespace tt::tt_metal::hal_1xx {
 std::vector<std::string> HalJitBuildQueryBase::defines(const HalJitBuildQueryInterface::Params& params) const {
     std::vector<std::string> defines;
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    const auto& l1_cache_disable_processors =
-        rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    const auto& l1_cache_enable_processors =
+        rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureEnableL1DataCache);
     auto processor_index = MetalContext::instance().hal().get_processor_index(
         params.core_type, params.processor_class, params.processor_id);
     defines.push_back(fmt::format("PROCESSOR_INDEX={}", processor_index));
-    if (l1_cache_disable_processors.contains(params.core_type, processor_index)) {
-        defines.push_back("DISABLE_L1_DATA_CACHE");
+    if (l1_cache_enable_processors.contains(params.core_type, processor_index)) {
+        defines.push_back("ENABLE_L1_DATA_CACHE");
     }
     switch (params.core_type) {
         case HalProgrammableCoreType::TENSIX:

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -10,13 +10,13 @@ namespace tt::tt_metal::hal_2xx {
 std::vector<std::string> HalJitBuildQueryBase::defines(const HalJitBuildQueryInterface::Params& params) const {
     std::vector<std::string> defines;
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    const auto& l1_cache_disable_processors =
-        rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    const auto& l1_cache_enable_processors =
+        rtoptions.get_feature_processors(tt::llrt::RunTimeDebugFeatureEnableL1DataCache);
     auto processor_index = MetalContext::instance().hal().get_processor_index(
         params.core_type, params.processor_class, params.processor_id);
     defines.push_back(fmt::format("PROCESSOR_INDEX={}", processor_index));
-    if (l1_cache_disable_processors.contains(params.core_type, processor_index)) {
-        defines.push_back("DISABLE_L1_DATA_CACHE");
+    if (l1_cache_enable_processors.contains(params.core_type, processor_index)) {
+        defines.push_back("ENABLE_L1_DATA_CACHE");
     }
     switch (params.core_type) {
         case HalProgrammableCoreType::TENSIX:

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -26,7 +26,7 @@ const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount] = {
     "READ_DEBUG_DELAY",
     "WRITE_DEBUG_DELAY",
     "ATOMIC_DEBUG_DELAY",
-    "DISABLE_L1_DATA_CACHE",
+    "ENABLE_L1_DATA_CACHE",
 };
 
 const char* RunTimeDebugClassNames[RunTimeDebugClassCount] = {"N/A", "worker", "dispatch", "all"};
@@ -535,17 +535,13 @@ void RunTimeOptions::ParseFeatureRiscvMask(
     if (env_var_str != nullptr) {
         feature_targets[feature].processors = hal.parse_processor_set_spec(env_var_str);
     } else {
-        // Default is all RISCVs enabled.
-        bool default_disabled = (feature == RunTimeDebugFeatures::RunTimeDebugFeatureDisableL1DataCache);
-        if (!default_disabled) {
-            auto& processors = feature_targets[feature].processors;
-            uint32_t num_core_types = hal.get_programmable_core_type_count();
-            for (uint32_t core_type_index = 0; core_type_index < num_core_types; ++core_type_index) {
-                auto core_type = hal.get_programmable_core_type(core_type_index);
-                uint32_t num_processors = hal.get_num_risc_processors(core_type);
-                for (uint32_t processor_index = 0; processor_index < num_processors; ++processor_index) {
-                    processors.add(core_type, processor_index);
-                }
+        auto& processors = feature_targets[feature].processors;
+        uint32_t num_core_types = hal.get_programmable_core_type_count();
+        for (uint32_t core_type_index = 0; core_type_index < num_core_types; ++core_type_index) {
+            auto core_type = hal.get_programmable_core_type(core_type_index);
+            uint32_t num_processors = hal.get_num_risc_processors(core_type);
+            for (uint32_t processor_index = 0; processor_index < num_processors; ++processor_index) {
+                processors.add(core_type, processor_index);
             }
         }
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -37,7 +37,7 @@ enum RunTimeDebugFeatures {
     RunTimeDebugFeatureReadDebugDelay,
     RunTimeDebugFeatureWriteDebugDelay,
     RunTimeDebugFeatureAtomicDebugDelay,
-    RunTimeDebugFeatureDisableL1DataCache,
+    RunTimeDebugFeatureEnableL1DataCache,
     // NOTE: Update RunTimeDebugFeatureNames if adding new features
     RunTimeDebugFeatureCount
 };
@@ -370,7 +370,7 @@ public:
                 } else {
                     return "false";
                 }
-            case RunTimeDebugFeatureDisableL1DataCache: return std::to_string(get_feature_enabled(feature));
+            case RunTimeDebugFeatureEnableL1DataCache: return std::to_string(get_feature_enabled(feature));
             default: return "";
         }
     }


### PR DESCRIPTION
### Ticket
#28756

### Problem description
Ops team is requesting for the l1 data cache to be disabled due to poor dev experience of needing to manage the cache. With newer device apis cache management should be hidden from kernel developers, until that is ready we default disable it. Kernels can opt in through `set_l1_data_cache` or globally enabled via `TT_METAL_ENABLE_L1_DATA_CACHE_RISCVS` env var 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18015737882) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17933836124) CI with demo tests passes (if applicable)
- [x] [Blackhole Multicard Demo](https://github.com/tenstorrent/tt-metal/actions/runs/17948780459)
- [x] [Blackhole Demo](https://github.com/tenstorrent/tt-metal/actions/runs/17948772958)
- [ ] [BH LLMBox](https://github.com/tenstorrent/tt-metal/actions/runs/17950424307)
- [x] New/Existing tests provide coverage for changes
