### PR TITLE
link tt_metal to execinfo

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -75,9 +75,9 @@ void RunDelayTestOnCore(
     const uint32_t NUM_TILES = 4;
     const uint32_t DRAM_BUFFER_SIZE =
         SINGLE_TILE_SIZE * NUM_TILES;  // NUM_TILES of FP16_B, hard-coded in the reader/writer kernels
-    const uint32_t PAGE_SIZE = DRAM_BUFFER_SIZE;
+    const uint32_t PAGE_SZE = DRAM_BUFFER_SIZE;
 
-    distributed::DeviceLocalBufferConfig dram_config{.page_size = PAGE_SIZE, .buffer_type = tt_metal::BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = PAGE_SZE, .buffer_type = tt_metal::BufferType::DRAM};
     distributed::ReplicatedBufferConfig buffer_config{.size = DRAM_BUFFER_SIZE};
 
     auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -138,6 +138,17 @@ target_sources(
             ${TT_LLK_HEADERS}
 )
 
+check_function_exists(
+    backtrace
+    HAVE_BACKTRACE
+)
+
+if(NOT HAVE_BACKTRACE)
+    find_library(EXECINFO_LIB execinfo)
+else()
+    set(EXECINFO_LIB "")
+endif()
+
 target_link_libraries(
     tt_metal
     PUBLIC
@@ -150,6 +161,7 @@ target_link_libraries(
         Reflect::Reflect
         TT::STL
         tt-logger::tt-logger
+        ${EXECINFO_LIB}
     PRIVATE
         Metalium::Metal::Impl
         metal_common_libs

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -138,6 +138,8 @@ target_sources(
             ${TT_LLK_HEADERS}
 )
 
+include(CheckFunctionExists)
+
 check_function_exists(
     backtrace
     HAVE_BACKTRACE


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18290

### Problem description
Previously tt-metal couldn't be build on alpine linux because musl lacks backtrace function. 

### What's changed
Use [libexecinfo](https://github.com/fam007e/libexecinfo) to provide backtrace function on alpine linux and link tt_metal against it.
Variable (PAGE_SIZE) of tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp is changed to PAGE_SZE because it matched with variable in included header file on alpine linux.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

Huge thanks to @afuller-TT for PR cleanup.