### PR TITLE
Add all to all dispatch test for blackhole machines

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
@@ -63,6 +63,8 @@ def test_all_to_all_dispatch_no_trace(
     device_params,
 ):
     topology = ttnn.Topology.Linear
+    num_devices = 4
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, cluster_axis)
     if cluster_axis is None:
         dispatch_devices = mesh_shape[0] * mesh_shape[1]
     else:
@@ -149,6 +151,9 @@ def test_all_to_all_dispatch_trace(
     output_memory_config,
     device_params,
 ):
+    topology = ttnn.Topology.Linear
+    num_devices = 4
+    validate_test(num_devices, topology, bh_1d_mesh_device.shape, cluster_axis)
     if cluster_axis is None:
         dispatch_devices = mesh_shape[0] * mesh_shape[1]
     else:

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import random
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_nightly import validate_test
+
+from tests.ttnn.unit_tests.operations.ccl.test_all_to_all_dispatch_t3000 import (
+    run_all_to_all_dispatch_test,
+)
+from tracy import signpost
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [False])
+@pytest.mark.parametrize("mesh_shape", [pytest.param((4, 1), id="4x1_grid")])
+@pytest.mark.parametrize("cluster_axis", [0], ids=["cluster_row"])
+@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("select_experts_k", [4])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize(
+    "batches_per_device, seq_len, num_iters, warmup_iters",
+    [
+        (16, 2, 2, 1),
+        (1, 3, 2, 1),
+    ],
+    ids=["b16s2", "b1s3"],
+)
+@pytest.mark.parametrize("num_links", ["MAX_LINKS"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
+@pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
+def test_all_to_all_dispatch_no_trace(
+    bh_1d_mesh_device,
+    trace_mode,
+    mesh_shape,
+    cluster_axis,
+    batches_per_device,
+    experts_per_device,
+    select_experts_k,
+    hidden_size,
+    seq_len,
+    num_iters,
+    warmup_iters,
+    num_links,
+    dtype,
+    input_memory_config,
+    output_memory_config,
+    device_params,
+):
+    topology = ttnn.Topology.Linear
+    if cluster_axis is None:
+        dispatch_devices = mesh_shape[0] * mesh_shape[1]
+    else:
+        dispatch_devices = mesh_shape[cluster_axis]
+    validate_test(dispatch_devices, topology, bh_1d_mesh_device.shape, 0)
+    batch = batches_per_device * dispatch_devices
+    experts = experts_per_device * dispatch_devices
+
+    if num_links == "MAX_LINKS":
+        num_links = 1
+
+    run_all_to_all_dispatch_test(
+        bh_1d_mesh_device,
+        mesh_shape,
+        batch,
+        experts,
+        select_experts_k,
+        hidden_size,
+        seq_len,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme="random",
+        topology=topology,
+        input_memory_config=input_memory_config,
+        output_memory_config=output_memory_config,
+        dtype=dtype,
+        cluster_axis=cluster_axis,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 500000,
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [True, False])
+@pytest.mark.parametrize("mesh_shape", [pytest.param((4, 1), id="4x1_grid")])
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("batches_per_device", [8])
+@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("select_experts_k", [4])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize(
+    "seq_len, num_iters, warmup_iters",
+    [
+        (128, 2, 1),
+        (1, 5, 2),
+    ],
+    ids=["s128", "s1"],
+)
+@pytest.mark.parametrize(
+    "input_memory_config",
+    [
+        ttnn.DRAM_MEMORY_CONFIG,
+    ],
+    ids=["dram"],
+)
+@pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["dram"])
+@pytest.mark.parametrize("num_links", ["MAX_LINKS"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_all_to_all_dispatch_trace(
+    bh_1d_mesh_device,
+    trace_mode,
+    mesh_shape,
+    cluster_axis,
+    batches_per_device,
+    experts_per_device,
+    select_experts_k,
+    hidden_size,
+    seq_len,
+    num_iters,
+    warmup_iters,
+    num_links,
+    dtype,
+    input_memory_config,
+    output_memory_config,
+    device_params,
+):
+    if cluster_axis is None:
+        dispatch_devices = mesh_shape[0] * mesh_shape[1]
+    else:
+        dispatch_devices = mesh_shape[cluster_axis]
+
+    batch = batches_per_device * dispatch_devices
+    experts = experts_per_device * dispatch_devices
+
+    if num_links == "MAX_LINKS":
+        num_links = 1
+
+    run_all_to_all_dispatch_test(
+        bh_1d_mesh_device,
+        mesh_shape,
+        batch,
+        experts,
+        select_experts_k,
+        hidden_size,
+        seq_len,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme="random",
+        input_memory_config=input_memory_config,
+        output_memory_config=output_memory_config,
+        dtype=dtype,
+        cluster_axis=cluster_axis,
+    )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Adding all to all dispatch test for blackhole machines


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17954158070
- [x] Blackhole Nightly Tests: https://github.com/tenstorrent/tt-metal/actions/runs/18010954271
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes