### PR TITLE
[skip ci] Specify exact torch version when testing

### DIFF
--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Run frequent regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-            pip install 'torch>=2.7.1+cpu' 'numpy>=1.24.4,<2' pytest
+            pip install 'torch==2.7.1+cpu' 'numpy>=1.24.4,<2' pytest
             ${{ matrix.test_group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
### Problem description
Docker smoke test are failing with `ERROR: Invalid requirement: 'torch>=2.7.1+cpu': Local version label can only be used with `==` or `!=` operators`
https://github.com/tenstorrent/tt-metal/actions/runs/17942404361/job/51026112663

### What's changed
Changed 'torch>=2.7.1+cpu' to 'torch==2.7.1+cpu'