### PR TITLE
Use correct alignment for ttnn copy (fixes slice_write BH test)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -94,7 +94,6 @@ def offset_increment_tensor(shape, offset=0, dtype=torch.int32, step=1):
     ).reshape(shape)
 
 
-@skip_for_blackhole("Fails on Blackhole. Issue #28021")
 @pytest.mark.parametrize("rank", range(1, 9))  # 1D … 8D
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 def test_slice_write_nd(rank, layout, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -55,7 +55,8 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = 2;
-    uint32_t aligned_input_unit_size = round_up_to_mul32(input_unit_size);
+    auto input_alignment = input.buffer()->alignment();
+    uint32_t aligned_input_unit_size = tt::align(input_unit_size, input_alignment);
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(
             num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
@@ -66,7 +67,8 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     if (convert_dtype) {
         output_cb_index = tt::CBIndex::c_16;
         uint32_t num_output_units = 2;
-        uint32_t aligned_output_unit_size = round_up_to_mul32(output_unit_size);
+        auto output_alignment = output.buffer()->alignment();
+        uint32_t aligned_output_unit_size = tt::align(output_unit_size, output_alignment);
         tt::tt_metal::CircularBufferConfig output_cb_config =
             tt::tt_metal::CircularBufferConfig(
                 num_output_units * aligned_output_unit_size, {{output_cb_index, output_cb_data_format}})


### PR DESCRIPTION
### Ticket
[#28021](https://github.com/tenstorrent/tt-metal/issues/28021)
#29185 

### Problem description
Slice Write wasn't passing on BH, due to to_memory_config innaccuracy

### What's changed
Turns out the problem was the input tensor getting corrupted after to_memory_config specifically for L1 interleaved (which calls copy).

### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17988021876) CI with demo tests passes (if applicable)
- [ ] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/17988019362)