### PR TITLE
Fix llama 90b demo test in CI

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,24 +23,24 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          # { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,24 +23,24 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          # { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -29,7 +29,7 @@ jobs:
           { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
           { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 60, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
           { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
           { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -449,11 +449,11 @@ def test_multimodal_demo_text(
         run_config = (tt_device_name, base_model_name, max_batch_size)
         targets_prefill_tok_s = {
             ("N300", "Llama-3.2-11B", 16): 22.4,
-            ("T3K", "Llama-3.2-90B", 1): 3,
+            ("T3K", "Llama-3.2-90B", 1): 15.3,
         }
         targets_decode_tok_s_u = {
             ("N300", "Llama-3.2-11B", 16): 17,
-            ("T3K", "Llama-3.2-90B", 1): 6,
+            ("T3K", "Llama-3.2-90B", 1): 4.3,
         }
 
         perf_targets = {}

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -157,7 +157,7 @@ def prepare_generator_args(
     ],
 )
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 14951424, "num_command_queues": 2}], indirect=True
+    "device_params", [{"fabric_config": True, "trace_region_size": 17000000, "num_command_queues": 2}], indirect=True
 )
 def test_multimodal_demo_text(
     mesh_device,

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -184,14 +184,15 @@ run_t3000_llama3_90b_vision_tests() {
   # Record the start time
   fail=0
   start_time=$(date +%s)
-
   echo "LOG_METAL: Running run_t3000_llama3_90b_vision_tests"
+
+  export PYTEST_ADDOPTS="--tb=short"
 
   # Llama3.2-90B
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct
   mesh_device=T3K
 
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama90b pytest -n auto models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace" --timeout 900 || fail=1
+  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama90b pytest -n auto models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace" --timeout 1000 || fail=1
   echo "LOG_METAL: Llama3.2-90B vision tests for $mesh_device completed"
 
   # Record the end time

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -191,7 +191,7 @@ run_t3000_llama3_90b_vision_tests() {
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct
   mesh_device=T3K
 
-  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama90b pytest -n auto models/tt_transformers/demo/simple_vision_demo.py -k "batch1-notrace" --timeout 1200; fail+=$?
+  MESH_DEVICE=$mesh_device LLAMA_DIR=$llama90b pytest -n auto models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace" --timeout 900 || fail=1
   echo "LOG_METAL: Llama3.2-90B vision tests for $mesh_device completed"
 
   # Record the end time


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Llama3.2-90B test appears hanging in CI. The problem is that we are running the non-traced test case and it is indeed quite slow and would appear to be hung in the perspective of `pytest` running on some hosts.

### What's changed
Fix the traced test case to run in CI instead which is much faster than the non-traced test case.

### Checklist
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/17948178767
- [x] revert 4ec942e3c3ca4cccfccd9adf61fe8ff482c48846
  - through [84bc10a](https://github.com/tenstorrent/tt-metal/pull/29115/commits/84bc10a8aae3e7beab4a6293645a51f47fca3036) 