### PR TITLE
Add multimodal benchmark step for Qwen-VL in vLLM nightly

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -40,8 +40,8 @@ jobs:
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
-            server-timeout: 30,
-            benchmark-timeout: 20,
+            server-timeout: 10,
+            benchmark-timeout: 5,
             runner-label: config-t3000,
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -263,7 +263,7 @@ jobs:
       - name: Run multimodal benchmark
         if: ${{ matrix.test-group.multimodal }}
         run: |
-          python3 benchmarks/benchmark_serving.py \
+          python3 vllm/benchmarks/benchmark_serving.py \
             --backend openai-chat \
             --endpoint /v1/chat/completions \
             --model ${{ matrix.test-group.model }} \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,7 +139,10 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
+        HF_HUB_OFFLINE: 1
+        HF_DATASETS_OFFLINE: 1
+        HF_HOME: /mnt/MLPerf/huggingface
+        HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,94 +24,94 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
+          {
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
+            model: "Qwen/Qwen2.5-VL-72B-Instruct",
+            server-timeout: 30,
+            benchmark-timeout: 20,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+            multimodal: true,
+            co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
+          },
+          {
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: BH-DeskBox,
+            mesh-device: P150x2,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: bh-LLMBox,
+            mesh-device: P150x4,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
+            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           # {
-          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
+          #   Removing this until #26734 is resolved
+          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: bh-rackbox,
+          #   mesh-device: P150x8,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
-          #   model: "Qwen/Qwen2.5-VL-72B-Instruct",
-          #   server-timeout: 30,
-          #   benchmark-timeout: 20,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
-          #   multimodal: true,
-          #   co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
-          # },
-          # {
-          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: BH-DeskBox,
-          #   mesh-device: P150x2,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 2}",
+          #   override-tt-config: "{\"data_parallel\": 8}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          # {
-          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: bh-LLMBox,
-          #   mesh-device: P150x4,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 4}",
-          #   multimodal: false,
-          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # # {
-          # #   Removing this until #26734 is resolved
-          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
-          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          # #   server-timeout: 35,
-          # #   benchmark-timeout: 10,
-          # #   runner-label: bh-rackbox,
-          # #   mesh-device: P150x8,
-          # #   tt-llama-text-ver: tt_transformers,
-          # #   override-tt-config: "{\"data_parallel\": 8}",
-          # #   multimodal: false,
-          # #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # # },
-          # {
-          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
-          #   model: "meta-llama/Llama-3.3-70B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   tt-llama-text-ver: llama3_70b_galaxy,
-          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-8B DP=16",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-GLX] Llama-8B DP=16",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
           {
             name: "[WH-T3K] Gemma3-27B",
             model: "google/gemma-3-27b-it",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -261,7 +261,7 @@ jobs:
             exit 1
           fi
 
-      - name: Run multimodal benchmark
+      - name: 🖼️ Run multimodal benchmark
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -263,32 +263,28 @@ jobs:
       - name: Run multimodal benchmark
         if: ${{ matrix.test-group.multimodal }}
         run: |
-          if [ "${{ matrix.test-group.multimodal }}" = "true" ]; then
-            python3 benchmarks/benchmark_serving.py \
-              --backend openai-chat \
-              --endpoint /v1/chat/completions \
-              --model ${{ matrix.test-group.model }} \
-              --dataset-name hf \
-              --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
-              --num-prompts 32 \
-              --random-input-len 100 \
-              --random-output-len 100 \
-              --ignore-eos \
-              --percentile-metrics ttft,tpot,itl,e2el \
-              --save-result \
-              --result-filename output/vllm_result.json \
-              2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
+          python3 benchmarks/benchmark_serving.py \
+            --backend openai-chat \
+            --endpoint /v1/chat/completions \
+            --model ${{ matrix.test-group.model }} \
+            --dataset-name hf \
+            --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
+            --num-prompts 32 \
+            --random-input-len 100 \
+            --random-output-len 100 \
+            --ignore-eos \
+            --percentile-metrics ttft,tpot,itl,e2el \
+            --save-result \
+            --result-filename output/vllm_result.json \
+            2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
 
-            # If the backend fails, the benchmark will still complete successfully but with all-zero results.
-            # It will contain a warning message, though
-            warning_message="All requests failed"
-            if grep -q "$warning_message" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
-              echo "❌ All requests failed"
-              echo "Check out the server log in a step below."
-              exit 1
-            fi
-          else
-            exit 0
+          # If the backend fails, the benchmark will still complete successfully but with all-zero results.
+          # It will contain a warning message, though
+          warning_message="All requests failed"
+          if grep -q "$warning_message" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
+            echo "❌ All requests failed"
+            echo "Check out the server log in a step below."
+            exit 1
           fi
       - name: 🧹 Cleanup server process
         if: always()

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -272,6 +272,7 @@ jobs:
             --model ${{ matrix.test-group.model }} \
             --dataset-name hf \
             --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
+            --no-stream \
             --num-prompts 32 \
             --random-input-len 100 \
             --random-output-len 100 \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,6 +139,7 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
+        HF_HUB_OFFLINE: 1
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
         FILE_SERVER_PID: "./server.pid"
@@ -268,6 +269,9 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
           pip list | grep datasets
+
+          unset HF_HUB_OFFLINE
+          echo "HF_HUB_OFFLINE: $HF_HUB_OFFLINE"
 
           python3 vllm/benchmarks/benchmark_serving.py \
             --backend openai-chat \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -141,6 +141,7 @@ jobs:
         LOGURU_LEVEL: INFO
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
+        HF_DATASETS_OFFLINE: 1
         TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -40,7 +40,7 @@ jobs:
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
-            server-timeout: 30,
+            server-timeout: 20,
             benchmark-timeout: 15,
             runner-label: config-t3000,
             mesh-device: T3K,
@@ -262,13 +262,14 @@ jobs:
 
       - name: Run multimodal benchmark
         if: ${{ matrix.test-group.multimodal }}
+        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
           python3 vllm/benchmarks/benchmark_serving.py \
             --backend openai-chat \
             --endpoint /v1/chat/completions \
             --model ${{ matrix.test-group.model }} \
             --dataset-name hf \
-            --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
+            --dataset-path /mnt/MLPerf/huggingface/hub/datasets--lmarena-ai--vision-arena-bench-v0.1/snapshots/3abe18efa30d674a8903386b463ce278e7f41f2d \
             --num-prompts 32 \
             --random-input-len 100 \
             --random-output-len 100 \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,9 +139,7 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        HF_HUB_OFFLINE: 1
-        HF_DATASETS_OFFLINE: 1
-        HF_HOME: /mnt/MLPerf/huggingface
+        HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -149,7 +149,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "[WH-T3K] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
+          # {
+          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -49,82 +49,82 @@ jobs:
             multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          {
-            name: "[BH-DB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: BH-DeskBox,
-            mesh-device: P150x2,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 2}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-QB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: bh-LLMBox,
-            mesh-device: P150x4,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 4}",
-            multimodal: false,
-            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
           # {
-          #   Removing this until #26734 is resolved
-          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: BH-DeskBox,
+          #   mesh-device: P150x2,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
+          #   override-tt-config: "{\"data_parallel\": 2}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          {
-            name: "[WH-GLX] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-GLX] Llama-8B DP=16",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
-          {
-            name: "[WH-T3K] Gemma3-27B",
-            model: "google/gemma-3-27b-it",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
+          # {
+          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: bh-LLMBox,
+          #   mesh-device: P150x4,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 4}",
+          #   multimodal: false,
+          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # # {
+          # #   Removing this until #26734 is resolved
+          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          # #   server-timeout: 35,
+          # #   benchmark-timeout: 10,
+          # #   runner-label: bh-rackbox,
+          # #   mesh-device: P150x8,
+          # #   tt-llama-text-ver: tt_transformers,
+          # #   override-tt-config: "{\"data_parallel\": 8}",
+          # #   multimodal: false,
+          # #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # # },
+          # {
+          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
+          #   model: "meta-llama/Llama-3.3-70B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   tt-llama-text-ver: llama3_70b_galaxy,
+          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-8B DP=16",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
+          # {
+          #   name: "[WH-T3K] Gemma3-27B",
+          #   model: "google/gemma-3-27b-it",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,94 +24,94 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "[WH-T3K] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
-            model: "Qwen/Qwen2.5-VL-72B-Instruct",
-            server-timeout: 30,
-            benchmark-timeout: 20,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
-            multimodal: true,
-            co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
-          },
-          {
-            name: "[BH-DB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: BH-DeskBox,
-            mesh-device: P150x2,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 2}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-QB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: bh-LLMBox,
-            mesh-device: P150x4,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 4}",
-            multimodal: false,
-            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
           # {
-          #   Removing this until #26734 is resolved
-          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
+          #   model: "Qwen/Qwen2.5-VL-72B-Instruct",
+          #   server-timeout: 30,
+          #   benchmark-timeout: 20,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+          #   multimodal: true,
+          #   co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
+          # },
+          # {
+          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: BH-DeskBox,
+          #   mesh-device: P150x2,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 2}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          {
-            name: "[WH-GLX] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-GLX] Llama-8B DP=16",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
+          # {
+          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: bh-LLMBox,
+          #   mesh-device: P150x4,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 4}",
+          #   multimodal: false,
+          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # # {
+          # #   Removing this until #26734 is resolved
+          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          # #   server-timeout: 35,
+          # #   benchmark-timeout: 10,
+          # #   runner-label: bh-rackbox,
+          # #   mesh-device: P150x8,
+          # #   tt-llama-text-ver: tt_transformers,
+          # #   override-tt-config: "{\"data_parallel\": 8}",
+          # #   multimodal: false,
+          # #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # # },
+          # {
+          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
+          #   model: "meta-llama/Llama-3.3-70B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   tt-llama-text-ver: llama3_70b_galaxy,
+          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-8B DP=16",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
           {
             name: "[WH-T3K] Gemma3-27B",
             model: "google/gemma-3-27b-it",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,6 +139,8 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
+        HF_HUB_OFFLINE: 1
+        HF_DATASETS_OFFLINE: 1
         HF_HOME: /mnt/MLPerf/huggingface
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
+          {
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -49,82 +49,82 @@ jobs:
             multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
+          {
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: BH-DeskBox,
+            mesh-device: P150x2,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: bh-LLMBox,
+            mesh-device: P150x4,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
+            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           # {
-          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
+          #   Removing this until #26734 is resolved
+          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: BH-DeskBox,
-          #   mesh-device: P150x2,
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: bh-rackbox,
+          #   mesh-device: P150x8,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 2}",
+          #   override-tt-config: "{\"data_parallel\": 8}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          # {
-          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: bh-LLMBox,
-          #   mesh-device: P150x4,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 4}",
-          #   multimodal: false,
-          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # # {
-          # #   Removing this until #26734 is resolved
-          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
-          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          # #   server-timeout: 35,
-          # #   benchmark-timeout: 10,
-          # #   runner-label: bh-rackbox,
-          # #   mesh-device: P150x8,
-          # #   tt-llama-text-ver: tt_transformers,
-          # #   override-tt-config: "{\"data_parallel\": 8}",
-          # #   multimodal: false,
-          # #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # # },
-          # {
-          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
-          #   model: "meta-llama/Llama-3.3-70B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   tt-llama-text-ver: llama3_70b_galaxy,
-          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-8B DP=16",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
-          # {
-          #   name: "[WH-T3K] Gemma3-27B",
-          #   model: "google/gemma-3-27b-it",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-GLX] Llama-8B DP=16",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
+          {
+            name: "[WH-T3K] Gemma3-27B",
+            model: "google/gemma-3-27b-it",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,8 +139,8 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        HF_HUB_OFFLINE: 1
         HF_HOME: /mnt/MLPerf/huggingface
+        HF_HUB_OFFLINE: 1
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
@@ -269,7 +269,7 @@ jobs:
             --endpoint /v1/chat/completions \
             --model ${{ matrix.test-group.model }} \
             --dataset-name hf \
-            --dataset-path /mnt/MLPerf/huggingface/hub/datasets--lmarena-ai--vision-arena-bench-v0.1/snapshots/3abe18efa30d674a8903386b463ce278e7f41f2d \
+            --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
             --num-prompts 32 \
             --random-input-len 100 \
             --random-output-len 100 \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -187,6 +187,9 @@ jobs:
       - name: 🚀 Run server
         timeout-minutes: 1
         run: |
+          ls $HF_HUB_CACHE
+          ls $TT_CACHE_HOME
+
           if [ -n "${{ matrix.test-group.override-tt-config }}" ]; then
             export OVERRIDE_TT_CONFIG=(--override-tt-config "$(printf "%s" '${{ matrix.test-group.override-tt-config }}')")
           else

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -121,7 +121,7 @@ jobs:
             mesh-device: T3K,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
             tt-llama-text-ver: tt_transformers,
-            multimodal: true,
+            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },
@@ -188,9 +188,6 @@ jobs:
       - name: 🚀 Run server
         timeout-minutes: 1
         run: |
-          ls $HF_HUB_CACHE
-          ls $TT_CACHE_HOME
-
           if [ -n "${{ matrix.test-group.override-tt-config }}" ]; then
             export OVERRIDE_TT_CONFIG=(--override-tt-config "$(printf "%s" '${{ matrix.test-group.override-tt-config }}')")
           else
@@ -268,10 +265,8 @@ jobs:
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
-          pip list | grep datasets
-
-          unset HF_HUB_OFFLINE
-          echo "HF_HUB_OFFLINE: $HF_HUB_OFFLINE"
+          echo "Using: $(pip list | grep datasets)"
+          unset HF_HUB_OFFLINE # Disable offline mode to allow downloading the dataset
 
           python3 vllm/benchmarks/benchmark_serving.py \
             --backend openai-chat \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -141,7 +141,7 @@ jobs:
         LOGURU_LEVEL: INFO
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
-        HF_HOME: /mnt/MLPerf/huggingface
+        TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
@@ -202,7 +202,7 @@ jobs:
           # Keep TT cache separate from HF hub
           export HF_MODEL="${{ matrix.test-group.model }}"
           MODEL_NAME="${HF_MODEL/\//--}"
-          export TT_CACHE_PATH="$HF_HOME/tt_cache/$MODEL_NAME"
+          export TT_CACHE_PATH="$TT_CACHE_HOME/$MODEL_NAME"
 
           # vLLM environment variables
           export VLLM_RPC_TIMEOUT=300000

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -33,6 +33,7 @@ jobs:
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
@@ -45,6 +46,7 @@ jobs:
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+            multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
           {
@@ -56,6 +58,7 @@ jobs:
             mesh-device: P150x2,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
             owner_id: U08GELBB1AP, # Ambrose Ling
           },
           {
@@ -67,6 +70,7 @@ jobs:
             mesh-device: P150x4,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
             owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
           # {
@@ -79,6 +83,7 @@ jobs:
           #   mesh-device: P150x8,
           #   tt-llama-text-ver: tt_transformers,
           #   override-tt-config: "{\"data_parallel\": 8}",
+          #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
           {
@@ -90,6 +95,7 @@ jobs:
             mesh-device: TG,
             tt-llama-text-ver: llama3_70b_galaxy,
             override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            multimodal: false,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
@@ -102,6 +108,7 @@ jobs:
             mesh-device: TG,
             override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
             tt-llama-text-ver: tt_transformers,
+            multimodal: false,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },
@@ -114,6 +121,7 @@ jobs:
             mesh-device: T3K,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
             tt-llama-text-ver: tt_transformers,
+            multimodal: false,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },
@@ -136,6 +144,7 @@ jobs:
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
+        FILE_MULTIMODAL_BENCHMARK_LOG: "./output/vllm_multimodal_benchmark.log"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -251,6 +260,36 @@ jobs:
             exit 1
           fi
 
+      - name: Run multimodal benchmark
+        if: ${{ matrix.test-group.multimodal }}
+        run: |
+          if [ "${{ matrix.test-group.multimodal }}" = "true" ]; then
+            python3 benchmarks/benchmark_serving.py \
+              --backend openai-chat \
+              --endpoint /v1/chat/completions \
+              --model ${{ matrix.test-group.model }} \
+              --dataset-name hf \
+              --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
+              --num-prompts 32 \
+              --random-input-len 100 \
+              --random-output-len 100 \
+              --ignore-eos \
+              --percentile-metrics ttft,tpot,itl,e2el \
+              --save-result \
+              --result-filename output/vllm_result.json \
+              2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
+
+            # If the backend fails, the benchmark will still complete successfully but with all-zero results.
+            # It will contain a warning message, though
+            warning_message="All requests failed"
+            if grep -q "$warning_message" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
+              echo "❌ All requests failed"
+              echo "Check out the server log in a step below."
+              exit 1
+            fi
+          else
+            exit 0
+          fi
       - name: 🧹 Cleanup server process
         if: always()
         run: |

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -140,8 +140,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
-        HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
-        HF_DATASETS_OFFLINE: 1
         TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -139,9 +139,7 @@ jobs:
         PYTHONPATH: /work:/work/vllm
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        HF_HUB_OFFLINE: 1
-        HF_DATASETS_OFFLINE: 1
-        HF_HOME: /mnt/MLPerf/huggingface
+        HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -149,7 +149,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -140,7 +140,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         HF_HOME: /mnt/MLPerf/huggingface
-        HF_HUB_OFFLINE: 1
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "[WH-T3K] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
+          # {
+          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -49,69 +49,69 @@ jobs:
             multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          {
-            name: "[BH-DB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: BH-DeskBox,
-            mesh-device: P150x2,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 2}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-QB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: bh-LLMBox,
-            mesh-device: P150x4,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 4}",
-            multimodal: false,
-            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
           # {
-          #   Removing this until #26734 is resolved
-          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: BH-DeskBox,
+          #   mesh-device: P150x2,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
+          #   override-tt-config: "{\"data_parallel\": 2}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          {
-            name: "[WH-GLX] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-GLX] Llama-8B DP=16",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
+          # {
+          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: bh-LLMBox,
+          #   mesh-device: P150x4,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 4}",
+          #   multimodal: false,
+          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # # {
+          # #   Removing this until #26734 is resolved
+          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
+          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          # #   server-timeout: 35,
+          # #   benchmark-timeout: 10,
+          # #   runner-label: bh-rackbox,
+          # #   mesh-device: P150x8,
+          # #   tt-llama-text-ver: tt_transformers,
+          # #   override-tt-config: "{\"data_parallel\": 8}",
+          # #   multimodal: false,
+          # #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # # },
+          # {
+          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
+          #   model: "meta-llama/Llama-3.3-70B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   tt-llama-text-ver: llama3_70b_galaxy,
+          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-8B DP=16",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
           {
             name: "[WH-T3K] Gemma3-27B",
             model: "google/gemma-3-27b-it",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -141,6 +141,7 @@ jobs:
         LOGURU_LEVEL: INFO
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         HF_DATASETS_CACHE: /mnt/MLPerf/huggingface/datasets
+        HF_HOME: /mnt/MLPerf/huggingface
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -40,8 +40,8 @@ jobs:
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
-            server-timeout: 20,
-            benchmark-timeout: 15,
+            server-timeout: 30,
+            benchmark-timeout: 20,
             runner-label: config-t3000,
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -265,6 +265,8 @@ jobs:
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
+          pip list | grep datasets
+
           python3 vllm/benchmarks/benchmark_serving.py \
             --backend openai-chat \
             --endpoint /v1/chat/completions \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -121,7 +121,7 @@ jobs:
             mesh-device: T3K,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
             tt-llama-text-ver: tt_transformers,
-            multimodal: false,
+            multimodal: true,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
+          {
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -49,69 +49,69 @@ jobs:
             multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
+          {
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: BH-DeskBox,
+            mesh-device: P150x2,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: bh-LLMBox,
+            mesh-device: P150x4,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
+            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           # {
-          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
+          #   Removing this until #26734 is resolved
+          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
           #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: BH-DeskBox,
-          #   mesh-device: P150x2,
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: bh-rackbox,
+          #   mesh-device: P150x8,
           #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 2}",
+          #   override-tt-config: "{\"data_parallel\": 8}",
           #   multimodal: false,
           #   owner_id: U08GELBB1AP, # Ambrose Ling
           # },
-          # {
-          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: bh-LLMBox,
-          #   mesh-device: P150x4,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 4}",
-          #   multimodal: false,
-          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # # {
-          # #   Removing this until #26734 is resolved
-          # #   name: "[BH-RB] Llama-3.1-8B-Instruct",
-          # #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          # #   server-timeout: 35,
-          # #   benchmark-timeout: 10,
-          # #   runner-label: bh-rackbox,
-          # #   mesh-device: P150x8,
-          # #   tt-llama-text-ver: tt_transformers,
-          # #   override-tt-config: "{\"data_parallel\": 8}",
-          # #   multimodal: false,
-          # #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # # },
-          # {
-          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
-          #   model: "meta-llama/Llama-3.3-70B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   tt-llama-text-ver: llama3_70b_galaxy,
-          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-8B DP=16",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-GLX] Llama-8B DP=16",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
           {
             name: "[WH-T3K] Gemma3-27B",
             model: "google/gemma-3-27b-it",


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Existing vLLM nightly runs text-only benchmarks on Qwen-VL and that provides insufficient coverage as Qwen-VL is multimodal.

### What's changed
Add an additional benchmark step to run on a small multimodal dataset -- `lmarena-ai/vision-arena-bench-v0.1`.

Tried to enable multimodal benchmarking for Gemma but encountered an error about `gated repo`:
- https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451

### Checklist
- [x] vLLM nightly for Qwen-VL
  - https://github.com/tenstorrent/tt-metal/actions/runs/18017369463/job/51266865143
- [x] vLLM nightly for all models
  - https://github.com/tenstorrent/tt-metal/actions/runs/18023383584   