### PR TITLE
SDXL: VAE attn update

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -79,7 +79,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_decode_perf_device():
-    expected_device_perf_cycles_per_iteration = 956_401_895
+    expected_device_perf_cycles_per_iteration = 954_689_017
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
@@ -104,7 +104,7 @@ def test_sdxl_vae_decode_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_encode_perf_device():
-    expected_device_perf_cycles_per_iteration = 504_636_286
+    expected_device_perf_cycles_per_iteration = 502_563_162
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -5,6 +5,7 @@ import gc
 import torch
 import pytest
 import ttnn
+from loguru import logger
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
@@ -19,14 +20,14 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize(
-    "block_name",
+    "block_name, pcc",
     [
-        "encoder",
-        "decoder",
+        ("encoder", 0.999),
+        ("decoder", 0.997),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_attention(device, input_shape, encoder_shape, block_name, is_ci_env, reset_seeds):
+def test_vae_attention(device, input_shape, encoder_shape, block_name, pcc, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -81,4 +82,5 @@ def test_vae_attention(device, input_shape, encoder_shape, block_name, is_ci_env
     del vae, tt_attention
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.995)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -19,7 +19,7 @@ from loguru import logger
 @pytest.mark.parametrize(
     "input_shape, pcc, vae_block",
     [
-        ((1, 4, 128, 128), 0.928, "decoder"),
+        ((1, 4, 128, 128), 0.933, "decoder"),
         ((1, 3, 1024, 1024), 0.977, "encoder"),
     ],
     ids=("test_decode", "test_encode"),

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
@@ -29,10 +29,9 @@ class TtAttention(LightweightModule):
         super().__init__()
         self.device = device
 
-        self.norm_core_grid = ttnn.CoreGrid(y=4, x=8)
+        self.norm_core_grid = ttnn.CoreGrid(y=8, x=8)
         self.norm_groups = 32
         self.norm_eps = 1e-6
-        self.num_out_blocks = 4
 
         self.inner_dim = out_dim if out_dim is not None else dim_head * heads
         self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
@@ -93,18 +92,27 @@ class TtAttention(LightweightModule):
         self.tt_out_weights, self.tt_out_bias = prepare_linear_params(device, out_weights, out_bias, ttnn.bfloat16)
 
     def forward(self, input_tensor, input_shape, encoder_hidden_states=None):
-        hidden_states = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+        B, C, H, W = input_shape
+        shard_shape = B * H * W // self.norm_core_grid.x, C // self.norm_core_grid.y
+        sharded_mem_config = ttnn.create_sharded_memory_config(
+            shard_shape,
+            core_grid=self.norm_core_grid,
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        hidden_states = ttnn.to_memory_config(input_tensor, sharded_mem_config)
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=self.norm_groups,
             input_mask=self.input_mask,
             weight=self.gamma_t,
             bias=self.beta_t,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=sharded_mem_config,
             core_grid=self.norm_core_grid,
             epsilon=self.norm_eps,
-            inplace=False,
-            num_out_blocks=self.num_out_blocks,
+            negative_mask=None,
+            inplace=False,  # We are working with tiled sharded GN
         )
 
         assert encoder_hidden_states is None, "VAE does self attention only"
@@ -117,6 +125,7 @@ class TtAttention(LightweightModule):
             dtype=ttnn.bfloat16,
             compute_kernel_config=self.compute_kernel_config,
         )
+        ttnn.deallocate(hidden_states)
 
         (
             q_heads,


### PR DESCRIPTION
### What's changed
No need for attention in VAE to use the DRAM GroupNorm; using sharded op version now.
### Checklist
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/17976188670) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/17976196919) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/17976207132) CI passes