### PR TITLE
Change pack_untilize_dest init for tiled output BH case

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -150,26 +150,20 @@ void MAIN {
                 }
             }
             if constexpr (is_output_tiled) {
-                if (last_c_block) {
 #ifdef ARCH_BLACKHOLE
-                    pack_untilize_dest_init<partial_iter_output_tiles>(
-                        pre_tilize_cb_id, num_out_sticks, num_faces_in_output_tile);
-#else
+                MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+#endif
+                if (last_c_block) {
                     PACK((llk_pack_untilize_init<
                           partial_iter_output_tiles,
                           partial_iter_output_tiles,
                           false,
                           false,
                           TILE_C_DIM>(pre_tilize_cb_id, 1, num_faces_in_output_tile)));
-#endif
+
                 } else if (first_c_block) {
-#ifdef ARCH_BLACKHOLE
-                    pack_untilize_dest_init<max_tiles_per_iter>(
-                        pre_tilize_cb_id, num_out_sticks, num_faces_in_output_tile);
-#else
                     PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
                         pre_tilize_cb_id, 1, num_faces_in_output_tile)));
-#endif
                 }
             }
             tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -149,23 +149,6 @@ void MAIN {
                         in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
                 }
             }
-            if constexpr (is_output_tiled) {
-#ifdef ARCH_BLACKHOLE
-                MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
-#endif
-                if (last_c_block) {
-                    PACK((llk_pack_untilize_init<
-                          partial_iter_output_tiles,
-                          partial_iter_output_tiles,
-                          false,
-                          false,
-                          TILE_C_DIM>(pre_tilize_cb_id, 1, num_faces_in_output_tile)));
-
-                } else if (first_c_block) {
-                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
-                        pre_tilize_cb_id, 1, num_faces_in_output_tile)));
-                }
-            }
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 cb_wait_front(curr_in_cb_id, 1);
@@ -233,9 +216,15 @@ void MAIN {
                             tensix_sync();
                         }
 
+                        tilize_stick_counter = 0;
                         // init math for reduction again since FPU gets reprogrammed by tilize
                         MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
-                        tilize_stick_counter = 0;
+#ifdef ARCH_BLACKHOLE
+                        // need this on BH to set swizzle bit before pack untilize dest
+                        MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+#endif
+                        PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                            pre_tilize_cb_id, 1, num_faces_in_output_tile)));
                     }
                 } else {
                     // ROW_MAJOR output: pack directly to output CB


### PR DESCRIPTION
### Ticket
#27314

### Problem description
In compute pool 2d kernel, `pack_untilize_dest_init` was called in a loop for BH, but does not have good perf.

### What's changed
Use `llk_math_hw_configure_disaggregated` + `llk_pack_untilize_init` instead of `pack_untilize_dest_init`. First call is needed on BH to set swizzle bit. Also move all of that after tilization is done, once after id enough to reconfigure packer for next pack untilize dests.

### Checklist 
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18381208256) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18381238727)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18381420958)