### PR TITLE
Add basic stream register test

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -255,7 +255,7 @@ TEST_F(MeshDeviceFixture, TensixDirectedStreamRegWriteRead) {
             }
         }
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
 
         uint32_t expected_value_to_read = 0x1234;
         for (uint32_t x = 0; x < logical_grid_size.x; x++) {
@@ -324,7 +324,7 @@ TEST_F(MeshDeviceFixture, TensixIncrementStreamRegWrite) {
             }
         }
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
     }
 }
 
@@ -363,7 +363,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWrite4BAlignment) {
             writer_core,
             {virtual_receiver_core.x, virtual_receiver_core.y, receiver_addr, value_to_write, 1, 0});
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
 
         tt_metal::detail::ReadFromDeviceL1(device, receiver_core, receiver_addr, sizeof(uint32_t), readback);
         EXPECT_EQ(readback[0], value_to_write);
@@ -420,7 +420,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNoc) {
             writer_core,
             {virtual_receiver_core.x, virtual_receiver_core.y, second_receiver_addr, value_to_write + 1, 1, 0});
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
 
         tt_metal::detail::ReadFromDeviceL1(device, receiver_core, first_receiver_addr, 32, readback);
         EXPECT_EQ(readback[0], value_to_write);
@@ -468,7 +468,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
              num_writes,
              sizeof(uint32_t)});
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
 
         tt_metal::detail::ReadFromDeviceL1(
             device, receiver_core, base_receiver_addr, num_writes * sizeof(uint32_t), readback);
@@ -546,7 +546,7 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
              num_writes_per_risc,
              l1_alignment});
 
-        distributed::EnqueueMeshWorkload(cq, workload, false);
+        distributed::EnqueueMeshWorkload(cq, workload, true);
 
         tt_metal::detail::ReadFromDeviceL1(
             device, receiver_core, receiver_addr0, readback.size() * sizeof(uint32_t), readback);
@@ -560,6 +560,118 @@ TEST_F(MeshDeviceFixture, TensixInlineWriteDynamicNoc) {
         std::iota(expected_values.begin(), expected_values.end(), value_to_write);
         EXPECT_EQ(readback, expected_values);
     }
+}
+
+void run_local_noc_stream_reg_inc(
+    MeshDispatchFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const CoreCoord& core,
+    const HalProgrammableCoreType& hal_programmable_core_type) {
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device = mesh_device->get_devices()[0];
+
+    // Set up program and command queue
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    auto& program_ = workload.get_programs().at(device_range);
+
+    // Create the kernel
+    KernelHandle stream_reg_kernel;
+    CoreType core_type = CoreType::COUNT;
+    uint32_t unreserved_base_addr = 0;
+    if (hal_programmable_core_type == HalProgrammableCoreType::TENSIX) {
+        core_type = CoreType::WORKER;
+        unreserved_base_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+        auto config = tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::NOC_0,
+        };
+        stream_reg_kernel = CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp",
+            core,
+            config);
+    } else {
+        core_type = CoreType::ETH;
+        unreserved_base_addr =
+            MetalContext::instance().hal().get_dev_addr(hal_programmable_core_type, HalL1MemAddrType::UNRESERVED);
+        tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0};
+        if (hal_programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) {
+            config.eth_mode = Eth::SENDER;
+        } else if (hal_programmable_core_type == HalProgrammableCoreType::IDLE_ETH) {
+            config.eth_mode = Eth::IDLE;
+        }
+        stream_reg_kernel = CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp",
+            core,
+            config);
+    }
+    tt_metal::SetRuntimeArgs(program_, stream_reg_kernel, core, {unreserved_base_addr});
+
+    std::vector<uint32_t> l1_buffer_data(1, static_cast<uint32_t>(-1));
+    tt_metal::detail::WriteToDeviceL1(device, core, unreserved_base_addr, l1_buffer_data, core_type);
+
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    tt_metal::detail::ReadFromDeviceL1(device, core, unreserved_base_addr, sizeof(uint32_t), l1_buffer_data, core_type);
+    switch (l1_buffer_data[0]) {
+        case 0: break;
+        case 1:
+            GTEST_FAIL() << "Stream register STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX is not correct after initialization";
+            break;
+        case 2:
+            GTEST_FAIL() << "Stream register STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX is not correct after "
+                            "initialization";
+            break;
+        case 3:
+            GTEST_FAIL()
+                << "Stream register STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX is not correct after increment";
+            break;
+        default: GTEST_FAIL() << "Unexpected status value"; break;
+    }
+}
+
+TEST_F(MeshDeviceFixture, TensixTestNocStreamRegs) {
+    auto mesh_device = this->devices_[0];
+
+    // Get first tensix core (0,0)
+    CoreCoord tensix_core(0, 0);
+
+    run_local_noc_stream_reg_inc(this, mesh_device, tensix_core, HalProgrammableCoreType::TENSIX);
+}
+
+TEST_F(MeshDeviceFixture, ActiveEthTestNocStreamRegs) {
+    auto mesh_device = this->devices_[0];
+    auto device = mesh_device->get_devices()[0];
+
+    // Skip if no active ethernet cores on this device
+    if (device->get_active_ethernet_cores(true).empty()) {
+        GTEST_SKIP() << "Skipping device due to no active ethernet cores...";
+    }
+
+    // Get first active ethernet core
+    CoreCoord eth_core = *(device->get_active_ethernet_cores(true).begin());
+
+    run_local_noc_stream_reg_inc(this, mesh_device, eth_core, HalProgrammableCoreType::ACTIVE_ETH);
+}
+
+TEST_F(MeshDeviceFixture, IdleEthTestNocStreamRegs) {
+    auto mesh_device = this->devices_[0];
+    auto device = mesh_device->get_devices()[0];
+
+    // Skip if no idle ethernet cores on this device
+    if (device->get_inactive_ethernet_cores().empty()) {
+        GTEST_SKIP() << "Skipping device due to no idle ethernet cores...";
+    }
+
+    // Get first idle ethernet core
+    CoreCoord eth_core = *(device->get_inactive_ethernet_cores().begin());
+
+    run_local_noc_stream_reg_inc(this, mesh_device, eth_core, HalProgrammableCoreType::IDLE_ETH);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
             i,
             STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
             increment_value << REMOTE_DEST_BUF_WORDS_FREE_INC);
-        for (uint32_t i = 0; i < 1000; i++) {
+        for (uint32_t retry = 0; retry < 1000; retry++) {
             read_value = NOC_STREAM_READ_REG(i, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &
                          ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1);
             if (read_value == expected_value) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/local_noc_stream_reg_inc.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "noc_overlay_parameters.h"
+
+void kernel_main() {
+#if defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC)
+    constexpr uint32_t num_streams = ETH_NOC_NUM_STREAMS;
+#else
+    constexpr uint32_t num_streams = NOC_NUM_STREAMS;
+#endif
+    uint32_t read_value = 0;
+    volatile tt_l1_ptr uint32_t* status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_val<uint32_t>(0));
+    for (uint32_t i = 0; i < num_streams; i++) {
+        uint32_t initial_value = i;
+        uint32_t increment_value = i;
+        uint32_t expected_value = initial_value + increment_value;
+
+        NOC_STREAM_WRITE_REG(i, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, initial_value);
+        read_value =
+            NOC_STREAM_READ_REG(i, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX) & ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1);
+        if (read_value != initial_value) {
+            *status_ptr = 1;
+            return;
+        }
+
+        read_value = NOC_STREAM_READ_REG(i, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &
+                     ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1);
+        if (read_value != initial_value) {
+            *status_ptr = 2;
+            return;
+        }
+
+        NOC_STREAM_WRITE_REG(
+            i,
+            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
+            increment_value << REMOTE_DEST_BUF_WORDS_FREE_INC);
+        for (uint32_t i = 0; i < 1000; i++) {
+            read_value = NOC_STREAM_READ_REG(i, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &
+                         ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1);
+            if (read_value == expected_value) {
+                break;
+            }
+        }
+        if (read_value != expected_value) {
+            *status_ptr = 3;
+            return;
+        }
+    }
+    *status_ptr = 0;
+}

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -78,17 +78,6 @@ void set_deassert_addresses() {
 #endif
 }
 
-void init_sync_registers() {
-    volatile tt_reg_ptr uint* tiles_received_ptr;
-    volatile tt_reg_ptr uint* tiles_acked_ptr;
-    for (uint32_t operand = 0; operand < NUM_CIRCULAR_BUFFERS; operand++) {
-        tiles_received_ptr = get_cb_tiles_received_ptr(operand);
-        tiles_received_ptr[0] = 0;
-        tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
-        tiles_acked_ptr[0] = 0;
-    }
-}
-
 inline void run_subordinate_eriscs(uint32_t enables) {
 #if defined(ARCH_BLACKHOLE)
     if (enables & (1u << static_cast<std::underlying_type<EthProcessorTypes>::type>(EthProcessorTypes::DM1))) {
@@ -140,7 +129,6 @@ int main() {
 
     DeviceProfilerInit();
     while (1) {
-        init_sync_registers();
         // Wait...
         WAYPOINT("GW");
         while (mailboxes->go_messages[0].signal != RUN_MSG_GO) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
1. We were initializing stream registers for CBs on idle eth. We don't support circular buffers on eth cores, and we were also going out of bounds since there are only 32 streams on eth, but we were initializing stream 8-39.
2. Some tests were running EnqueueMeshWorkload but setting blocking to false, and doing a SD read immediately after. While our current behaviour of enqueue_mesh_workload means we'll always block for SD, it doesn't make sense for us to manually set it to false and risk issues if underlying support changes, when the test expects it to actually be blocking.
3. Lacking basic stream reg tests that don't use noc txns for testing functionality.

### What's changed
1. Remote cb stream reg initialization from idle eth fw.
2. Set blocking to true for the tests that expect it to be blocking.
3. Add a basic stream reg tests that does local writes and readback to test autoinc registers.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17960419650
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes