### PR TITLE
Implement Multicore Tiled Pad

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -78,7 +78,7 @@ def run_pad_with_program_cache(device, n, c, h, w, padding, torch_padding, value
 @pytest.mark.parametrize("value", [0, 1])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout):
+def test_pad_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout):
     if layout == ttnn.TILE_LAYOUT and dtype != ttnn.bfloat16:
         pytest.skip("tiled multicore pad only supported for bf16")
     for _ in range(2):

--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -56,13 +56,13 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     assert torch.equal(torch_output_tensor, output_tensor)
 
 
-def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype):
+def run_pad_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout):
     torch.manual_seed(0)
 
     torch_input_tensor = random_torch_tensor(dtype, (n, c, h, w))
     torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device, dtype=dtype)
     output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -77,9 +77,12 @@ def run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, va
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 32), (0, 32)), (0, 32, 0, 32, 0, 1))])
 @pytest.mark.parametrize("value", [0, 1])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype):
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout):
+    if layout == ttnn.TILE_LAYOUT and dtype != ttnn.bfloat16:
+        pytest.skip("tiled multicore pad only supported for bf16")
     for _ in range(2):
-        run_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype)
+        run_pad_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -458,10 +461,13 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
 @pytest.mark.parametrize("shape", [[1, 1, 18, 13]])
 @pytest.mark.parametrize("padshape", [[1, 1, TILE_HEIGHT, TILE_WIDTH]])
 @pytest.mark.parametrize("use_multicore", [False, True])
-def test_pad_op(device, in_dtype, shape, padshape, use_multicore):
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+def test_pad_op(device, in_dtype, shape, padshape, use_multicore, layout):
+    if layout == ttnn.TILE_LAYOUT and in_dtype != ttnn.bfloat16:
+        pytest.skip("tiled multicore pad only supported for bf16")
     torch_input = random_torch_tensor(in_dtype, shape)
 
-    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=layout)
     output_tt = ttnn.pad(ttnn_input, padshape, [0, 0, 0, 0], value=0, use_multicore=use_multicore)
     output_tt = ttnn.to_torch(output_tt)
     assert output_tt.shape == torch.Size(padshape)

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Takes in an id_per_dim and dims array, both of size ndims
+// Advances the id_per_dim by one, wrapping and carrying as needed
+static inline int advance_tensor_index(
+    volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (uint32_t d = ndims; d-- > 0;) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
@@ -7,7 +7,7 @@
 static inline int advance_tensor_index(
     volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
     // increment least-significant dim first
-    for (uint32_t d = ndims; d-- > 0;) {
+    for (int32_t d = ndims - 1; d >= 0; d--) {
         uint32_t v = idx[d] + 1;
         if (v < dims[d]) {
             idx[d] = v;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -48,8 +48,6 @@ void kernel_main() {
                 break;
             }
         }
-        // DPRINT << "within_input_region: " << (uint32_t)within_input_region << ENDL();
-        DPRINT << "written pages: " << out_pages_written << ENDL();
 
         if (within_input_region) {
             cb_reserve_back(input_cb_id, 1);
@@ -58,11 +56,9 @@ void kernel_main() {
             noc_async_read(src_noc_addr, l1_write_addr, page_size);
             noc_async_read_barrier();
             cb_push_back(input_cb_id, 1);
-            DPRINT << "SENT PAGE" << ENDL();
             input_page_offset++;
             next_index_u32(input_odo, input_page_shape, num_dims);
         }
         next_index_u32(output_odo, output_page_shape, num_dims);
     }
-    DPRINT << "Finished!" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include "dataflow_api.h"
+
+static inline int next_index_u32(volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (uint32_t d = ndims; d-- > 0;) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}
+
+void kernel_main() {
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+
+    uint32_t rt_ind = 0;
+    const uint32_t input_addr = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
+    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
+    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* input_odo = output_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* output_odo = input_odo + num_dims;
+
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+
+    const auto s0 = TensorAccessor(dst_args, input_addr, page_size);
+
+    bool within_input_region;
+    uint32_t input_page_offset = start_offset;
+
+    for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
+        within_input_region = true;
+        for (uint32_t d = 0; d < num_dims; d++) {
+            if (input_odo[d] < output_odo[d]) {
+                within_input_region = false;
+                break;
+            }
+        }
+        // DPRINT << "within_input_region: " << (uint32_t)within_input_region << ENDL();
+        DPRINT << "written pages: " << out_pages_written << ENDL();
+
+        if (within_input_region) {
+            cb_reserve_back(input_cb_id, 1);
+            uint32_t l1_write_addr = get_write_ptr(input_cb_id);
+            uint64_t src_noc_addr = get_noc_addr(input_page_offset, s0);
+            noc_async_read(src_noc_addr, l1_write_addr, page_size);
+            noc_async_read_barrier();
+            cb_push_back(input_cb_id, 1);
+            DPRINT << "SENT PAGE" << ENDL();
+            input_page_offset++;
+            next_index_u32(input_odo, input_page_shape, num_dims);
+        }
+        next_index_u32(output_odo, output_page_shape, num_dims);
+    }
+    DPRINT << "Finished!" << ENDL();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -31,6 +31,10 @@ void kernel_main() {
     // This kernel keeps track of which page (tile) we are on from a logical tensor perspective
     // and reads from the input tensor only when we are within the input region
     // The writer will be waiting for the correct page to be available in the input circular buffer
+    // For example, if we are padding (2, 2, 32, 32) -> (4, 4, 64, 64), then we condense the inner dims to tiles:
+    // (2, 2, 1, 1) -> (4, 4, 2, 2) and as incrementing through writing the output, [0:2, 0:2, 0:1, 0:1] will be
+    // tiles read from input, and the rest will be padding. So for this reader kernel, we will only read when
+    // [0:2, 0:2, 0:1, 0:1] is reached, and skip reads otherwise.
 
     for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
         within_input_region = true;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -5,20 +5,10 @@
 #include <stdint.h>
 #include <algorithm>
 #include "dataflow_api.h"
+#include "common.hpp"
 
-static inline int next_index_u32(volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
-    // increment least-significant dim first
-    for (uint32_t d = ndims; d-- > 0;) {
-        uint32_t v = idx[d] + 1;
-        if (v < dims[d]) {
-            idx[d] = v;
-            return 1;
-        }
-        idx[d] = 0;  // wrap and carry
-    }
-    return 0;  // overflowed most-significant dim
-}
-
+// This kernel keeps track of which page (tile) we are on from a logical tensor perspective, and fills the output with
+// either the input or padding respectively
 void kernel_main() {
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
@@ -34,8 +24,8 @@ void kernel_main() {
     const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
     volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
     volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* input_odo = output_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* output_odo = input_odo + num_dims;
+    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
 
     constexpr auto dst_args = TensorAccessorArgs<6>();
 
@@ -46,40 +36,42 @@ void kernel_main() {
     uint32_t l1_write_addr = get_write_ptr(pad_val_cb_id);
     volatile tt_l1_ptr uint8_t* pad_val_page = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
     const volatile tt_l1_ptr uint8_t* pad_val = reinterpret_cast<const volatile tt_l1_ptr uint8_t*>(&pad_value);
-    // volatile tt_l1_ptr uint32_t* l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
     for (uint32_t i = 0; i < page_size / element_size; i++) {
         for (uint32_t b = 0; b < element_size; b++) {
             pad_val_page[i * element_size + b] = pad_val[b];
         }
     }
     cb_push_back(pad_val_cb_id, 1);
-    // tt::data_movement::common::print_bf16_pages(l1_write_addr, page_size / 2, 1);
+    // Our scratchpad cb is now a tile full of padding.
 
     bool within_input_region;
     uint32_t output_page_offset = start_offset;
 
+    // Loop over all output pages to write
     for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
         within_input_region = true;
         for (uint32_t d = 0; d < num_dims; d++) {
-            if (input_odo[d] < output_odo[d]) {
+            if (input_id_per_dim[d] < output_id_per_dim[d]) {
                 within_input_region = false;
                 break;
             }
         }
 
+        // We have two cases, if we are within the input region, we wait for the reader to send us the correct tile
+        // Otherwise we simply write the padding tile we have in our circular buffer
         uint64_t dst_noc_addr = get_noc_addr(output_page_offset, s0);
         if (within_input_region) {
             cb_wait_front(input_cb_id, 1);
             uint32_t l1_read_addr = get_read_ptr(input_cb_id);
             noc_async_write(l1_read_addr, dst_noc_addr, page_size);
             noc_async_write_barrier();
-            next_index_u32(input_odo, input_page_shape, num_dims);
+            advance_tensor_index(input_id_per_dim, input_page_shape, num_dims);
             cb_pop_front(input_cb_id, 1);
         } else {
             noc_async_write(l1_write_addr, dst_noc_addr, page_size);
             noc_async_write_barrier();
         }
-        next_index_u32(output_odo, output_page_shape, num_dims);
+        advance_tensor_index(output_id_per_dim, output_page_shape, num_dims);
         output_page_offset++;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+
+static inline int next_index_u32(volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (uint32_t d = ndims; d-- > 0;) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}
+
+void kernel_main() {
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t pad_val_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(4);
+    constexpr uint32_t pad_value = get_compile_time_arg_val(5);
+    const uint32_t element_size = get_compile_time_arg_val(6);
+
+    uint32_t rt_ind = 0;
+    const uint32_t output_addr = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
+    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
+    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
+    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* input_odo = output_page_shape + num_dims;
+    volatile tt_l1_ptr uint32_t* output_odo = input_odo + num_dims;
+
+    // DPRINT << "input_odo: ";
+    // for (uint32_t i = 0; i < num_dims; i++) {
+    //     DPRINT << input_odo[i] << ", ";
+    // }
+    // DPRINT << ENDL();
+    // DPRINT << "output_odo: ";
+    // for (uint32_t i = 0; i < num_dims; i++) {
+    //     DPRINT << output_odo[i] << ", ";
+    // }
+    // DPRINT << ENDL();
+
+    constexpr auto dst_args = TensorAccessorArgs<6>();
+
+    const auto s0 = TensorAccessor(dst_args, output_addr, page_size);
+
+    // Reserve and push the pad value into the circular buffer, generalized for any contiguous dtype
+    cb_reserve_back(pad_val_cb_id, 1);
+    uint32_t l1_write_addr = get_write_ptr(pad_val_cb_id);
+    volatile tt_l1_ptr uint8_t* pad_val_page = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+    const volatile tt_l1_ptr uint8_t* pad_val = reinterpret_cast<const volatile tt_l1_ptr uint8_t*>(&pad_value);
+    // volatile tt_l1_ptr uint32_t* l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
+    for (uint32_t i = 0; i < page_size / element_size; i++) {
+        for (uint32_t b = 0; b < element_size; b++) {
+            pad_val_page[i * element_size + b] = pad_val[b];
+        }
+    }
+    cb_push_back(pad_val_cb_id, 1);
+    // tt::data_movement::common::print_bf16_pages(l1_write_addr, page_size / 2, 1);
+
+    bool within_input_region;
+    uint32_t output_page_offset = start_offset;
+
+    for (uint32_t out_pages_written = 0; out_pages_written < num_pages_to_write; out_pages_written++) {
+        within_input_region = true;
+        for (uint32_t d = 0; d < num_dims; d++) {
+            if (input_odo[d] < output_odo[d]) {
+                within_input_region = false;
+                break;
+            }
+        }
+        // DPRINT << "within_input_region: " << (uint32_t)within_input_region << ENDL();
+        DPRINT << "written pages: " << out_pages_written << ENDL();
+
+        uint64_t dst_noc_addr = get_noc_addr(output_page_offset, s0);
+        if (within_input_region) {
+            DPRINT << "WAITING" << ENDL();
+            cb_wait_front(input_cb_id, 1);
+            DPRINT << "RECEIVED PAGE" << ENDL();
+            uint32_t l1_read_addr = get_read_ptr(input_cb_id);
+            noc_async_write(l1_read_addr, dst_noc_addr, page_size);
+            next_index_u32(input_odo, input_page_shape, num_dims);
+            cb_pop_front(input_cb_id, 1);
+        } else {
+            noc_async_write(l1_write_addr, dst_noc_addr, page_size);
+        }
+        noc_async_write_barrier();
+        next_index_u32(output_odo, output_page_shape, num_dims);
+        output_page_offset++;
+    }
+    DPRINT << "Finished!" << ENDL();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -9,6 +9,11 @@
 
 // This kernel keeps track of which page (tile) we are on from a logical tensor perspective, and fills the output with
 // either the input or padding respectively
+// For example, if we are padding (2, 2, 32, 32) -> (4, 4, 64, 64), then we condense the inner dims to tiles:
+// (2, 2, 1, 1) -> (4, 4, 2, 2) and as incrementing through writing the output, [0:2, 0:2, 0:1, 0:1] will be
+// tiles read from input, and the rest will be padding. So for this writer kernel, if we are within
+// [0:2, 0:2, 0:1, 0:1] we wait for the reader to send us the correct tile, and then write it, otherwise we
+// write padding.
 void kernel_main() {
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -16,7 +16,8 @@ void kernel_main() {
     constexpr uint32_t page_size = get_compile_time_arg_val(3);
     constexpr uint32_t num_dims = get_compile_time_arg_val(4);
     constexpr uint32_t pad_value = get_compile_time_arg_val(5);
-    const uint32_t element_size = get_compile_time_arg_val(6);
+    constexpr uint32_t element_size = get_compile_time_arg_val(6);
+    constexpr uint32_t num_elements = page_size / element_size;
 
     uint32_t rt_ind = 0;
     const uint32_t output_addr = get_arg_val<uint32_t>(rt_ind++);
@@ -36,7 +37,7 @@ void kernel_main() {
     uint32_t l1_write_addr = get_write_ptr(pad_val_cb_id);
     volatile tt_l1_ptr uint8_t* pad_val_page = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
     const volatile tt_l1_ptr uint8_t* pad_val = reinterpret_cast<const volatile tt_l1_ptr uint8_t*>(&pad_value);
-    for (uint32_t i = 0; i < page_size / element_size; i++) {
+    for (uint32_t i = 0; i < num_elements; i++) {
         for (uint32_t b = 0; b < element_size; b++) {
             pad_val_page[i * element_size + b] = pad_val[b];
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -6,6 +6,8 @@
 #include "pad_op.hpp"
 #include "pad_program_factory.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/full/device/full_device_operation.hpp"
+#include "ttnn/operations/creation.hpp"
 
 using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
@@ -140,10 +142,17 @@ operation::ProgramWithCallbacks Pad::create_program(
         }
     } else if (input_tensor.layout() == Layout::TILE) {
         if (this->use_multicore) {
+            // New implementation goes here
+            // Output tensor should already be allocated
+            // fill_pad input
+            //   -- make a copy of the input, not in place
+            // fill output pages with the aligned input pages or fill_value
             log_warning(
                 tt::LogType::LogOp, "TILE layout does not have multicore implementation yet. Falling back to 1 core.");
         }
-        return detail::pad_tile(
+        // return detail::pad_tile(
+        // input_tensor, output_tensor, this->output_padded_shape, this->input_tensor_start, this->pad_value);
+        return detail::pad_tile_multicore(
             input_tensor, output_tensor, this->output_padded_shape, this->input_tensor_start, this->pad_value);
     } else {
         TT_THROW("Unsupported layout for pad");

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -141,13 +141,15 @@ operation::ProgramWithCallbacks Pad::create_program(
             }
         }
     } else if (input_tensor.layout() == Layout::TILE) {
-        if (this->use_multicore && input_tensor.dtype() == DataType::BFLOAT16) {
+        if (this->use_multicore && input_tensor.dtype() == DataType::BFLOAT16 &&
+            !(input_tensor.memory_config().buffer_type() == BufferType::L1)) {
             return detail::pad_tile_multicore(
                 input_tensor, output_tensor, this->output_padded_shape, this->input_tensor_start, this->pad_value);
         }
         log_warning(
             tt::LogType::LogOp,
-            "Only bfloat16 tiled tensors are currently supported for multicore tiled pad. Falling back to 1 core.");
+            "Only bfloat16 and non-L1 tiled tensors are currently supported for multicore tiled pad. Falling back to 1 "
+            "core. #29295");
         return detail::pad_tile(
             input_tensor, output_tensor, this->output_padded_shape, this->input_tensor_start, this->pad_value);
     } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1463,4 +1463,232 @@ operation::ProgramWithCallbacks pad_rm_sharded_width_only(
     };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
+
+static inline int next_index_u32(std::vector<uint32_t>& idx, ttnn::Shape& dims, uint32_t ndims) {
+    // increment least-significant dim first
+    for (uint32_t d = ndims; d-- > 0;) {
+        uint32_t v = idx[d] + 1;
+        if (v < dims[d]) {
+            idx[d] = v;
+            return 1;
+        }
+        idx[d] = 0;  // wrap and carry
+    }
+    return 0;  // overflowed most-significant dim
+}
+
+operation::ProgramWithCallbacks pad_tile_multicore(
+    const Tensor& a,
+    Tensor& output,
+    const ttnn::Shape& output_padded_shape,
+    const ttnn::Shape& input_tensor_start,
+    const float pad_value) {
+    Program program{};
+
+    const auto& a_shape = a.logical_shape();
+    uint32_t num_pages = get_num_pages(output);
+
+    IDevice* device = a.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages);
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t page_size = output.buffer()->page_size();
+    uint32_t input_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig input_cb_config =
+        tt::tt_metal::CircularBufferConfig(page_size * 2, {{input_cb_index, cb_data_format}})
+            .set_page_size(input_cb_index, page_size);
+    tt::tt_metal::CreateCircularBuffer(program, total_cores, input_cb_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_1;
+    tt::tt_metal::CircularBufferConfig output_cb_config =
+        tt::tt_metal::CircularBufferConfig(page_size * 2, {{output_cb_index, cb_data_format}})
+            .set_page_size(output_cb_index, page_size);
+    tt::tt_metal::CreateCircularBuffer(program, total_cores, output_cb_config);
+
+    uint32_t pad_val_cb_index = tt::CBIndex::c_2;
+    tt::tt_metal::CircularBufferConfig pad_val_cb_config =
+        tt::tt_metal::CircularBufferConfig(page_size, {{pad_val_cb_index, cb_data_format}})
+            .set_page_size(pad_val_cb_index, page_size);
+    tt::tt_metal::CreateCircularBuffer(program, total_cores, pad_val_cb_config);
+
+    Buffer* input_buffer = a.buffer();
+    Buffer* output_buffer = output.buffer();
+    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    uint32_t packed_pad_value;
+    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+        packed_pad_value = pad_value;
+    } else {
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+    }
+
+    std::vector<uint32_t> reader_ct_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)page_size,
+        (std::uint32_t)output_padded_shape.rank(),
+    };
+    TensorAccessorArgs(*input_buffer).append_to(reader_ct_args);
+
+    std::vector<uint32_t> writer_ct_args = {
+        (std::uint32_t)input_cb_index,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)pad_val_cb_index,
+        (std::uint32_t)page_size,
+        (std::uint32_t)output_padded_shape.rank(),
+        (std::uint32_t)packed_pad_value,
+        (std::uint32_t)output.element_size(),
+    };
+    TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
+
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp",
+        total_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp",
+        total_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+
+    std::vector<uint32_t> input_odo, output_odo;  // input and output odometers
+    // initialize odos to vectors of length num_dims filled with 0
+    input_odo.resize(a_shape.rank(), 0);
+    output_odo.resize(output_padded_shape.rank(), 0);
+    // instantiate the input and output tensor padded shapes
+    auto input_page_shape = a.padded_shape();
+    auto output_page_shape = output_padded_shape;
+    input_page_shape[-1] /= 32;
+    input_page_shape[-2] /= 32;
+    output_page_shape[-1] /= 32;
+    output_page_shape[-2] /= 32;
+    bool within_input_region;
+    uint32_t input_page_offset = 0;
+    uint32_t output_page_offset = 0;
+
+    std::vector<uint32_t> all_runtime_args;
+
+    std::cout << "num_pages_per_core_group_1: " << num_pages_per_core_group_1 << std::endl;
+    std::cout << "num_pages_per_core_group_2: " << num_pages_per_core_group_2 << std::endl;
+
+    for (uint32_t i = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_pages_per_core;
+        if (core_group_1.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_2;
+        } else {
+            num_pages_per_core = 0;  // no-op
+        }
+
+        all_runtime_args = {
+            a.buffer()->address(),
+            num_pages_per_core,
+            input_page_offset,
+        };
+        all_runtime_args.insert(all_runtime_args.end(), input_page_shape.cbegin(), input_page_shape.cend());
+        all_runtime_args.insert(all_runtime_args.end(), output_page_shape.cbegin(), output_page_shape.cend());
+        all_runtime_args.insert(all_runtime_args.end(), input_odo.begin(), input_odo.end());
+        all_runtime_args.insert(all_runtime_args.end(), output_odo.begin(), output_odo.end());
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args);
+        all_runtime_args[0] = output.buffer()->address();  // change input addr to output addr before setting writer
+                                                           // args
+        all_runtime_args[2] =
+            output_page_offset;  // change input page offset to output page offset before setting writer args
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args);
+
+        for (uint32_t p = 0; p < num_pages_per_core; p++) {
+            within_input_region = true;
+            for (uint32_t d = 0; d < input_odo.size(); d++) {
+                if (input_odo[d] < output_odo[d]) {
+                    within_input_region = false;
+                }
+            }
+            if (within_input_region) {
+                next_index_u32(input_odo, input_page_shape, input_odo.size());
+                input_page_offset++;
+            }
+            next_index_u32(output_odo, output_page_shape, output_odo.size());
+            output_page_offset++;
+        }
+        std::cout << "input_odo: ";
+        for (auto v : input_odo) {
+            std::cout << v << ", ";
+        }
+        std::cout << std::endl;
+        std::cout << "output_odo: ";
+        for (auto v : output_odo) {
+            std::cout << v << ", ";
+        }
+        std::cout << std::endl;
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id, writer_kernel_id, compute_with_storage_grid_size, input_tensor_start](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& src_tensor = input_tensors.at(0);
+
+            // auto dst_tensor = output_tensors.at(0);
+
+            // uint32_t num_cores_x = compute_with_storage_grid_size.x;
+            // uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+            // uint32_t num_cores_total = num_cores_x * num_cores_y;
+
+            // auto output_tensor_shape = dst_tensor.logical_shape();
+            // uint32_t H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1],
+            //          N_padded = output_tensor_shape[0];
+            // uint32_t NCH_padded = H_padded * C_padded * N_padded;
+
+            // auto
+            //     [num_cores,
+            //      all_cores,
+            //      core_group_1,
+            //      core_group_2,
+            //      num_pages_per_core_group_1,
+            //      num_pages_per_core_group_2] =
+            //         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, NCH_padded);
+            // auto all_runtime_args = get_runtime_args_rm(
+            //     src_tensor,
+            //     dst_tensor,
+            //     input_tensor_start,
+            //     num_cores_total,
+            //     num_cores,
+            //     num_cores_y,
+            //     core_group_1,
+            //     num_pages_per_core_group_1,
+            //     core_group_2,
+            //     num_pages_per_core_group_2);
+
+            // for (uint32_t i = 0; i < num_cores_total; i++) {
+            //     CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            //     {
+            //         SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
+            //     }
+
+            //     {
+            //         SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
+            //     }
+            // }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1466,7 +1466,7 @@ operation::ProgramWithCallbacks pad_rm_sharded_width_only(
 
 static inline int advance_tensor_index(std::vector<uint32_t>& idx, ttnn::Shape& dims, uint32_t ndims) {
     // increment least-significant dim first
-    for (uint32_t d = ndims; d-- > 0;) {
+    for (int32_t d = ndims - 1; d >= 0; d--) {
         uint32_t v = idx[d] + 1;
         if (v < dims[d]) {
             idx[d] = v;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1501,15 +1501,16 @@ operation::ProgramWithCallbacks pad_tile_multicore(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t page_size = output.buffer()->page_size();
+    uint32_t multi_buffering_size = 2;
     uint32_t input_cb_index = tt::CBIndex::c_0;
     tt::tt_metal::CircularBufferConfig input_cb_config =
-        tt::tt_metal::CircularBufferConfig(page_size * 2, {{input_cb_index, cb_data_format}})
+        tt::tt_metal::CircularBufferConfig(page_size * multi_buffering_size, {{input_cb_index, cb_data_format}})
             .set_page_size(input_cb_index, page_size);
     tt::tt_metal::CreateCircularBuffer(program, total_cores, input_cb_config);
 
     uint32_t output_cb_index = tt::CBIndex::c_1;
     tt::tt_metal::CircularBufferConfig output_cb_config =
-        tt::tt_metal::CircularBufferConfig(page_size * 2, {{output_cb_index, cb_data_format}})
+        tt::tt_metal::CircularBufferConfig(page_size * multi_buffering_size, {{output_cb_index, cb_data_format}})
             .set_page_size(output_cb_index, page_size);
     tt::tt_metal::CreateCircularBuffer(program, total_cores, output_cb_config);
 
@@ -1577,9 +1578,6 @@ operation::ProgramWithCallbacks pad_tile_multicore(
 
     std::vector<uint32_t> all_runtime_args;
 
-    std::cout << "num_pages_per_core_group_1: " << num_pages_per_core_group_1 << std::endl;
-    std::cout << "num_pages_per_core_group_2: " << num_pages_per_core_group_2 << std::endl;
-
     for (uint32_t i = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -1590,6 +1588,7 @@ operation::ProgramWithCallbacks pad_tile_multicore(
             num_pages_per_core = num_pages_per_core_group_2;
         } else {
             num_pages_per_core = 0;  // no-op
+            continue;
         }
 
         all_runtime_args = {
@@ -1623,16 +1622,6 @@ operation::ProgramWithCallbacks pad_tile_multicore(
             next_index_u32(output_odo, output_page_shape, output_odo.size());
             output_page_offset++;
         }
-        std::cout << "input_odo: ";
-        for (auto v : input_odo) {
-            std::cout << v << ", ";
-        }
-        std::cout << std::endl;
-        std::cout << "output_odo: ";
-        for (auto v : output_odo) {
-            std::cout << v << ", ";
-        }
-        std::cout << std::endl;
     }
 
     auto override_runtime_args_callback =
@@ -1644,49 +1633,28 @@ operation::ProgramWithCallbacks pad_tile_multicore(
             const std::vector<Tensor>& output_tensors) {
             const auto& src_tensor = input_tensors.at(0);
 
-            // auto dst_tensor = output_tensors.at(0);
+            auto src_buffer = input_tensors.at(0).buffer();
+            auto dst_buffer = output_tensors.at(0).buffer();
 
-            // uint32_t num_cores_x = compute_with_storage_grid_size.x;
-            // uint32_t num_cores_y = compute_with_storage_grid_size.y;
+            uint32_t num_cores_x = compute_with_storage_grid_size.x;
+            uint32_t num_cores_y = compute_with_storage_grid_size.y;
+            uint32_t num_cores_total = num_cores_x * num_cores_y;
 
-            // uint32_t num_cores_total = num_cores_x * num_cores_y;
+            for (uint32_t i = 0; i < num_cores_total; i++) {
+                CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-            // auto output_tensor_shape = dst_tensor.logical_shape();
-            // uint32_t H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1],
-            //          N_padded = output_tensor_shape[0];
-            // uint32_t NCH_padded = H_padded * C_padded * N_padded;
+                // Update reader kernel runtime args
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_buffer->address();
+                }
 
-            // auto
-            //     [num_cores,
-            //      all_cores,
-            //      core_group_1,
-            //      core_group_2,
-            //      num_pages_per_core_group_1,
-            //      num_pages_per_core_group_2] =
-            //         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, NCH_padded);
-            // auto all_runtime_args = get_runtime_args_rm(
-            //     src_tensor,
-            //     dst_tensor,
-            //     input_tensor_start,
-            //     num_cores_total,
-            //     num_cores,
-            //     num_cores_y,
-            //     core_group_1,
-            //     num_pages_per_core_group_1,
-            //     core_group_2,
-            //     num_pages_per_core_group_2);
-
-            // for (uint32_t i = 0; i < num_cores_total; i++) {
-            //     CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-            //     {
-            //         SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-            //     }
-
-            //     {
-            //         SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
-            //     }
-            // }
+                // Update writer kernel runtime args
+                {
+                    auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_buffer->address();
+                }
+            }
         };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1561,8 +1561,24 @@ operation::ProgramWithCallbacks pad_tile_multicore(
         total_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
 
-    std::vector<uint32_t> input_id_per_dim, output_id_per_dim;  // input and output odometers
-    // initialize odos to vectors of length num_dims filled with 0
+    /*
+    As an example, lets say we want to pad a [2, 2, 32, 32] tensor to [2, 3, 64, 64]
+    The input tensor exists as [2, 2, 1, 1] if we reduce by tile (page) size, and the output as [2, 3, 2, 2]
+    we increment through these shapes, and will write a total of 2 * 3 * 2 * 2 = 24 tiles, so we will utilize 24 cores
+    for each core, we calculate if we are within the "input region" of the output. this does a simple check of
+    if any element in the incremented input_id_per_dim is less than the output_id_per_dim, if so, we are outside
+    the input region, and we will write a padding tile, and we will not increment the input_id_per_dim for that tile.
+    if we are within the input region, we will write the tile from input to the output, and increment the
+    input_id_per_dim. This works because we increment the least-significant dim first, and the input region correctly
+    matches the output after the output wraps around. In this example:
+    core 3: in_per_dim: [0,0,1,1] ; out_per_dim: [0,0,1,1], we copy the tile and increment, next ->
+    core 4: in_per_dim: [0,1,0,0] ; out_per_dim: [0,0,1,2], the last 2 output dims are greater than input,
+    so we write the pad tile, and increment only output dim. This continues until the out_per_dim wraps...
+    core 7: in_per_dim: [0,1,0,0] ; out_per_dim: [0,1,0,0], and so on and so forth
+    */
+
+    std::vector<uint32_t> input_id_per_dim, output_id_per_dim;  // input and output id_per_dims
+    // initialize id_per_dims to vectors of length num_dims filled with 0
     input_id_per_dim.resize(a_shape.rank(), 0);
     output_id_per_dim.resize(output_padded_shape.rank(), 0);
     // instantiate the input and output tensor padded shapes

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1464,7 +1464,7 @@ operation::ProgramWithCallbacks pad_rm_sharded_width_only(
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-static inline int next_index_u32(std::vector<uint32_t>& idx, ttnn::Shape& dims, uint32_t ndims) {
+static inline int advance_tensor_index(std::vector<uint32_t>& idx, ttnn::Shape& dims, uint32_t ndims) {
     // increment least-significant dim first
     for (uint32_t d = ndims; d-- > 0;) {
         uint32_t v = idx[d] + 1;
@@ -1561,10 +1561,10 @@ operation::ProgramWithCallbacks pad_tile_multicore(
         total_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
 
-    std::vector<uint32_t> input_odo, output_odo;  // input and output odometers
+    std::vector<uint32_t> input_id_per_dim, output_id_per_dim;  // input and output odometers
     // initialize odos to vectors of length num_dims filled with 0
-    input_odo.resize(a_shape.rank(), 0);
-    output_odo.resize(output_padded_shape.rank(), 0);
+    input_id_per_dim.resize(a_shape.rank(), 0);
+    output_id_per_dim.resize(output_padded_shape.rank(), 0);
     // instantiate the input and output tensor padded shapes
     auto input_page_shape = a.padded_shape();
     auto output_page_shape = output_padded_shape;
@@ -1598,8 +1598,8 @@ operation::ProgramWithCallbacks pad_tile_multicore(
         };
         all_runtime_args.insert(all_runtime_args.end(), input_page_shape.cbegin(), input_page_shape.cend());
         all_runtime_args.insert(all_runtime_args.end(), output_page_shape.cbegin(), output_page_shape.cend());
-        all_runtime_args.insert(all_runtime_args.end(), input_odo.begin(), input_odo.end());
-        all_runtime_args.insert(all_runtime_args.end(), output_odo.begin(), output_odo.end());
+        all_runtime_args.insert(all_runtime_args.end(), input_id_per_dim.begin(), input_id_per_dim.end());
+        all_runtime_args.insert(all_runtime_args.end(), output_id_per_dim.begin(), output_id_per_dim.end());
 
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args);
         all_runtime_args[0] = output.buffer()->address();  // change input addr to output addr before setting writer
@@ -1610,16 +1610,17 @@ operation::ProgramWithCallbacks pad_tile_multicore(
 
         for (uint32_t p = 0; p < num_pages_per_core; p++) {
             within_input_region = true;
-            for (uint32_t d = 0; d < input_odo.size(); d++) {
-                if (input_odo[d] < output_odo[d]) {
+            for (uint32_t d = 0; d < input_id_per_dim.size(); d++) {
+                if (input_id_per_dim[d] < output_id_per_dim[d]) {
                     within_input_region = false;
+                    break;
                 }
             }
             if (within_input_region) {
-                next_index_u32(input_odo, input_page_shape, input_odo.size());
+                advance_tensor_index(input_id_per_dim, input_page_shape, input_id_per_dim.size());
                 input_page_offset++;
             }
-            next_index_u32(output_odo, output_page_shape, output_odo.size());
+            advance_tensor_index(output_id_per_dim, output_page_shape, output_id_per_dim.size());
             output_page_offset++;
         }
     }
@@ -1631,8 +1632,6 @@ operation::ProgramWithCallbacks pad_tile_multicore(
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>&,
             const std::vector<Tensor>& output_tensors) {
-            const auto& src_tensor = input_tensors.at(0);
-
             auto src_buffer = input_tensors.at(0).buffer();
             auto dst_buffer = output_tensors.at(0).buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
@@ -48,7 +48,7 @@ tt::tt_metal::operation::ProgramWithCallbacks pad_rm_sharded_width_only(
     const ttnn::Shape& input_tensor_start,
     float pad_value);
 
-operation::ProgramWithCallbacks pad_tile_multicore(
+tt::tt_metal::operation::ProgramWithCallbacks pad_tile_multicore(
     const Tensor& a,
     Tensor& output,
     const ttnn::Shape& output_padded_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
@@ -48,4 +48,10 @@ tt::tt_metal::operation::ProgramWithCallbacks pad_rm_sharded_width_only(
     const ttnn::Shape& input_tensor_start,
     float pad_value);
 
+operation::ProgramWithCallbacks pad_tile_multicore(
+    const Tensor& a,
+    Tensor& output,
+    const ttnn::Shape& output_padded_shape,
+    const ttnn::Shape& input_tensor_start,
+    const float pad_value);
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
@@ -53,5 +53,5 @@ tt::tt_metal::operation::ProgramWithCallbacks pad_tile_multicore(
     Tensor& output,
     const ttnn::Shape& output_padded_shape,
     const ttnn::Shape& input_tensor_start,
-    const float pad_value);
+    float pad_value);
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25361)

### Problem description
Padding did not support multicore for tiled inputs

### What's changed
Added new implementation that parallelizes off of number of pages in the output tensor. Writes the appropriate tile from input to output if within input region, otherwise writes a tile filled with the padding value.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/17960625384) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18016673353) CI with demo tests passes (if applicable)