### PR TITLE
Rename OptimizedConvNew to Conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -700,7 +700,7 @@ Result conv2d_L1(
         }
     }
 
-    // call optimized conv op or matmul micro op
+    // call conv op or matmul micro op
     bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor_post_tm);
     TT_ASSERT(input_is_on_device);
 
@@ -753,7 +753,7 @@ Result conv2d_L1(
         }
 
         // call conv micro op
-        auto conv_output = optimized_conv_new(
+        auto conv_output = conv2d(
             input_tensor_post_tm,
             weight_tensor_on_device,
             bias_tensor_on_device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -48,8 +48,8 @@ uint32_t calculate_act_cb_size_with_reuse(
 
 std::vector<CBInfo> get_cb_info(
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const OptimizedConvBlockConfig& block_config,
-    const OptimizedConvParallelizationConfig& pconfig,
+    const Conv2dBlockConfig& block_config,
+    const Conv2dParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 2> input_shape,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -62,8 +62,8 @@ struct CBInfo {
 // CBInfo::index and CBInfo::handle won't be valid until allocate_cbs() is called.
 std::vector<CBInfo> get_cb_info(
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const OptimizedConvBlockConfig& block_config,
-    const OptimizedConvParallelizationConfig& pconfig,
+    const Conv2dBlockConfig& block_config,
+    const Conv2dParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 2> input_shape,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -310,7 +310,7 @@ MemoryConfig create_sharded_memory_config_from_parallel_config(
     return MemoryConfig{shard_scheme, BufferType::L1, shard_spec};
 }
 
-OptimizedConvParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(
+Conv2dParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(
     const MemoryConfig& conv_output_mem_config,
     uint32_t num_cores_nhw,
     uint32_t num_cores_c_in,
@@ -360,9 +360,9 @@ static std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
     return {subblock_h, subblock_w};
 }
 
-OptimizedConvBlockConfig determine_per_core_conv_block_config(
+Conv2dBlockConfig determine_per_core_conv_block_config(
     const ParallelConfig& parallel_config,
-    const OptimizedConvParallelizationConfig& conv_op_parallel_config,
+    const Conv2dParallelizationConfig& conv_op_parallel_config,
     uint32_t padded_in_channels,
     uint32_t padded_output_height_ntiles_per_core,
     uint32_t act_block_h_override,
@@ -474,8 +474,7 @@ bool is_1d_deptwise_conv(
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 
-SkipMcast conv_skip_mcast(
-    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
+SkipMcast conv_skip_mcast(const Conv2dParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout) {
     bool skip_act_mcast = false;
     bool skip_weights_mcast = false;
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED || memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
@@ -797,8 +796,8 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
 }
 
 ttnn::operations::matmul::MatmulProgramConfig determine_matmul_op_config_from_conv_op_config(
-    OptimizedConvParallelizationConfig conv_parallelization_config,
-    OptimizedConvBlockConfig conv_blocking_config,
+    Conv2dParallelizationConfig conv_parallelization_config,
+    Conv2dBlockConfig conv_blocking_config,
     bool height_sharded,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
     bool transpose_mcast,
@@ -1031,7 +1030,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     return winning_config.conv_config;
 }
 
-std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryConfig> get_conv_configs(
+std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_conv_configs(
     const Conv2dConfig& conv_config,
     const DeviceComputeKernelConfig& compute_config,
     const ParallelConfig& input_parallel_config,
@@ -1050,7 +1049,7 @@ std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryC
     MemoryConfig conv_out_memory_config = create_sharded_memory_config_from_parallel_config(
         ttnn::Shape({1, 1, nhw_out, out_channels_padded}), output_parallel_config, round_up_size);
 
-    OptimizedConvParallelizationConfig opt_conv_op_parallel_config =
+    Conv2dParallelizationConfig opt_conv_op_parallel_config =
         determine_conv_op_parallel_config_from_conv_output_mem_config(
             conv_out_memory_config,
             get_num_cores_nhw_from_parallel_config(input_parallel_config),
@@ -1060,7 +1059,7 @@ std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryC
     uint32_t nhw_out_padded_ntile_per_core =
         conv_out_memory_config.shard_spec().value().shape[0] / tt::constants::TILE_HEIGHT;
 
-    OptimizedConvBlockConfig opt_conv_op_block_config = determine_per_core_conv_block_config(
+    Conv2dBlockConfig opt_conv_op_block_config = determine_per_core_conv_block_config(
         input_parallel_config,
         opt_conv_op_parallel_config,
         in_channels_padded,
@@ -1391,8 +1390,8 @@ uint32_t calculate_conv_dram_slice_L1_usage(
 }
 conv_op_l1_usage conv2d::calculate_L1_usage(
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const OptimizedConvBlockConfig& block_config,
-    const OptimizedConvParallelizationConfig& pconfig,
+    const Conv2dBlockConfig& block_config,
+    const Conv2dParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     const SlidingWindowConfig& sliding_window_config,
     std::array<uint32_t, 2> dilation,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -60,8 +60,7 @@ struct SkipMcast {
     bool skip_weights_mcast;
 };
 
-SkipMcast conv_skip_mcast(
-    const OptimizedConvParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout);
+SkipMcast conv_skip_mcast(const Conv2dParallelizationConfig& parallelization_config, TensorMemoryLayout memory_layout);
 
 sliding_window::ParallelConfig determine_parallel_config(
     TensorMemoryLayout shard_layout,
@@ -99,23 +98,23 @@ uint32_t get_num_cores_channels_from_parallel_config(const sliding_window::Paral
 MemoryConfig create_sharded_memory_config_from_parallel_config(
     const ttnn::Shape& tensor_shape, const sliding_window::ParallelConfig& parallel_config, uint32_t tile_size);
 
-OptimizedConvParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(
+Conv2dParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(
     const MemoryConfig& conv_output_mem_config,
     uint32_t num_cores_nhw,
     uint32_t num_cores_c_in,
     uint32_t num_cores_c_out);
 
 ttnn::operations::matmul::MatmulProgramConfig determine_matmul_op_config_from_conv_op_config(
-    OptimizedConvParallelizationConfig conv_parallelization_config,
-    OptimizedConvBlockConfig conv_blocking_config,
+    Conv2dParallelizationConfig conv_parallelization_config,
+    Conv2dBlockConfig conv_blocking_config,
     bool height_sharded,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
     bool transpose_mcast,
     uint32_t grid_size_along_c);
 
-OptimizedConvBlockConfig determine_per_core_conv_block_config(
+Conv2dBlockConfig determine_per_core_conv_block_config(
     const sliding_window::ParallelConfig& parallel_config,
-    const OptimizedConvParallelizationConfig& conv_op_parallel_config,
+    const Conv2dParallelizationConfig& conv_op_parallel_config,
     uint32_t padded_in_channels,
     uint32_t padded_output_height_ntiles_per_core,
     uint32_t act_block_h_override,
@@ -127,7 +126,7 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     bool full_inner_dim,
     bool enable_activation_reuse = false);
 
-std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryConfig> get_conv_configs(
+std::tuple<Conv2dParallelizationConfig, Conv2dBlockConfig, MemoryConfig> get_conv_configs(
     const Conv2dConfig& conv_config,
     const DeviceComputeKernelConfig& compute_config,
     const sliding_window::ParallelConfig& input_parallel_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -27,7 +27,7 @@
 namespace ttnn::operations::conv {
 namespace conv2d {
 
-Tensor optimized_conv_new(
+Tensor conv2d(
     const Tensor& a,
     const Tensor& b,
     std::optional<const Tensor> bias,
@@ -36,8 +36,8 @@ Tensor optimized_conv_new(
     uint32_t groups,
     bool untilize_out,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     const MemoryConfig& memory_config,
     DataType dtype,
     std::array<std::uint32_t, 4> input_tensor_shape,
@@ -62,7 +62,7 @@ Tensor optimized_conv_new(
             .pad_shape = bias.value().padded_shape(), .pad_value = 0, .target_layout = Layout::TILE};
     }
 
-    auto optimized_conv_op = OptimizedConvNew(
+    auto conv_op = Conv2d(
         sliding_window_config,
         output_channels,
         groups,
@@ -83,12 +83,12 @@ Tensor optimized_conv_new(
         force_split_reader);
     IDevice* device = a.device();
 
-    optimized_conv_op.pre_op_l1_allocation_size_bytes =
+    conv_op.pre_op_l1_allocation_size_bytes =
         device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    return tt::tt_metal::operation::run_without_autoformat(optimized_conv_op, {a, b}, {bias}).at(0);
+    return tt::tt_metal::operation::run_without_autoformat(conv_op, {a, b}, {bias}).at(0);
 }
 
-void OptimizedConvNew::validate(
+void Conv2d::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
@@ -124,7 +124,7 @@ void OptimizedConvNew::validate(
     }
 }
 
-std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+std::vector<TensorSpec> Conv2d::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a_shape = this->input_tensor_shape;
     uint32_t batch_size = input_tensor_a_shape[0];
 
@@ -168,7 +168,7 @@ std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector
             dtype, tt::tt_metal::PageConfig(output_layout), memory_config, output_shape, padded_output_shape))};
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
+tt::tt_metal::operation::ProgramWithCallbacks Conv2d::create_program(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
     std::vector<Tensor>& output_tensors) const {
@@ -199,7 +199,7 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
         std::vector<sliding_window::ShardBoundary> shard_boundaries =
             ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
 
-        program_with_cbs = multi_core_optimized_conv_width_sharded_v2_impl(
+        program_with_cbs = multi_core_conv2d_width_sharded(
             program,
             input_tensor_a,
             input_tensor_b,
@@ -235,7 +235,7 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
         std::vector<sliding_window::ShardBoundary> shard_boundaries =
             ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
 
-        program_with_cbs = multi_core_optimized_conv_sharded_v2_impl(
+        program_with_cbs = multi_core_conv2d_sharded(
             program,
             input_tensor_a,
             input_tensor_b,
@@ -321,7 +321,7 @@ tt::tt_metal::operation::ProgramWithCallbacks OptimizedConvNew::create_program(
     return program_with_cbs;
 }
 
-tt::tt_metal::operation::OpPerformanceModel OptimizedConvNew::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModel Conv2d::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
     const std::vector<Tensor>& output_tensors) const {
@@ -364,7 +364,7 @@ tt::tt_metal::operation::OpPerformanceModel OptimizedConvNew::create_op_performa
     tt::tt_metal::operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
 
 #if 0
-    log_info(tt::LogOp, "OptimizedConv PerfModel:");
+    log_info(tt::LogOp, "Conv2d PerfModel:");
     log_info(tt::LogOp, "\t Batch: {}", batch_size);
     log_info(tt::LogOp, "\t In (H, W, C): ({}, {}, {})", conv_activation_h, conv_activation_w, conv_activation_c);
     log_info(tt::LogOp, "\t Filter (H, W): ({}, {})", filter_h, filter_w);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -179,9 +179,9 @@ struct Conv2dSliceConfig {
 };
 
 // TODO: Accept parallelization
-enum class OptimizedConvOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_REUSE, MULTI_CORE_REUSE_MCAST, SINGLE_CORE };
+enum class Conv2dOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_REUSE, MULTI_CORE_REUSE_MCAST, SINGLE_CORE };
 
-struct OptimizedConvParallelizationConfig {
+struct Conv2dParallelizationConfig {
     CoreCoord grid_size;  // (x,y)
     uint32_t num_cores_nhw = 1;
     uint32_t num_cores_c_in = 1;
@@ -192,14 +192,14 @@ struct OptimizedConvParallelizationConfig {
     CoreCoord get_grid_size() const { return this->grid_size; }
 };
 
-struct OptimizedConvBlockConfig {
+struct Conv2dBlockConfig {
     uint32_t act_block_h_ntiles;
     uint32_t act_block_w_ntiles;
     uint32_t out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles;
 };
 
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
     tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
@@ -214,15 +214,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     bool untilize_out,
     bool has_bias,
     const std::optional<unary::UnaryWithParam>& fused_activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,
     bool enable_weights_double_buffer,
     bool config_tensors_in_dram);
 
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
     tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
@@ -237,8 +237,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool untilize_out,
     bool has_bias,
     const std::optional<unary::UnaryWithParam>& fused_activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     bool transpose_mcast,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -250,9 +250,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     std::optional<bool> force_split_reader);
 
 // new micro op
-struct OptimizedConvNew {
-    OptimizedConvParallelizationConfig parallelization_config;
-    OptimizedConvBlockConfig block_config;
+struct Conv2d {
+    Conv2dParallelizationConfig parallelization_config;
+    Conv2dBlockConfig block_config;
     const sliding_window::SlidingWindowConfig& sliding_window_config;
     const uint32_t output_channels;
     const uint32_t groups;
@@ -269,15 +269,15 @@ struct OptimizedConvNew {
     bool config_tensors_in_dram;
     uint32_t pre_op_l1_allocation_size_bytes{};
     std::optional<bool> force_split_reader = std::nullopt;
-    OptimizedConvNew(
+    Conv2d(
         const sliding_window::SlidingWindowConfig& sliding_window_config,
         uint32_t output_channels,
         uint32_t groups,
         bool untile_out,
         bool has_bias,
         std::optional<ttnn::operations::unary::UnaryWithParam> activation,
-        const OptimizedConvParallelizationConfig& p_config,
-        const OptimizedConvBlockConfig& b_config,
+        const Conv2dParallelizationConfig& p_config,
+        const Conv2dBlockConfig& b_config,
         tt::tt_metal::MemoryConfig memory_config,
         tt::tt_metal::DataType dtype,
         std::array<std::uint32_t, 4> input_tensor_shape,
@@ -358,7 +358,7 @@ struct OptimizedConvNew {
     }
 };
 
-Tensor optimized_conv_new(
+Tensor conv2d(
     const Tensor& a,
     const Tensor& b,
     std::optional<const Tensor> bias,
@@ -367,8 +367,8 @@ Tensor optimized_conv_new(
     uint32_t groups,
     bool untilize_out,
     const std::optional<ttnn::operations::unary::UnaryWithParam>& activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     const tt::tt_metal::MemoryConfig& memory_config,
     tt::tt_metal::DataType dtype,
     std::array<std::uint32_t, 4> input_tensor_shape,
@@ -395,8 +395,8 @@ struct conv_op_l1_usage {
 // L1 allocation is either for the output tensor or for Circular Buffers.
 conv_op_l1_usage calculate_L1_usage(
     const DeviceComputeKernelConfig& compute_kernel_config,
-    const OptimizedConvBlockConfig& block_config,
-    const OptimizedConvParallelizationConfig& pconfig,
+    const Conv2dBlockConfig& block_config,
+    const Conv2dParallelizationConfig& pconfig,
     const ttnn::Shape& weights_shape,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     std::array<uint32_t, 2> dilation,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -154,7 +154,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     return config;
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
     tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
@@ -169,8 +169,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool untilize_out,
     bool has_bias,
     const std::optional<unary::UnaryWithParam>& fused_activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     bool transpose_mcast,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -41,7 +41,7 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
     return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
     tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
@@ -56,8 +56,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     bool untilize_out,
     bool has_bias,
     const std::optional<unary::UnaryWithParam>& fused_activation,
-    const OptimizedConvParallelizationConfig& parallelization_config,
-    const OptimizedConvBlockConfig& block_config,
+    const Conv2dParallelizationConfig& parallelization_config,
+    const Conv2dBlockConfig& block_config,
     Tensor& output,
     DeviceComputeKernelConfig compute_kernel_config,
     bool enable_act_double_buffer,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -953,7 +953,7 @@ bool is_valid_device_conv_bias(
     return true;
 }
 
-static OptimizedConvBlockConfig get_opt_block_config(
+static Conv2dBlockConfig get_opt_block_config(
     bool mm_conv,
     uint32_t in_channels,
     uint32_t out_channels,
@@ -1051,7 +1051,7 @@ static OptimizedConvBlockConfig get_opt_block_config(
     ParallelConfig largest_parallel_config = output_parallel_config.grid.num_cores() > parallel_config.grid.num_cores()
                                                  ? output_parallel_config
                                                  : parallel_config;
-    OptimizedConvParallelizationConfig opt_conv_op_parallel_config =
+    Conv2dParallelizationConfig opt_conv_op_parallel_config =
         determine_conv_op_parallel_config_from_conv_output_mem_config(
             conv_out_memory_config,
             get_num_cores_nhw_from_parallel_config(parallel_config),

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -275,7 +275,7 @@ Result conv_transpose2d(
         return matmul_output;
     }
     // call conv micro op
-    auto conv_output = optimized_conv_new(
+    auto conv_output = ttnn::operations::conv::conv2d::conv2d(
         halo_output,
         weight_tensor_on_device,
         bias_tensor_on_device,


### PR DESCRIPTION
Remove "Optimized" from various conv2d types.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17950335845)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/17943678161)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17943684387)