### PR TITLE
#0: Fix issues in test_dynamic_noc and add reset_noc_trid_barrier_counter to reset transaction id counters

### DIFF
--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -17,16 +17,15 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
-#include "command_queue_fixture.hpp"
 #include "env_lib.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_metal/test_utils/df/float32.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "mesh_dispatch_fixture.hpp"
 
 namespace tt::tt_metal {
 
@@ -62,7 +61,13 @@ void build_and_run_program(
     CreateCircularBuffer(program1, cr_set, cb_config);
     CreateCircularBuffer(program2, cr_set, cb_config);
 
-    vector<uint32_t> compile_args = {MAX_LOOP, page_size};
+    // Add 2 semaphores initialized to 0 for each program, 1 per risc
+    uint32_t program1_semaphore0 = CreateSemaphore(program1, cr_set, 0);
+    uint32_t program1_semaphore1 = CreateSemaphore(program1, cr_set, 0);
+    uint32_t program2_semaphore0 = CreateSemaphore(program2, cr_set, 0);
+    uint32_t program2_semaphore1 = CreateSemaphore(program2, cr_set, 0);
+
+    vector<uint32_t> compile_args = {MAX_LOOP, page_size, 2};
     tt_metal::TensorAccessorArgs().append_to(compile_args);
 
     auto brisc_kernel1 = CreateKernel(
@@ -127,10 +132,23 @@ void build_and_run_program(
                 top_left_core_physical.y,
                 bottom_right_core_physical.x,
                 bottom_right_core_physical.y,
-                device_grid.x * device_grid.y};
+                device_grid.x * device_grid.y,
+                0,  // risc index
+                // semaphore IDs for program1
+                program1_semaphore0,   // semaphore 0
+                program1_semaphore1};  // semaphore 1
+
             tt::tt_metal::SetRuntimeArgs(program1, brisc_kernel1, core, rt_args);
+            rt_args[8] = 1;  // risc index
             tt::tt_metal::SetRuntimeArgs(program1, ncrisc_kernel1, core, rt_args);
+
+            rt_args[8] = 0;  // risc index
+            // Override semaphore IDs for program2
+            rt_args[9] = program2_semaphore0;   // semaphore 0
+            rt_args[10] = program2_semaphore1;  // semaphore 1
+
             tt::tt_metal::SetRuntimeArgs(program2, brisc_kernel2, core, rt_args);
+            rt_args[8] = 1;  // risc index
             tt::tt_metal::SetRuntimeArgs(program2, ncrisc_kernel2, core, rt_args);
         }
     }
@@ -153,27 +171,27 @@ void build_and_run_program(
     distributed::Finish(device->mesh_command_queue());
 }
 
-TEST_F(UnitMeshCQFixture, TestDynamicNoCOneProgram) {
+TEST_F(MeshDispatchFixture, TestDynamicNoCOneProgram) {
     uint32_t NUM_PROGRAMS = 1;
-    uint32_t MAX_LOOP = 65536;
+    uint32_t MAX_LOOP = 20;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
     build_and_run_program(this->devices_[0], this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
 }
 
-TEST_F(UnitMeshCQFixture, TestDynamicNoCMutlipleProgram) {
+TEST_F(MeshDispatchFixture, TestDynamicNoCMutlipleProgram) {
     uint32_t NUM_PROGRAMS = 3;
-    uint32_t MAX_LOOP = 65536;
+    uint32_t MAX_LOOP = 20;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
     build_and_run_program(this->devices_[0], this->slow_dispatch_, NUM_PROGRAMS, MAX_LOOP, page_size, mix_noc_mode);
 }
 
-TEST_F(UnitMeshCQFixture, TestDynamicNoCMutlipleProgramMixedMode) {
+TEST_F(MeshDispatchFixture, TestDynamicNoCMutlipleProgramMixedMode) {
     uint32_t NUM_PROGRAMS = 5;
-    uint32_t MAX_LOOP = 65536;
+    uint32_t MAX_LOOP = 20;
     uint32_t page_size = 1024;
     bool mix_noc_mode = true;
 

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -32,7 +32,6 @@ namespace tt::tt_metal {
 using std::vector;
 using namespace tt;
 using namespace tt::test_utils;
-using namespace tt::test_utils::df;
 
 void build_and_run_program(
     const std::shared_ptr<distributed::MeshDevice>& device,
@@ -173,7 +172,7 @@ void build_and_run_program(
 
 TEST_F(MeshDispatchFixture, TestDynamicNoCOneProgram) {
     uint32_t NUM_PROGRAMS = 1;
-    uint32_t MAX_LOOP = 20;
+    uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
@@ -182,7 +181,7 @@ TEST_F(MeshDispatchFixture, TestDynamicNoCOneProgram) {
 
 TEST_F(MeshDispatchFixture, TestDynamicNoCMutlipleProgram) {
     uint32_t NUM_PROGRAMS = 3;
-    uint32_t MAX_LOOP = 20;
+    uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = false;
 
@@ -191,7 +190,7 @@ TEST_F(MeshDispatchFixture, TestDynamicNoCMutlipleProgram) {
 
 TEST_F(MeshDispatchFixture, TestDynamicNoCMutlipleProgramMixedMode) {
     uint32_t NUM_PROGRAMS = 5;
-    uint32_t MAX_LOOP = 20;
+    uint32_t MAX_LOOP = 65536;
     uint32_t page_size = 1024;
     bool mix_noc_mode = true;
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -98,6 +98,32 @@ void kernel_main() {
 #endif
     }
 
+    // barrier on all txns
+    noc_async_full_barrier(noc_index);
+
+    // Previous multicasts would have put trids into a non-zero state, so reset the barrier counter
+    reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+
+    // DRAM sharded read API
+    uint32_t src_addr = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % 16;
+        noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+    }
+
+    for (uint32_t i = 0; i < 16; i++) {
+        noc_async_read_barrier_with_trid(i, noc_index);
+    }
+
+    // L1 sharded write API
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % 16;
+        noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
+    }
+    for (uint32_t i = 0; i < 16; i++) {
+        noc_async_write_barrier_with_trid(i, noc_index);
+    }
+
     DPRINT << "END" << ENDL();
     DPRINT << "noc_mode " << (uint)noc_mode << ENDL();
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -107,20 +107,20 @@ void kernel_main() {
     // DRAM sharded read API
     uint32_t src_addr = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16;
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
     }
 
-    for (uint32_t i = 0; i < 16; i++) {
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_read_barrier_with_trid(i, noc_index);
     }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16;
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
     }
-    for (uint32_t i = 0; i < 16; i++) {
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_write_barrier_with_trid(i, noc_index);
     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -163,25 +163,25 @@ void kernel_main() {
     uint32_t src_addr_1 =
         noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16;
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_read_tile_dram_sharded_with_state_with_trid(
             src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
         noc_async_read_tile_dram_sharded_with_state_with_trid(
             src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
     }
-    for (uint32_t i = 0; i < 16; i++) {
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_read_barrier_with_trid(i, noc_index);
         noc_async_read_barrier_with_trid(i, 1 - noc_index);
     }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16;
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
         noc_async_write_one_packet_with_trid(
             l1_read_addr, addr_other_noc, page_size, trid, write_cmd_buf, 1 - noc_index);
     }
-    for (uint32_t i = 0; i < 16; i++) {
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_write_barrier_with_trid(i, noc_index);
         noc_async_write_barrier_with_trid(i, 1 - noc_index);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -139,11 +139,7 @@ void kernel_main() {
 
     // barrier on all txns
     for (int noc = 0; noc < NUM_NOCS; noc++) {
-        while (!ncrisc_dynamic_noc_reads_flushed(noc));
-        while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc));
-        while (!ncrisc_dynamic_noc_nonposted_writes_flushed(noc));
-        while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc));
-        while (!ncrisc_dynamic_noc_posted_writes_sent(noc));
+        noc_async_full_barrier(noc);
     }
 
     // Sync all riscs since we should only clear the trid counters when there are no outstanding requests
@@ -178,8 +174,7 @@ void kernel_main() {
         noc_async_read_barrier_with_trid(i, 1 - noc_index);
     }
 
-#ifndef ARCH_BLACKHOLE
-    // DRAM sharded write API
+    // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % 16;
         noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
@@ -190,7 +185,6 @@ void kernel_main() {
         noc_async_write_barrier_with_trid(i, noc_index);
         noc_async_write_barrier_with_trid(i, 1 - noc_index);
     }
-#endif
 
     DPRINT << "END" <<ENDL();
     DPRINT << "noc_mode " << (uint)noc_mode << ENDL();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -4,12 +4,14 @@
 
 #include <cstdint>
 
+#include "blackhole/noc/noc_parameters.h"
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 
 void kernel_main() {
     constexpr std::uint32_t iteration = get_compile_time_arg_val(0);
     constexpr std::uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr std::uint32_t num_riscs = get_compile_time_arg_val(2);
 
     std::uint32_t noc_x = get_arg_val<uint32_t>(0);
     std::uint32_t noc_y = get_arg_val<uint32_t>(1);
@@ -19,6 +21,12 @@ void kernel_main() {
     std::uint32_t bottom_right_core_x = get_arg_val<uint32_t>(5);
     std::uint32_t bottom_right_core_y = get_arg_val<uint32_t>(6);
     std::uint32_t num_dests = get_arg_val<uint32_t>(7);
+    std::uint32_t risc_index = get_arg_val<uint32_t>(8);
+
+    volatile tt_l1_ptr uint32_t* semaphore_ptrs[num_riscs];
+    for (uint32_t i = 0; i < num_riscs; i++) {
+        semaphore_ptrs[i] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(9 + i)));
+    }
 
     constexpr uint32_t cb_id = 0;
     uint32_t l1_read_addr = get_read_ptr(cb_id);
@@ -129,37 +137,6 @@ void kernel_main() {
 #endif
     }
 
-    // DRAM sharded read API
-    noc_async_read_tile_dram_sharded_set_state<true>(0x32, page_size, 0, 0, noc_index);
-    noc_async_read_tile_dram_sharded_set_state<true>(0x32, page_size, 0, 0, 1 - noc_index);
-    for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16 + 1;
-        noc_async_read_tile_dram_sharded_with_state_with_trid(0, 0x32, l1_read_addr, trid, noc_index);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(0, 0x32, l1_read_addr, trid, 1 - noc_index);
-    }
-    for (uint32_t i = 1; i < 15; i++) {
-        noc_async_read_barrier_with_trid(i, noc_index);
-        noc_async_read_barrier_with_trid(i, 1 - noc_index);
-    }
-
-// Some mem corruption issue when using the noc_async_write_barrier_with_trid
-#ifndef ARCH_BLACKHOLE
-    // DRAM sharded write API
-    for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % 16 + 1;
-        noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
-        noc_async_write_one_packet_with_trid(
-            l1_read_addr, addr_other_noc, page_size, trid, write_cmd_buf, 1 - noc_index);
-    }
-    for (uint32_t i = 1; i < 15; i++) {
-        noc_async_write_barrier_with_trid(i, noc_index);
-        noc_async_write_barrier_with_trid(i, 1 - noc_index);
-    }
-#endif
-
-    DPRINT << "END" <<ENDL();
-    DPRINT << "noc_mode " << (uint)noc_mode << ENDL();
-
     // barrier on all txns
     for (int noc = 0; noc < NUM_NOCS; noc++) {
         while (!ncrisc_dynamic_noc_reads_flushed(noc));
@@ -168,6 +145,55 @@ void kernel_main() {
         while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc));
         while (!ncrisc_dynamic_noc_posted_writes_sent(noc));
     }
+
+    // Sync all riscs since we should only clear the trid counters when there are no outstanding requests
+    *semaphore_ptrs[risc_index] = 1;
+    for (uint32_t i = 0; i < num_riscs; i++) {
+        noc_semaphore_wait(semaphore_ptrs[i], 1);
+    }
+
+    // Previous multicasts would have put trids into a non-zero state, so reset the barrier counter
+    reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+    reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, 1 - noc_index);
+
+    // Sync all riscs so that we don't issue new requests while clearing the trid counters
+    *semaphore_ptrs[risc_index] = 2;
+    for (uint32_t i = 0; i < num_riscs; i++) {
+        noc_semaphore_wait(semaphore_ptrs[i], 2);
+    }
+
+    // DRAM sharded read API
+    uint32_t src_addr_0 = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
+    uint32_t src_addr_1 =
+        noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, 1 - noc_index);
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % 16;
+        noc_async_read_tile_dram_sharded_with_state_with_trid(
+            src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_tile_dram_sharded_with_state_with_trid(
+            src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
+    }
+    for (uint32_t i = 0; i < 16; i++) {
+        noc_async_read_barrier_with_trid(i, noc_index);
+        noc_async_read_barrier_with_trid(i, 1 - noc_index);
+    }
+
+#ifndef ARCH_BLACKHOLE
+    // DRAM sharded write API
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % 16;
+        noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
+        noc_async_write_one_packet_with_trid(
+            l1_read_addr, addr_other_noc, page_size, trid, write_cmd_buf, 1 - noc_index);
+    }
+    for (uint32_t i = 0; i < 16; i++) {
+        noc_async_write_barrier_with_trid(i, noc_index);
+        noc_async_write_barrier_with_trid(i, 1 - noc_index);
+    }
+#endif
+
+    DPRINT << "END" <<ENDL();
+    DPRINT << "noc_mode " << (uint)noc_mode << ENDL();
 
     // Barrier test - test barrier itself working properly
     for (int noc = 0; noc < NUM_NOCS; noc++) {

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -204,6 +204,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
 
 inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_reads_flushed(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    invalidate_l1_cache();
     uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc);
     uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::READS_NUM_ISSUED>(noc);
     return (status_reg_val == (self_risc_acked + other_risc_acked));
@@ -365,6 +366,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
 
 inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_writes_sent(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    invalidate_l1_cache();
     uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc);
     uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc);
     return (status_reg_val == (self_risc_acked + other_risc_acked));
@@ -376,6 +378,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_sent(uint
 
 inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_posted_writes_sent(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+    invalidate_l1_cache();
     uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc);
     uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc);
     return (status_reg_val == (self_risc_acked + other_risc_acked));
@@ -387,6 +390,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_posted_writes_sent(uint32_
 
 inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_writes_flushed(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    invalidate_l1_cache();
     uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc);
     uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc);
     return (status_reg_val == (self_risc_acked + other_risc_acked));
@@ -408,6 +412,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_trans
 
 inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_atomics_flushed(uint32_t noc) {
     uint32_t status_reg_val = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    invalidate_l1_cache();
     uint32_t self_risc_acked = get_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
     uint32_t other_risc_acked = get_noc_counter_val<1 - proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc);
     return (status_reg_val == (self_risc_acked + other_risc_acked));

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -142,6 +142,12 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
     return (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) == NOC_CTRL_STATUS_READY);
 }
 
+inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_t noc, uint32_t id_mask) {
+    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
+    volatile uint32_t* ptr = (volatile uint32_t*)offset;
+    *ptr = id_mask;
+}
+
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1983,7 +1983,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
  * This is similar to \a noc_async_read_set_state, except that the source location is determined by the bank_base_address and bank_id.
  * In addition, the VC used for the transactions can also be configured.
  *
- * Return value: None
+ * Return value: source address
  *
  * | Argument                   | Description                               | Data type | Valid range                                            | required |
  * |----------------------------|-------------------------------------------|-----------|--------------------------------------------------------|----------|
@@ -2288,4 +2288,22 @@ void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     }
     invalidate_l1_cache();
     WAYPOINT("NWTD");
+}
+
+// clang-format off
+/**
+ * This resets the barrier counter for a given transaction id on a given NOC using a mask.
+ * Only the the N bits up to the number of transaction ids are used.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                               | Type     | Valid Range      | Required |
+ * |----------|-------------------------------------------|----------|------------------|----------|
+ * | id_mask  | Transaction id mask for the transaction   | uint32_t | 0x0 - 0xFFFFFFFF | False    |
+ * | noc      | Which NOC to use for the transaction      | uint8_t  | 0 or 1           | False    |
+ */
+// clang-format on
+FORCE_INLINE
+void reset_noc_trid_barrier_counter(uint32_t id_mask = NOC_CLEAR_OUTSTANDING_REQ_MASK, uint32_t noc = noc_index) {
+    noc_clear_outstanding_req_cnt(noc, id_mask);
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2293,7 +2293,7 @@ void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
 // clang-format off
 /**
  * This resets the barrier counter for a given transaction id on a given NOC using a mask.
- * Only the the N bits up to the number of transaction ids are used.
+ * Only the N bits up to the number of transaction ids are used.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1528,9 +1528,7 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
 
     WAYPOINT("NRBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_reads_flushed(noc)) {
-            invalidate_l1_cache();
-        }
+        while (!ncrisc_dynamic_noc_reads_flushed(noc));
     } else {
         while (!ncrisc_noc_reads_flushed(noc));
     }
@@ -1558,9 +1556,7 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
 
     WAYPOINT("NWBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_nonposted_writes_flushed(noc)) {
-            invalidate_l1_cache();
-        }
+        while (!ncrisc_dynamic_noc_nonposted_writes_flushed(noc));
     } else {
         while (!ncrisc_noc_nonposted_writes_flushed(noc));
     }
@@ -1587,9 +1583,7 @@ void noc_async_writes_flushed(uint8_t noc = noc_index) {
 
     WAYPOINT("NWFW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc)) {
-            invalidate_l1_cache();
-        }
+        while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc));
     } else {
         while (!ncrisc_noc_nonposted_writes_sent(noc));
     }
@@ -1612,9 +1606,7 @@ FORCE_INLINE
 void noc_async_posted_writes_flushed(uint8_t noc = noc_index) {
     WAYPOINT("NPWW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_posted_writes_sent(noc)) {
-            invalidate_l1_cache();
-        }
+        while (!ncrisc_dynamic_noc_posted_writes_sent(noc));
     } else {
         while (!ncrisc_noc_posted_writes_sent(noc));
     }
@@ -1640,9 +1632,7 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 
     WAYPOINT("NABW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc_idx)) {
-            invalidate_l1_cache();
-        }
+        while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc_idx));
     } else {
         while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx));
     }

--- a/tt_metal/hw/inc/dataflow_api_common.h
+++ b/tt_metal/hw/inc/dataflow_api_common.h
@@ -41,6 +41,7 @@ extern uint32_t tt_l1_ptr* sem_l1_base[];
 #define EXCLUDE_START_Y_OFFSET 14
 #define EXCLUDE_START_X_OFFSET 8
 #define DYNAMIC_NOC_DIRECTION(noc, direction) (noc == 1 ? 1 - direction : direction)
+#define NOC_CLEAR_OUTSTANDING_REQ_MASK ((1ULL << (NOC_MAX_TRANSACTION_ID + 1)) - 1)
 
 static_assert(NUM_NOCS == 2);
 // "Scratch" in L1 has space allocated for 256 DRAM and L1 enteries, to store offsets and NOC XY data.

--- a/tt_metal/hw/inc/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/quasar/noc_nonblocking_api.h
@@ -142,6 +142,12 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
     return (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) == NOC_CTRL_STATUS_READY);
 }
 
+inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_t noc, uint32_t id_mask) {
+    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
+    volatile uint32_t* ptr = (volatile uint32_t*)offset;
+    *ptr = id_mask;
+}
+
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -133,6 +133,12 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
     return (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) == NOC_CTRL_STATUS_READY);
 }
 
+inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_t noc, uint32_t id_mask) {
+    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
+    volatile uint32_t* ptr = (volatile uint32_t*)offset;
+    *ptr = id_mask;
+}
+
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
     uint32_t noc,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There were a few bugs/issues with the dynamic_noc_writer.cpp kernel code.
- Issuing unaligned DRAM reads. Src address was hardcoded to 0x32 whereas dst address is a 64B aligned address
- Incorrectly trying to use trid with ID 16
- Could not properly test use of all trid ids, because previous multicast transactions causes one of the counters to become non-zero
- noc_async_full_barrier was missing l1 cache invalidates since it polls on L1 counters

### What's changed
- Change test fixture to support both fast and slow dispatch
- Remove hardcoded dram src address of 0x32 to use DRAM_ALIGNMENT instead
- Add a trid counter clear API and use it in the kernel. This will reset all counters back to zero allowing us to use all 16 trids for testing
- Add risc syncs before and after the trid counter clear. This is so that we don't have any in flight or new transactions issued by the other risc before the current risc has finished clearing the trid counters
- Move l1 cache invalidates for dynamic noc counters into noc_nonblocking_api instead of in dataflow_api, since dataflow_api shouldn't be responsible if lower level apis read from l1 to clear the cache

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18027378390
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18051034911
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes