### PR TITLE
SDXL: DiT encoders

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -93,7 +93,7 @@ def test_clip_encoder(
     test_text = "A coffee shop on Main Street that serves excellent pastries and opens at 7 AM on weekdays"
 
     hf_inputs = tokenizer(test_text, padding=True, truncation=True, max_length=77, return_tensors="pt")
-    tt_prompt = ttnn.from_torch(
+    tt_tokens = ttnn.from_torch(
         hf_inputs.input_ids,
         dtype=ttnn.uint32,
         layout=ttnn.TILE_LAYOUT,
@@ -117,12 +117,12 @@ def test_clip_encoder(
     logger.info(f"HF text encoder 1 pooled output mean: {pooled_output.mean():.6f}, std: {pooled_output.std():.6f}")
 
     logger.info("compiling text encoder...")
-    tt_clip(tt_prompt, mesh_device, with_projection=has_projection)
+    tt_clip(tt_tokens, mesh_device, with_projection=has_projection)
 
     logger.info("executing text encoder...")
     start_time = time.time()
 
-    tt_sequence_output, tt_projected_output = tt_clip(tt_prompt, mesh_device, with_projection=has_projection)
+    tt_sequence_output, tt_projected_output = tt_clip(tt_tokens, mesh_device, with_projection=has_projection)
 
     logger.info(f"text encoder TT-NN runtime: {time.time() - start_time}")
     logger.info("text encoder done...")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -39,7 +39,7 @@ def test_clip_encoder(
 
     # Note: Factor for SDXL should always be 1; since we don't support TP
     parallel_config = EncoderParallelConfig(
-        tensor_parallel=ParallelFactor(factor=mesh_device.shape[1], mesh_axis=1),
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
     )
     ccl_manager = None
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -108,8 +108,6 @@ def test_clip_encoder(
         pooled_output = hf_output.text_embeds if has_projection else hf_output.pooler_output
     logger.info(f"text encoder 1 CPU runtime: {time.time() - start_time}")
 
-    print(f"HF LIST LEN: {len(hf_output.hidden_states)}")
-
     # debug
     logger.info(f"HF text encoder 1 sequence output shape: {sequence_output.shape}")
     logger.info(f"HF text encoder 1 pooled output shape: {pooled_output.shape}")
@@ -129,9 +127,7 @@ def test_clip_encoder(
     logger.info(f"text encoder TT-NN runtime: {time.time() - start_time}")
     logger.info("text encoder done...")
 
-    print(f"TT LIST LEN: {len(tt_sequence_output)}")
-
-    tt_sequence_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_sequence_output[-3])[0])
+    tt_sequence_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_sequence_output[-2])[0])
     tt_projected_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_projected_output)[0])
 
     # debug

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -242,7 +242,7 @@ def batch_encode_prompt_on_device(
             tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device, with_projection=(ind > 0))
 
             tt_sequence_output_torch = ttnn.to_torch(
-                tt_sequence_output[-3],
+                tt_sequence_output[-2],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
             ).to(torch.float32)
             tt_pooled_output_torch = ttnn.to_torch(
@@ -256,7 +256,7 @@ def batch_encode_prompt_on_device(
             # I think this may be a bug in the reference implementation, but at the moment, we'll do the same (take the last hidden state of the first text encoder)
             if ind == 0:
                 tt_pooled_prompt_embeds = ttnn.to_torch(
-                    tt_sequence_output[-2],
+                    tt_sequence_output[-1],
                     mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
                 ).to(torch.float32)
                 pooled_prompt_embeds = tt_pooled_prompt_embeds.to(torch.float32)
@@ -328,7 +328,7 @@ def batch_encode_prompt_on_device(
                 tt_tokens, ttnn_device, with_projection=(ind > 0)
             )
             tt_sequence_output_neg_torch = ttnn.to_torch(
-                tt_sequence_output_neg[-3],
+                tt_sequence_output_neg[-2],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
             ).to(torch.float32)
             tt_pooled_output_neg_torch = ttnn.to_torch(
@@ -343,7 +343,7 @@ def batch_encode_prompt_on_device(
             if ind == 0:
                 tt_pooled_prompt_embeds = (
                     ttnn.to_torch(
-                        tt_sequence_output_neg[-2],
+                        tt_sequence_output_neg[-1],
                         mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
                     )
                 ).to(torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -10,12 +10,9 @@ import inspect
 from typing import List, Optional, Union
 
 from ttnn.distributed.distributed import ConcatMeshToTensor
-from models.experimental.stable_diffusion_35_large.tt.clip_encoder import (
-    TtCLIPConfig,
-    TtCLIPTextTransformer,
-    TtCLIPTextTransformerParameters,
-)
-from models.common.utility_functions import profiler
+from models.experimental.tt_dit.encoders.clip.model_clip import CLIPEncoder, CLIPConfig
+from models.experimental.tt_dit.parallel.config import EncoderParallelConfig, ParallelFactor
+from models.utility_functions import profiler
 
 from tqdm import tqdm
 import ttnn
@@ -28,47 +25,52 @@ SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 
 
 def create_tt_clip_text_encoders(pipeline, ttnn_device):
-    tt_parameters_text_encoder = TtCLIPTextTransformerParameters.from_torch(
-        pipeline.text_encoder.state_dict(),
-        device=ttnn_device,
-        dtype=ttnn.bfloat16,
-        parallel_manager=None,
-        has_text_projection=False,  # Text encoder 1 does not have text projection
+    text_encoder_1 = pipeline.text_encoder
+    config_1 = CLIPConfig(
+        vocab_size=text_encoder_1.config.vocab_size,
+        embed_dim=text_encoder_1.config.hidden_size,
+        ff_dim=text_encoder_1.config.intermediate_size,
+        num_heads=text_encoder_1.config.num_attention_heads,
+        num_hidden_layers=text_encoder_1.config.num_hidden_layers,
+        max_prompt_length=77,
+        layer_norm_eps=text_encoder_1.config.layer_norm_eps,
+        attention_dropout=text_encoder_1.config.attention_dropout,
+        hidden_act=text_encoder_1.config.hidden_act,
     )
-    tt_config_text_encoder = TtCLIPConfig(
-        vocab_size=pipeline.text_encoder.config.vocab_size,
-        d_model=pipeline.text_encoder.config.hidden_size,
-        d_ff=pipeline.text_encoder.config.intermediate_size,
-        num_heads=pipeline.text_encoder.config.num_attention_heads,
-        num_layers=pipeline.text_encoder.config.num_hidden_layers,
-        max_position_embeddings=77,
-        layer_norm_eps=pipeline.text_encoder.config.layer_norm_eps,
-        attention_dropout=pipeline.text_encoder.config.attention_dropout,
-        hidden_act=pipeline.text_encoder.config.hidden_act,
-    )
-    tt_text_encoder = TtCLIPTextTransformer(tt_parameters_text_encoder, tt_config_text_encoder)
+    ccl_manager = None
 
-    # TT text encoder 2 setup
-    tt_parameters_text_encoder_2 = TtCLIPTextTransformerParameters.from_torch(
-        pipeline.text_encoder_2.state_dict(),
-        device=ttnn_device,
-        dtype=ttnn.bfloat16,
-        parallel_manager=None,
-        has_text_projection=True,  # Text encoder 2 has text projection
+    # Note: Factor for SDXL should always be 1; since we don't support TP
+    parallel_config_1 = EncoderParallelConfig(
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
     )
 
-    tt_config_text_encoder_2 = TtCLIPConfig(
-        vocab_size=pipeline.text_encoder_2.config.vocab_size,
-        d_model=pipeline.text_encoder_2.config.hidden_size,
-        d_ff=pipeline.text_encoder_2.config.intermediate_size,
-        num_heads=pipeline.text_encoder_2.config.num_attention_heads,
-        num_layers=pipeline.text_encoder_2.config.num_hidden_layers,
-        max_position_embeddings=77,
-        layer_norm_eps=pipeline.text_encoder_2.config.layer_norm_eps,
-        attention_dropout=pipeline.text_encoder_2.config.attention_dropout,
-        hidden_act=pipeline.text_encoder_2.config.hidden_act,
+    tt_text_encoder = CLIPEncoder(
+        config_1, ttnn_device, ccl_manager, parallel_config_1, text_encoder_1.config.eos_token_id
     )
-    tt_text_encoder_2 = TtCLIPTextTransformer(tt_parameters_text_encoder_2, tt_config_text_encoder_2)
+    tt_text_encoder.load_state_dict(text_encoder_1.state_dict())
+
+    text_encoder_2 = pipeline.text_encoder_2
+    config_2 = CLIPConfig(
+        vocab_size=text_encoder_2.config.vocab_size,
+        embed_dim=text_encoder_2.config.hidden_size,
+        ff_dim=text_encoder_2.config.intermediate_size,
+        num_heads=text_encoder_2.config.num_attention_heads,
+        num_hidden_layers=text_encoder_2.config.num_hidden_layers,
+        max_prompt_length=77,
+        layer_norm_eps=text_encoder_2.config.layer_norm_eps,
+        attention_dropout=text_encoder_2.config.attention_dropout,
+        hidden_act=text_encoder_2.config.hidden_act,
+    )
+
+    # Note: Factor for SDXL should always be 1; since we don't support TP
+    parallel_config_2 = EncoderParallelConfig(
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
+    )
+
+    tt_text_encoder_2 = CLIPEncoder(
+        config_2, ttnn_device, ccl_manager, parallel_config_2, text_encoder_2.config.eos_token_id
+    )
+    tt_text_encoder_2.load_state_dict(text_encoder_2.state_dict())
 
     return tt_text_encoder, tt_text_encoder_2
 
@@ -106,8 +108,8 @@ def warmup_tt_text_encoders(tt_text_encoder, tt_text_encoder_2, tokenizer, token
         mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
     )
 
-    _, _ = tt_text_encoder(tt_tokens_1, ttnn_device, parallel_manager=None)
-    _, _ = tt_text_encoder_2(tt_tokens_2, ttnn_device, parallel_manager=None)
+    _, _ = tt_text_encoder(tt_tokens_1, ttnn_device, with_projection=False)
+    _, _ = tt_text_encoder_2(tt_tokens_2, ttnn_device, with_projection=True)
     ttnn.synchronize_device(ttnn_device)
 
 
@@ -237,10 +239,10 @@ def batch_encode_prompt_on_device(
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
 
-            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device, parallel_manager=None)
+            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device, with_projection=(ind > 0))
 
             tt_sequence_output_torch = ttnn.to_torch(
-                tt_sequence_output.hidden_states[-2],
+                tt_sequence_output[-3],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
             ).to(torch.float32)
             tt_pooled_output_torch = ttnn.to_torch(
@@ -254,7 +256,7 @@ def batch_encode_prompt_on_device(
             # I think this may be a bug in the reference implementation, but at the moment, we'll do the same (take the last hidden state of the first text encoder)
             if ind == 0:
                 tt_pooled_prompt_embeds = ttnn.to_torch(
-                    tt_sequence_output.hidden_states[-1],
+                    tt_sequence_output[-2],
                     mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
                 ).to(torch.float32)
                 pooled_prompt_embeds = tt_pooled_prompt_embeds.to(torch.float32)
@@ -266,7 +268,7 @@ def batch_encode_prompt_on_device(
             else:
                 assert False, "Clip skip not none path not tested, use at your own risk!"
                 prompt_embeds = ttnn.to_torch(
-                    tt_sequence_output.hidden_states[-(clip_skip + 2)],
+                    tt_sequence_output[-(clip_skip + 2)],
                     mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
                 ).to(torch.float32)
 
@@ -322,9 +324,11 @@ def batch_encode_prompt_on_device(
                 device=ttnn_device,
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
-            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(tt_tokens, ttnn_device, parallel_manager=None)
+            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(
+                tt_tokens, ttnn_device, with_projection=(ind > 0)
+            )
             tt_sequence_output_neg_torch = ttnn.to_torch(
-                tt_sequence_output_neg.hidden_states[-2],
+                tt_sequence_output_neg[-3],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
             ).to(torch.float32)
             tt_pooled_output_neg_torch = ttnn.to_torch(
@@ -339,7 +343,7 @@ def batch_encode_prompt_on_device(
             if ind == 0:
                 tt_pooled_prompt_embeds = (
                     ttnn.to_torch(
-                        tt_sequence_output_neg.hidden_states[-1],
+                        tt_sequence_output_neg[-2],
                         mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),
                     )
                 ).to(torch.float32)


### PR DESCRIPTION
### What's changed
Adapted SDXL to use the new implementation of DiT encoders.

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17957718554) CI passes
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17957739255) CI passes