### PR TITLE
Disable test that repro BH dram arbiter hang so it doesn't run on CI

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -344,7 +344,11 @@ TEST_F(MeshDispatchFixture, IdleEthDRAMLoopbackSingleCore) {
 // This test will hang on BH when both nocs use the same DRAM endpoint due to SYS-1419, hang can be reproduced by
 // increasing `num_iterations` DRAM arbiter seems to drop requests from one noc when both nocs are issuing requests to
 // the same DRAM endpoint at a fast rate.
-TEST_F(MeshDispatchFixture, TensixLoopDRAMReadSingleCoreBothProcessors) {
+// This test should be kept to facilitate getting a scandump for root-causing SYS-1419 but keep it DISABLED so it doesn't run on CI
+TEST_F(MeshDispatchFixture, DISABLED_TensixLoopDRAMReadSingleCoreBothProcessors) {
+    if (this->arch_ != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "This test has hardcoded parameters for Blackhole to repro hang described in SYS-1419";
+    }
     auto mesh_device = devices_.at(0);
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29224

### Problem description
A test with hardcoded params to repro a specific BH dram hang was unnecessarily (sorry @tt-aho) running on CI and WH. Want to keep the test here so syseng can easily run it and generate a scandump 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18022635368) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18022648155) CI