### PR TITLE
#14356: Add nan handling for acos and asin

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -78,41 +78,43 @@ def test_unary_abs_ttnn(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([100])),
+        (torch.Size([32, 64])),
+        (torch.Size([3, 128, 32])),
         (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 320, 12])),
     ),
 )
-def test_unary_asin_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.asin(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.asin(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
 @pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
+    "torch_dtype, ttnn_dtype, pcc",
+    [
+        (torch.float32, ttnn.float32, 0.999),
+        (torch.bfloat16, ttnn.bfloat16, 0.999),
+        (torch.bfloat16, ttnn.bfloat8_b, 0.99),
+    ],
 )
-def test_unary_acos_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+@pytest.mark.parametrize(
+    "low, high",
+    [(-0.9, 0.9), (-1, 1), (-100, 100)],
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [ttnn.asin, ttnn.acos],
+)
+def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device):
+    in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-    cq_id = 0
-    ttnn.acos(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.acos(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    output_tensor = ttnn_op(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    golden_tensor = golden_function(in_data, device=device)
+    ulp_threshold = 5
+    if high > 0.9 or low < -0.9:
+        ulp_threshold = 65
+    output_tensor = ttnn.to_torch(output_tensor)
+    if ttnn_dtype == ttnn.bfloat16 and low != -100:
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=ulp_threshold)
+    assert_with_pcc(output_tensor, golden_tensor, pcc=pcc)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -216,8 +216,9 @@ inline void calculate_asin() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v);
-        dst_reg[0] = v;
+        v_if(v < vConstNeg1 || v > vConst1) { dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_else { dst_reg[0] = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_endif;
         dst_reg++;
     }
 }
@@ -228,9 +229,9 @@ inline void calculate_acos() {
     // acos = (pi/2 - asin)
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v);
-        v = PI_2 - v;
-        dst_reg[0] = v;
+        v_if(v < vConstNeg1 || v > vConst1) { dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_else { dst_reg[0] = PI_2 - sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_endif;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -216,8 +216,9 @@ inline void calculate_asin() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v);
-        dst_reg[0] = v;
+        v_if(v < vConstNeg1 || v > vConst1) { dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_else { dst_reg[0] = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_endif;
         dst_reg++;
     }
 }
@@ -228,9 +229,9 @@ inline void calculate_acos() {
     // acos = (pi/2 - asin)
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        v = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v);
-        v = PI_2 - v;
-        dst_reg[0] = v;
+        v_if(v < vConstNeg1 || v > vConst1) { dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_else { dst_reg[0] = PI_2 - sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_endif;
         dst_reg++;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1803,13 +1803,13 @@ void py_module(py::module& module) {
         ttnn::acos,
         R"doc(\mathrm{{output\_tensor}}_i = \verb|acos|(\mathrm{{input\_tensor}}_i))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation(
         module,
         ttnn::asin,
         R"doc(\mathrm{{output\_tensor}}_i = \verb|asin|(\mathrm{{input\_tensor}}_i))doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation(
         module,
         ttnn::atan,

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -177,8 +177,12 @@ for unary_function in TTNN_ELTWISE_UNARY_CPP_FUNCTIONS:
 def _golden_function_asin(input_tensor_a, *args, device, **kwargs):
     import torch
 
-    return torch.nan_to_num(
-        torch.asin(input_tensor_a), nan=device.sfpu_nan(), posinf=device.sfpu_inf(), neginf=-device.sfpu_inf()
+    result = torch.asin(input_tensor_a)
+    # ttnn returns inf instead of nan for bfloat16, so mask NaNs to inf in torch.asin
+    return (
+        result.masked_fill_((input_tensor_a < -1) | (input_tensor_a > 1), float("inf"))
+        if input_tensor_a.dtype == torch.bfloat16
+        else result
     )
 
 
@@ -188,8 +192,12 @@ ttnn.attach_golden_function(ttnn.asin, golden_function=_golden_function_asin)
 def _golden_function_acos(input_tensor_a, *args, device, **kwargs):
     import torch
 
-    return torch.nan_to_num(
-        torch.acos(input_tensor_a), nan=device.sfpu_nan(), posinf=device.sfpu_inf(), neginf=-device.sfpu_inf()
+    result = torch.acos(input_tensor_a)
+    # ttnn returns inf instead of nan for bfloat16, so mask NaNs to inf in torch.acos
+    return (
+        result.masked_fill_((input_tensor_a < -1) | (input_tensor_a > 1), float("inf"))
+        if input_tensor_a.dtype == torch.bfloat16
+        else result
     )
 
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #14356 

### Problem description
If Input value is not within range [-1,1] , it should produce nan as result. This case is not handled in the ckernel file for both ttnn.acos and ttnn.asin.

### What's changed
Updated the llk to handle this case.

### Perf Results :

**Updated version:**
asin -2772 ns (~10% slower)
acos - 2876 ns (~2% slower)

**Older version:**
asin - 2512 ns
acos -  2805 ns

### Note :
The valid range for acos and asin is -1 to +1. Within -0.9 to +0.9, the ULP stays below 5, but outside this range it increases significantly — around 30 for asin and 65 for acos

### Checklist
- [ ] All post commit