### PR TITLE
Generalizing all_to_all_async by adding a composite implementation

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all.py
@@ -133,8 +133,9 @@ def run_all_to_all_impl(
     layout,
     topology,
     num_iters=1,
+    input_mem_config=None,
+    output_mem_config=None,
     trace_mode=False,
-    mem_config=None,
     do_check=True,
     reuse_inputs=False,
 ):
@@ -162,8 +163,6 @@ def run_all_to_all_impl(
     logger.info(f"in_dim: {in_dim}")
     logger.info(f"out_dim: {out_dim}")
 
-    input_mem_config = mem_config
-    output_mem_config = mem_config
     ###
 
     ### Create persistent output buffers
@@ -268,17 +267,19 @@ def run_all_to_all_impl(
                 else:
                     eq, output = comp_pcc(tt_output_tensor, output_tensor)
                 if not eq:
-                    logger.error(f"output mismatch for tensor {i}")
+                    logger.error(f"output mismatch for tensor {i}: {output}")
                     passed = False
 
-    assert (
-        mesh_device.num_program_cache_entries() == 1
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+    # native implementation uses 1 program cache entry, but
+    # composite implementation uses 7 program cache entries
+    # assert (
+    #    mesh_device.num_program_cache_entries() == 1
+    # ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()
-    if do_check and not passed:
-        assert eq, f"{i} FAILED: {output}"
+    if do_check:
+        assert passed, f"FAILED: output mismatch"
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
@@ -342,8 +343,192 @@ def test_all_to_all(
         layout,
         topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        mem_config=mem_config,
+        input_mem_config=mem_config,
+        output_mem_config=mem_config,
         do_check=do_check,
         trace_mode=enable_trace,
         reuse_inputs=reuse_inputs,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "num_links, logical_shape, in_dim, out_dim",
+    [
+        (1, [1, 1, 256 + 32, 128 * 3], 2, 3),
+        (1, [1, 1, 256, 128 + 32], 3, 2),
+    ],
+    ids=["pad_dim2", "pad_dim3"],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [
+        ttnn.TILE_LAYOUT,
+        ttnn.ROW_MAJOR_LAYOUT,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize(
+    "num_iters, do_check, reuse_inputs",
+    [(2, True, False), (20, False, True)],
+    ids=["check", "stress"],
+)
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 200000, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True
+)
+def test_all_to_all_unaligned(
+    mesh_device,
+    logical_shape,
+    in_dim,
+    out_dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    do_check,
+    reuse_inputs,
+):
+    if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
+        pytest.skip("Row-major layout is not supported for bfloat8_b")
+
+    # TODO add link to github issue
+    if mem_config.buffer_type == ttnn.BufferType.L1 and in_dim == 3:
+        pytest.skip("Mesh-sharding along last dim combined with L1 storage fails")
+
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape,
+        in_dim,
+        out_dim,
+        num_links,
+        input_dtype,
+        layout,
+        topology=ttnn.Topology.Ring,
+        num_iters=num_iters,
+        input_mem_config=mem_config,
+        output_mem_config=mem_config,
+        do_check=do_check,
+        trace_mode=False,
+        reuse_inputs=reuse_inputs,
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "num_links, input_dtype, layout",
+    [
+        (1, ttnn.bfloat16, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "logical_shape, in_dim, out_dim, input_shard_shape, input_shard_grid, input_mem_layout, output_shard_shape, output_shard_grid, output_mem_layout",
+    [
+        (
+            [1, 1, 256, 1536],
+            3,
+            2,
+            (256, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (32, 256),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            [1, 1, 1536, 1024],
+            3,
+            2,
+            (256, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (32, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            [1, 1, 768, 3072],
+            3,
+            2,
+            (128, 384),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (96, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 200000, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True
+)
+def test_all_to_all_sharded_to_sharded(
+    mesh_device,
+    num_links,
+    input_dtype,
+    layout,
+    logical_shape,
+    in_dim,
+    out_dim,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    input_mem_layout,
+    output_mem_layout,
+):
+    # Skipping all sharded tests for now.
+    # Composite implementation is finnicky with sharding because of fussy intermediate
+    # ops and non-foolproof shard spec manipulation.
+    # Supporting sharding will likely require a proper native implementation.
+    pytest.skip("Sharding is not properly implemented")
+
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_shard_spec = ttnn.ShardSpec(
+        output_shard_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    input_mem_config = ttnn.MemoryConfig(
+        input_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=input_shard_spec
+    )
+    output_mem_config = ttnn.MemoryConfig(
+        output_mem_layout, buffer_type=ttnn.BufferType.DRAM, shard_spec=output_shard_spec
+    )
+
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape,
+        in_dim,
+        out_dim,
+        num_links,
+        input_dtype,
+        layout,
+        topology=ttnn.Topology.Ring,
+        num_iters=2,
+        input_mem_config=input_mem_config,
+        output_mem_config=output_mem_config,
+        do_check=True,
+        trace_mode=False,
+        reuse_inputs=False,
     )

--- a/tests/nightly/t3000/ccl/test_all_to_all.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all.py
@@ -405,7 +405,7 @@ def test_all_to_all_unaligned(
     if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
         pytest.skip("Row-major layout is not supported for bfloat8_b")
 
-    # The below fails because of a bug in all_broadcast_async (Issue #29183)
+    # TODO uncomment the below once all_broadcast_async is fixed (Issue #29183)
     if mem_config.buffer_type == ttnn.BufferType.L1 and in_dim == 3:
         pytest.skip("Temporarily skipping due to bug in all_broadcast_async (Issue #29183)")
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
@@ -21,17 +21,28 @@ ttnn::Tensor ExecuteAllToAllAsync::invoke(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id) {
-    return ttnn::operations::experimental::ccl::all_to_all_async(
-        input_tensor,
-        persistent_intermediate_buffer,
-        persistent_output_buffer,
-        in_dim,
-        out_dim,
-        multi_device_global_semaphore,
-        num_links,
-        memory_config,
-        topology,
-        subdevice_id);
+    bool composite_all_to_all_case =
+        composite_common::use_composite_all_to_all(input_tensor, in_dim, out_dim, memory_config);
+    if (composite_all_to_all_case) {
+        // Ugly code: the native implementation forces the user to pre-allocate the output buffer,
+        // but the composite implementation is unable to reuse it. So overwrite persistent_output_buffer
+        // to point to the real output buffer internally created by the composite implementation.
+        persistent_output_buffer = composite_common::composite_all_to_all(
+            input_tensor, in_dim, out_dim, num_links, memory_config, subdevice_id);
+        return persistent_output_buffer;
+    } else {
+        return ttnn::operations::experimental::ccl::all_to_all_async(
+            input_tensor,
+            persistent_intermediate_buffer,
+            persistent_output_buffer,
+            in_dim,
+            out_dim,
+            multi_device_global_semaphore,
+            num_links,
+            memory_config,
+            topology,
+            subdevice_id);
+    }
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/experimental/ccl/common.hpp"
 
 namespace ttnn {
 namespace operations::experimental::ccl {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -287,11 +287,10 @@ ttnn::Tensor composite_all_to_all(
     ttnn::DataType input_dtype = input_tensor.dtype();
     bool convert_to_bfloat16_for_composite = is_tiled_and_not_tile_aligned && input_dtype == ttnn::DataType::BFLOAT8_B;
 
+    bool is_sharded = input_tensor.is_sharded();
     auto input_memory_config = input_tensor.memory_config();
-    auto sliced_memory_config = input_memory_config;
-    auto concat_memory_config = input_memory_config;
+    auto interim_memory_config = is_sharded ? ttnn::DRAM_MEMORY_CONFIG : input_memory_config;
     auto output_memory_config = memory_config.value_or(input_memory_config);
-    bool is_sharded = input_memory_config.is_sharded();
 
     // Convert to row major
     if (is_tiled_and_not_tile_aligned) {
@@ -302,46 +301,30 @@ ttnn::Tensor composite_all_to_all(
         input_tensor = ttnn::to_layout(input_tensor, ttnn::Layout::ROW_MAJOR);
     }
 
+    // Sharded input is challenging to work with, because we perform slice and concat separately
+    // and the user can't give us intermediate shard specs. So the most foolproof solution is
+    // to simply undo sharding by converting to DRAM interleaved storage.
+    if (is_sharded) {
+        input_tensor = ttnn::to_memory_config(input_tensor, interim_memory_config);
+    }
+
     // Step 1: make every device have a copy of every tensor
     std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::experimental::ccl::all_broadcast_async(
         input_tensor,
         num_links,
-        input_memory_config,
+        interim_memory_config,
         ttnn::ccl::Topology::Linear,
         /* cluster_axis */ std::nullopt,
         subdevice_id);
 
-    // Note on sharded inputs:
-    // We perform slice and concat as two separate operations, but the user can't give us
-    // intermediate shard specs. One solution is to always convert the input to interleaved
-    // to undo sharding. Another solution, which is what we do here, is to manipulate the
-    // input shard spec to account for what the slice and concat operations do.
-    if (is_sharded) {
-        auto input_shard_spec = input_memory_config.shard_spec().value();
-        if (out_dim == 3) {
-            input_shard_spec.shape[1] /= broadcasted_tensors.size();
-            sliced_memory_config = input_memory_config.with_shard_spec(input_shard_spec);
-        } else {
-            input_shard_spec.shape[0] /= broadcasted_tensors.size();
-            sliced_memory_config = input_memory_config.with_shard_spec(input_shard_spec);
-        }
-        if (in_dim == 3) {
-            input_shard_spec.shape[1] *= broadcasted_tensors.size();
-            concat_memory_config = input_memory_config.with_shard_spec(input_shard_spec);
-        } else {
-            input_shard_spec.shape[0] *= broadcasted_tensors.size();
-            concat_memory_config = input_memory_config.with_shard_spec(input_shard_spec);
-        }
-    }
-
     // Step 2: Slice out the index range each device cares about, along out_dim
     for (size_t i = 0; i < broadcasted_tensors.size(); i++) {
         broadcasted_tensors[i] = ttnn::mesh_partition(
-            broadcasted_tensors[i], out_dim, /* cluster_axis */ std::nullopt, sliced_memory_config);
+            broadcasted_tensors[i], out_dim, /* cluster_axis */ std::nullopt, interim_memory_config);
     }
 
     // Step 3: Concatenate along in_dim
-    ttnn::Tensor output_tensor = ttnn::concat(broadcasted_tensors, in_dim, concat_memory_config);
+    ttnn::Tensor output_tensor = ttnn::concat(broadcasted_tensors, in_dim, interim_memory_config);
 
     // Convert back to tiled
     if (is_tiled_and_not_tile_aligned) {
@@ -353,7 +336,7 @@ ttnn::Tensor composite_all_to_all(
         }
     }
 
-    if (input_memory_config.memory_layout() != output_memory_config.memory_layout()) {
+    if (output_memory_config.memory_layout() != interim_memory_config.memory_layout()) {
         output_tensor = ttnn::to_memory_config(output_tensor, output_memory_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -178,15 +178,15 @@ bool use_composite_all_to_all(
                                      (input_shape[2] % tile_height == 0 && input_shape[3] % tile_width == 0);
 
     // the current native implementation works for very specific cases
-    if (input_tensor.layout() == ttnn::Layout::TILE && input_tensor.buffer()->buffer_type() == ttnn::BufferType::DRAM &&
-        input_tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED &&
-        (!memory_config.has_value() ||
-         memory_config.value().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED) &&
-        (in_dim == 2 || in_dim == 3) && (out_dim == 2 || out_dim == 3) && is_tiled_and_tile_aligned) {
-        return false;
-    }
-    // all other cases use composite implementation
-    return true;
+    bool use_native =
+        (input_tensor.layout() == ttnn::Layout::TILE &&
+         input_tensor.buffer()->buffer_type() == ttnn::BufferType::DRAM &&
+         input_tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED &&
+         (!memory_config.has_value() ||
+          memory_config.value().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED) &&
+         (in_dim == 2 || in_dim == 3) && (out_dim == 2 || out_dim == 3) && is_tiled_and_tile_aligned);
+
+    return !use_native;
 }
 
 ttnn::Tensor composite_all_gather(
@@ -292,20 +292,28 @@ ttnn::Tensor composite_all_to_all(
     auto interim_memory_config = is_sharded ? ttnn::DRAM_MEMORY_CONFIG : input_memory_config;
     auto output_memory_config = memory_config.value_or(input_memory_config);
 
+    ttnn::Tensor temp_tensor;
+
     // Convert to row major
     if (is_tiled_and_not_tile_aligned) {
         // If input is tiled bfloat8_b, convert to bfloat16 to do the all_broadcast_async + concat
         if (convert_to_bfloat16_for_composite) {
-            input_tensor = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
+            temp_tensor = ttnn::typecast(input_tensor, ttnn::DataType::BFLOAT16);
+            input_tensor.deallocate();
+            input_tensor = temp_tensor;
         }
-        input_tensor = ttnn::to_layout(input_tensor, ttnn::Layout::ROW_MAJOR);
+        temp_tensor = ttnn::to_layout(input_tensor, ttnn::Layout::ROW_MAJOR);
+        input_tensor.deallocate();
+        input_tensor = temp_tensor;
     }
 
     // Sharded input is challenging to work with, because we perform slice and concat separately
     // and the user can't give us intermediate shard specs. So the most foolproof solution is
     // to simply undo sharding by converting to DRAM interleaved storage.
     if (is_sharded) {
-        input_tensor = ttnn::to_memory_config(input_tensor, interim_memory_config);
+        temp_tensor = ttnn::to_memory_config(input_tensor, interim_memory_config);
+        input_tensor.deallocate();
+        input_tensor = temp_tensor;
     }
 
     // Step 1: make every device have a copy of every tensor
@@ -316,28 +324,40 @@ ttnn::Tensor composite_all_to_all(
         ttnn::ccl::Topology::Linear,
         /* cluster_axis */ std::nullopt,
         subdevice_id);
+    input_tensor.deallocate();
 
     // Step 2: Slice out the index range each device cares about, along out_dim
     for (size_t i = 0; i < broadcasted_tensors.size(); i++) {
-        broadcasted_tensors[i] = ttnn::mesh_partition(
+        temp_tensor = ttnn::mesh_partition(
             broadcasted_tensors[i], out_dim, /* cluster_axis */ std::nullopt, interim_memory_config);
+        broadcasted_tensors[i].deallocate();
+        broadcasted_tensors[i] = temp_tensor;
     }
 
     // Step 3: Concatenate along in_dim
     ttnn::Tensor output_tensor = ttnn::concat(broadcasted_tensors, in_dim, interim_memory_config);
+    for (auto& tensor : broadcasted_tensors) {
+        tensor.deallocate();
+    }
 
     // Convert back to tiled
     if (is_tiled_and_not_tile_aligned) {
-        output_tensor = ttnn::to_layout(output_tensor, ttnn::Layout::TILE);
+        temp_tensor = ttnn::to_layout(output_tensor, ttnn::Layout::TILE);
+        output_tensor.deallocate();
+        output_tensor = temp_tensor;
         // If we had to convert the input dtype in order to execute the row-major composite op, convert back to the
         // input dtype
         if (convert_to_bfloat16_for_composite) {
-            output_tensor = ttnn::typecast(output_tensor, input_dtype);
+            temp_tensor = ttnn::typecast(output_tensor, input_dtype);
+            output_tensor.deallocate();
+            output_tensor = temp_tensor;
         }
     }
 
     if (output_memory_config.memory_layout() != interim_memory_config.memory_layout()) {
-        output_tensor = ttnn::to_memory_config(output_tensor, output_memory_config);
+        temp_tensor = ttnn::to_memory_config(output_tensor, output_memory_config);
+        output_tensor.deallocate();
+        output_tensor = temp_tensor;
     }
 
     return output_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.hpp
@@ -14,6 +14,7 @@
 
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
@@ -27,6 +28,11 @@ bool use_composite_reduce_scatter(const ttnn::Tensor& input_tensor, int32_t dim,
 bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const ttnn::MemoryConfig& output_mem_config);
 bool use_composite_all_gather(
     const ttnn::Tensor& input_tensor, int32_t dim, const std::optional<ttnn::MemoryConfig>& memory_config);
+bool use_composite_all_to_all(
+    const ttnn::Tensor& input_tensor,
+    int32_t in_dim,
+    int32_t out_dim,
+    const std::optional<ttnn::MemoryConfig>& memory_config);
 
 ttnn::Tensor composite_all_gather(
     ttnn::Tensor input_tensor,
@@ -43,5 +49,13 @@ std::vector<ttnn::Tensor> composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis);
+
+ttnn::Tensor composite_all_to_all(
+    ttnn::Tensor input_tensor,
+    int32_t in_dim,
+    int32_t out_dim,
+    uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id);
 
 }  // namespace composite_common


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27780)

### Problem description
The all_to_all_async native implementation only handles very specific cases. We don't have a generic composite implementation to fall back on.

### What's changed
- Added a composite implementation for all_to_all_async, which will be used for all the unsupported cases by native implementation
- Added more T3K pytests for all_to_all_async
- Fixed bugs in pytest test logic for all_to_all_async

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/17957596259)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] T3000 frequent tests (https://github.com/tenstorrent/tt-metal/actions/runs/17957631916)
- [ ] New/Existing tests provide coverage for changes