### PR TITLE
Change is_link_up on erisc1

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -861,8 +861,9 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
         const auto& send_chip = devices_.at(std::get<0>(it->first));
         CoreCoord sender_core = std::get<1>(it->first);
 
+        auto send_device = send_chip->get_devices()[0];
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
-                send_chip->id(), sender_core)) {
+                send_device->id(), sender_core)) {
             continue;
         }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28334

### Problem description
The check link status command may initiate retraining.  This is undesirable because erisc0 also does it.
On erisc1, we only need to read the status, and potentially wait for retraining if the link is down to see if it's recoverable.

### What's changed
Changed erisc1 to only read the status and delay.

Fixed a unit test.

### Checklist
- Ran unit_tests_eth on bh-db-03 w/ watcher on.
   - Verified it does not hang under normal operation.
   - Manually flipped the return value and verified that watcher catches a down link.
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17958444001) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17958450237) CI with demo tests passes (if applicable)