### PR TITLE
#29256: [skip ci] Disable failing stress test

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -87,6 +87,8 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   blackhole-multi-card-ttnn-stress-tests:
+    # Disabled due to https://github.com/tenstorrent/tt-metal/issues/29256
+    if: false
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/ttnn-stress-tests-impl.yaml


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/29256)

Skip test for now in blackhole nightly pipeline