### PR TITLE
Disabling vector-of-mesh ReduceScatter test

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -93,47 +93,47 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherCommandProcessorAsync) {
     }
 }
 
-// TODO uncomment this once the composite implementation is completed
-// TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherMinimalAsyncComposite) {
-//     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-//     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
-//
-//     std::vector<ttnn::Tensor> tensors;
-//     TensorSpec tensor_spec(
-//         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-//         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
-//         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
-//     }
-//     auto forward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-//     auto backward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-//     std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-//         forward_semaphore, backward_semaphore};
-//     tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
-//
-//     auto all_gathered = ttnn::experimental::all_gather_async(
-//         /* input_tensors */ tensors,
-//         /* persistent_output_buffer */ std::nullopt,
-//         /* dim */ 0,
-//         /* multi_device_global_semaphore */ multi_dev_semaphore,
-//         /* num_links */ 1,
-//         /* memory_config */ std::nullopt,
-//         /* topology */ ttnn::ccl::Topology::Linear,
-//         /* subdevice_id */ SubDeviceId(0),
-//         /* cluster_axis */ std::nullopt,
-//         /* use_optimal_ccl_for_llama */ false,
-//         /* barrier_semaphore */ std::nullopt,
-//         /* chunks_per_sync */ std::nullopt,
-//         /* num_workers_per_link */ std::nullopt,
-//         /* num_buffers_per_channel */ std::nullopt);
-//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-//         auto data = all_gathered[dev_idx].to_vector<bfloat16>();
-//         for (int i = 0; i < data.size(); i++) {
-//             float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
-//             EXPECT_EQ(static_cast<float>(data[i]), expected);
-//         }
-//     }
-// }
+// TODO: uncomment this once the composite implementation is completed (#28556)
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AllGatherMinimalAsyncComposite) {
+    auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
+    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
+
+    std::vector<ttnn::Tensor> tensors;
+    TensorSpec tensor_spec(
+        ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
+        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+    }
+    auto forward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+    auto backward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
+        forward_semaphore, backward_semaphore};
+    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
+
+    auto all_gathered = ttnn::experimental::all_gather_async(
+        /* input_tensors */ tensors,
+        /* persistent_output_buffer */ std::nullopt,
+        /* dim */ 0,
+        /* multi_device_global_semaphore */ multi_dev_semaphore,
+        /* num_links */ 1,
+        /* memory_config */ std::nullopt,
+        /* topology */ ttnn::ccl::Topology::Linear,
+        /* subdevice_id */ SubDeviceId(0),
+        /* cluster_axis */ std::nullopt,
+        /* use_optimal_ccl_for_llama */ false,
+        /* barrier_semaphore */ std::nullopt,
+        /* chunks_per_sync */ std::nullopt,
+        /* num_workers_per_link */ std::nullopt,
+        /* num_buffers_per_channel */ std::nullopt);
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        auto data = all_gathered[dev_idx].to_vector<bfloat16>();
+        for (int i = 0; i < data.size(); i++) {
+            float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
+            EXPECT_EQ(static_cast<float>(data[i]), expected);
+        }
+    }
+}
 
 // same as above but with a different tensor shape which triggers the native implementation
 TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherMinimalAsyncNative) {
@@ -177,42 +177,41 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherMinimalAsyncNative) {
     }
 }
 
-// TODO this is failing in CI pipeline "(T3K) T3000 unit tests", unable to reproduce locally
-// though ... Temporarily disabling this test, we'll soon deprecate this API anyway.
-//
-// TEST_F(MultiCQFabricMeshDevice2x4Fixture, ReduceScatterAsync) {
-//     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-//     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
-//
-//     std::vector<ttnn::Tensor> tensors;
-//     TensorSpec tensor_spec(
-//         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-//         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-//         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
-//     }
-//     auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-//     auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-//
-//     tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
-//     auto reduced = ttnn::experimental::reduce_scatter_async(
-//         tensors,
-//         3,
-//         from_remote_multi_device_global_semaphore,
-//         to_remote_multi_device_global_semaphore,
-//         ttnn::operations::reduction::ReduceType::Sum,
-//         std::nullopt,
-//         ttnn::ccl::Topology::Linear,
-//         1,
-//         SubDeviceId(0));
-//
-//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-//         auto data = reduced[dev_idx].to_vector<bfloat16>();
-//         for (int i = 0; i < data.size(); i++) {
-//             float expected = static_cast<float>(mesh_devices.size());
-//             EXPECT_EQ(static_cast<float>(data[i]), expected);
-//         }
-//     }
-// }
+// TODO: This test is failing in the CI pipeline "(T3K) T3000 unit tests" but cannot be reproduced locally.
+// Temporarily disabling this test as we plan to deprecate this API soon (#29340).
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_ReduceScatterAsync) {
+    auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
+    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
+
+    std::vector<ttnn::Tensor> tensors;
+    TensorSpec tensor_spec(
+        ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
+        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+    }
+    auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+    auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+
+    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
+    auto reduced = ttnn::experimental::reduce_scatter_async(
+        tensors,
+        3,
+        from_remote_multi_device_global_semaphore,
+        to_remote_multi_device_global_semaphore,
+        ttnn::operations::reduction::ReduceType::Sum,
+        std::nullopt,
+        ttnn::ccl::Topology::Linear,
+        1,
+        SubDeviceId(0));
+
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        auto data = reduced[dev_idx].to_vector<bfloat16>();
+        for (int i = 0; i < data.size(); i++) {
+            float expected = static_cast<float>(mesh_devices.size());
+            EXPECT_EQ(static_cast<float>(data[i]), expected);
+        }
+    }
+}
 
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -177,39 +177,42 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherMinimalAsyncNative) {
     }
 }
 
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, ReduceScatterAsync) {
-    auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
-
-    std::vector<ttnn::Tensor> tensors;
-    TensorSpec tensor_spec(
-        ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
-    }
-    auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-
-    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
-    auto reduced = ttnn::experimental::reduce_scatter_async(
-        tensors,
-        3,
-        from_remote_multi_device_global_semaphore,
-        to_remote_multi_device_global_semaphore,
-        ttnn::operations::reduction::ReduceType::Sum,
-        std::nullopt,
-        ttnn::ccl::Topology::Linear,
-        1,
-        SubDeviceId(0));
-
-    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-        auto data = reduced[dev_idx].to_vector<bfloat16>();
-        for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(mesh_devices.size());
-            EXPECT_EQ(static_cast<float>(data[i]), expected);
-        }
-    }
-}
+// TODO this is failing in CI pipeline "(T3K) T3000 unit tests", unable to reproduce locally
+// though ... Temporarily disabling this test, we'll soon deprecate this API anyway.
+//
+// TEST_F(MultiCQFabricMeshDevice2x4Fixture, ReduceScatterAsync) {
+//     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
+//     auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
+//
+//     std::vector<ttnn::Tensor> tensors;
+//     TensorSpec tensor_spec(
+//         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+//         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
+//         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+//     }
+//     auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+//     auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
+//
+//     tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
+//     auto reduced = ttnn::experimental::reduce_scatter_async(
+//         tensors,
+//         3,
+//         from_remote_multi_device_global_semaphore,
+//         to_remote_multi_device_global_semaphore,
+//         ttnn::operations::reduction::ReduceType::Sum,
+//         std::nullopt,
+//         ttnn::ccl::Topology::Linear,
+//         1,
+//         SubDeviceId(0));
+//
+//     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+//         auto data = reduced[dev_idx].to_vector<bfloat16>();
+//         for (int i = 0; i < data.size(); i++) {
+//             float expected = static_cast<float>(mesh_devices.size());
+//             EXPECT_EQ(static_cast<float>(data[i]), expected);
+//         }
+//     }
+// }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
Link to Github Issue - N/A
Pipeline: https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml
Sample failure: https://github.com/tenstorrent/tt-metal/actions/runs/18011940157/job/51247699124

### Problem description
The vector-of-mesh ReduceScatter test is failing in "(T3K) T3000 unit tests" pipeline. I'm unable to reproduce locally on an IRD machine though, the test passes :/

Temporarily disabling this test. Plan is to deprecate this API soon (command processor version) and replace it with the ReduceScatter minimal version.

### What's changed
Temporarily disabled the failing test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/18018916364
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) - https://github.com/tenstorrent/tt-metal/actions/runs/18016362110
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes