### PR TITLE
Fixes to HAL API

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -38,7 +38,7 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
     std::vector<uint64_t> print_buffer_addrs;
     print_buffer_addrs.reserve(num_processors);
     for (int i = 0; i < num_processors; i++) {
-        print_buffer_addrs.push_back(reinterpret_cast<uint64_t>(dprint_msg_addr + i * sizeof(DebugPrintMemLayout)));
+        print_buffer_addrs.push_back(dprint_msg_addr + i * sizeof(DebugPrintMemLayout));
     }
     for (const auto& worker_core : worker_cores_used_in_program) {
         for (const auto& buffer_addr : print_buffer_addrs) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -23,22 +23,22 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
     // TODO: use enums from profiler_common.h
     enum BufferIndex { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
     enum TimerDataIndex { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     auto worker_cores_used_in_program = device->worker_cores_from_logical_cores(
-        program.impl().logical_cores()[tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX)]);
+        program.impl()
+            .logical_cores()[hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::TENSIX)]);
     auto device_id = device->id();
     uint64_t min_cycle = -1;
     uint64_t max_cycle = 0;
-    auto* dprint_msg = tt::tt_metal::MetalContext::instance().hal().get_dev_addr<DebugPrintMemLayout*>(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
+    tt::tt_metal::DeviceAddr dprint_msg_addr =
+        hal.get_dev_addr(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
 
     // This works for tensix only, will need to be updated for eth
-    auto num_processors = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
-        tt::tt_metal::HalProgrammableCoreType::TENSIX);
+    auto num_processors = hal.get_num_risc_processors(tt::tt_metal::HalProgrammableCoreType::TENSIX);
     std::vector<uint64_t> print_buffer_addrs;
     print_buffer_addrs.reserve(num_processors);
     for (int i = 0; i < num_processors; i++) {
-        print_buffer_addrs.push_back(reinterpret_cast<uint64_t>(&dprint_msg[i]));
+        print_buffer_addrs.push_back(reinterpret_cast<uint64_t>(dprint_msg_addr + i * sizeof(DebugPrintMemLayout)));
     }
     for (const auto& worker_core : worker_cores_used_in_program) {
         for (const auto& buffer_addr : print_buffer_addrs) {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -65,9 +65,9 @@ static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
 }
 
 inline uint64_t GetDprintBufAddr(chip_id_t device_id, const CoreCoord& virtual_core, int risc_id) {
-    auto* buf = tt::tt_metal::MetalContext::instance().hal().get_dev_addr<DebugPrintMemLayout*>(
+    uint64_t addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         llrt::get_core_type(device_id, virtual_core), tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
-    return reinterpret_cast<uint64_t>(&buf[risc_id]);
+    return addr + sizeof(DebugPrintMemLayout) * risc_id;
 }
 
 inline std::string_view get_core_type_name(CoreType ct) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -437,7 +437,8 @@ KernelGroup::KernelGroup(
     // Fast dispatch kernel config mangement happens under the CQ and will re-program the base
     const auto& hal = MetalContext::instance().hal();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-        kernel_config.kernel_config_base()[index] = hal.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
+        kernel_config.kernel_config_base()[index] =
+            hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
     }
 
     std::set<NOC_MODE> noc_modes;
@@ -919,8 +920,9 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
 
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
+    const auto& hal = MetalContext::instance().hal();
     uint64_t kernel_config_base =
-        MetalContext::instance().hal().get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
+        hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
     uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
     CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -41,7 +41,8 @@ BuildEnvManager::BuildEnvManager() {
     uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
     build_state_indices_.resize(programmable_core_type_count);
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
-        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count =
+            hal.get_processor_classes_count(hal.get_programmable_core_type(programmable_core));
         build_state_indices_[programmable_core].resize(processor_class_count);
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
             uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
@@ -150,7 +151,8 @@ std::vector<JitBuildState> create_build_state(
     // Loop through programmable core types and their processor classes/types.
     uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
-        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count =
+            hal.get_processor_classes_count(hal.get_programmable_core_type(programmable_core));
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
             JitBuiltStateConfig config{
                 .core_type = static_cast<HalProgrammableCoreType>(programmable_core),

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -385,7 +385,7 @@ public:
     HalProgrammableCoreType get_programmable_core_type(uint32_t core_type_index) const;
     uint32_t get_programmable_core_type_index(HalProgrammableCoreType programmable_core_type_index) const;
     CoreType get_core_type(uint32_t programmable_core_type_index) const;
-    uint32_t get_processor_classes_count(std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type) const;
+    uint32_t get_processor_classes_count(HalProgrammableCoreType programmable_core_type) const;
     uint32_t get_processor_types_count(
         std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type, uint32_t processor_class_idx) const;
     // Query device features. Returns true if the feature is enabled.
@@ -486,18 +486,8 @@ public:
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }
 
-inline uint32_t Hal::get_processor_classes_count(
-    std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type) const {
-    // TODO extract as reusable function like `to_index(programmable_core_type)`
-    uint32_t index = std::visit(
-        ttsl::overloaded{
-            [](HalProgrammableCoreType core_type_specifier) -> uint32_t {
-                return utils::underlying_type(core_type_specifier);
-            },
-            [](uint32_t core_type_specifier) { return core_type_specifier; },
-        },
-        programmable_core_type);
-    TT_ASSERT(index < this->core_info_.size());
+inline uint32_t Hal::get_processor_classes_count(HalProgrammableCoreType programmable_core_type) const {
+    uint32_t index = get_programmable_core_type_index(programmable_core_type);
     return this->core_info_[index].get_processor_classes_count();
 }
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -167,8 +167,7 @@ public:
         supports_receiving_multicast_cmds_(supports_receiving_multicast_cmds),
         dev_msgs_factory_(dev_msgs_factory) {}
 
-    template <typename T = DeviceAddr>
-    T get_dev_addr(HalL1MemAddrType addr_type) const;
+    DeviceAddr get_dev_addr(HalL1MemAddrType addr_type) const;
     uint32_t get_dev_size(HalL1MemAddrType addr_type) const;
     uint32_t get_processor_classes_count() const;
     uint32_t get_processor_types_count(uint32_t processor_class_idx) const;
@@ -178,11 +177,10 @@ public:
     const dev_msgs::Factory& get_dev_msgs_factory() const;
 };
 
-template <typename T>
-inline T HalCoreInfoType::get_dev_addr(HalL1MemAddrType addr_type) const {
+inline DeviceAddr HalCoreInfoType::get_dev_addr(HalL1MemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalL1MemAddrType>(addr_type);
     TT_ASSERT(index < this->mem_map_bases_.size());
-    return reinterpret_cast<T>(this->mem_map_bases_[index]);
+    return this->mem_map_bases_[index];
 }
 
 inline uint32_t HalCoreInfoType::get_dev_size(HalL1MemAddrType addr_type) const {
@@ -395,8 +393,7 @@ public:
     // This value can be found in the ELF file.
     bool get_core_kernel_stored_in_config_buffer(HalProgrammableCoreType programmable_core_type) const;
 
-    template <typename T = DeviceAddr>
-    T get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
+    DeviceAddr get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
     uint32_t get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
 
     // Overloads for Dram Params
@@ -508,14 +505,13 @@ inline HalProgrammableCoreType Hal::get_programmable_core_type(uint32_t core_typ
 
 inline CoreType Hal::get_core_type(uint32_t core_type_index) const { return core_info_[core_type_index].core_type_; }
 
-template <typename T>
-inline T Hal::get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {
+inline DeviceAddr Hal::get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
     TT_ASSERT(index < this->core_info_.size());
     TT_FATAL(
         !(programmable_core_type == HalProgrammableCoreType::TENSIX && addr_type == HalL1MemAddrType::UNRESERVED),
         "Attempting to read addr of unreserved memory");
-    return this->core_info_[index].get_dev_addr<T>(addr_type);
+    return this->core_info_[index].get_dev_addr(addr_type);
 }
 
 inline uint32_t Hal::get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -397,13 +397,10 @@ public:
 
     template <typename T = DeviceAddr>
     T get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
-    template <typename T = DeviceAddr>
-    T get_dev_addr(uint32_t programmable_core_type_index, HalL1MemAddrType addr_type) const;
     uint32_t get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
 
     // Overloads for Dram Params
-    template <typename T = DeviceAddr>
-    T get_dev_addr(HalDramMemAddrType addr_type) const;
+    DeviceAddr get_dev_addr(HalDramMemAddrType addr_type) const;
     uint32_t get_dev_size(HalDramMemAddrType addr_type) const;
 
     uint32_t get_alignment(HalMemType memory_type) const;
@@ -521,16 +518,6 @@ inline T Hal::get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1
     return this->core_info_[index].get_dev_addr<T>(addr_type);
 }
 
-template <typename T>
-inline T Hal::get_dev_addr(uint32_t programmable_core_type_index, HalL1MemAddrType addr_type) const {
-    TT_ASSERT(programmable_core_type_index < this->core_info_.size());
-    TT_FATAL(
-        !(get_programmable_core_type(programmable_core_type_index) == HalProgrammableCoreType::TENSIX &&
-          addr_type == HalL1MemAddrType::UNRESERVED),
-        "Attempting to read addr of unreserved memory");
-    return this->core_info_[programmable_core_type_index].get_dev_addr<T>(addr_type);
-}
-
 inline uint32_t Hal::get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
     TT_ASSERT(index < this->core_info_.size());
@@ -543,11 +530,10 @@ inline uint32_t Hal::get_dev_size(HalProgrammableCoreType programmable_core_type
     return this->core_info_[index].get_dev_size(addr_type);
 }
 
-template <typename T>
-inline T Hal::get_dev_addr(HalDramMemAddrType addr_type) const {
+inline DeviceAddr Hal::get_dev_addr(HalDramMemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalDramMemAddrType>(addr_type);
     TT_ASSERT(index < this->dram_bases_.size());
-    return reinterpret_cast<T>(this->dram_bases_[index]);
+    return this->dram_bases_[index];
 }
 
 inline uint32_t Hal::get_dev_size(HalDramMemAddrType addr_type) const {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -162,8 +162,9 @@ void ConfigureKernelGroup(
     const KernelGroup* kernel_group,
     IDevice* device,
     const CoreCoord& logical_core) {
+    const auto& hal = MetalContext::instance().hal();
     uint32_t kernel_config_base =
-        MetalContext::instance().hal().get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
+        hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
     for (auto kernel_id : kernel_group->kernel_ids) {
         // Need the individual offsets of each bin
         // TODO: make configure take a std::span
@@ -822,7 +823,8 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                             circular_buffer_config_vec[base_index + 1] = circular_buffer->page_size(buffer_index);
                         }
                     }  // PROF_END("CBS")
-                    uint64_t kernel_config_base = hal.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
+                    uint64_t kernel_config_base =
+                        hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
                     uint64_t addr = kernel_config_base + program.impl().get_program_config(index).cb_offset;
                     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                         device_id, physical_core, circular_buffer_config_vec, addr);


### PR DESCRIPTION
### Ticket
#29194 

### Problem description
Two problems:
- We should not take `std::variant<HalProgrammableCoreType, uint32_t>` or have overloads that can accept either.
- `get_dev_addr` should not be a template that casts device address into host pointer.  Even though practically this works fine, strictly speaking doing pointer arithmetic for device address on host is not valid (I think it's UB by language standard).

### What's changed

- Only take HalProgrammableCoreType.
- `get_dev_addr` always returns DeviceAddr.  Caller should do integer arithmetic instead of pointer arithmetic.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17958917706) CI passes (t3k fabric tests have a known issue)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17958920931) CI with demo tests passes (if applicable)