### PR TITLE
remove less performant e2e variants of resnet from CI

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -13,7 +13,6 @@ from models.demos.ttnn_resnet.tests.perf_e2e_resnet50 import run_perf_resnet
 
 
 @run_for_blackhole()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
@@ -42,7 +41,6 @@ def test_perf(
 
 
 @run_for_blackhole()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 5554176}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
@@ -71,7 +69,6 @@ def test_perf_trace(
 
 
 @run_for_blackhole()
-@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",

--- a/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -18,7 +18,7 @@ from models.demos.ttnn_resnet.tests.perf_e2e_resnet50 import run_perf_resnet
     "batch_size, expected_inference_time, expected_compile_time",
     (
         (16, 0.0065, 30),
-        (32, 0.0067, 30),
+        (32, 0.0071, 30),
     ),
 )
 def test_perf(


### PR DESCRIPTION
### Problem description

https://github.com/tenstorrent/tt-metal/actions/runs/17933988583/job/51012927955

We run 4 variants of e2e tests for Resnet50 on BH - without e2e perf features, and with trace and/or 2cqs. The most performant version is the one with both features on, so we should measure this time only. The version without any of these features can be flaky, so we get fails on CI.

For WH, we already run just the most performant and stable variant. 

### What's changed
- Bump target to account for flakiness. 
- Remove 3 less performant variants from the CI.

### Checklist

- [x] Model perf pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/17939196464