### PR TITLE
Change SDPA defaults to high precision

### DIFF
--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -129,13 +129,6 @@ def run_ring_joint_sdpa(
         exp_approx_mode=False,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.HiFi2,
-        math_approx_mode=False,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-
     Q = fa_rand(b, nh, seq_len, d)
     K = fa_rand(b, nh, seq_len, d)
     V = fa_rand(b, nh, seq_len, d)
@@ -220,7 +213,6 @@ def run_ring_joint_sdpa(
                 joint_strategy="rear",
                 logical_n=seq_len,
                 program_config=program_config,
-                compute_kernel_config=compute_kernel_config,
                 dim=2,
                 multi_device_global_semaphore=ccl_semaphore_handles[i],
                 num_links=num_links,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -34,7 +34,18 @@ def fa_rand(*shape):
 
 
 def run_test_sdpa_tt(
-    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_high_precision_compute=False, rmse_threshold=None
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    dtype,
+    compute_kernel_config=None,
+    rmse_threshold=None,
+    PCC_threshold=0.994,
 ):
     torch.manual_seed(1234)
 
@@ -42,23 +53,8 @@ def run_test_sdpa_tt(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
-        exp_approx_mode=True,
+        exp_approx_mode=False,
     )
-
-    if use_high_precision_compute:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
-            math_approx_mode=False,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
-        )
 
     Q = fa_rand(b, nh, s, d)
     K = fa_rand(b, nkv, s, d)
@@ -78,7 +74,7 @@ def run_test_sdpa_tt(
     V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)  # b, nh, d, S
     gt = torch.nn.functional.scaled_dot_product_attention(Q, K_repeated, V_repeated, is_causal=True)
 
-    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.994)
+    out_pass, out_pcc = comp_pcc(gt, tt_back, PCC_threshold)
     logger.debug(f"python vs pytorch: {out_pcc}")
     rmse = torch.sqrt(((gt - tt_back) ** 2).mean()).item()
     logger.debug(f"rmse: {rmse}")
@@ -89,7 +85,20 @@ def run_test_sdpa_tt(
 
 
 def run_sdpa_noncausal(
-    device, b, nh, nkv, sq, d, q_chunk_size, k_chunk_size, dtype, sk=None, use_mask=True, rmse_threshold=None
+    device,
+    b,
+    nh,
+    nkv,
+    sq,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    dtype,
+    sk=None,
+    use_mask=True,
+    compute_kernel_config=None,
+    rmse_threshold=None,
+    PCC_threshold=0.994,
 ):
     torch.manual_seed(1234)
     if sk is None:
@@ -99,14 +108,7 @@ def run_sdpa_noncausal(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
-        exp_approx_mode=True,
-    )
-
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.HiFi2,
-        math_approx_mode=False,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
+        exp_approx_mode=False,
     )
 
     Q = fa_rand(b, nh, sq, d)
@@ -153,7 +155,7 @@ def run_sdpa_noncausal(
 
     gt = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=False, attn_mask=mask)
 
-    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.994)
+    out_pass, out_pcc = comp_pcc(gt, tt_back, PCC_threshold)
     logger.debug(f"python vs pytorch: {out_pcc}")
     rmse = torch.sqrt(((gt - tt_back) ** 2).mean()).item()
     logger.debug(f"rmse: {rmse}")
@@ -186,12 +188,27 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
         pytest.skip("nkv must divide nh")
     if is_ci_env and (b == 1 or nh == 1 or s == 1 or q_chunk_size == 512 or k_chunk_size == 512):
         pytest.skip("Skipping to avoid CI timeout")
-    ttnn.device.DisablePersistentKernelCache()
+
+    MAX_RMSE = 0.0102
+    MIN_PCC = 0.9988
     if is_causal:
-        run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=0.033)
+        run_test_sdpa_tt(
+            device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=MAX_RMSE, PCC_threshold=MIN_PCC
+        )
     else:
         run_sdpa_noncausal(
-            device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_mask=False, rmse_threshold=0.033
+            device,
+            b,
+            nh,
+            nkv,
+            s,
+            d,
+            q_chunk_size,
+            k_chunk_size,
+            dtype,
+            use_mask=False,
+            rmse_threshold=MAX_RMSE,
+            PCC_threshold=MIN_PCC,
         )
 
 
@@ -216,11 +233,20 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
         pytest.skip("just need to single test case for sanity-check bfp4")
     if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
-    if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
-        pytest.skip("Can cause OOM if profiling is enabled.")
-    rmse_threshold = 0.0092 if (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b) else 0.0093
-    ttnn.device.DisablePersistentKernelCache()
-    run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
+
+    if dtype == ttnn.bfloat4_b:
+        MAX_RMSE = 0.062
+        MIN_PCC = 0.9986
+    elif dtype == ttnn.bfloat8_b:
+        MAX_RMSE = 0.0070
+        MIN_PCC = 0.9986
+    elif dtype == ttnn.bfloat16:
+        MAX_RMSE = 0.0064
+        MIN_PCC = 0.9988
+
+    run_test_sdpa_tt(
+        device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=MAX_RMSE, PCC_threshold=MIN_PCC
+    )
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
@@ -237,7 +263,7 @@ def test_sdpa_tt_small_chunks(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_si
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
+
     run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype)
 
 
