### PR TITLE
[skip ci] reduce unnecessary merge gate pinging

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -278,12 +278,12 @@ jobs:
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
-      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')
+      - if: (contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
           owner: "U08GTDV8MDH,U0908S3LUMD"
-      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
+      - if: (contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -61,24 +61,24 @@ jobs:
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
 
-  # code-analysis:
-  #   # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
-  #   # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
-  #   # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
-  #   if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
-  #   uses: ./.github/workflows/code-analysis.yaml
-  #   secrets: inherit
-  #   with:
-  #     version: 22.04
+  code-analysis:
+    # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
+    # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
+    # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
+    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+    uses: ./.github/workflows/code-analysis.yaml
+    secrets: inherit
+    with:
+      version: 22.04
 
-  # fail-fast:
-  #   if: failure()
-  #   runs-on: ubuntu-latest
-  #   needs: [code-analysis]
-  #   permissions:
-  #     actions: write
-  #   steps:
-  #     - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+  fail-fast:
+    if: failure()
+    runs-on: ubuntu-latest
+    needs: [code-analysis]
+    permissions:
+      actions: write
+    steps:
+      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
   find-changes:
     if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
@@ -95,6 +95,11 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
   build:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -106,149 +111,149 @@ jobs:
       version: 22.04
       skip-tt-train: false
 
-  # build-docs:
-  #   if: ${{ needs.find-changes.outputs.any-code-changed == 'true' ||
-  #           needs.find-changes.outputs.docs-changed == 'true'
-  #       }}
-  #   needs: [find-changes, build]
-  #   uses: ./.github/workflows/docs-latest-public.yaml
-  #   secrets: inherit
-  #   with:
-  #     docker-image: ${{ needs.build.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+  build-docs:
+    if: ${{ needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true'
+        }}
+    needs: [find-changes, build]
+    uses: ./.github/workflows/docs-latest-public.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-  # build-tsan:
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.any-code-changed == 'true'
-  #       }}
-  #   needs: find-changes
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   permissions:
-  #     packages: write
-  #   secrets: inherit
-  #   with:
-  #     build-type: TSan
-  #     version: 24.04
-  #     skip-tt-train: false
-  #     publish-artifact: false
+  build-tsan:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: TSan
+      version: 24.04
+      skip-tt-train: false
+      publish-artifact: false
 
-  # build-sweeps:
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.any-code-changed == 'true'
-  #       }}
-  #   needs: find-changes
-  #   uses: ./.github/workflows/build-wrapper.yaml
-  #   permissions:
-  #     packages: write
-  #   secrets: inherit
+  build-sweeps:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-wrapper.yaml
+    permissions:
+      packages: write
+    secrets: inherit
 
-  # metalium-smoke-tests:
-  #   needs: [find-changes, build-tsan]
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-  #       }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: [
-  #         "N300-viommu",
-  #         "N300-llmbox-viommu",
-  #       ]
-  #   uses: ./.github/workflows/smoke.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-  #     runner: ${{ matrix.platform }}
-  #     per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-  #     product: tt-metalium
+  metalium-smoke-tests:
+    needs: [find-changes, build-tsan]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N300-viommu",
+          "N300-llmbox-viommu",
+        ]
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
+      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      product: tt-metalium
 
-  # ttnn-smoke-tests:
-  #   needs: [find-changes, build-tsan]
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-nn-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-  #       }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: [
-  #         "N300-viommu",
-  #         "N300-llmbox-viommu",
-  #       ]
-  #   uses: ./.github/workflows/smoke.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-  #     runner: ${{ matrix.platform }}
-  #     per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-  #     product: tt-nn
+  ttnn-smoke-tests:
+    needs: [find-changes, build-tsan]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N300-viommu",
+          "N300-llmbox-viommu",
+        ]
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
+      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      product: tt-nn
 
-  # build-asan:
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.any-code-changed == 'true'
-  #       }}
-  #   needs: find-changes
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   permissions:
-  #     packages: write
-  #   secrets: inherit
-  #   with:
-  #     build-type: ASan
-  #     version: 22.04
-  #     skip-tt-train: false
-  #     publish-artifact: false
+  build-asan:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ASan
+      version: 22.04
+      skip-tt-train: false
+      publish-artifact: false
 
-  # metalium-basic-tests:
-  #   if: ${{
-  #       github.ref_name == 'main' ||
-  #       needs.find-changes.outputs.cmake-changed == 'true' ||
-  #       needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-  #       needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-  #     }}
-  #   needs: [ build-asan, find-changes ]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: [
-  #         "N150-viommu",
-  #       ]
-  #   uses: ./.github/workflows/basic.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-  #     per-test-timeout: 11
-  #     runner: ${{ matrix.platform }}
-  #     product: tt-metalium
+  metalium-basic-tests:
+    if: ${{
+        github.ref_name == 'main' ||
+        needs.find-changes.outputs.cmake-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+      }}
+    needs: [ build-asan, find-changes ]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N150-viommu",
+        ]
+    uses: ./.github/workflows/basic.yaml
+    with:
+      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      per-test-timeout: 11
+      runner: ${{ matrix.platform }}
+      product: tt-metalium
 
-  # ttnn-basic-tests:
-  #   needs: [build-asan, find-changes]
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-nn-changed == 'true' ||
-  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-  #       }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: [
-  #         "N150-viommu",
-  #       ]
-  #   uses: ./.github/workflows/basic.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-  #     package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-  #     per-test-timeout: 11
-  #     runner: ${{ matrix.platform }}
-  #     product: tt-nn
+  ttnn-basic-tests:
+    needs: [build-asan, find-changes]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N150-viommu",
+        ]
+    uses: ./.github/workflows/basic.yaml
+    with:
+      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      per-test-timeout: 11
+      runner: ${{ matrix.platform }}
+      product: tt-nn
 
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
@@ -263,23 +268,23 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, build]
+    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
-          required-jobs: "static-checks,"
+          required-jobs: "static-checks, code-analysis, find-changes"
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
-      - if: (failure() && contains(join(needs.*.result, ','), 'failure'))
+      - if: (failure() && contains(join(needs.*.result, ',') && github.event_name == 'merge_group')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
           owner: "U08GTDV8MDH,U0908S3LUMD"
-      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
+      - if: (failure() && contains(join(needs.*.result, ',') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
           owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -278,12 +278,12 @@ jobs:
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
-      - if: (failure() && contains(join(needs.*.result, ',') && github.event_name == 'merge_group')
+      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
           owner: "U08GTDV8MDH,U0908S3LUMD"
-      - if: (failure() && contains(join(needs.*.result, ',') && github.ref == 'refs/heads/main')
+      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -80,19 +80,19 @@ jobs:
   #   steps:
   #     - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
-  # find-changes:
-  #   if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
-  #     docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
-  #     cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
-  #     tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
-  #     tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
-  #     tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
-  #   steps:
-  #     - id: find-changes
-  #       uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+  find-changes:
+    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
+      docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
+      cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
+      tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
+      tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
+      tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
+    steps:
+      - id: find-changes
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
   build:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -278,7 +278,7 @@ jobs:
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
-      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')
+      - if: (failure() && contains(join(needs.*.result, ','), 'failure'))
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -94,22 +94,22 @@ jobs:
   #     - id: find-changes
   #       uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
-  # build:
-  #   if: ${{ github.ref_name == 'main' ||
-  #           needs.find-changes.outputs.cmake-changed == 'true' ||
-  #           needs.find-changes.outputs.any-code-changed == 'true' ||
-  #           needs.find-changes.outputs.docs-changed == 'true'
-  #       }}
-  #   needs: find-changes
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   permissions:
-  #     packages: write
-  #   secrets: inherit
-  #   with:
-  #     build-type: Release
-  #     build-wheel: true
-  #     version: 22.04
-  #     skip-tt-train: false
+  build:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: Release
+      build-wheel: true
+      version: 22.04
+      skip-tt-train: false
 
   # build-docs:
   #   if: ${{ needs.find-changes.outputs.any-code-changed == 'true' ||
@@ -288,18 +288,3 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -274,7 +274,7 @@ jobs:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
-          required-jobs: "static-checks, code-analysis, find-changes"
+          required-jobs: "static-checks"
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
@@ -288,3 +288,18 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -61,199 +61,199 @@ jobs:
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
 
-  code-analysis:
-    # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
-    # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
-    # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
-    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
-    uses: ./.github/workflows/code-analysis.yaml
-    secrets: inherit
-    with:
-      version: 22.04
+  # code-analysis:
+  #   # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
+  #   # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
+  #   # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
+  #   if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+  #   uses: ./.github/workflows/code-analysis.yaml
+  #   secrets: inherit
+  #   with:
+  #     version: 22.04
 
-  fail-fast:
-    if: failure()
-    runs-on: ubuntu-latest
-    needs: [code-analysis]
-    permissions:
-      actions: write
-    steps:
-      - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
+  # fail-fast:
+  #   if: failure()
+  #   runs-on: ubuntu-latest
+  #   needs: [code-analysis]
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - uses: action-pack/cancel@bb57491c99942855e9da36ffbe86a686b2bd35a3
 
-  find-changes:
-    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
-      docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
-      cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
-      tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
-      tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
-      tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
-    steps:
-      - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+  # find-changes:
+  #   if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
+  #     docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
+  #     cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
+  #     tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
+  #     tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
+  #     tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
+  #   steps:
+  #     - id: find-changes
+  #       uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
-  build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true'
-        }}
-    needs: find-changes
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: Release
-      build-wheel: true
-      version: 22.04
-      skip-tt-train: false
+  # build:
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.any-code-changed == 'true' ||
+  #           needs.find-changes.outputs.docs-changed == 'true'
+  #       }}
+  #   needs: find-changes
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   permissions:
+  #     packages: write
+  #   secrets: inherit
+  #   with:
+  #     build-type: Release
+  #     build-wheel: true
+  #     version: 22.04
+  #     skip-tt-train: false
 
-  build-docs:
-    if: ${{ needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true'
-        }}
-    needs: [find-changes, build]
-    uses: ./.github/workflows/docs-latest-public.yaml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+  # build-docs:
+  #   if: ${{ needs.find-changes.outputs.any-code-changed == 'true' ||
+  #           needs.find-changes.outputs.docs-changed == 'true'
+  #       }}
+  #   needs: [find-changes, build]
+  #   uses: ./.github/workflows/docs-latest-public.yaml
+  #   secrets: inherit
+  #   with:
+  #     docker-image: ${{ needs.build.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-  build-tsan:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
-        }}
-    needs: find-changes
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: TSan
-      version: 24.04
-      skip-tt-train: false
-      publish-artifact: false
+  # build-tsan:
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.any-code-changed == 'true'
+  #       }}
+  #   needs: find-changes
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   permissions:
+  #     packages: write
+  #   secrets: inherit
+  #   with:
+  #     build-type: TSan
+  #     version: 24.04
+  #     skip-tt-train: false
+  #     publish-artifact: false
 
-  build-sweeps:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
-        }}
-    needs: find-changes
-    uses: ./.github/workflows/build-wrapper.yaml
-    permissions:
-      packages: write
-    secrets: inherit
+  # build-sweeps:
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.any-code-changed == 'true'
+  #       }}
+  #   needs: find-changes
+  #   uses: ./.github/workflows/build-wrapper.yaml
+  #   permissions:
+  #     packages: write
+  #   secrets: inherit
 
-  metalium-smoke-tests:
-    needs: [find-changes, build-tsan]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N300-viommu",
-          "N300-llmbox-viommu",
-        ]
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      runner: ${{ matrix.platform }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-      product: tt-metalium
+  # metalium-smoke-tests:
+  #   needs: [find-changes, build-tsan]
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+  #       }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: [
+  #         "N300-viommu",
+  #         "N300-llmbox-viommu",
+  #       ]
+  #   uses: ./.github/workflows/smoke.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+  #     runner: ${{ matrix.platform }}
+  #     per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+  #     product: tt-metalium
 
-  ttnn-smoke-tests:
-    needs: [find-changes, build-tsan]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-nn-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N300-viommu",
-          "N300-llmbox-viommu",
-        ]
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      runner: ${{ matrix.platform }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-      product: tt-nn
+  # ttnn-smoke-tests:
+  #   needs: [find-changes, build-tsan]
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-nn-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+  #       }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: [
+  #         "N300-viommu",
+  #         "N300-llmbox-viommu",
+  #       ]
+  #   uses: ./.github/workflows/smoke.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+  #     runner: ${{ matrix.platform }}
+  #     per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+  #     product: tt-nn
 
-  build-asan:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
-        }}
-    needs: find-changes
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      build-type: ASan
-      version: 22.04
-      skip-tt-train: false
-      publish-artifact: false
+  # build-asan:
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.any-code-changed == 'true'
+  #       }}
+  #   needs: find-changes
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   permissions:
+  #     packages: write
+  #   secrets: inherit
+  #   with:
+  #     build-type: ASan
+  #     version: 22.04
+  #     skip-tt-train: false
+  #     publish-artifact: false
 
-  metalium-basic-tests:
-    if: ${{
-        github.ref_name == 'main' ||
-        needs.find-changes.outputs.cmake-changed == 'true' ||
-        needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-        needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-      }}
-    needs: [ build-asan, find-changes ]
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N150-viommu",
-        ]
-    uses: ./.github/workflows/basic.yaml
-    with:
-      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-      per-test-timeout: 11
-      runner: ${{ matrix.platform }}
-      product: tt-metalium
+  # metalium-basic-tests:
+  #   if: ${{
+  #       github.ref_name == 'main' ||
+  #       needs.find-changes.outputs.cmake-changed == 'true' ||
+  #       needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+  #       needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+  #     }}
+  #   needs: [ build-asan, find-changes ]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: [
+  #         "N150-viommu",
+  #       ]
+  #   uses: ./.github/workflows/basic.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+  #     per-test-timeout: 11
+  #     runner: ${{ matrix.platform }}
+  #     product: tt-metalium
 
-  ttnn-basic-tests:
-    needs: [build-asan, find-changes]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-nn-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N150-viommu",
-        ]
-    uses: ./.github/workflows/basic.yaml
-    with:
-      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-      per-test-timeout: 11
-      runner: ${{ matrix.platform }}
-      product: tt-nn
+  # ttnn-basic-tests:
+  #   needs: [build-asan, find-changes]
+  #   if: ${{ github.ref_name == 'main' ||
+  #           needs.find-changes.outputs.cmake-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-nn-changed == 'true' ||
+  #           needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+  #       }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: [
+  #         "N150-viommu",
+  #       ]
+  #   uses: ./.github/workflows/basic.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+  #     package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+  #     per-test-timeout: 11
+  #     runner: ${{ matrix.platform }}
+  #     product: tt-nn
 
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
@@ -268,7 +268,7 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests]
+    needs: [static-checks]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
@@ -278,13 +278,13 @@ jobs:
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
-      - if: (failure() && github.event_name == 'merge_group')
+      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate@main
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           owner: "U08GTDV8MDH,U0908S3LUMD"
-      - if: (failure() && github.ref == 'refs/heads/main')
+      - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main')
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -263,13 +263,13 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks]
+    needs: [static-checks, build]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
-          required-jobs: "static-checks"
+          required-jobs: "static-checks,"
           optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -95,11 +95,6 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true'
-        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -64,6 +64,8 @@ enum class FabricConfig : uint32_t;
 struct RuntimeArgsData;
 struct TraceDescriptor;
 
+#error "Intentional failure for merge-gate test"
+
 namespace {
 
 CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet>& specified_core_spec) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -63,183 +63,173 @@ namespace tt_metal {
 enum class FabricConfig : uint32_t;
 struct RuntimeArgsData;
 struct TraceDescriptor;
+alsdkfhasdlkfja;
+lsdjf;
+ladsfja;
+sldfj;
+lasdfjas;
+ldfjd;
+lkdasjfl;
+ksd
 
-namespace {
+    namespace {
+    CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet>& specified_core_spec) {
+        ZoneScoped;
+        return std::visit(
+            ttsl::overloaded{
+                [](const CoreCoord& core_spec) { return CoreRangeSet(CoreRange(core_spec, core_spec)); },
+                [](const CoreRange& core_spec) { return CoreRangeSet(core_spec); },
+                [](const CoreRangeSet& core_spec) { return core_spec; },
+            },
+            specified_core_spec);
+    }
 
-CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet>& specified_core_spec) {
-    ZoneScoped;
-    return std::visit(
-        ttsl::overloaded{
-            [](const CoreCoord& core_spec) { return CoreRangeSet(CoreRange(core_spec, core_spec)); },
-            [](const CoreRange& core_spec) { return CoreRangeSet(core_spec); },
-            [](const CoreRangeSet& core_spec) { return core_spec; },
-        },
-        specified_core_spec);
-}
-
-struct DataMovementConfigStatus {
-    bool riscv0_in_use;
-    bool riscv1_in_use;
-    bool noc0_in_use;
-    bool noc1_in_use;
-};
-
-DataMovementConfigStatus CheckDataMovementConfig(
-    const HalProgrammableCoreType& programmable_core, Program& program, const CoreRangeSet& core_ranges) {
-    DataMovementConfigStatus data_movement_config_status{
-        .riscv0_in_use = false, .riscv1_in_use = false, .noc0_in_use = false, .noc1_in_use = false};
-
-    auto set_global_and_local_noc_usage = [&](const std::shared_ptr<Kernel>& kernel,
-                                              bool& local_noc0_usage,
-                                              bool& local_noc1_usage) {
-        int noc_value;
-        switch (programmable_core) {
-            case HalProgrammableCoreType::TENSIX:
-                noc_value = enchantum::to_underlying(std::get<DataMovementConfig>(kernel->config()).noc);
-                break;
-            case HalProgrammableCoreType::ACTIVE_ETH:
-            case HalProgrammableCoreType::IDLE_ETH:
-                noc_value = enchantum::to_underlying(std::get<EthernetConfig>(kernel->config()).noc);
-                break;
-            default:
-                TT_THROW(
-                    "Checking NoC and DataMovementProcessor is unsupported for programmable core {}",
-                    enchantum::to_string(programmable_core));
-        }
-        local_noc0_usage = noc_value == 0;
-        local_noc1_usage = noc_value == 1;
-        data_movement_config_status.noc0_in_use = local_noc0_usage;
-        data_movement_config_status.noc1_in_use = local_noc1_usage;
+    struct DataMovementConfigStatus {
+        bool riscv0_in_use;
+        bool riscv1_in_use;
+        bool noc0_in_use;
+        bool noc1_in_use;
     };
 
-    const auto& hal = MetalContext::instance().hal();
-    for (const auto& core_range : core_ranges.ranges()) {
-        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                const KernelGroup* kernel_group = program.impl().kernels_on_core(
-                    CoreCoord(x, y), hal.get_programmable_core_type_index(programmable_core));
-                if (kernel_group != nullptr) {
-                    bool local_noc0_in_use = false;
-                    bool local_noc1_in_use = false;
-                    bool has_dm0 = false;
-                    bool has_dm1 = false;
-                    for (auto kernel_id : kernel_group->kernel_ids) {
-                        const auto kernel = program.impl().get_kernel(kernel_id);
-                        if (kernel->get_kernel_processor_class() == HalProcessorClassType::DM) {
-                            switch (kernel->get_kernel_processor_type(0)) {
-                                case 0:
-                                    has_dm0 = true;
-                                    data_movement_config_status.riscv0_in_use = true;
-                                    set_global_and_local_noc_usage(kernel, local_noc0_in_use, local_noc1_in_use);
-                                    break;
-                                case 1:
-                                    has_dm1 = true;
-                                    data_movement_config_status.riscv1_in_use = true;
-                                    set_global_and_local_noc_usage(kernel, local_noc0_in_use, local_noc1_in_use);
-                                    break;
-                                default: TT_THROW("Unknown DataMovementProcessor type"); break;
+    DataMovementConfigStatus CheckDataMovementConfig(
+        const HalProgrammableCoreType& programmable_core, Program& program, const CoreRangeSet& core_ranges) {
+        DataMovementConfigStatus data_movement_config_status{
+            .riscv0_in_use = false, .riscv1_in_use = false, .noc0_in_use = false, .noc1_in_use = false};
+
+        auto set_global_and_local_noc_usage =
+            [&](const std::shared_ptr<Kernel>& kernel, bool& local_noc0_usage, bool& local_noc1_usage) {
+                int noc_value;
+                switch (programmable_core) {
+                    case HalProgrammableCoreType::TENSIX:
+                        noc_value = enchantum::to_underlying(std::get<DataMovementConfig>(kernel->config()).noc);
+                        break;
+                    case HalProgrammableCoreType::ACTIVE_ETH:
+                    case HalProgrammableCoreType::IDLE_ETH:
+                        noc_value = enchantum::to_underlying(std::get<EthernetConfig>(kernel->config()).noc);
+                        break;
+                    default:
+                        TT_THROW(
+                            "Checking NoC and DataMovementProcessor is unsupported for programmable core {}",
+                            enchantum::to_string(programmable_core));
+                }
+                local_noc0_usage = noc_value == 0;
+                local_noc1_usage = noc_value == 1;
+                data_movement_config_status.noc0_in_use = local_noc0_usage;
+                data_movement_config_status.noc1_in_use = local_noc1_usage;
+            };
+
+        const auto& hal = MetalContext::instance().hal();
+        for (const auto& core_range : core_ranges.ranges()) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                    const KernelGroup* kernel_group = program.impl().kernels_on_core(
+                        CoreCoord(x, y), hal.get_programmable_core_type_index(programmable_core));
+                    if (kernel_group != nullptr) {
+                        bool local_noc0_in_use = false;
+                        bool local_noc1_in_use = false;
+                        bool has_dm0 = false;
+                        bool has_dm1 = false;
+                        for (auto kernel_id : kernel_group->kernel_ids) {
+                            const auto kernel = program.impl().get_kernel(kernel_id);
+                            if (kernel->get_kernel_processor_class() == HalProcessorClassType::DM) {
+                                switch (kernel->get_kernel_processor_type(0)) {
+                                    case 0:
+                                        has_dm0 = true;
+                                        data_movement_config_status.riscv0_in_use = true;
+                                        set_global_and_local_noc_usage(kernel, local_noc0_in_use, local_noc1_in_use);
+                                        break;
+                                    case 1:
+                                        has_dm1 = true;
+                                        data_movement_config_status.riscv1_in_use = true;
+                                        set_global_and_local_noc_usage(kernel, local_noc0_in_use, local_noc1_in_use);
+                                        break;
+                                    default: TT_THROW("Unknown DataMovementProcessor type"); break;
+                                }
                             }
                         }
-                    }
-                    if (has_dm0 and has_dm1) {
-                        TT_FATAL(
-                            local_noc0_in_use and local_noc1_in_use,
-                            "Illegal NOC usage: data movement kernels on logical core {} cannot use the same NOC, "
-                            "doing so results in hangs!",
-                            CoreCoord(x, y).str());
+                        if (has_dm0 and has_dm1) {
+                            TT_FATAL(
+                                local_noc0_in_use and local_noc1_in_use,
+                                "Illegal NOC usage: data movement kernels on logical core {} cannot use the same NOC, "
+                                "doing so results in hangs!",
+                                CoreCoord(x, y).str());
+                        }
                     }
                 }
             }
         }
+
+        return data_movement_config_status;
     }
 
-    return data_movement_config_status;
-}
-
-void ConfigureKernelGroup(
-    Program& program,
-    uint32_t programmable_core_type_index,
-    const KernelGroup* kernel_group,
-    IDevice* device,
-    const CoreCoord& logical_core) {
-    const auto& hal = MetalContext::instance().hal();
-    uint32_t kernel_config_base =
-        hal.get_dev_addr(hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
-    for (auto kernel_id : kernel_group->kernel_ids) {
-        // Need the individual offsets of each bin
-        // TODO: make configure take a std::span
-        program.impl().get_kernel(kernel_id)->configure(
-            device, logical_core, kernel_config_base, kernel_group->kernel_text_offsets.data());
-    }
-}
-
-std::optional<uint32_t> get_semaphore_id(const Program& program, const CoreRange& core_range, CoreType core_type) {
-    std::optional<uint32_t> semaphore_id = std::nullopt;
-    std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
-    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-            CoreCoord logical_core(x, y);
-            auto semaphores = program.impl().semaphores_on_core(logical_core, core_type);
-            if (semaphores.size() == NUM_SEMAPHORES) {
-                TT_THROW(
-                    "Cannot add semaphore on core {}. Max number of semaphores ({}) reached!",
-                    logical_core.str(),
-                    NUM_SEMAPHORES);
-            }
-
-            for (const auto& semaphore : semaphores) {
-                semaphore_histogram[semaphore.get().id()]++;
-            }
+    void ConfigureKernelGroup(
+        Program & program,
+        uint32_t programmable_core_type_index,
+        const KernelGroup* kernel_group,
+        IDevice* device,
+        const CoreCoord& logical_core) {
+        const auto& hal = MetalContext::instance().hal();
+        uint32_t kernel_config_base = hal.get_dev_addr(
+            hal.get_programmable_core_type(programmable_core_type_index), HalL1MemAddrType::KERNEL_CONFIG);
+        for (auto kernel_id : kernel_group->kernel_ids) {
+            // Need the individual offsets of each bin
+            // TODO: make configure take a std::span
+            program.impl().get_kernel(kernel_id)->configure(
+                device, logical_core, kernel_config_base, kernel_group->kernel_text_offsets.data());
         }
     }
 
-    std::optional<uint32_t> uninitialized_sem_id = std::nullopt;
-    for (int sem_id = 0; sem_id < semaphore_histogram.size(); sem_id++) {
-        if (semaphore_histogram.at(sem_id) == 0) {
-            uninitialized_sem_id = sem_id;
-            break;
-        }
-    }
+    std::optional<uint32_t> get_semaphore_id(const Program& program, const CoreRange& core_range, CoreType core_type) {
+        std::optional<uint32_t> semaphore_id = std::nullopt;
+        std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                CoreCoord logical_core(x, y);
+                auto semaphores = program.impl().semaphores_on_core(logical_core, core_type);
+                if (semaphores.size() == NUM_SEMAPHORES) {
+                    TT_THROW(
+                        "Cannot add semaphore on core {}. Max number of semaphores ({}) reached!",
+                        logical_core.str(),
+                        NUM_SEMAPHORES);
+                }
 
-    if (uninitialized_sem_id.has_value()) {
-        semaphore_id = uninitialized_sem_id;
-    } else {
-        TT_THROW("Unable to initialize semaphores on core range {}", core_range.str());
-    }
-
-    return semaphore_id;
-}
-
-inline void SetRuntimeArgsImpl(
-    const Program& program, KernelHandle kernel_id, const CoreCoord& c, stl::Span<const uint32_t> runtime_args) {
-    if (!runtime_args.empty()) {
-        program.impl().get_kernel(kernel_id)->set_runtime_args(c, runtime_args);
-    }
-}
-
-inline void SetRuntimeArgsImpl(
-    const Program& program,
-    KernelHandle kernel_id,
-    const CoreRange& core_range,
-    stl::Span<const uint32_t> runtime_args) {
-    if (!runtime_args.empty()) {
-        auto kernel = program.impl().get_kernel(kernel_id);
-        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
-            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
-                kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
+                for (const auto& semaphore : semaphores) {
+                    semaphore_histogram[semaphore.get().id()]++;
+                }
             }
         }
-    }
-}
 
-inline void SetRuntimeArgsImpl(
-    const Program& program,
-    KernelHandle kernel_id,
-    const CoreRangeSet& core_range_set,
-    stl::Span<const uint32_t> runtime_args) {
-    if (!runtime_args.empty()) {
-        auto kernel = program.impl().get_kernel(kernel_id);
-        for (const auto& core_range : core_range_set.ranges()) {
+        std::optional<uint32_t> uninitialized_sem_id = std::nullopt;
+        for (int sem_id = 0; sem_id < semaphore_histogram.size(); sem_id++) {
+            if (semaphore_histogram.at(sem_id) == 0) {
+                uninitialized_sem_id = sem_id;
+                break;
+            }
+        }
+
+        if (uninitialized_sem_id.has_value()) {
+            semaphore_id = uninitialized_sem_id;
+        } else {
+            TT_THROW("Unable to initialize semaphores on core range {}", core_range.str());
+        }
+
+        return semaphore_id;
+    }
+
+    inline void SetRuntimeArgsImpl(
+        const Program& program, KernelHandle kernel_id, const CoreCoord& c, stl::Span<const uint32_t> runtime_args) {
+        if (!runtime_args.empty()) {
+            program.impl().get_kernel(kernel_id)->set_runtime_args(c, runtime_args);
+        }
+    }
+
+    inline void SetRuntimeArgsImpl(
+        const Program& program,
+        KernelHandle kernel_id,
+        const CoreRange& core_range,
+        stl::Span<const uint32_t> runtime_args) {
+        if (!runtime_args.empty()) {
+            auto kernel = program.impl().get_kernel(kernel_id);
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                     kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
@@ -247,7 +237,23 @@ inline void SetRuntimeArgsImpl(
             }
         }
     }
-}
+
+    inline void SetRuntimeArgsImpl(
+        const Program& program,
+        KernelHandle kernel_id,
+        const CoreRangeSet& core_range_set,
+        stl::Span<const uint32_t> runtime_args) {
+        if (!runtime_args.empty()) {
+            auto kernel = program.impl().get_kernel(kernel_id);
+            for (const auto& core_range : core_range_set.ranges()) {
+                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
+                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
+                        kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
+                    }
+                }
+            }
+        }
+    }
 
 }  // namespace
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -64,8 +64,6 @@ enum class FabricConfig : uint32_t;
 struct RuntimeArgsData;
 struct TraceDescriptor;
 
-#error "Intentional failure for merge-gate test"
-
 namespace {
 
 CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet>& specified_core_spec) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -89,27 +89,28 @@ DataMovementConfigStatus CheckDataMovementConfig(
     DataMovementConfigStatus data_movement_config_status{
         .riscv0_in_use = false, .riscv1_in_use = false, .noc0_in_use = false, .noc1_in_use = false};
 
-    auto set_global_and_local_noc_usage =
-        [&](const std::shared_ptr<Kernel>& kernel, bool& local_noc0_usage, bool& local_noc1_usage) {
-            int noc_value;
-            switch (programmable_core) {
-                case HalProgrammableCoreType::TENSIX:
-                    noc_value = enchantum::to_underlying(std::get<DataMovementConfig>(kernel->config()).noc);
-                    break;
-                case HalProgrammableCoreType::ACTIVE_ETH:
-                case HalProgrammableCoreType::IDLE_ETH:
-                    noc_value = enchantum::to_underlying(std::get<EthernetConfig>(kernel->config()).noc);
-                    break;
-                default:
-                    TT_THROW(
-                        "Checking NoC and DataMovementProcessor is unsupported for programmable core {}",
-                        enchantum::to_string(programmable_core));
-            }
-            local_noc0_usage = noc_value == 0;
-            local_noc1_usage = noc_value == 1;
-            data_movement_config_status.noc0_in_use = local_noc0_usage;
-            data_movement_config_status.noc1_in_use = local_noc1_usage;
-        };
+    auto set_global_and_local_noc_usage = [&](const std::shared_ptr<Kernel>& kernel,
+                                              bool& local_noc0_usage,
+                                              bool& local_noc1_usage) {
+        int noc_value;
+        switch (programmable_core) {
+            case HalProgrammableCoreType::TENSIX:
+                noc_value = enchantum::to_underlying(std::get<DataMovementConfig>(kernel->config()).noc);
+                break;
+            case HalProgrammableCoreType::ACTIVE_ETH:
+            case HalProgrammableCoreType::IDLE_ETH:
+                noc_value = enchantum::to_underlying(std::get<EthernetConfig>(kernel->config()).noc);
+                break;
+            default:
+                TT_THROW(
+                    "Checking NoC and DataMovementProcessor is unsupported for programmable core {}",
+                    enchantum::to_string(programmable_core));
+        }
+        local_noc0_usage = noc_value == 0;
+        local_noc1_usage = noc_value == 1;
+        data_movement_config_status.noc0_in_use = local_noc0_usage;
+        data_movement_config_status.noc1_in_use = local_noc1_usage;
+    };
 
     const auto& hal = MetalContext::instance().hal();
     for (const auto& core_range : core_ranges.ranges()) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29309)

### Problem description
merge-gate-alerts pings developers any time a merge gate run is canceled, meaning that if one merge gate run fails, all the ones behind it in queue cause a ping to the merge-gate-alert channel

### What's changed
now merge gate will only ping if a job has actually failed, not if it's just been canceled

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes