### PR TITLE
Disable numeric_stable softmax in segformer segmentation model

### DIFF
--- a/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
+++ b/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
@@ -199,7 +199,11 @@ class TtSegformerEfficientSelfAttention:
         attention_scores = ttnn.to_memory_config(attention_scores, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
         scale_value = self.attention_head_size**-0.5
         attention_scores = ttnn.multiply(attention_scores, scale_value)
-        attention_probs = ttnn.softmax(attention_scores, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        # TODO: remove numeric_stable=False once accuracy issue is resolved
+        # See issue: #29132
+        attention_probs = ttnn.softmax(
+            attention_scores, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG, numeric_stable=False
+        )
         ttnn.deallocate(attention_scores)
         attention_probs = ttnn.to_layout(attention_probs, ttnn.TILE_LAYOUT)
 


### PR DESCRIPTION
### Ticket

### Problem description
There is a PCC error in a few tests based on the segformer model after commit https://github.com/tenstorrent/tt-metal/commit/dd91ffffaf9488b4e01f824964f7e260a8e2a651, which changes ttnn.softmax() to use the numeric stable version by default.
For some more details, see issue https://github.com/tenstorrent/tt-metal/issues/29132.

### What's changed
This PR changes the segformer model to use the former softmax algorithm by setting numeric_stable=False in the call to ttnn.softmax.
This is meant to be a work around solution until the accuracy delta is understood and resolved through https://github.com/tenstorrent/tt-metal/issues/29132.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes