### PR TITLE
initialize CB wr pointer at the beginning of each act block h

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -80,6 +80,7 @@ void kernel_main() {
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
 #ifdef ACTIVATION_REUSE
         uint32_t l1_write_addr_act = cb_start_addr;
+        get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
 #endif
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -105,6 +105,7 @@ void kernel_main() {
 #ifdef SPLIT_READER
 #ifdef ACTIVATION_REUSE
         uint32_t l1_write_addr_act = cb_start_addr;
+        get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
 #endif
         uint32_t reader_offset = act_l1_read_addr;
 #endif

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -151,6 +151,7 @@ void kernel_main() {
 #ifdef SPLIT_READER
 #ifdef ACTIVATION_REUSE
         uint32_t l1_write_addr_act = cb_start_addr;
+        get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
 #endif
         uint32_t reader_offset = act_l1_read_addr;
 #endif


### PR DESCRIPTION
### Ticket
#29005

### Problem description
Watcher asserted in conv with activation reuse when ran on BH.

### What's changed
Beacuse of the optimization, we need to set the write address ourself and not rely on cb wr pointer. 
When doing a new act block h, we reinitialize the write address to the beginning of the CB, but we don't update hte CB wr pointer as well so push back at some points sets write pointer to an address beyound limit. Since we don't use the write ptr for actual data write, this didn't result in PCC issues.

### Checklist

- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/18099934758
- [x] BH post commit: https://github.com/tenstorrent/tt-metal/actions/runs/18099928891 (LLM box failing as on main)
- [x] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/18099939334 (swin v2 failing on main, PR to fix in progress)
- [x] Nightly L2: https://github.com/tenstorrent/tt-metal/actions/runs/18099915046