### PR TITLE
Fix 6u packet size hang in the fabric test infra

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -641,8 +641,8 @@ private:
             allocation_policies_.receiver_config.max_configs_per_core);
 
         // Create memory maps directly using constructors
-        sender_memory_map_ = tt::tt_fabric::fabric_tests::SenderMemoryMap(
-            l1_unreserved_base, l1_unreserved_size, l1_alignment, max_configs_per_core);
+        sender_memory_map_ =
+            tt::tt_fabric::fabric_tests::SenderMemoryMap(l1_unreserved_base, l1_unreserved_size, l1_alignment);
 
         receiver_memory_map_ = tt::tt_fabric::fabric_tests::ReceiverMemoryMap(
             l1_unreserved_base, l1_unreserved_size, l1_alignment, default_payload_chunk_size, max_configs_per_core);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_memory_map.hpp
@@ -101,8 +101,7 @@ struct SenderMemoryMap {
     // Default constructor
     SenderMemoryMap() : common(), packet_headers(0, 0), payload_buffers(0, 0), highest_usable_address(0) {}
 
-    SenderMemoryMap(
-        uint32_t l1_unreserved_base, uint32_t l1_unreserved_size, uint32_t l1_alignment, uint32_t num_configs) :
+    SenderMemoryMap(uint32_t l1_unreserved_base, uint32_t l1_unreserved_size, uint32_t l1_alignment) :
         common(0, 0, 0, 0, 0, 0),  // Will be set below
         packet_headers(0, 0),      // Will be set below
         payload_buffers(0, 0),     // Will be set below
@@ -135,12 +134,6 @@ struct SenderMemoryMap {
         current_addr += PACKET_HEADER_BUFFER_SIZE;
         packet_headers = BaseMemoryRegion(packet_header_base, PACKET_HEADER_BUFFER_SIZE);
 
-        // Payload buffers - use small fixed size per config since sender buffer is virtual
-        uint32_t payload_buffer_base = current_addr;
-        uint32_t payload_buffer_size = MAX_PAYLOAD_SIZE_PER_CONFIG * num_configs;
-        current_addr += payload_buffer_size;
-        payload_buffers = BaseMemoryRegion(payload_buffer_base, payload_buffer_size);
-
         // global sync region
         uint32_t global_sync_region_base = current_addr;
         uint32_t global_sync_region_size = l1_alignment;
@@ -152,6 +145,13 @@ struct SenderMemoryMap {
         uint32_t local_sync_region_size = l1_alignment;
         current_addr += local_sync_region_size;
         local_sync_region = BaseMemoryRegion(local_sync_region_base, local_sync_region_size);
+
+        // Payload buffers - use small fixed size per config since sender buffer is virtual
+        // needs to be after the sync regions to avoid overflow
+        uint32_t payload_buffer_base = current_addr;
+        uint32_t payload_buffer_size = highest_usable_address - current_addr;
+        current_addr += payload_buffer_size;
+        payload_buffers = BaseMemoryRegion(payload_buffer_base, payload_buffer_size);
 
         TT_FATAL(
             current_addr <= highest_usable_address,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28976

### Problem description
Packet size test was hanging because the number of packets being sent was > the amount of space available for them so they overflowed into regions associated with synchronization. Was only visible on 6u due to the size of the machine

### What's changed
Modified sender memory map to avoid allocating based on num_configs and moved it to the bottom of the memory map region to allow unlimited allocation as space is provided.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes