### PR TITLE
Llama galaxy: host sampling for structured decoding 

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -780,7 +780,9 @@ def test_demo_text(
                 v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(batch_size, -1)
-
+        device_sampling_params = SamplingParams(
+            temperature=sampling_params["temperature"], top_k=32, top_p=sampling_params["top_p"]
+        )
         if batch_idx == 0:
             logger.info("Starting prefill warmup...")
             profiler.start(f"compile_prefill", iteration=batch_idx)
@@ -793,6 +795,7 @@ def test_demo_text(
                     prompt_lens=decoding_pos,
                     enable_trace=prefill_enable_trace,
                     tt_out_logits_all_users=tt_out_logits_all_users,
+                    sampling_params=device_sampling_params,
                 )
             except Exception as e:
                 logger.error(f"Error during prefill warmup: {str(e)}")
@@ -815,6 +818,7 @@ def test_demo_text(
                 prompt_lens=decoding_pos,
                 enable_trace=prefill_enable_trace,
                 tt_out_logits_all_users=tt_out_logits_all_users,
+                sampling_params=device_sampling_params,
             )
             if prefill_profile:
                 signpost("stop")
@@ -862,10 +866,6 @@ def test_demo_text(
 
         # Keeps track when a user reaches EoD token
         user_done = [False] * batch_size
-
-        device_sampling_params = SamplingParams(
-            temperature=sampling_params["temperature"], top_k=32, top_p=sampling_params["top_p"]
-        )
 
         # Initial positions
         current_pos = torch.tensor([decoding_pos[b] for b in range(batch_size)])

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -542,11 +542,18 @@ class Generator:
     def process_decode_output_host(self, tt_out, is_tokens=True):
         if isinstance(tt_out, tuple):
             tt_out = tt_out[0]
+        # Check if tensor is distributed across mesh devices (vocab_size // 8 indicates sharding)
+        # If so, convert from distributed TT tensor to consolidated torch tensor
         if tt_out.shape[-1] >= self.model.vocab_size // 8:
+            # Convert from TT tensor format using mesh composition to concatenate
+            # across devices in an 8x4 mesh layout (dims 3,1 specify concatenation axes)
             out = ttnn.to_torch(
                 tt_out, mesh_composer=ttnn.ConcatMesh2dToTensor(self.mesh_device, dims=(3, 1), mesh_shape=(8, 4))
             )
+            # Extract the first sequence, first batch element, all tokens up to vocab_size
+            # and add back the sequence dimension that was removed
             return out[0, 0, :, : self.model.vocab_size].unsqueeze(1)
+        # If not sharded (it is a sampled token), convert directly from device tensor to torch tensor
         return ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0])[0, 0, 0, :]
 
     def chat_completion(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -374,8 +374,6 @@ class Generator:
                 temp=[1 / sampling_params.temperature] * 32,
             )
         if tt_out_logits_saved is not None:
-            if return_logits and tt_out_logits_saved is None:
-                tt_out_logits_saved = torch.zeros(1, 131072)
             decode_kwargs["tt_out_logits_saved"] = tt_out_logits_saved
         if enable_trace:
             tt_tok = self._easy_trace_text(**decode_kwargs, reset_inputs=reset_inputs, return_logits=return_logits)

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -338,6 +338,9 @@ class Generator:
         is_page_table_sharded=False,
         return_logits=False,
     ):
+        if return_logits:
+            assert reset_inputs, "reset_inputs must be True when return_logits is True"
+            assert not read_from_device, "read_from_device must be False when return_logits is True"
         if self.prev_page_table is None:
             self.prev_page_table = page_table
         if torch.any(self.prev_page_table != page_table).item():


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/vllm/issues/167)

This PR implements host sampling for structured decoding in the Llama 3 70B Galaxy model by adding support for returning logits instead of performing device-side sampling. This enables more flexible sampling strategies on the host side.

Key changes:

return_logits is true when sampling params is None
Modified prefill and decode forward methods to conditionally return logits based on sampling_params
Enhanced output processing to handle logits when vocab size is large


Galaxy APC: https://github.com/tenstorrent/tt-metal/actions/runs/17986421169
Galaxy demo: https://github.com/tenstorrent/tt-metal/actions/runs/17986433692