### PR TITLE
Fix AR out of memory issue

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
@@ -516,6 +516,8 @@ def test_line_all_reduce_on_TG_cols_post_commit(
         (32, 3, [1, 1, 128000, 4096], ttnn.TILE_LAYOUT),
         (32, 3, [1, 1, 4096, 128000], ttnn.TILE_LAYOUT),
         (32, 3, [1, 1, 1024, 50304], ttnn.TILE_LAYOUT),
+        (32, 3, [1, 1, 33, 66], ttnn.TILE_LAYOUT),
+        (32, 3, [1, 1, 4094, 50300], ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/29182
https://github.com/tenstorrent/tt-metal/issues/29058

### Problem description
All reduce currently runs AG + local reduce for training shapes. This results in running out of memory

### What's changed
Force AR to execute RS+AG path when possible:
- pick dim 3 for RS if possible (last dim is multiple of tile_width * number of devices) which triggers the RS + AG path
- pad with zeros when that is not the case and pick dim 3

This PR also changes the composite path of AR (AG + local reduction) to use moreh sum and dim 0 for AG, which reduces the memory usage of the op
It also deallocates intermediate tensors when possible in the composite paths

The graph tracing tool shows the memory usage below:
Shape 1: [1, 1, 50304, 4096] : output tensor is 0.38 GB; uses 0.78 GB of memory
Shape 2: [1, 1, 50304, 2048]: output tensor is 0.19 GB; uses 0.39 GB of memory
Shape 3: [1, 1, 50304, 1024]: output tensor is 0.096 GB; uses 0.19 GB of memory
Shape 4: [1, 1, 128000, 4096]: output tensor is 0.976GB; uses 1.98 GB of memory
Shape 5: [1, 1, 4096, 50304]: output tensor is 0.38 GB; uses 1.18 GB of memory
Shape 6: [1, 1, 2048, 50304]: output tensor is 0.19 GB; uses 0.59 GB of memory
Shape 7: [1, 1, 1024, 50304]: output tensor is 0.096 GB; uses 0.29 GB of memory
Shape 8: [1, 1, 4096, 128000]: output tensor is 0.976 GB; uses 1.98 GB of memory

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18013018490
- [ ] t3k frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/18013047132
- [ ] t3k nightly tests https://github.com/tenstorrent/tt-metal/actions/runs/18013069374
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes