### PR TITLE
Fused Activation - Add Non-Approx Gelu

### DIFF
--- a/models/demos/bert/tt/ttnn_optimized_bert.py
+++ b/models/demos/bert/tt/ttnn_optimized_bert.py
@@ -107,7 +107,7 @@ def bert_intermediate(
         memory_config=ttnn.L1_MEMORY_CONFIG,
         dtype=ttnn.bfloat8_b,
         core_grid=ttnn.CoreGrid(y=batch_size, x=num_cores_x),
-        activation="gelu",
+        activation="gelu_approx",
         compute_kernel_config=ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -358,7 +358,7 @@ class TtFalconMLPDecode(nn.Module):
         hidden_states = falcon_dense_h_to_4h_matmul(
             x,
             self.dense_h_to_4h_weights,
-            fused_activation="gelu",
+            fused_activation="gelu_approx",
             output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
             output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
             core_grid=get_falcon_default_core_grid(x.device()),

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -257,7 +257,7 @@ class TtFalconMLPPrefill(nn.Module):
                 dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
                 core_grid=get_falcon_default_core_grid(x.device()),
                 compute_kernel_config=self.model_config["MLP_KERNEL_CONFIG"],
-                activation="gelu",
+                activation="gelu_approx",
             )
             x.deallocate()
 

--- a/models/demos/wormhole/distilbert/tt/ttnn_optimized_distilbert.py
+++ b/models/demos/wormhole/distilbert/tt/ttnn_optimized_distilbert.py
@@ -128,7 +128,7 @@ def ffn(configs, hidden_state, device, base_address, parameters, num_cores_x=12,
         bias=parameters.lin1.bias,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         dtype=ttnn.bfloat16,
-        activation="gelu",
+        activation="gelu_approx",
         core_grid=ttnn.CoreGrid(y=device.core_grid.y, x=device.core_grid.x),
     )
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -166,7 +166,37 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
 
-    # Test the compound op, unfused code path
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("m_size", [32, 64])
+@pytest.mark.parametrize("k_size", [1024])
+@pytest.mark.parametrize("n_size", [1024])
+@pytest.mark.parametrize(
+    "activation", [None, "relu", "relu6", "silu", "gelu", "gelu_approx", "sigmoid", "sigmoid_approx"]
+)
+def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_size, activation):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((k_size, n_size), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor_a @ torch_input_tensor_b
+    if activation == "relu":
+        torch_output_tensor = torch.relu(torch_output_tensor)
+    elif activation == "relu6":
+        torch_output_tensor = torch.nn.functional.relu6(torch_output_tensor)
+    elif activation == "silu":
+        torch_output_tensor = torch.nn.functional.silu(torch_output_tensor)
+    elif activation in ["gelu", "gelu_approx"]:
+        torch_output_tensor = torch.nn.functional.gelu(torch_output_tensor)
+    elif activation in ["sigmoid", "sigmoid_approx"]:
+        torch_output_tensor = torch.nn.functional.sigmoid(torch_output_tensor)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, core_grid=device.core_grid, activation=activation)
+
+    # We supply no program config or core grid, so this uses the unfused path.
     output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, activation=activation)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -140,7 +140,7 @@ def test_linear_with_core_grid(
 @pytest.mark.parametrize("m_size", [32, 64])
 @pytest.mark.parametrize("k_size", [1024])
 @pytest.mark.parametrize("n_size", [1024])
-@pytest.mark.parametrize("activation", [None, "relu", "silu", "gelu", "gelu_non_approx", "relu6"])
+@pytest.mark.parametrize("activation", [None, "relu", "silu", "gelu", "gelu_approx", "relu6"])
 def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     device, batch_size, m_size, k_size, n_size, activation
 ):
@@ -155,8 +155,7 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
         torch_output_tensor = torch.nn.functional.relu6(torch_output_tensor)
     elif activation == "silu":
         torch_output_tensor = torch.nn.functional.silu(torch_output_tensor)
-
-    elif activation == "gelu" or activation == "gelu_non_approx":
+    elif activation == "gelu" or activation == "gelu_approx":
         torch_output_tensor = torch.nn.functional.gelu(torch_output_tensor)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -804,8 +804,10 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::RELU);
     } else if (name == "relu6") {
         return UnaryWithParam(UnaryOpType::RELU6);
+    } else if (name == "gelu_non_approx") {
+        return UnaryWithParam(UnaryOpType::GELU, {static_cast<float>(false)});
     } else if (name == "gelu") {
-        return UnaryWithParam(UnaryOpType::GELU, static_cast<float>(true));
+        return UnaryWithParam(UnaryOpType::GELU, {static_cast<float>(true)});
     } else if (name == "silu") {
         return UnaryWithParam(UnaryOpType::SILU);
     } else if (name == "sigmoid") {
@@ -860,7 +862,11 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
     switch (unary_op.op_type) {
         case UnaryOpType::RELU: return "relu";
         case UnaryOpType::RELU6: return "relu6";
-        case UnaryOpType::GELU: return "gelu";
+        case UnaryOpType::GELU:
+            if (unary_op.params.size() >= 1 && unary_op.params[0] == static_cast<float>(true)) {
+                return "gelu";
+            }
+            return "gelu_non_approx";
         case UnaryOpType::SILU: return "silu";
         case UnaryOpType::SIGMOID:
             if (unary_op.params.size() >= 2 && unary_op.params[1] == static_cast<float>(true)) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -804,10 +804,10 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::RELU);
     } else if (name == "relu6") {
         return UnaryWithParam(UnaryOpType::RELU6);
-    } else if (name == "gelu_non_approx") {
-        return UnaryWithParam(UnaryOpType::GELU, {static_cast<float>(false)});
     } else if (name == "gelu") {
-        return UnaryWithParam(UnaryOpType::GELU, {static_cast<float>(true)});
+        return UnaryWithParam(UnaryOpType::GELU, static_cast<float>(false));
+    } else if (name == "gelu_approx") {
+        return UnaryWithParam(UnaryOpType::GELU, static_cast<float>(true));
     } else if (name == "silu") {
         return UnaryWithParam(UnaryOpType::SILU);
     } else if (name == "sigmoid") {
@@ -864,9 +864,9 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
         case UnaryOpType::RELU6: return "relu6";
         case UnaryOpType::GELU:
             if (unary_op.params.size() >= 1 && unary_op.params[0] == static_cast<float>(true)) {
-                return "gelu";
+                return "gelu_approx";
             }
-            return "gelu_non_approx";
+            return "gelu";
         case UnaryOpType::SILU: return "silu";
         case UnaryOpType::SIGMOID:
             if (unary_op.params.size() >= 2 && unary_op.params[1] == static_cast<float>(true)) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -863,7 +863,7 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
         case UnaryOpType::RELU: return "relu";
         case UnaryOpType::RELU6: return "relu6";
         case UnaryOpType::GELU:
-            if (unary_op.params.size() >= 1 && unary_op.params[0] == static_cast<float>(true)) {
+            if (!unary_op.params.empty() && unary_op.params[0] == static_cast<float>(true)) {
                 return "gelu_approx";
             }
             return "gelu";


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26847

### Problem description
Using GELU as a fused activation to `ttnn.linear` or `ttnn.matmul` always results in the approximate implementation. On the other hand, the unfused GELU defaults to the non-approximate implementation.

Models require the non-approximate GELU to ensure correctness.

### What's changed
Made fused Gelu default to non-approx, thereby matching the unfused implementation. 
Add a `gelu_approx` activation, mirroring the existing `sigmoid` and `sigmoid_approx` activations.

Expand testing for the composite op activation, which was changed in https://github.com/tenstorrent/tt-metal/pull/30149

Any models that failed the pipelines due to perf or correctness were changed to `gelu_approx`, so that they remain unchanged. Their respective owners can see if the non-approx GELU is required/worth the impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18289490662) [rebase](https://github.com/tenstorrent/tt-metal/actions/runs/18352715189)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18289515281) [rebase](https://github.com/tenstorrent/tt-metal/actions/runs/18352709957)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18287235015)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18287265793) 
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18288796595)
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI [matches main](https://github.com/tenstorrent/tt-metal/actions/runs/18287332956)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI [matches main](https://github.com/tenstorrent/tt-metal/actions/runs/18326905373)
- [x] Frequent Model & TTNN Tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18231064443) 
- [x] Nightly L2 [matches main](https://github.com/tenstorrent/tt-metal/actions/runs/18232447936)
