### PR TITLE
Segformer PCC Fix

### DIFF
--- a/models/demos/segformer/tests/pcc/test_segformer_for_semantic_segmentation.py
+++ b/models/demos/segformer/tests/pcc/test_segformer_for_semantic_segmentation.py
@@ -150,4 +150,4 @@ def test_segformer_for_semantic_segmentation(device, model_location_generator):
     h = w = int(math.sqrt(ttnn_output.shape[-1]))
     ttnn_final_output = torch.reshape(ttnn_output, (ttnn_output.shape[0], ttnn_output.shape[1], h, w))
 
-    assert_with_pcc(torch_output.logits, ttnn_final_output, pcc=0.984)
+    assert_with_pcc(torch_output.logits, ttnn_final_output, pcc=0.983)


### PR DESCRIPTION
### Ticket
Segformer PCC fix
issue: https://github.com/tenstorrent/tt-metal/issues/29132

### Problem description
Softmax API changed to increase stability, that caused slight decrease in PCC for segformer.

### What's changed
Modified PCC value for Segformer test from 0.984 --> 0.983

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17956003714)
- [x] [Frequent Models test](https://github.com/tenstorrent/tt-metal/actions/runs/17956055385)
