### PR TITLE
AI generated slice program factory kb for multicore, any stride, run …

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -155,6 +155,7 @@ target_sources(
         sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
         slice/device/slice_op.cpp
         slice/device/slice_program_factory.cpp
+        slice/device/slice_program_factory_kb.cpp
         slice/slice.cpp
         split/device/split_op.cpp
         split/device/split_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_reader_multicore_slice_4d.cpp
@@ -41,6 +41,7 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
@@ -54,151 +55,68 @@ inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t 
 }
 
 void kernel_main() {
-    DPRINT << "LLONG reader kernel_main" << ENDL();
-    // Runtime arguments for 4D slice support with multi-core work distribution
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t tensor_rank = get_arg_val<uint32_t>(1);
-    uint32_t input_w = get_arg_val<uint32_t>(2);
-    uint32_t input_h = get_arg_val<uint32_t>(3);
-    uint32_t input_d = get_arg_val<uint32_t>(4);
-    uint32_t input_n = get_arg_val<uint32_t>(5);
-    uint32_t output_w = get_arg_val<uint32_t>(6);
-    uint32_t output_h = get_arg_val<uint32_t>(7);
-    uint32_t output_d = get_arg_val<uint32_t>(8);
-    uint32_t output_n = get_arg_val<uint32_t>(9);
-    uint32_t slice_start_w = get_arg_val<uint32_t>(10);
-    uint32_t slice_end_w = get_arg_val<uint32_t>(11);
-    uint32_t slice_step_w = get_arg_val<uint32_t>(12);
-    uint32_t slice_start_h = get_arg_val<uint32_t>(13);
-    uint32_t slice_end_h = get_arg_val<uint32_t>(14);
-    uint32_t slice_step_h = get_arg_val<uint32_t>(15);
-    uint32_t slice_start_d = get_arg_val<uint32_t>(16);
-    uint32_t slice_end_d = get_arg_val<uint32_t>(17);
-    uint32_t slice_step_d = get_arg_val<uint32_t>(18);
-    uint32_t slice_start_n = get_arg_val<uint32_t>(19);
-    uint32_t slice_end_n = get_arg_val<uint32_t>(20);
-    uint32_t slice_step_n = get_arg_val<uint32_t>(21);
-    uint32_t element_size = get_arg_val<uint32_t>(22);
-    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(23);
-    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(24);
-    DPRINT << "num_rows_for_this_core: " << num_rows_for_this_core << ENDL();
-    DPRINT << "start_row_for_this_core: " << start_row_for_this_core << ENDL();
+    // Runtime arguments - optimized for direct stick indexing like production
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
+    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
+    const uint32_t num_dims = get_arg_val<uint32_t>(4);
+    const uint32_t misalignment = get_arg_val<uint32_t>(5);
+    const uint32_t start_id = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(7);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(8);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(9);
+
+    // Dimensional indexing arrays (like production)
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(10));
+    volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
+    volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
     // Compile-time arguments
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
     constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(2);
 
-    // Calculate sizes - working with rows, not tiles
-    uint32_t input_bytes_per_row = input_w * element_size;  // Dynamic element size
-    uint32_t output_bytes_per_row = output_w * element_size;
+    // Use TensorAccessor like production for optimized addressing
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    uint32_t read_size = unpadded_stick_size + misalignment;
+    const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
 
-    // Set up InterleavedAddrGenFast for input data - use row size as page size
-    const InterleavedAddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr,
-        .page_size = input_bytes_per_row,  // Each page is one input row
-    };
+    // Direct stick indexing with batch processing (like production)
+    uint32_t src_stick_id = start_id;
+    uint32_t sticks_read = 0;
 
-    // Multi-core work distribution: this core processes rows [start_row_for_this_core, start_row_for_this_core +
-    // num_rows_for_this_core) We need to map these logical output row indices back to the corresponding (n,d,h)
-    // coordinates
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read && sticks_read < num_sticks_per_core; ++iter) {
+        cb_reserve_back(cb_id_out, num_read_per_barrier);
+        uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_out);
 
-    uint32_t rows_processed = 0;
-    uint32_t current_logical_row = 0;
-    bool found_start = false;
+        for (uint32_t i = 0; i < num_read_per_barrier && sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+            noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
 
-    // Set loop bounds based on tensor rank
-    uint32_t n_start = (tensor_rank >= 4) ? slice_start_n : 0;
-    uint32_t n_end = (tensor_rank >= 4) ? slice_end_n : 1;
-    uint32_t n_step = (tensor_rank >= 4) ? slice_step_n : 1;
-
-    uint32_t d_start = (tensor_rank >= 3) ? slice_start_d : 0;
-    uint32_t d_end = (tensor_rank >= 3) ? slice_end_d : 1;
-    uint32_t d_step = (tensor_rank >= 3) ? slice_step_d : 1;
-
-    uint32_t h_start = (tensor_rank >= 2) ? slice_start_h : 0;
-    uint32_t h_end = (tensor_rank >= 2) ? slice_end_h : 1;
-    uint32_t h_step = (tensor_rank >= 2) ? slice_step_h : 1;
-
-    // Multi-dimensional slicing with nested loops
-    // 4D: Batch dimension loop
-    for (uint32_t n = n_start; n < n_end && rows_processed < num_rows_for_this_core; n += n_step) {
-        // 3D: Depth dimension loop
-        for (uint32_t d = d_start; d < d_end && rows_processed < num_rows_for_this_core; d += d_step) {
-            // 2D: Height dimension loop
-            for (uint32_t h = h_start; h < h_end && rows_processed < num_rows_for_this_core; h += h_step) {
-                // Check if this logical row should be processed by this core
-                if (!found_start) {
-                    if (current_logical_row == start_row_for_this_core) {
-                        found_start = true;
-                    } else {
-                        current_logical_row++;
-                        if (tensor_rank == 1) {
-                            break;  // For 1D, exit after checking once
-                        }
-                        continue;
-                    }
-                }
-
-                if (rows_processed >= num_rows_for_this_core) {
-                    break;
-                }
-
-                // Calculate input row index based on tensor rank
-                uint32_t input_row_idx;
-                if (tensor_rank == 1) {
-                    input_row_idx = 0;  // Single row for 1D
-                } else if (tensor_rank == 2) {
-                    input_row_idx = h;
-                } else if (tensor_rank == 3) {
-                    input_row_idx = d * input_h + h;
-                } else {  // 4D
-                    input_row_idx = n * input_d * input_h + d * input_h + h;
-                }
-
-                cb_reserve_back(cb_id_out, 1);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_out);
-
-                // Read the full input row first
-                uint64_t input_row_noc_addr = get_noc_addr(input_row_idx, s);
-                noc_async_read(input_row_noc_addr, l1_write_addr, input_bytes_per_row);
+            // Handle misalignment like production
+            if (misalignment != 0) {
                 noc_async_read_barrier();
+                tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+            }
 
-                // Now slice the row according to width slice parameters
-                // Copy sliced elements to the beginning of the buffer
-                if (slice_start_w != 0 || slice_step_w != 1 || slice_end_w != input_w) {
-                    // Need to reorganize the data in the buffer
-                    volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
-                    volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+            src_buffer_l1_addr += stick_size_offset;
+            src_stick_id++;
 
-                    uint32_t out_col = 0;
-                    for (uint32_t input_col = slice_start_w; input_col < slice_end_w && out_col < output_w;
-                         input_col += slice_step_w) {
-                        // Copy element by element for the slice
-                        for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
-                            dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
-                        }
-                        out_col++;
-                    }
-                }
-
-                cb_push_back(cb_id_out, 1);
-                rows_processed++;
-                current_logical_row++;
-
-                // Early exit for 1D tensors
-                if (tensor_rank == 1) {
+            // Multi-dimensional indexing with padding (like production)
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks[j];
+                } else {
                     break;
                 }
             }
-            // Early exit for 2D tensors
-            if (tensor_rank <= 2) {
-                break;
-            }
         }
-        // Early exit for 3D tensors
-        if (tensor_rank <= 3) {
-            break;
-        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id_out, num_read_per_barrier);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_reader_multicore_slice_4d.cpp
@@ -1,0 +1,204 @@
+/*
+ * TTNN Slice Operation - Multi-Core Reader Kernel (4D Support)
+ *
+ * This kernel handles the input data reading phase of the slice operation for multi-core
+ * execution, implementing slice logic for 1D, 2D, 3D, and 4D tensors with work distribution
+ * across multiple cores for improved performance.
+ *
+ * Key Responsibilities:
+ * - Read assigned portion of input tensor data from DRAM using InterleavedAddrGenFast
+ * - Apply slice logic (start, end, step) for all dimensions (N, D, H, W)
+ * - Handle different data types with proper element size calculations
+ * - Process assigned rows for this core based on work distribution
+ * - Output sliced rows to circular buffer for writer kernel consumption
+ *
+ * Architecture:
+ * - Uses InterleavedAddrGenFast for efficient DRAM address generation
+ * - Processes data row-by-row for optimal memory access patterns
+ * - Supports slicing with configurable start, end, and step parameters for all dimensions
+ * - Handles 1D (W), 2D (H,W), 3D (D,H,W), and 4D (N,D,H,W) tensors
+ * - Multi-core work distribution: each core processes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering for continuous data flow
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal branching in inner loops for consistent execution
+ * - Efficient memory copy operations using NOC async transfers
+ * - Cache-friendly access patterns aligned to memory hierarchy
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Author: claude (based on pad operation template and single-core 4D slice)
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
+    for (uint32_t page = 0; page < npages; ++page) {
+        DPRINT << start + page << ": ";
+        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
+            DPRINT << BF16(*ptr) << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
+void kernel_main() {
+    DPRINT << "LLONG reader kernel_main" << ENDL();
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(1);
+    uint32_t input_w = get_arg_val<uint32_t>(2);
+    uint32_t input_h = get_arg_val<uint32_t>(3);
+    uint32_t input_d = get_arg_val<uint32_t>(4);
+    uint32_t input_n = get_arg_val<uint32_t>(5);
+    uint32_t output_w = get_arg_val<uint32_t>(6);
+    uint32_t output_h = get_arg_val<uint32_t>(7);
+    uint32_t output_d = get_arg_val<uint32_t>(8);
+    uint32_t output_n = get_arg_val<uint32_t>(9);
+    uint32_t slice_start_w = get_arg_val<uint32_t>(10);
+    uint32_t slice_end_w = get_arg_val<uint32_t>(11);
+    uint32_t slice_step_w = get_arg_val<uint32_t>(12);
+    uint32_t slice_start_h = get_arg_val<uint32_t>(13);
+    uint32_t slice_end_h = get_arg_val<uint32_t>(14);
+    uint32_t slice_step_h = get_arg_val<uint32_t>(15);
+    uint32_t slice_start_d = get_arg_val<uint32_t>(16);
+    uint32_t slice_end_d = get_arg_val<uint32_t>(17);
+    uint32_t slice_step_d = get_arg_val<uint32_t>(18);
+    uint32_t slice_start_n = get_arg_val<uint32_t>(19);
+    uint32_t slice_end_n = get_arg_val<uint32_t>(20);
+    uint32_t slice_step_n = get_arg_val<uint32_t>(21);
+    uint32_t element_size = get_arg_val<uint32_t>(22);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(23);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(24);
+    DPRINT << "num_rows_for_this_core: " << num_rows_for_this_core << ENDL();
+    DPRINT << "start_row_for_this_core: " << start_row_for_this_core << ENDL();
+
+    // Compile-time arguments
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(2);
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t input_bytes_per_row = input_w * element_size;  // Dynamic element size
+    uint32_t output_bytes_per_row = output_w * element_size;
+
+    // Set up InterleavedAddrGenFast for input data - use row size as page size
+    const InterleavedAddrGen<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = input_bytes_per_row,  // Each page is one input row
+    };
+
+    // Multi-core work distribution: this core processes rows [start_row_for_this_core, start_row_for_this_core +
+    // num_rows_for_this_core) We need to map these logical output row indices back to the corresponding (n,d,h)
+    // coordinates
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+
+    // Set loop bounds based on tensor rank
+    uint32_t n_start = (tensor_rank >= 4) ? slice_start_n : 0;
+    uint32_t n_end = (tensor_rank >= 4) ? slice_end_n : 1;
+    uint32_t n_step = (tensor_rank >= 4) ? slice_step_n : 1;
+
+    uint32_t d_start = (tensor_rank >= 3) ? slice_start_d : 0;
+    uint32_t d_end = (tensor_rank >= 3) ? slice_end_d : 1;
+    uint32_t d_step = (tensor_rank >= 3) ? slice_step_d : 1;
+
+    uint32_t h_start = (tensor_rank >= 2) ? slice_start_h : 0;
+    uint32_t h_end = (tensor_rank >= 2) ? slice_end_h : 1;
+    uint32_t h_step = (tensor_rank >= 2) ? slice_step_h : 1;
+
+    // Multi-dimensional slicing with nested loops
+    // 4D: Batch dimension loop
+    for (uint32_t n = n_start; n < n_end && rows_processed < num_rows_for_this_core; n += n_step) {
+        // 3D: Depth dimension loop
+        for (uint32_t d = d_start; d < d_end && rows_processed < num_rows_for_this_core; d += d_step) {
+            // 2D: Height dimension loop
+            for (uint32_t h = h_start; h < h_end && rows_processed < num_rows_for_this_core; h += h_step) {
+                // Check if this logical row should be processed by this core
+                if (!found_start) {
+                    if (current_logical_row == start_row_for_this_core) {
+                        found_start = true;
+                    } else {
+                        current_logical_row++;
+                        if (tensor_rank == 1) {
+                            break;  // For 1D, exit after checking once
+                        }
+                        continue;
+                    }
+                }
+
+                if (rows_processed >= num_rows_for_this_core) {
+                    break;
+                }
+
+                // Calculate input row index based on tensor rank
+                uint32_t input_row_idx;
+                if (tensor_rank == 1) {
+                    input_row_idx = 0;  // Single row for 1D
+                } else if (tensor_rank == 2) {
+                    input_row_idx = h;
+                } else if (tensor_rank == 3) {
+                    input_row_idx = d * input_h + h;
+                } else {  // 4D
+                    input_row_idx = n * input_d * input_h + d * input_h + h;
+                }
+
+                cb_reserve_back(cb_id_out, 1);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_out);
+
+                // Read the full input row first
+                uint64_t input_row_noc_addr = get_noc_addr(input_row_idx, s);
+                noc_async_read(input_row_noc_addr, l1_write_addr, input_bytes_per_row);
+                noc_async_read_barrier();
+
+                // Now slice the row according to width slice parameters
+                // Copy sliced elements to the beginning of the buffer
+                if (slice_start_w != 0 || slice_step_w != 1 || slice_end_w != input_w) {
+                    // Need to reorganize the data in the buffer
+                    volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                    volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                    uint32_t out_col = 0;
+                    for (uint32_t input_col = slice_start_w; input_col < slice_end_w && out_col < output_w;
+                         input_col += slice_step_w) {
+                        // Copy element by element for the slice
+                        for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                            dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                        }
+                        out_col++;
+                    }
+                }
+
+                cb_push_back(cb_id_out, 1);
+                rows_processed++;
+                current_logical_row++;
+
+                // Early exit for 1D tensors
+                if (tensor_rank == 1) {
+                    break;
+                }
+            }
+            // Early exit for 2D tensors
+            if (tensor_rank <= 2) {
+                break;
+            }
+        }
+        // Early exit for 3D tensors
+        if (tensor_rank <= 3) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_writer_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_writer_multicore_slice_4d.cpp
@@ -1,0 +1,88 @@
+/*
+ * TTNN Slice Operation - Multi-Core Writer Kernel (4D Support)
+ *
+ * This kernel handles the output data writing phase of the slice operation for multi-core
+ * execution, writing sliced tensor data from circular buffer to output tensor memory.
+ * Supports 1D, 2D, 3D, and 4D tensors with work distribution across cores.
+ *
+ * Key Responsibilities:
+ * - Read sliced data from circular buffer (produced by reader kernel)
+ * - Write assigned portion of output data to DRAM using InterleavedAddrGenFast
+ * - Handle different tensor dimensions with proper address calculations
+ * - Support different data types with proper element size handling
+ * - Process assigned rows for this core based on work distribution
+ *
+ * Architecture:
+ * - Uses InterleavedAddrGenFast for efficient DRAM address generation
+ * - Processes data row-by-row to match reader kernel output
+ * - Simple sequential write pattern for optimal memory controller utilization
+ * - Multi-core work distribution: each core writes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering synchronized with reader kernel
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal synchronization overhead with reader kernel
+ * - Efficient memory write operations using NOC async transfers
+ * - Sequential access patterns optimized for DRAM controllers
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Author: claude (based on pad operation template and single-core 4D slice)
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t tensor_rank = get_arg_val<uint32_t>(1);
+    uint32_t output_w = get_arg_val<uint32_t>(2);
+    uint32_t output_h = get_arg_val<uint32_t>(3);
+    uint32_t output_d = get_arg_val<uint32_t>(4);
+    uint32_t output_n = get_arg_val<uint32_t>(5);
+    uint32_t element_size = get_arg_val<uint32_t>(6);
+    uint32_t num_rows_for_this_core = get_arg_val<uint32_t>(7);
+    uint32_t start_row_for_this_core = get_arg_val<uint32_t>(8);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t compile_time_element_size = get_compile_time_arg_val(2);
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t output_bytes_per_row = output_w * element_size;  // Dynamic element size
+
+    // Set up InterleavedAddrGenFast for output data - use row size as page size
+    const InterleavedAddrGen<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = output_bytes_per_row,  // Each page is one output row
+    };
+
+    // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
+    // Write each row from circular buffer to output tensor at the correct logical position
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_wait_front(cb_id_in, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_in);
+
+        // Calculate global output row index for this local row
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+
+        // Calculate output address for this row
+        uint64_t output_row_noc_addr = get_noc_addr(global_output_row, s);
+
+        // Write the complete row to output tensor
+        noc_async_write(l1_read_addr, output_row_noc_addr, output_bytes_per_row);
+        noc_async_write_barrier();
+
+        cb_pop_front(cb_id_in, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -87,6 +87,7 @@ void SliceDeviceOperation::validate_with_output_tensors(
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR, "Error");
+    log_info(tt::LogMetal, "LLONG input_tensor_a.layout() = {}", input_tensor_a.layout());
     TT_FATAL(
         input_tensor_a.padded_shape().rank() == this->slice_start.rank() &&
             this->slice_start.rank() == this->slice_end.rank(),
@@ -172,7 +173,7 @@ operation::ProgramWithCallbacks SliceDeviceOperation::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-
+    log_info(tt::LogMetal, "LLONG create_program input_tensor_a.layout() = {}", input_tensor_a.layout());
     return detail::slice_multi_core(input_tensor_a, output_tensor, this->slice_start, this->slice_end, this->step);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -855,6 +855,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
 operation::ProgramWithCallbacks slice_tile_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    std::cout << "LLONG slice_tile_multi_core" << std::endl;
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
@@ -982,13 +983,16 @@ operation::ProgramWithCallbacks slice_multi_core(
             break;
         }
     }
+    std::cout << "LLONG has step: " << has_step << std::endl;
     switch (a.layout()) {
         case Layout::ROW_MAJOR:
+            std::cout << "LLONG input is row major" << std::endl;
             return a.is_sharded() ? slice_rm_multi_core_sharded(a, output, output_tensor_start, output_tensor_end)
-                                  : (has_step ? slice_rm_strided_single_core_n_dims(
-                                                    a, output, output_tensor_start, output_tensor_end, step)
-                                              : slice_rm_multi_core(a, output, output_tensor_start, output_tensor_end));
-        case Layout::TILE: return slice_tile_multi_core(a, output, output_tensor_start, output_tensor_end);
+                                  : slice_rm_multi_core_kb(a, output, output_tensor_start, output_tensor_end, step);
+            // :slice_rm_multi_core(a, output, output_tensor_start, output_tensor_end);
+        case Layout::TILE:
+            std::cout << "LLONG input is tile" << std::endl;
+            return slice_tile_multi_core(a, output, output_tensor_start, output_tensor_end);
         default: TT_ASSERT(false, "Unsupported Layout");
     }
     return {};

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -14,4 +14,11 @@ tt::tt_metal::operation::ProgramWithCallbacks slice_multi_core(
     const ttnn::Shape& output_tensor_end,
     const ttnn::Shape& step);
 
+tt::tt_metal::operation::ProgramWithCallbacks slice_rm_multi_core_kb(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& slice_step);
+
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_kb.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_kb.cpp
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "optional"
+#include "ttnn/operations/math.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <cmath>
+#include <algorithm>
+
+#include "slice_op.hpp"
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::data_movement::detail {
+
+/**
+ * Get element size in bytes for different TTNN data types.
+ * Translated from Python _get_element_size method.
+ */
+inline uint32_t get_element_size_kb(const DataType& dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT16: return 2;   // 16-bit brain floating point
+        case DataType::FLOAT32: return 4;    // 32-bit IEEE floating point
+        case DataType::INT32: return 4;      // 32-bit signed integer
+        case DataType::UINT32: return 4;     // 32-bit unsigned integer
+        case DataType::BFLOAT8_B: return 1;  // 8-bit brain floating point
+        default: TT_THROW("Unsupported data type for KB slice operation");
+    }
+}
+
+/**
+ * Calculate total output rows based on tensor rank - this is what we distribute across cores.
+ * Translated from Python get_multicore_slice_descriptor method.
+ */
+inline uint32_t calculate_total_output_rows_kb(const ttnn::Shape& output_shape) {
+    auto rank = output_shape.rank();
+
+    if (rank == 1) {
+        return 1;
+    } else if (rank == 2) {
+        return output_shape[-2];  // output_h
+    } else if (rank == 3) {
+        return output_shape[-3] * output_shape[-2];  // output_d * output_h
+    } else if (rank == 4) {
+        return output_shape[-4] * output_shape[-3] * output_shape[-2];  // output_n * output_d * output_h
+    } else {
+        TT_THROW("KB slice operation supports only 1D-4D tensors");
+    }
+}
+
+/**
+ * Core allocation and work distribution for KB multi-core slice operation.
+ * This implements the key insight from Python: use only as many cores as we have work for.
+ * Translated from Python get_multicore_slice_descriptor method.
+ */
+inline std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> calculate_core_allocation_kb(
+    tt::tt_metal::IDevice* device, uint32_t total_output_rows) {
+    // Get hardware compute grid dimensions
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t max_cores_available = compute_grid.x * compute_grid.y;
+
+    // CORE ALLOCATION DECISION:
+    // Use min(available_cores, rows_to_process) to avoid over-parallelization
+    // Each core processes at least one row, so more cores than rows is wasteful
+    uint32_t num_cores_needed = std::min(max_cores_available, total_output_rows);
+
+    // GRID LAYOUT OPTIMIZATION:
+    // Arrange cores in optimal rectangular grid for memory access patterns
+    uint32_t grid_x, grid_y;
+    if (num_cores_needed <= compute_grid.x) {
+        // Small workload: use single row of cores for simplicity
+        grid_x = num_cores_needed;
+        grid_y = 1;
+    } else {
+        // Large workload: use full grid width, calculate required height
+        grid_x = compute_grid.x;
+        grid_y = (num_cores_needed + grid_x - 1) / grid_x;  // Ceiling division
+    }
+
+    uint32_t num_cores = grid_x * grid_y;
+
+    return std::make_tuple(grid_x, grid_y, num_cores, max_cores_available, num_cores_needed);
+}
+
+/**
+ * Prepare runtime arguments for KB multi-core slice kernels.
+ * Handles both 4D kernels and maintains compatibility with 2D kernels.
+ * Translated from Python get_multicore_slice_descriptor method.
+ */
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_kb(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& slice_step,
+    uint32_t grid_x,
+    uint32_t grid_y,
+    uint32_t num_cores,
+    uint32_t total_output_rows,
+    const std::string& reader_kernel_path,
+    const std::string& writer_kernel_path) {
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+    uint32_t element_size = get_element_size_kb(input_tensor.dtype());
+
+    // Extract dimensions with proper defaults for lower-rank tensors
+    uint32_t tensor_rank = input_shape.rank();
+
+    // Input dimensions (padded to 4D)
+    uint32_t input_n = (tensor_rank >= 4) ? input_shape[-4] : 1;
+    uint32_t input_d = (tensor_rank >= 3) ? input_shape[-3] : 1;
+    uint32_t input_h = (tensor_rank >= 2) ? input_shape[-2] : 1;
+    uint32_t input_w = input_shape[-1];
+
+    // Output dimensions (padded to 4D)
+    uint32_t output_n = (tensor_rank >= 4) ? output_shape[-4] : 1;
+    uint32_t output_d = (tensor_rank >= 3) ? output_shape[-3] : 1;
+    uint32_t output_h = (tensor_rank >= 2) ? output_shape[-2] : 1;
+    uint32_t output_w = output_shape[-1];
+
+    // Slice parameters (padded to 4D)
+    uint32_t start_n = (tensor_rank >= 4) ? slice_start[-4] : 0;
+    uint32_t start_d = (tensor_rank >= 3) ? slice_start[-3] : 0;
+    uint32_t start_h = (tensor_rank >= 2) ? slice_start[-2] : 0;
+    uint32_t start_w = slice_start[-1];
+
+    uint32_t end_n = (tensor_rank >= 4) ? slice_end[-4] : 1;
+    uint32_t end_d = (tensor_rank >= 3) ? slice_end[-3] : 1;
+    uint32_t end_h = (tensor_rank >= 2) ? slice_end[-2] : 1;
+    uint32_t end_w = slice_end[-1];
+
+    uint32_t step_n = (tensor_rank >= 4) ? slice_step[-4] : 1;
+    uint32_t step_d = (tensor_rank >= 3) ? slice_step[-3] : 1;
+    uint32_t step_h = (tensor_rank >= 2) ? slice_step[-2] : 1;
+    uint32_t step_w = slice_step[-1];
+
+    // WORK DISTRIBUTION ALGORITHM:
+    // Distribute rows as evenly as possible across cores
+    // Some cores may get one extra row to handle remainder
+    uint32_t base_rows_per_core = total_output_rows / num_cores;  // Minimum rows per core
+    uint32_t extra_rows = total_output_rows % num_cores;          // Remainder rows to distribute
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
+
+    uint32_t row_start_id = 0;
+    uint32_t extra_rows_remaining = extra_rows;
+
+    // Determine kernel type
+    bool using_4d_kernels = (reader_kernel_path.find("4d") != std::string::npos);
+
+    for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
+        // Calculate work distribution for this core
+        uint32_t rows_for_this_core = base_rows_per_core;
+        if (extra_rows_remaining > 0) {
+            rows_for_this_core += 1;
+            extra_rows_remaining -= 1;
+        }
+
+        // Prepare runtime arguments based on kernel type
+        std::vector<uint32_t> reader_args, writer_args;
+
+        if (using_4d_kernels) {
+            // 4D kernels expect 25 arguments for reader, 9 for writer
+            reader_args = {
+                input_tensor.buffer()->address(),  // 0: src_addr - input tensor memory address
+                tensor_rank,                       // 1: tensor_rank - 1D, 2D, 3D, or 4D
+                input_w,                           // 2: input_w - input width
+                input_h,                           // 3: input_h - input height
+                input_d,                           // 4: input_d - input depth
+                input_n,                           // 5: input_n - input batch
+                output_w,                          // 6: output_w - output width
+                output_h,                          // 7: output_h - output height
+                output_d,                          // 8: output_d - output depth
+                output_n,                          // 9: output_n - output batch
+                start_w,                           // 10: slice_start_w - start index for width
+                end_w,                             // 11: slice_end_w - end index for width
+                step_w,                            // 12: slice_step_w - step size for width
+                start_h,                           // 13: slice_start_h - start index for height
+                end_h,                             // 14: slice_end_h - end index for height
+                step_h,                            // 15: slice_step_h - step size for height
+                start_d,                           // 16: slice_start_d - start index for depth
+                end_d,                             // 17: slice_end_d - end index for depth
+                step_d,                            // 18: slice_step_d - step size for depth
+                start_n,                           // 19: slice_start_n - start index for batch
+                end_n,                             // 20: slice_end_n - end index for batch
+                step_n,                            // 21: slice_step_n - step size for batch
+                element_size,                      // 22: element_size - bytes per element
+                rows_for_this_core,                // 23: num_rows - rows for this core
+                row_start_id                       // 24: start_row - starting row for this core
+            };
+
+            writer_args = {
+                output_tensor.buffer()->address(),  // 0: dst_addr - output tensor memory address
+                tensor_rank,                        // 1: tensor_rank - 1D, 2D, 3D, or 4D
+                output_w,                           // 2: output_w - output width
+                output_h,                           // 3: output_h - output height
+                output_d,                           // 4: output_d - output depth
+                output_n,                           // 5: output_n - output batch
+                element_size,                       // 6: element_size - bytes per element
+                rows_for_this_core,                 // 7: num_rows - rows for this core
+                row_start_id                        // 8: start_row - starting row for this core
+            };
+        } else {
+            // Original 2D multicore kernels for backward compatibility
+            reader_args = {
+                input_tensor.buffer()->address(),  // 0: src_addr - input tensor memory address
+                input_h,                           // 1: input_h - input height in elements
+                input_w,                           // 2: input_w - input width in elements
+                output_h,                          // 3: output_h - output height in elements
+                output_w,                          // 4: output_w - output width in elements
+                start_h,                           // 5: slice_start_h - start index for height
+                end_h,                             // 6: slice_end_h - end index for height
+                step_h,                            // 7: slice_step_h - step size for height
+                start_w,                           // 8: slice_start_w - start index for width
+                end_w,                             // 9: slice_end_w - end index for width
+                step_w,                            // 10: slice_step_w - step size for width
+                element_size,                      // 11: element_size - bytes per element
+                rows_for_this_core,                // 12: num_rows - rows for this core
+                row_start_id                       // 13: start_row - starting row for this core
+            };
+
+            writer_args = {
+                output_tensor.buffer()->address(),  // 0: dst_addr - output tensor memory address
+                output_h,                           // 1: output_h - output height in elements
+                output_w,                           // 2: output_w - output width in elements
+                element_size,                       // 3: element_size - bytes per element
+                rows_for_this_core,                 // 4: num_rows - rows for this core
+                row_start_id                        // 5: start_row - starting row for this core
+            };
+        }
+
+        ret_val[core_idx] = {reader_args, writer_args};
+        row_start_id += rows_for_this_core;
+    }
+
+    return ret_val;
+}
+
+/**
+ * Main KB multi-core slice program factory.
+ * Implements the intelligent multi-core slice strategy from kernel_bench.
+ * Translated from Python MulticoreSlice.__call__ and get_multicore_slice_descriptor methods.
+ */
+operation::ProgramWithCallbacks slice_rm_multi_core_kb(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& slice_step) {
+    std::cout << "LLONG slice_rm_multi_core_kb" << std::endl;
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+    uint32_t element_size = get_element_size_kb(input_tensor.dtype());
+
+    // Calculate total output rows based on tensor rank - this is what we distribute across cores
+    uint32_t total_output_rows = calculate_total_output_rows_kb(output_shape);
+
+    // MULTI-CORE ALLOCATION STRATEGY:
+    // The key insight is to use only as many cores as we have work for
+    // This avoids the overhead of idle cores and optimizes resource utilization
+    auto [grid_x, grid_y, num_cores, max_cores_available, num_cores_needed] =
+        calculate_core_allocation_kb(device, total_output_rows);
+
+    // DEBUG OUTPUT: Show core allocation decisions for performance analysis
+    log_debug(
+        tt::LogOp,
+        "KB Multi-core slice allocation - Total output rows: {}, Available cores: {}",
+        total_output_rows,
+        max_cores_available);
+    log_debug(tt::LogOp, "Tensor shape: {}D {}", input_shape.rank(), output_shape);
+    log_debug(tt::LogOp, "Using grid: {}x{} = {} cores", grid_x, grid_y, num_cores);
+
+    CoreCoord start_core = {0, 0};
+    CoreCoord end_core = {grid_x - 1, grid_y - 1};
+    CoreRange full_grid_range(start_core, end_core);
+    CoreRangeSet core_grid({full_grid_range});
+
+    // Use KB 4D kernels
+    std::string reader_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_reader_multicore_slice_4d.cpp";
+    std::string writer_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/tt_writer_multicore_slice_4d.cpp";
+
+    // Circular buffer configuration - same as single-core but for multiple cores
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t actual_output_w = output_shape[-1];
+    uint32_t output_bytes_per_row = actual_output_w * element_size;
+    uint32_t cb_page_size = output_bytes_per_row;
+
+    // Align to 32-byte boundaries for optimal DRAM memory controller performance
+    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? tt::tt_metal::hal::get_dram_alignment()
+                                    : tt::tt_metal::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? tt::tt_metal::hal::get_dram_alignment()
+                                    : tt::tt_metal::hal::get_l1_alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
+    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
+    // Double buffering allows continuous data flow (producer/consumer overlap)
+    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+
+    // Circular buffer indices following TTNN conventions
+    constexpr uint32_t in_cb = 0;  // Input data buffer (reader -> writer)
+
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_total_size, {{in_cb, cb_data_format}})
+            .set_page_size(in_cb, cb_page_size_aligned);
+    tt::tt_metal::CreateCircularBuffer(program, core_grid, cb_src0_config);
+
+    // Prepare kernel compilation arguments
+    uint32_t is_dram_input = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    uint32_t is_dram_output = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    // Reader kernel compile-time args: DRAM flag, CB index, element size
+    std::vector<uint32_t> reader_compile_time_args = {is_dram_input, in_cb, element_size};
+    // Writer kernel compile-time args: CB index, DRAM flag, element size
+    std::vector<uint32_t> writer_compile_time_args = {in_cb, is_dram_output, element_size};
+
+    // Create kernels
+    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program, reader_kernel_path, core_grid, tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program, writer_kernel_path, core_grid, tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    // Get runtime arguments for all cores
+    auto all_runtime_args = get_slice_runtime_args_kb(
+        input_tensor,
+        output_tensor,
+        slice_start,
+        slice_end,
+        slice_step,
+        grid_x,
+        grid_y,
+        num_cores,
+        total_output_rows,
+        reader_kernel_path,
+        writer_kernel_path);
+
+    // Set runtime arguments for each core
+    for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
+        uint32_t x = core_idx % grid_x;
+        uint32_t y = core_idx / grid_x;
+        CoreCoord core = {x, y};
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[core_idx].first);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[core_idx].second);
+    }
+
+    // Runtime arguments override callback for buffer address updates
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, grid_x, grid_y, num_cores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) {
+        const auto& src_tensor = input_tensors.at(0);
+        auto dst_tensor = output_tensors.at(0);
+
+        // Update buffer addresses in runtime arguments for all cores
+        for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
+            uint32_t x = core_idx % grid_x;
+            uint32_t y = core_idx / grid_x;
+            CoreCoord core = {x, y};
+
+            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
+            reader_runtime_args[0] = src_tensor.buffer()->address();
+
+            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
+            writer_runtime_args[0] = dst_tensor.buffer()->address();
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -30,6 +30,7 @@ ttnn::Tensor SliceOperation::invoke(
     const auto& input_shape = input_tensor.logical_shape();
     uint32_t input_rank = input_shape.rank();
     auto input_layout = input_tensor.layout();
+    log_info(tt::LogMetal, "LLONG in SliceOperation::invoke input_layout = {}", input_layout);
 
     if (input_rank == 0) {
         return input_tensor;
@@ -116,6 +117,7 @@ ttnn::Tensor SliceOperation::invoke(
             input.dtype() != DataType::UINT16,
             "This slice requires an implicit Tile->RM conversion and that is not currently supported for uint16");
         input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
+        log_info(tt::LogMetal, "LLONG tiled to row major happened", input.layout());
     }
 
     ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
@@ -156,7 +158,7 @@ ttnn::Tensor SliceOperation::invoke(
             input_tensor.device(),
             memory_config_arg.value_or(input_tensor.memory_config()));
     }
-
+    log_info(tt::LogMetal, "LLONG in SliceOperation::invoke input.layout() = {}", input.layout());
     auto res =
         tt::tt_metal::operation::run(
             SliceDeviceOperation{


### PR DESCRIPTION
…and test with tracy. Low performance, need improvement.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes