### PR TITLE
[tt-train] Add wrapper around setFabricConfig

### DIFF
--- a/tt-train/configs/training_shakespeare_tinyllama_ddp.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama_ddp.yaml
@@ -1,0 +1,37 @@
+training_config:
+  project_name: "tt_train_nano_gpt"
+  model_type: "llama"
+  seed: 5489
+  model_save_interval: 500
+  batch_size: 8
+  gradient_accumulation_steps: 1
+  num_epochs: 1
+  max_steps: 5000
+  learning_rate: 0.0003
+  weight_decay: 0.01
+  use_moreh_adamw: true
+  use_kahan_summation: false
+  use_clip_grad_norm: false
+  clip_grad_norm_max_norm: 1.0
+  tokenizer_path: "data/tinyllama-tokenizer.json"
+  tokenizer_type: "bpe"
+  transformer_config:
+    num_heads: 32
+    num_groups: 4
+    embedding_dim: 2048
+    dropout_prob: 0.0
+    num_blocks: 22
+    vocab_size: 32000
+    max_sequence_length: 2048
+    runner_type: memory_efficient
+    theta: 10000.0
+
+eval_config:
+  repetition_penalty: 1.0
+  temperature: 0.7
+  top_k: 50
+  top_p: 1.0
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [1, 8]

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -23,6 +23,7 @@
 #include "ops/losses.hpp"
 #include "optimizers/sgd.hpp"
 #include "serialization/serializable.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "utils.hpp"
 
 using ttml::autograd::TensorPtr;
@@ -170,7 +171,7 @@ int main(int argc, char **argv) {
         dataset.test_images, dataset.test_labels);
 
     if (enable_tp) {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
     }
 
     auto *device = &ttml::autograd::ctx().get_device();

--- a/tt-train/sources/examples/nano_gpt/3tier/aggregator_worker.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/aggregator_worker.cpp
@@ -15,6 +15,7 @@
 #include "socket_manager.hpp"
 #include "tokenizers/bpe_tokenizer.hpp"
 #include "tokenizers/char_tokenizer.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 using SortedParameters = std::map<std::string, ttml::autograd::TensorPtr>;
@@ -86,12 +87,8 @@ int main(int argc, char **argv) {
     three_tier_arch::DeviceConfig device_config = three_tier_arch::parse_device_config(yaml_config);
 
     if (config.socket_type == ttnn::distributed::SocketType::FABRIC) {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
-        if (device_config.mesh_shape != tt::tt_metal::distributed::MeshShape(1, 8)) {
-            throw std::runtime_error(fmt::format(
-                "Fabric config is set to 2D dynamic, but mesh shape is not (1, 8). Mesh shape: {}",
-                device_config.mesh_shape));
-        }
+        auto num_devices = device_config.mesh_shape[0] * device_config.mesh_shape[1];
+        ttml::ttnn_fixed::distributed::enable_fabric(num_devices);
     }
     three_tier_arch::initialize_device(device_config.mesh_shape, device_config.device_ids);
 

--- a/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
+++ b/tt-train/sources/examples/nano_gpt/3tier/optimizer_worker.cpp
@@ -16,6 +16,7 @@
 #include "socket_manager.hpp"
 #include "tokenizers/bpe_tokenizer.hpp"
 #include "tokenizers/char_tokenizer.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 
 using SortedParameters = std::map<std::string, ttml::autograd::TensorPtr>;
 
@@ -72,12 +73,8 @@ int main(int argc, char **argv) {
     three_tier_arch::DeviceConfig device_config = three_tier_arch::parse_device_config(yaml_config);
 
     if (config.socket_type == ttnn::distributed::SocketType::FABRIC) {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
-        if (device_config.mesh_shape != tt::tt_metal::distributed::MeshShape(1, 8)) {
-            throw std::runtime_error(fmt::format(
-                "Fabric config is set to 2D dynamic, but mesh shape is not (1, 8). Mesh shape: {}",
-                device_config.mesh_shape));
-        }
+        auto num_devices = device_config.mesh_shape[0] * device_config.mesh_shape[1];
+        ttml::ttnn_fixed::distributed::enable_fabric(num_devices);
     }
 
     three_tier_arch::initialize_device(device_config.mesh_shape, device_config.device_ids);

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -568,7 +568,7 @@ int main(int argc, char **argv) {
     auto num_devices = device_config.mesh_shape[0] * device_config.mesh_shape[1];
     // enable fabric config for 3-tier architecture, tp, ddp
     if (config.socket_type == SocketType::FABRIC || device_config.enable_tp || device_config.enable_ddp) {
-        ttml::ttnn_fixed::distributed::enable_fabric_config(num_devices);
+        ttml::ttnn_fixed::distributed::enable_fabric(num_devices);
     }
 
     initialize_device(device_config.mesh_shape, device_config.device_ids);

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -6,8 +6,6 @@
 #include <core/ttnn_all_includes.hpp>
 #include <csignal>
 #include <cstdint>
-#include <ttnn/distributed/create_socket.hpp>
-#include <ttnn/tensor/tensor.hpp>
 #include <wandbcpp.hpp>
 
 #include "3tier/remote_optimizer.hpp"
@@ -30,6 +28,7 @@
 #include "optimizers/no_op.hpp"
 #include "tokenizers/bpe_tokenizer.hpp"
 #include "tokenizers/char_tokenizer.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 #include "utils.hpp"
 
@@ -566,15 +565,10 @@ int main(int argc, char **argv) {
     fmt::print("Vocab size: {}\n", tokenizer->get_vocab_size());
     fmt::print("Tokenizer type: {}\n", config.tokenizer_type);
 
-    if (config.socket_type == SocketType::FABRIC) {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
-        if (device_config.mesh_shape != tt::tt_metal::distributed::MeshShape(1, 8)) {
-            throw std::runtime_error(fmt::format(
-                "Fabric config is set to 2D dynamic, but mesh shape is not (1, 8). Mesh shape: {}",
-                device_config.mesh_shape));
-        }
-    } else if (device_config.enable_tp || device_config.enable_ddp) {
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+    auto num_devices = device_config.mesh_shape[0] * device_config.mesh_shape[1];
+    // enable fabric config for 3-tier architecture, tp, ddp
+    if (config.socket_type == SocketType::FABRIC || device_config.enable_tp || device_config.enable_ddp) {
+        ttml::ttnn_fixed::distributed::enable_fabric_config(num_devices);
     }
 
     initialize_device(device_config.mesh_shape, device_config.device_ids);
@@ -659,7 +653,6 @@ int main(int argc, char **argv) {
     auto train_dataloader = DataLoader(dataset, /* batch_size */ config.batch_size, /* shuffle */ true, collate_fn);
 
     fmt::print("Overriding vocab size to be divisible by 32\n");
-    auto num_devices = static_cast<uint32_t>(device->num_devices());
     // this is workaround for tensor parallel case, we need to have vocab size divisible by 32 per device
     std::visit(
         [&](auto &&arg) {

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -164,6 +164,8 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/tokenizer_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/ttnn_ops.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/ttnn_ops.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/tt_metal.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/tt_metal.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/matmuls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/matmuls.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/trivial_ttnn_ops.cpp

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
@@ -16,7 +16,7 @@ namespace ttml::ttnn_fixed::distributed {
 const char* kTTMetalHomeEnvVar = "TT_METAL_HOME";
 const char* kTTMeshGraphDescriptorEnvVar = "TT_MESH_GRAPH_DESC_PATH";
 
-void enable_fabric_config(uint32_t num_devices) {
+void enable_fabric(uint32_t num_devices) {
     const char* mesh_graph_descriptor_path_env = std::getenv(kTTMeshGraphDescriptorEnvVar);
     if (!mesh_graph_descriptor_path_env) {
         const char* metal_home = std::getenv(kTTMetalHomeEnvVar);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal.hpp"
+
+#include <fmt/core.h>
+
+#include <core/ttnn_all_includes.hpp>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace ttml::ttnn_fixed::distributed {
+
+const char* kTTMetalHomeEnvVar = "TT_METAL_HOME";
+const char* kTTMeshGraphDescriptorEnvVar = "TT_MESH_GRAPH_DESC_PATH";
+
+void enable_fabric_config(uint32_t num_devices) {
+    const char* mesh_graph_descriptor_path_env = std::getenv(kTTMeshGraphDescriptorEnvVar);
+    if (!mesh_graph_descriptor_path_env) {
+        const char* metal_home = std::getenv(kTTMetalHomeEnvVar);
+        if (!metal_home) {
+            throw std::runtime_error("TT_METAL_HOME is not set");
+        }
+        auto mesh_graph_descriptor_path =
+            std::string(metal_home) + "/tests/tt_metal/tt_fabric/custom_mesh_descriptors/";
+
+        if (num_devices == 8U) {
+            mesh_graph_descriptor_path += "t3k_1x8_mesh_graph_descriptor.yaml";
+        } else if (num_devices == 32U) {
+            mesh_graph_descriptor_path += "galaxy_1x32_mesh_graph_descriptor.yaml";
+        }
+
+        // set environment variable
+        setenv(kTTMeshGraphDescriptorEnvVar, mesh_graph_descriptor_path.c_str(), 1);
+        fmt::println("[tt-train] TT_MESH_GRAPH_DESC_PATH is set to {}", mesh_graph_descriptor_path);
+    }
+
+    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+}
+
+}  // namespace ttml::ttnn_fixed::distributed

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.cpp
@@ -23,9 +23,11 @@ void enable_fabric(uint32_t num_devices) {
         if (!metal_home) {
             throw std::runtime_error("TT_METAL_HOME is not set");
         }
+
         auto mesh_graph_descriptor_path =
             std::string(metal_home) + "/tests/tt_metal/tt_fabric/custom_mesh_descriptors/";
 
+        bool set_env_var = (num_devices == 8U || num_devices == 32U);
         if (num_devices == 8U) {
             mesh_graph_descriptor_path += "t3k_1x8_mesh_graph_descriptor.yaml";
         } else if (num_devices == 32U) {
@@ -33,8 +35,10 @@ void enable_fabric(uint32_t num_devices) {
         }
 
         // set environment variable
-        setenv(kTTMeshGraphDescriptorEnvVar, mesh_graph_descriptor_path.c_str(), 1);
-        fmt::println("[tt-train] TT_MESH_GRAPH_DESC_PATH is set to {}", mesh_graph_descriptor_path);
+        if (set_env_var) {
+            setenv(kTTMeshGraphDescriptorEnvVar, mesh_graph_descriptor_path.c_str(), 1);
+            fmt::println("[tt-train] TT_MESH_GRAPH_DESC_PATH is set to {}", mesh_graph_descriptor_path);
+        }
     }
 
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttml::ttnn_fixed::distributed {
+
+void enable_fabric_config(uint32_t num_devices);
+
+}  // namespace ttml::ttnn_fixed::distributed

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/tt_metal.hpp
@@ -8,6 +8,6 @@
 
 namespace ttml::ttnn_fixed::distributed {
 
-void enable_fabric_config(uint32_t num_devices);
+void enable_fabric(uint32_t num_devices);
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -13,6 +13,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 using namespace ttml;
@@ -28,7 +29,7 @@ protected:
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
 
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
         ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().set_seed(42);
     }

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -18,6 +18,7 @@
 #include "modules/linear_module.hpp"
 #include "ops/losses.hpp"
 #include "optimizers/sgd.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {
 
@@ -34,7 +35,7 @@ protected:
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
 
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
         ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -15,6 +15,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {
 
@@ -40,7 +41,7 @@ protected:
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
 
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
         ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().set_seed(42);
     }

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -13,6 +13,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {
 
@@ -28,7 +29,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
         ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().set_seed(42);
     }

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -13,6 +13,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/device.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 namespace {
@@ -27,7 +28,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+        ttml::ttnn_fixed::distributed::enable_fabric(2U);
         ttml::autograd::ctx().open_device(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 


### PR DESCRIPTION
### Problem description
We need to pass MGD in case of LoudBox and Galaxy. In most cases it is pretty straightforward. In perfect world, user of fabric should not be aware about it except special cases. 

### What's changed
If TT_MESH_GRAPH_DESC variable is not set -> set it based on number of devices. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17952891584) CI passes
- [x] New/Existing tests provide coverage for changes