### PR TITLE
workaround tt-run hang

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -353,6 +353,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         buffer_address += field_size;
     }
 
+    // Issue: https://github.com/tenstorrent/tt-metal/issues/29249. Move it back to after edm_local_sync_address once
+    // the hang is root caused for multiprocess test.
     this->edm_local_tensix_sync_address = buffer_address;
     buffer_address += field_size;
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -298,8 +298,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         edm_channel_ack_addr +
         (4 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
     this->edm_local_sync_address = termination_signal_address + field_size;
-    this->edm_local_tensix_sync_address = edm_local_sync_address + field_size;
-    this->edm_status_address = edm_local_tensix_sync_address + field_size;
+    this->edm_status_address = edm_local_sync_address + field_size;
 
     uint32_t buffer_address = edm_status_address + field_size;
 
@@ -353,6 +352,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         this->receiver_channels_downstream_teardown_semaphore_address[i] = buffer_address;
         buffer_address += field_size;
     }
+
+    this->edm_local_tensix_sync_address = buffer_address + field_size;
+    buffer_address += field_size;
 
     // Channel Allocations
     this->max_l1_loading_size =

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -353,7 +353,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         buffer_address += field_size;
     }
 
-    this->edm_local_tensix_sync_address = buffer_address + field_size;
+    this->edm_local_tensix_sync_address = buffer_address;
     buffer_address += field_size;
 
     // Channel Allocations


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29249)

### Problem description
multi-process test currently hang at device init, workaround by moving the newly added address downwards make it pass.
Need to be root caused still.


### Checklist
- [x] [All post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/17984877061
- [ ] t3000 unit https://github.com/tenstorrent/tt-metal/actions/runs/17984898637
- [x] BH nightly https://github.com/tenstorrent/tt-metal/actions/runs/17984885474