@@ -258,8 +284,28 @@ def test_sdpa_perf(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
-    run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_mask=False)
+
+    perf_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    run_sdpa_noncausal(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        use_mask=False,
+        compute_kernel_config=perf_compute_kernel_config,
+    )
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
@@ -271,12 +317,16 @@ def test_sdpa_perf(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
     ([1, 8, 1, 128 * 1024, 128],),  # Llama2-70B 128K sequence
 )
 def test_sdpa_tt_large_seq(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
-    if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
-        pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
-    if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
-        pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
-    rmse_threshold = 0.0094
+    correct_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+    MAX_RMSE = 0.0094
+    MIN_PCC = 0.9992
+
     run_test_sdpa_tt(
         device,
         b,
@@ -287,8 +337,9 @@ def test_sdpa_tt_large_seq(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size,
         q_chunk_size,
         k_chunk_size,
         dtype,
-        use_high_precision_compute=True,
-        rmse_threshold=rmse_threshold,
+        rmse_threshold=MAX_RMSE,
+        PCC_threshold=MIN_PCC,
+        compute_kernel_config=correct_compute_kernel_config,
     )
 
 
@@ -360,8 +411,15 @@ def test_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
     if s > 2048 and (q_chunk_size == 128 or k_chunk_size == 128):
         pytest.skip("Bad PCC for small chunks")
     ttnn.device.DisablePersistentKernelCache()
-    rmse_threshold = 0.0069
-    run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
+    if dtype == ttnn.bfloat16:
+        MAX_RMSE = 0.0060
+        MIN_PCC = 0.9988
+    else:
+        MAX_RMSE = 0.0063
+        MIN_PCC = 0.9986
+    run_sdpa_noncausal(
+        device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=MAX_RMSE, PCC_threshold=MIN_PCC
+    )
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
@@ -403,7 +461,7 @@ def run_test_chunked_sdpa(
         compute_with_storage_grid_size=grid_size or device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
-        exp_approx_mode=True,
+        exp_approx_mode=False,
     )
 
     if use_high_precision_compute:
@@ -414,12 +472,7 @@ def run_test_chunked_sdpa(
             packer_l1_acc=False,
         )
     else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
-        )
+        compute_kernel_config = None
 
     Q = fa_rand(b, nh, s, d)
     K = fa_rand(b, nkv, s, d)
@@ -624,7 +677,7 @@ def run_test_joint_sdpa(
         compute_with_storage_grid_size=grid_size or device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
-        exp_approx_mode=True,
+        exp_approx_mode=False,
     )
 
     if use_high_precision_compute:
@@ -635,12 +688,7 @@ def run_test_joint_sdpa(
             packer_l1_acc=False,
         )
     else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
-        )
+        compute_kernel_config = None
 
     Q = fa_rand(b, nh, seq_len, d)
     K = fa_rand(b, nh, seq_len, d)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_program_factory.cpp
@@ -146,8 +146,8 @@ operation::ProgramWithCallbacks joint_sdpa(
                                                      : device->compute_with_storage_grid_size();
     bool exp_approx_mode =
         program_config.has_value()
-            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : true)
-            : true;
+            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : false)
+            : false;
 
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -83,7 +83,7 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     // Precondition: in_cb has num_tiles produced
     // Postcondition: in_cb has num_tiles produced
     copy_tile_to_dst_init_short(in_cb);
-    recip_tile_init();
+    recip_tile_init<false>();
     reconfig_data_format_srca(in_cb);
     pack_reconfig_data_format(in_cb);
 
@@ -91,7 +91,7 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     for (uint32_t i = 0; i < num_tiles; ++i) {
         acquire_dst();
         copy_tile(in_cb, i, 0);
-        recip_tile(0, static_cast<int>(VectorMode::C));
+        recip_tile<false>(0, static_cast<int>(VectorMode::C));
         pack_tile(0, in_cb);
         release_dst();
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -153,8 +153,8 @@ operation::ProgramWithCallbacks ring_joint_sdpa(
                                                      : device->compute_with_storage_grid_size();
     bool exp_approx_mode =
         program_config.has_value()
-            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : true)
-            : true;
+            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : false)
+            : false;
 
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -164,8 +164,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                                                      : device->compute_with_storage_grid_size();
     bool exp_approx_mode =
         program_config.has_value()
-            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : true)
-            : true;
+            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : false)
+            : false;
 
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;
@@ -469,7 +469,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
     tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
                                                        // tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat stats_df = im_df;
+    tt::DataFormat stats_df = tt::DataFormat::Float16_b;
 
     uint32_t q_tile_size = tt::tt_metal::detail::TileSize(q_df);
     uint32_t k_tile_size = tt::tt_metal::detail::TileSize(k_df);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -31,7 +31,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     return tt::tt_metal::operation::run(
                ScaledDotProductAttention{
@@ -65,7 +65,7 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     return tt::tt_metal::operation::run(
                ScaledDotProductAttention{
@@ -100,7 +100,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ExecuteJointAttention::invoke(
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     auto results = tt::tt_metal::operation::run(
         JointScaledDotProductAttention{
@@ -145,7 +145,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     /**
      * Create RingAttentionAllGatherAsync struct.
@@ -223,7 +223,7 @@ ttnn::Tensor ExecuteFlashMLAPrefill::invoke(
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     return tt::tt_metal::operation::run(
                ScaledDotProductAttention{
@@ -258,7 +258,7 @@ ttnn::Tensor ExecuteChunkedFlashMLAPrefill::invoke(
             ? input_tensor_q.device()->arch()
             : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, false, true, false);
 
     return tt::tt_metal::operation::run(
                ScaledDotProductAttention{


### PR DESCRIPTION
### Problem description
The various SDPA prefill ops did not default to high precision compute configs.

### What's changed
In order to push towards "accurate by default", the default compute kernel config has been modified to use fp32 dst accumulation, and exp-approx has been disabled by default.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17951358424) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17951369841) CI with demo tests passes (if applicable)
- [ ] [T3K pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17951406274)
- [ ] [Galaxy pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/17951423339)
