### PR TITLE
[skip ci] Fix accessor benchmarks failing with watcher enabled

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_get_noc_addr_page_id_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_get_noc_addr_page_id_benchmark.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
         auto page_id = i % tensor_accessor.dspec().tensor_volume();
         {
             DeviceZoneScopedN(ACCESSOR_CONFIG_NAME);
-            volatile auto _ = tensor_accessor.get_noc_addr(i);
+            volatile auto _ = tensor_accessor.get_noc_addr(page_id);
         }
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/29228)

### Problem description
TT_METAL_WATCHER=1 ./build/test/ttnn/unit_tests_ttnn_accessor --gtest_filter="AccessorTests/AccessorBenchmarks.GetNocAddr/0" fails

### What's changed
Use bound checked page-id in benchmark