### PR TITLE
#29017: Gather watcher fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_gather.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 import numpy as np
 from models.common.utility_functions import skip_for_blackhole
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_allclose
 
 TILE_HEIGHT = 32
 
@@ -48,7 +48,7 @@ def test_gather_general(input_shape, index_shape, dim, device):
     ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
 
     assert ttnn_gather.shape == index.shape
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
 @pytest.mark.parametrize(
@@ -79,7 +79,7 @@ def test_gather_preallocated_output(input_shape, index_shape, dim, device):
 
     assert ttnn_output.shape == index.shape
 
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_output))
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_output))
 
 
 @pytest.mark.parametrize(
@@ -107,7 +107,7 @@ def test_gather_multicore_cases(input_shape, index_shape, dim, device):
     ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
 
     assert ttnn_gather.shape == index.shape
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
 @pytest.mark.parametrize(
@@ -136,7 +136,7 @@ def test_gather_datatype_cases(
     ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
 
     assert ttnn_gather.shape == index.shape
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
 @pytest.mark.parametrize(
@@ -169,7 +169,7 @@ def test_gather_long_tensor(input_shape, index_shape, dim, device):
     ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
 
     assert ttnn_gather.shape == index.shape
-    assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
 @pytest.mark.parametrize(
@@ -196,4 +196,4 @@ def test_gather_cache_run(input_shape, index_shape, dim, runs, device):
     for _ in range(runs):
         ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
         assert ttnn_gather.shape == index.shape
-        assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
+        assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -334,7 +334,7 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
             if (core_grid_calculated_columns_number != 0) {
                 const CoreRange additional_range(
                     {0, core_grid_calculated_rows_number},
-                    {core_grid_calculated_columns_number, core_grid_calculated_rows_number});
+                    {core_grid_calculated_columns_number - 1, core_grid_calculated_rows_number});
                 core_range = core_range.merge(CoreRangeSet(additional_range));
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -121,11 +121,7 @@ void kernel_main() {
                                 // Calculate local index
                                 const uint32_t tile_idx = global_index >> __builtin_ctz(tile_width);
 
-                                ASSERT(
-                                    tile_idx <= Wt_input,
-                                    "Index out of range. Index: {}, Max index: {}",
-                                    global_index,
-                                    Wt_input * tile_width);
+                                ASSERT(tile_idx <= Wt_input);
 
                                 if (tile_idx != wi) {
                                     // Index not in current input tile, skip


### PR DESCRIPTION
### Ticket
#29017

### Problem description
- Bug in calculating core range resulting in usage of additional core that was processing garbage data,
- ASSERT macro does not take message to user resulting in watcher error.  

### What's changed
- Fixed core range calculation,
- Removed ASSERT message leaving only the condition,
- Updated tests to use new assert_allclose function instead of pcc check.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/17971630010
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/17971642712
- [ ] [Watcher APC](https://github.com/tenstorrent/tt-metal/actions/workflows/apc-select-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/17971674711