### PR TITLE
Fix building purely with clang

### DIFF
--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -60,8 +60,7 @@ ExternalProject_Add(
     INSTALL_COMMAND
         cp ${TRACY_HOME}/csvexport/build/unix/csvexport-release .
     BUILD_COMMAND
-        cd ${TRACY_HOME}/csvexport/build/unix && CXX=g++ TRACY_NO_LTO=1 make -f
-        ${TRACY_HOME}/csvexport/build/unix/Makefile
+        cd ${TRACY_HOME}/csvexport/build/unix && TRACY_NO_LTO=1 make -f ${TRACY_HOME}/csvexport/build/unix/Makefile
 )
 ExternalProject_Add(
     tracy_capture_tools
@@ -78,7 +77,7 @@ ExternalProject_Add(
     INSTALL_COMMAND
         cp ${TRACY_HOME}/capture/build/unix/capture-release .
     BUILD_COMMAND
-        cd ${TRACY_HOME}/capture/build/unix && CXX=g++ TRACY_NO_LTO=1 make -f ${TRACY_HOME}/capture/build/unix/Makefile
+        cd ${TRACY_HOME}/capture/build/unix && TRACY_NO_LTO=1 make -f ${TRACY_HOME}/capture/build/unix/Makefile
 )
 add_custom_target(
     tracy_tools


### PR DESCRIPTION
### Problem description
When building with nix and using the recommended compiler, clang, we don't get GCC unless we include it. It doesn't make sense to require 2 C compilers in the build closure.

### What's changed

Only removed the hard coding which forces tracy to build with GCC.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes

*Can't check any of these off due to many problems I've found with using tt-metal with tt-mlir in nix (reference https://github.com/tenstorrent/tt-mlir/issues/5035)*