### PR TITLE
disabling unused function suppression and fixing get_common_arg_addr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,6 @@ add_compile_options(
     # Vars that are used only in Asserts will appear as dead stores in builds
     # where the preprocessor has stripped away the assert.
     -Wno-unused-but-set-variable
-    -Wno-unused-function
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-narrowing>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-deprecated-volatile>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-logical-op-parentheses>"

--- a/tt_metal/hw/inc/accessor/dspec.h
+++ b/tt_metal/hw/inc/accessor/dspec.h
@@ -15,6 +15,9 @@
 // Forward declared from dataflow_api.h
 static uint32_t get_common_arg_addr(int arg_idx);
 #else
+// In non-kernel/non-firmware builds, get_common_arg_addr is a stub that always returns 0U.
+// This is safe because the function should not be called in these builds; if it is, 0U is an invalid address
+// and will likely cause a detectable error, making misuse obvious during development.
 [[maybe_unused]] static inline uint32_t get_common_arg_addr(int /*arg_idx*/) { return 0U; }
 #endif
 

--- a/tt_metal/hw/inc/accessor/dspec.h
+++ b/tt_metal/hw/inc/accessor/dspec.h
@@ -11,8 +11,12 @@
 #include "compile_time_args.h"
 #include <cstring>
 
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
 // Forward declared from dataflow_api.h
 static uint32_t get_common_arg_addr(int arg_idx);
+#else
+[[maybe_unused]] static inline uint32_t get_common_arg_addr(int /*arg_idx*/) { return 0U; }
+#endif
 
 namespace tensor_accessor {
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29325

### Problem description
get_common_arg_addr was preventing us from easily removing the unused function suppression due to its forward declaration.

### What's changed
created a conditional declaration to avoid issues in the translation units and removed the unused function suppression.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18014714726
- [x] [Merge gate](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18014683133
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes