### PR TITLE
Matmul - Specify Datatype for Fused Activation

### DIFF
--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -72,6 +72,7 @@ enum class StorageType {
 };
 
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
+tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat);
 
 static constexpr std::size_t MAX_NUM_DIMENSIONS = 8;
 

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -50,7 +50,7 @@ tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype)
         case tt::tt_metal::DataType::UINT32: return tt::DataFormat::UInt32;
         case tt::tt_metal::DataType::UINT16: return tt::DataFormat::UInt16;
         case tt::tt_metal::DataType::UINT8: return tt::DataFormat::UInt8;
-        default: TT_THROW("Unsupported DataType");
+        default: TT_THROW("Unsupported DataType"); return tt::DataFormat::Float16_b;  // for clang-tidy
     }
 }
 
@@ -64,7 +64,7 @@ tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataforma
         case tt::DataFormat::UInt32: return tt::tt_metal::DataType::UINT32;
         case tt::DataFormat::UInt16: return tt::tt_metal::DataType::UINT16;
         case tt::DataFormat::UInt8: return tt::tt_metal::DataType::UINT8;
-        default: TT_THROW("Unsupported DataFormat");
+        default: TT_THROW("Unsupported DataFormat"); return tt::tt_metal::DataType::BFLOAT16;  // for clang-tidy
     }
 }
 

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -64,7 +64,7 @@ tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataforma
         case tt::DataFormat::UInt32: return tt::tt_metal::DataType::UINT32;
         case tt::DataFormat::UInt16: return tt::tt_metal::DataType::UINT16;
         case tt::DataFormat::UInt8: return tt::tt_metal::DataType::UINT8;
-        default: TT_ASSERT(false, "Unsupported DataFormat"); return tt::tt_metal::DataType::BFLOAT16;
+        default: TT_ASSERT(false, "Unsupported DataFormat");
     }
 }
 

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -54,4 +54,18 @@ tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype)
     }
 }
 
+tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat) {
+    switch (dataformat) {
+        case tt::DataFormat::Float16_b: return tt::tt_metal::DataType::BFLOAT16;
+        case tt::DataFormat::Bfp8_b: return tt::tt_metal::DataType::BFLOAT8_B;
+        case tt::DataFormat::Bfp4_b: return tt::tt_metal::DataType::BFLOAT4_B;
+        case tt::DataFormat::Float32: return tt::tt_metal::DataType::FLOAT32;
+        case tt::DataFormat::Int32: return tt::tt_metal::DataType::INT32;
+        case tt::DataFormat::UInt32: return tt::tt_metal::DataType::UINT32;
+        case tt::DataFormat::UInt16: return tt::tt_metal::DataType::UINT16;
+        case tt::DataFormat::UInt8: return tt::tt_metal::DataType::UINT8;
+        default: TT_ASSERT(false, "Unsupported DataFormat"); return tt::tt_metal::DataType::BFLOAT16;
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -50,7 +50,7 @@ tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype)
         case tt::tt_metal::DataType::UINT32: return tt::DataFormat::UInt32;
         case tt::tt_metal::DataType::UINT16: return tt::DataFormat::UInt16;
         case tt::tt_metal::DataType::UINT8: return tt::DataFormat::UInt8;
-        default: TT_ASSERT(false, "Unsupported DataType"); return tt::DataFormat::Float16_b;
+        default: TT_THROW("Unsupported DataType");
     }
 }
 
@@ -64,7 +64,7 @@ tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataforma
         case tt::DataFormat::UInt32: return tt::tt_metal::DataType::UINT32;
         case tt::DataFormat::UInt16: return tt::tt_metal::DataType::UINT16;
         case tt::DataFormat::UInt8: return tt::tt_metal::DataType::UINT8;
-        default: TT_ASSERT(false, "Unsupported DataFormat");
+        default: TT_THROW("Unsupported DataFormat");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -435,8 +435,12 @@ process_mcast_in0_program_and_create_override_variables(
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
             using ttnn::operations::unary::utils::get_defines;
-            mm_kernel_defines.merge(
-                get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(get_defines(
+                fused_activation.value().op_type,
+                fused_activation.value().params,
+                "ACTIVATION",
+                "i",
+                tt_metal::dataformat_to_datatype_converter(output_data_format)));
         }
     }
     if (packer_l1_acc_en) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -528,8 +528,12 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
             using ttnn::operations::unary::utils::get_defines;
-            mm_kernel_defines.merge(
-                get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(get_defines(
+                fused_activation.value().op_type,
+                fused_activation.value().params,
+                "ACTIVATION",
+                "i",
+                tt_metal::dataformat_to_datatype_converter(output_data_format)));
         }
     }
     if (packer_l1_acc_en) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -355,8 +355,12 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
             using ttnn::operations::unary::utils::get_defines;
-            mm_kernel_defines.merge(
-                get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(get_defines(
+                fused_activation.value().op_type,
+                fused_activation.value().params,
+                "ACTIVATION",
+                "i",
+                tt_metal::dataformat_to_datatype_converter(output_data_format)));
         }
     }
     if (packer_l1_acc_en) {


### PR DESCRIPTION
### Ticket
#29250 

### Problem description
Matmul did not pass a dtype when setting up the fused activation functions. This is incompatible for certain activation functions that mandate a dtype.

### What's changed
Add a helper function for the DataFormat -> DataType conversion (we currently only have the other direction)

Use the helper to supply the output dataformat as a dtype for the activation functions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17987903514) (matching existing [conv CI failure](https://github.com/tenstorrent/tt-metal/actions/runs/17985234433/job/51183774562))
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/17987910102)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes