### PR TITLE
Fix ttnn tests crashing on blackhole simulator

### DIFF
--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -375,7 +375,7 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
  *
  * Return value: std::string
  */
-std::string get_physical_architecture_name();
+std::string get_platform_architecture_name();
 
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -354,8 +354,8 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     return true;
 }
 
-std::string get_physical_architecture_name() {
-    return tt::get_string_lowercase(tt::tt_metal::get_physical_architecture());
+std::string get_platform_architecture_name() {
+    return tt::get_string_lowercase(tt::tt_metal::get_platform_architecture({}));
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -520,7 +520,7 @@ void device_module(py::module& m_device) {
 
     m_device.def(
         "get_arch_name",
-        &tt::tt_metal::detail::get_physical_architecture_name,
+        &tt::tt_metal::detail::get_platform_architecture_name,
         "Return the name of the architecture present.");
 
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);


### PR DESCRIPTION
### Ticket

### Problem description
Currently ttnn tests crash on blackhole simulator. This is caused by python code incorrectly identifying the current architecture for simulator use-case.

### What's changed
Changed implementation of python's `get_arch_name` to use `get_platform_architecture` instead of `get_physical_architecture` which provides correct results.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/17957879617)
- [x] [Blackhole Post commit CI with demo tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/17957890268)
- [x] New/Existing tests provide coverage for changes