### PR TITLE
Fixing Inspector RPC sad path

### DIFF
--- a/tt_metal/impl/debug/inspector/rpc_server_controller.cpp
+++ b/tt_metal/impl/debug/inspector/rpc_server_controller.cpp
@@ -39,6 +39,9 @@ void RpcServerController::start(const std::string& host, uint16_t port) {
     std::unique_lock start_lock(server_start_mutex);
     server_start_cv.wait(start_lock, [this] { return this->server_start_finished.load(); });
     if (!is_running) {
+        if (server_thread.joinable()) {
+            server_thread.join();
+        }
         throw std::runtime_error(server_start_error_message);
     }
 }


### PR DESCRIPTION
When Inspector RPC cannot start, it prints warning about it.
Problem was that in destructor it crashes the app.
This PR fixes the problem by ensuring server thread is joined on start failure in RpcServerController.