### PR TITLE
[skip ci] Add long-context support to Qwen-VL models for vLLM

### DIFF
--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -154,19 +154,6 @@ def create_tt_model(
             False,  # stop_at_eos
             True,  # ci_only
         ),
-        (  # Batch-1 run with 300 dpi scanned document (Latency) - single user, real-world test
-            "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
-            True,  # instruct mode
-            4,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
-            12288,  # max_seq_len, allow for image tokens
-            1,  # batch_size -- samples to load from the prompt JSON
-            200,  # max_generated_tokens
-            True,  # paged_attention
-            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params
-            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-            True,  # stop_at_eos
-            False,  # ci_only
-        ),
         (  # Batch-4 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
             "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
             True,  # instruct mode
@@ -180,7 +167,7 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Batch-2 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+        (  # Batch-2 run with 300 dpi scanned document (Latency) - 32k long context, real-world test
             "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
             True,  # instruct mode
             1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
@@ -193,7 +180,7 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Batch-1 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+        (  # Batch-1 run with 300 dpi scanned document (Latency) - 64k long context, real-world test
             "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
             True,  # instruct mode
             1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
@@ -206,16 +193,29 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
+        (  # Batch-1 run with 300 dpi scanned document (Latency) - 128k long context, real-world test
+            "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
+            True,  # instruct mode
+            1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
+            131072,  # max_seq_len, allow for image tokens
+            1,  # batch_size -- samples to load from the prompt JSON
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+        ),
     ],
     ids=[
         "batch-1",  # latency
         "batch-32",  # 32 users (special because it fills tile size)
         "ci-only-bert-score",  # ci_only batch-bert-score for testing coverage in CI pipelines
         "ci-only-text-only",  # ci_only batch-text-only for testing coverage in CI pipelines
-        "real-world-test",  # real-world test for 300DPI scanned document
-        "long-context-16k",  # real-world test for 300DPI scanned document with 32k long context
-        "long-context-32k",  # real-world test for 300DPI scanned document with 64k long context
-        "long-context-64k",  # real-world test for 300DPI scanned document with 128k long context
+        "long-context-16k",  # real-world test for 300DPI scanned document with 16k long context
+        "long-context-32k",  # real-world test for 300DPI scanned document with 32k long context
+        "long-context-64k",  # real-world test for 300DPI scanned document with 64k long context
+        "long-context-128k",  # real-world test for 300DPI scanned document with 128k long context
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -167,15 +167,41 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Batch-32 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+        (  # Batch-4 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
             "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
             True,  # instruct mode
             1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
             16384,  # max_seq_len, allow for image tokens
-            32,  # batch_size -- samples to load from the prompt JSON
+            4,  # batch_size -- samples to load from the prompt JSON
             200,  # max_generated_tokens
             True,  # paged_attention
-            {"page_block_size": 32, "page_max_num_blocks": 16384},  # page_params
+            {"page_block_size": 64, "page_max_num_blocks": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+        ),
+        (  # Batch-2 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+            "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
+            True,  # instruct mode
+            1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
+            32768,  # max_seq_len, allow for image tokens
+            2,  # batch_size -- samples to load from the prompt JSON
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+        ),
+        (  # Batch-1 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+            "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
+            True,  # instruct mode
+            1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
+            65536,  # max_seq_len, allow for image tokens
+            1,  # batch_size -- samples to load from the prompt JSON
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
             True,  # stop_at_eos
             False,  # ci_only
@@ -187,7 +213,9 @@ def create_tt_model(
         "ci-only-bert-score",  # ci_only batch-bert-score for testing coverage in CI pipelines
         "ci-only-text-only",  # ci_only batch-text-only for testing coverage in CI pipelines
         "real-world-test",  # real-world test for 300DPI scanned document
-        "long-context-32k",  # real-world test for 300DPI scanned document with 32k long context
+        "long-context-16k",  # real-world test for 300DPI scanned document with 32k long context
+        "long-context-32k",  # real-world test for 300DPI scanned document with 64k long context
+        "long-context-64k",  # real-world test for 300DPI scanned document with 128k long context
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -167,6 +167,19 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
+        (  # Batch-32 run with 300 dpi scanned document (Latency) - 16k long context, real-world test
+            "models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json",  # single qwen demo prompt
+            True,  # instruct mode
+            1,  # repeat_batches to simulate multiple users (batch_size=1) with the same prompt
+            16384,  # max_seq_len, allow for image tokens
+            32,  # batch_size -- samples to load from the prompt JSON
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 16384},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+        ),
     ],
     ids=[
         "batch-1",  # latency
@@ -174,6 +187,7 @@ def create_tt_model(
         "ci-only-bert-score",  # ci_only batch-bert-score for testing coverage in CI pipelines
         "ci-only-text-only",  # ci_only batch-text-only for testing coverage in CI pipelines
         "real-world-test",  # real-world test for 300DPI scanned document
+        "long-context-32k",  # real-world test for 300DPI scanned document with 32k long context
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json
+++ b/models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json
@@ -1,418 +1,482 @@
 [
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    },
-    {
-        "role": "user",
-        "content": [
-            {
-                "type": "image",
-                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
-            },
-            {
-                "type": "text",
-                "text": "Transcribe the text in the image."
-            }
-        ]
-    }
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ],
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+                },
+                {
+                    "type": "text",
+                    "text": "Transcribe the text in the image."
+                }
+            ]
+        }
+    ]
 ]

--- a/models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json
+++ b/models/demos/qwen25_vl/demo/sample_prompts/demo_300dpi.json
@@ -11,5 +11,408 @@
                 "text": "Transcribe the text in the image."
             }
         ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "image": "https://gist.github.com/gwangTT/ae3ac698de56020bc459018c7c2bff08/raw/a91b2df96c61234d83a7f61c4495bfc826786c74/paper.png"
+            },
+            {
+                "type": "text",
+                "text": "Transcribe the text in the image."
+            }
+        ]
     }
 ]

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -47,7 +47,7 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: Transformer
 
 def get_platform_specific_optimizations(model_name):
     is_72B = "72B" in model_name
-    max_seq_len = 4096 if is_72B else 12288
+    max_seq_len = 65536 if is_72B else 131072
 
     performance_opt = lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There is a artificially low number for `max_seq_len` for testing purposes. The upper bound for `max_seq_len` was not explored.

### What's changed
Added new test cases to explore upper bound of `max_seq_len` for the currently supported. Here are the results:

|       | max_seq_len | mesh_device | Notes |
| --- | --- | --- | --- | 
| Qwen2.5-VL-3B | 128K | N150 or N300 | `max_seq_len` is the total token budget, i.e., 128K w/ bs=1, 64K w/ bs=2, etc. all work | 
| Qwen2.5-VL-32B | 128K |  T3K | `max_seq_len` is the total token budget, i.e., 128K w/ bs=1, 64K w/ bs=2, etc. all work | 
| Qwen2.5-VL-72B | 64K |  T3K | `max_seq_len` is the total token budget, i.e., 64K w/ bs=1, 32K w/ bs=2, etc. all work | 
* Note: I believe it is possible to enable `max_seq_len=128K` for Qwen2.5-VL-72B on T3K as well, with additional work (track in [this issue](https://github.com/tenstorrent/tt-metal/issues/29341))

### Checklist
We do not run these long-context test cases in CI so this PR can skip CI tests; however, I will conduct integration tests with vLLM on an IRD machine to make sure the changes to `generator_vllm.py` in this PR works as expected.
- [x] Test with tenstorrent/vLLM
<img width="1527" height="407" alt="image" src="https://github.com/user-attachments/assets/ac1d0a00-1b78-4b35-8c47-6818c69cdf1e" />
