### PR TITLE
Fuse YoloV4 leaky RELU activations with convolution layers

### DIFF
--- a/models/demos/yolov4/common.py
+++ b/models/demos/yolov4/common.py
@@ -158,7 +158,7 @@ def create_sharding_strategy(conv2d_args):
         return AutoShardedStrategyConfiguration()
 
 
-def create_conv2d_config(conv_args, weight, bias):
+def create_conv2d_config(conv_args, weight, bias, activation=None):
     """Helper to create Conv2dConfiguration with proper sharding parameters"""
     return Conv2dConfiguration.from_model_args(
         conv_args,
@@ -172,4 +172,5 @@ def create_conv2d_config(conv_args, weight, bias):
         packer_l1_acc=False,
         enable_act_double_buffer=True,
         output_layout=ttnn.TILE_LAYOUT,
+        activation=activation,
     )

--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "yolov4", 102),
+        (1, "yolov4", 108),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov4/tt/head.py
+++ b/models/demos/yolov4/tt/head.py
@@ -12,7 +12,12 @@ class TtHead:
         self.parameters = parameters
 
         self.conv1 = TtConv2d(
-            create_conv2d_config(conv_args.c1, parameters.c1.weight, parameters.c1.bias),
+            create_conv2d_config(
+                conv_args.c1,
+                parameters.c1.weight,
+                parameters.c1.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
 
@@ -21,31 +26,66 @@ class TtHead:
             device=device,
         )
         self.conv3 = TtConv2d(
-            create_conv2d_config(conv_args.c3, parameters.c3.weight, parameters.c3.bias),
+            create_conv2d_config(
+                conv_args.c3,
+                parameters.c3.weight,
+                parameters.c3.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv4 = TtConv2d(
-            create_conv2d_config(conv_args.c4, parameters.c4.weight, parameters.c4.bias),
+            create_conv2d_config(
+                conv_args.c4,
+                parameters.c4.weight,
+                parameters.c4.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv5 = TtConv2d(
-            create_conv2d_config(conv_args.c5, parameters.c5.weight, parameters.c5.bias),
+            create_conv2d_config(
+                conv_args.c5,
+                parameters.c5.weight,
+                parameters.c5.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv6 = TtConv2d(
-            create_conv2d_config(conv_args.c6, parameters.c6.weight, parameters.c6.bias),
+            create_conv2d_config(
+                conv_args.c6,
+                parameters.c6.weight,
+                parameters.c6.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7 = TtConv2d(
-            create_conv2d_config(conv_args.c7, parameters.c7.weight, parameters.c7.bias),
+            create_conv2d_config(
+                conv_args.c7,
+                parameters.c7.weight,
+                parameters.c7.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv8 = TtConv2d(
-            create_conv2d_config(conv_args.c8, parameters.c8.weight, parameters.c8.bias),
+            create_conv2d_config(
+                conv_args.c8,
+                parameters.c8.weight,
+                parameters.c8.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv9 = TtConv2d(
-            create_conv2d_config(conv_args.c9, parameters.c9.weight, parameters.c9.bias),
+            create_conv2d_config(
+                conv_args.c9,
+                parameters.c9.weight,
+                parameters.c9.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv10 = TtConv2d(
@@ -53,32 +93,67 @@ class TtHead:
             device=device,
         )
         self.conv11 = TtConv2d(
-            create_conv2d_config(conv_args.c11, parameters.c11.weight, parameters.c11.bias),
+            create_conv2d_config(
+                conv_args.c11,
+                parameters.c11.weight,
+                parameters.c11.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
 
         self.conv12 = TtConv2d(
-            create_conv2d_config(conv_args.c12, parameters.c12.weight, parameters.c12.bias),
+            create_conv2d_config(
+                conv_args.c12,
+                parameters.c12.weight,
+                parameters.c12.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv13 = TtConv2d(
-            create_conv2d_config(conv_args.c13, parameters.c13.weight, parameters.c13.bias),
+            create_conv2d_config(
+                conv_args.c13,
+                parameters.c13.weight,
+                parameters.c13.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv14 = TtConv2d(
-            create_conv2d_config(conv_args.c14, parameters.c14.weight, parameters.c14.bias),
+            create_conv2d_config(
+                conv_args.c14,
+                parameters.c14.weight,
+                parameters.c14.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv15 = TtConv2d(
-            create_conv2d_config(conv_args.c15, parameters.c15.weight, parameters.c15.bias),
+            create_conv2d_config(
+                conv_args.c15,
+                parameters.c15.weight,
+                parameters.c15.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv16 = TtConv2d(
-            create_conv2d_config(conv_args.c16, parameters.c16.weight, parameters.c16.bias),
+            create_conv2d_config(
+                conv_args.c16,
+                parameters.c16.weight,
+                parameters.c16.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv17 = TtConv2d(
-            create_conv2d_config(conv_args.c17, parameters.c17.weight, parameters.c17.bias),
+            create_conv2d_config(
+                conv_args.c17,
+                parameters.c17.weight,
+                parameters.c17.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv18 = TtConv2d(
@@ -88,12 +163,10 @@ class TtHead:
 
     def __call__(self, input_tensor):
         output_tensor = self.conv1(input_tensor[0])
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor_left_1 = self.conv2(output_tensor)
 
         output_tensor = self.conv3(input_tensor[0])
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
         outfrom_Neck1 = input_tensor[2]
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -108,27 +181,20 @@ class TtHead:
         output_tensor = ttnn.concat([output_tensor, outfrom_Neck1], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         output_tensor = self.conv4(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv5(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv6(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv7(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv8(output_tensor)
-        output_tensor_split = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
+        output_tensor_split = self.conv8(output_tensor)
 
         output_tensor = self.conv9(output_tensor_split)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor_left_2 = self.conv10(output_tensor)
 
         output_tensor = self.conv11(output_tensor_split)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         outfromNeck2 = input_tensor[1]
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -142,22 +208,16 @@ class TtHead:
         output_tensor = ttnn.concat([output_tensor, outfromNeck2], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         output_tensor = self.conv12(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv13(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv14(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv15(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv16(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv17(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor_left_3 = self.conv18(output_tensor)
 

--- a/models/demos/yolov4/tt/neck.py
+++ b/models/demos/yolov4/tt/neck.py
@@ -49,97 +49,194 @@ class TtNeck:
         self.conv_args = conv_args
         self.parameters = parameters
         self.conv1 = TtConv2d(
-            create_conv2d_config(conv_args.c1, parameters.c1.weight, parameters.c1.bias),
+            create_conv2d_config(
+                conv_args.c1,
+                parameters.c1.weight,
+                parameters.c1.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv2 = TtConv2d(
-            create_conv2d_config(conv_args.c2, parameters.c2.weight, parameters.c2.bias),
+            create_conv2d_config(
+                conv_args.c2,
+                parameters.c2.weight,
+                parameters.c2.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv3 = TtConv2d(
-            create_conv2d_config(conv_args.c3, parameters.c3.weight, parameters.c3.bias),
+            create_conv2d_config(
+                conv_args.c3,
+                parameters.c3.weight,
+                parameters.c3.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv4 = TtConv2d(
-            create_conv2d_config(conv_args.c4, parameters.c4.weight, parameters.c4.bias),
+            create_conv2d_config(
+                conv_args.c4,
+                parameters.c4.weight,
+                parameters.c4.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv5 = TtConv2d(
-            create_conv2d_config(conv_args.c5, parameters.c5.weight, parameters.c5.bias),
+            create_conv2d_config(
+                conv_args.c5,
+                parameters.c5.weight,
+                parameters.c5.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv6 = TtConv2d(
-            create_conv2d_config(conv_args.c6, parameters.c6.weight, parameters.c6.bias),
+            create_conv2d_config(
+                conv_args.c6,
+                parameters.c6.weight,
+                parameters.c6.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7 = TtConv2d(
-            create_conv2d_config(conv_args.c7, parameters.c7.weight, parameters.c7.bias),
+            create_conv2d_config(
+                conv_args.c7,
+                parameters.c7.weight,
+                parameters.c7.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7_2 = TtConv2d(
-            create_conv2d_config(conv_args.c7_2, parameters.c7_2.weight, parameters.c7_2.bias),
+            create_conv2d_config(
+                conv_args.c7_2,
+                parameters.c7_2.weight,
+                parameters.c7_2.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7_3 = TtConv2d(
-            create_conv2d_config(conv_args.c7_3, parameters.c7_3.weight, parameters.c7_3.bias),
+            create_conv2d_config(
+                conv_args.c7_3,
+                parameters.c7_3.weight,
+                parameters.c7_3.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv8 = TtConv2d(
-            create_conv2d_config(conv_args.c8, parameters.c8.weight, parameters.c8.bias),
+            create_conv2d_config(
+                conv_args.c8,
+                parameters.c8.weight,
+                parameters.c8.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7_4 = TtConv2d(
-            create_conv2d_config(conv_args.c7_4, parameters.c7_4.weight, parameters.c7_4.bias),
+            create_conv2d_config(
+                conv_args.c7_4,
+                parameters.c7_4.weight,
+                parameters.c7_4.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv8_2 = TtConv2d(
-            create_conv2d_config(conv_args.c8_2, parameters.c8_2.weight, parameters.c8_2.bias),
+            create_conv2d_config(
+                conv_args.c8_2,
+                parameters.c8_2.weight,
+                parameters.c8_2.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv7_5 = TtConv2d(
-            create_conv2d_config(conv_args.c7_5, parameters.c7_5.weight, parameters.c7_5.bias),
+            create_conv2d_config(
+                conv_args.c7_5,
+                parameters.c7_5.weight,
+                parameters.c7_5.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
 
         self.conv9 = TtConv2d(
-            create_conv2d_config(conv_args.c9, parameters.c9.weight, parameters.c9.bias),
+            create_conv2d_config(
+                conv_args.c9,
+                parameters.c9.weight,
+                parameters.c9.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv9_2 = TtConv2d(
-            create_conv2d_config(conv_args.c9_2, parameters.c9_2.weight, parameters.c9_2.bias),
+            create_conv2d_config(
+                conv_args.c9_2,
+                parameters.c9_2.weight,
+                parameters.c9_2.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv9_3 = TtConv2d(
-            create_conv2d_config(conv_args.c9_3, parameters.c9_3.weight, parameters.c9_3.bias),
+            create_conv2d_config(
+                conv_args.c9_3,
+                parameters.c9_3.weight,
+                parameters.c9_3.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv10 = TtConv2d(
-            create_conv2d_config(conv_args.c10, parameters.c10.weight, parameters.c10.bias),
+            create_conv2d_config(
+                conv_args.c10,
+                parameters.c10.weight,
+                parameters.c10.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
 
         self.conv9_4 = TtConv2d(
-            create_conv2d_config(conv_args.c9_4, parameters.c9_4.weight, parameters.c9_4.bias),
+            create_conv2d_config(
+                conv_args.c9_4,
+                parameters.c9_4.weight,
+                parameters.c9_4.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv10_2 = TtConv2d(
-            create_conv2d_config(conv_args.c10_2, parameters.c10_2.weight, parameters.c10_2.bias),
+            create_conv2d_config(
+                conv_args.c10_2,
+                parameters.c10_2.weight,
+                parameters.c10_2.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
         self.conv9_5 = TtConv2d(
-            create_conv2d_config(conv_args.c9_5, parameters.c9_5.weight, parameters.c9_5.bias),
+            create_conv2d_config(
+                conv_args.c9_5,
+                parameters.c9_5.weight,
+                parameters.c9_5.bias,
+                activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.LEAKY_RELU, 0.1),
+            ),
             device=device,
         )
 
     def __call__(self, input_tensor):
         output_tensor = self.conv1(input_tensor[0])
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv2(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv3(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor_pool_in = output_tensor
         if output_tensor_pool_in.memory_config().is_sharded():
@@ -203,16 +300,12 @@ class TtNeck:
         output_tensor = ttnn.concat([pool_all, output_tensor], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         output_tensor = self.conv4(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv5(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv6(output_tensor)
-        output_tensor_left_1 = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
+        output_tensor_left_1 = self.conv6(output_tensor)
 
         output_tensor = self.conv7(output_tensor_left_1)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_shape = output_tensor.shape
         output_tensor = ttnn.untilize_with_unpadding(
@@ -288,7 +381,6 @@ class TtNeck:
         outDowSample5 = input_tensor[1]
 
         output_tensor = self.conv7_2(outDowSample5)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
         if self.parameters.resolution[0] == 320:
@@ -299,19 +391,14 @@ class TtNeck:
         ttnn.deallocate(output_tensor_upsample_1)
 
         output_tensor = self.conv7_3(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv8(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv7_4(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv8_2(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv7_5(output_tensor)
-        output_tensor_left_2 = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
+        output_tensor_left_2 = self.conv7_5(output_tensor)
 
         if self.parameters.resolution[0] == 320:
             shard_grid = ttnn.CoreRangeSet(
@@ -329,7 +416,6 @@ class TtNeck:
             output_tensor_left_2 = ttnn.to_memory_config(output_tensor_left_2, memory_config=in_sharded_mem_config)
 
         output_tensor = self.conv9(output_tensor_left_2)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_shape = output_tensor.shape
         output_tensor = ttnn.untilize_with_unpadding(
@@ -406,7 +492,6 @@ class TtNeck:
         outDowSample3 = input_tensor[2]
 
         output_tensor = self.conv9_2(outDowSample3)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
         if self.parameters.resolution[0] == 320:
@@ -417,19 +502,14 @@ class TtNeck:
         ttnn.deallocate(output_tensor_upsample_2)
 
         output_tensor = self.conv9_3(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv10(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv9_4(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv10_2(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = self.conv9_5(output_tensor)
-        output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         ttnn.deallocate(input_tensor[0])
         ttnn.deallocate(input_tensor[1])


### PR DESCRIPTION
### Summary

Use `ttnn.UnaryWithParam()` to fuse leaky RELU activations with `ttnn.conv2d` layers wherever they are used. This improves device performance by 6 fps and removes dispatch overhead for running standalone activation ops from end-to-end performance.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17981487309
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/17981483090