### PR TITLE
Fix all gather blackhole alignment

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
@@ -13,7 +13,7 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [2], ids=["2_links"])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape,dim, layout",
+    "num_devices, ag_output_shape, dim, layout",
     [
         (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
         (2, [1, 1, 128, 128], 3, ttnn.TILE_LAYOUT),

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py
@@ -13,7 +13,7 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize("num_links", [2], ids=["2_links"])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout",
+    "num_devices, ag_output_shape,dim, layout",
     [
         (4, [1, 1, 128, 2048], 3, ttnn.TILE_LAYOUT),
         (2, [1, 1, 128, 128], 3, ttnn.TILE_LAYOUT),
@@ -171,6 +171,114 @@ def test_all_gather_2d(
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
 def test_all_gather_1d(
+    bh_2d_mesh_device,
+    num_devices,
+    ag_output_shape,
+    dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+    chunks_per_sync,
+    num_workers_per_link,
+    num_buffers_per_channel,
+):
+    if (2 == num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires more than 2 devices")
+    if (bh_2d_mesh_device.shape[0] != num_devices) and (all_gather_topology == ttnn.Topology.Ring):
+        pytest.skip("Ring configuration requires the entire row or column so it loops around")
+    if bh_2d_mesh_device.shape[0] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    cluster_axis = 0
+    run_all_gather_impl(
+        submesh_device,
+        num_devices,
+        ag_output_shape,
+        dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        cluster_axis=cluster_axis,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
+        allowed_pcc=0.9999,
+    )
+    ttnn.ReadDeviceProfiler(submesh_device)
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize("num_links", [2], ids=["2_links"])
+@pytest.mark.parametrize(
+    "num_devices, ag_output_shape,dim",
+    [
+        (4, [3, 1, 4096, 576], 3),
+        (4, [3, 4, 4096, 144], 1),
+    ],
+    ids=["gemma dim 3", "gemma dim 1"],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ids=[
+        "tile",
+        "row major",
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.uint32,
+        ttnn.bfloat8_b,
+    ],
+    ids=[
+        "float_16",
+        "uint_32",
+        "bfloat_8",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ),
+    ],
+    ids=["dram_only"],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (True, 10),
+        (False, 10),
+    ],
+    ids=["trace", "non-trace"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 150000}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 150000}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_linear", "fabric_ring"],
+)
+@pytest.mark.parametrize("chunks_per_sync", [20])
+@pytest.mark.parametrize("num_workers_per_link", [2])
+@pytest.mark.parametrize("num_buffers_per_channel", [2])
+def test_all_gather_failing_shapes(
     bh_2d_mesh_device,
     num_devices,
     ag_output_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -73,7 +73,6 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
-    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
     auto [num_targets_forward, num_targets_backward] =
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, true);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/29238

### Problem description
All gather results in PCC failure on blackhole when last dim is not a multiple of 64B. It is due to Noc read alignment limitation of 64B on blackhole

### What's changed
This PR fixes the page size in the composite path of AG to account for alignment

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18011560768
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18011569573
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes