### PR TITLE
#0: Fix FreeListOpt to return absolute addresses for allocated and available addresses

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -429,3 +429,49 @@ TEST(FreeListOptTest, AllocatedAddresses) {
     auto after_reset = allocator.allocated_addresses();
     ASSERT_EQ(after_reset, after_top);
 }
+
+TEST(FreeListOptTest, AddressesAPIWithNonzeroOffset) {
+    // Test APIs that expose addresses as inputs/outputs correctly expose absolute addresses with offset added
+    const size_t offset = 2_KiB;
+    const size_t alloc_size = 1_GiB;
+    auto allocator = tt::tt_metal::allocator::FreeListOpt(alloc_size, offset, 1_KiB, 1_KiB);
+
+    auto available_addresses = allocator.available_addresses(1_KiB);
+    ASSERT_EQ(available_addresses.size(), 1);
+    ASSERT_EQ(available_addresses[0].first, offset);
+    ASSERT_EQ(available_addresses[0].second, alloc_size + offset);
+
+    // Allocate a block with allocate_at_address
+    // The way offsets are used is essentially to manually block off some lower region of address space
+    // So we convert absolute addresses to local allocator address by subtracting the offset
+    // This means, in practice, we should only be allocating above the offset; otherwise UB
+    auto a = allocator.allocate_at_address(offset, 3_KiB);
+    // This assert is not that interesting; it will always return input absolute address
+    ASSERT_THAT(a, ::testing::Optional(offset));
+
+    auto allocated_addresses = allocator.allocated_addresses();
+    ASSERT_EQ(allocated_addresses.size(), 1);
+    ASSERT_EQ(allocated_addresses[0].first, offset);
+    ASSERT_EQ(allocated_addresses[0].second, 3_KiB + offset);
+
+    available_addresses = allocator.available_addresses(1_KiB);
+    ASSERT_EQ(available_addresses.size(), 1);
+    ASSERT_EQ(available_addresses[0].first, 3_KiB + offset);
+    ASSERT_EQ(available_addresses[0].second, alloc_size + offset);
+
+    // Allocate another block above using allocate
+    auto b = allocator.allocate(2_KiB, /*bottom_up=*/false);
+    ASSERT_THAT(b, ::testing::Optional(alloc_size - 2_KiB + offset));
+
+    allocated_addresses = allocator.allocated_addresses();
+    ASSERT_EQ(allocated_addresses.size(), 2);
+    ASSERT_EQ(allocated_addresses[0].first, offset);
+    ASSERT_EQ(allocated_addresses[0].second, 3_KiB + offset);
+    ASSERT_EQ(allocated_addresses[1].first, alloc_size - 2_KiB + offset);
+    ASSERT_EQ(allocated_addresses[1].second, alloc_size + offset);
+
+    available_addresses = allocator.available_addresses(1_KiB);
+    ASSERT_EQ(available_addresses.size(), 1);
+    ASSERT_EQ(available_addresses[0].first, 3_KiB + offset);
+    ASSERT_EQ(available_addresses[0].second, alloc_size - 2_KiB + offset);
+}

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -988,7 +988,7 @@ TEST(OverlappedAllocators, OverlappedAllocationsFromBothSides) {
 }
 
 TEST(OverlappedAllocators, NonzeroAddressLimit) {
-    // This test tests the clamping logic in BankManager::allocate_buffer when address_limit is not 0
+    // Tests the clamping logic in BankManager::allocate_buffer when address_limit is not 0
 
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     const uint64_t total_size = 1024 * 1024;
@@ -1095,4 +1095,84 @@ TEST(OverlappedAllocators, NonzeroAddressLimit) {
         std::nullopt,
         AllocatorID{0});
     EXPECT_EQ(alloc0_addr0_realloc, address_limit);  // Should still start at 256KB
+}
+
+TEST(OverlappedAllocators, NonzeroAllocOffset) {
+    // Tests that BankManager::allocate_buffer properly accounts for allocator offsets
+    // If there are dependencies, allocate_buffer will rely on available_addresses, allocated_addresses, and
+    // allocate_at_address APIs. Returned addresses must be absolute addresses otherwise possible bugs:
+    // - If top-down allocation and offset is larger than the allocation size, subsequent allocations will fail
+    //   * First allocation will incorrectly allocate at local address - offset
+    //   * Available addresses will incorrectly include top offset-sized gap as available address
+    //   * Subsequent allocation will attempt to call allocate_at_address at same allocated address and fail
+    // - If bottom-up allocation and offset is larger than the allocation size, subsequent allocations will fail but for
+    //   a different reason. If you assume address_limit is same as alloc offset, this is what will happen:
+    //   * First allocation will try to allocate at address_limit because of clamping logic so first allocation will be
+    //   correct
+    //   * Available addresses will include [alloc_size, ) as available address, which will still get clamped to
+    //   address_limit
+    //   * Subsequent allocation will attempt to call allocate_at_address at same allocated address and fail
+    // TLDR: Support for address_limit, alloc_offset, and bottom_up/top_down allocation seems very fragile
+
+    // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
+
+    // Create a BankManager mocking how L1BankingAllocator is setup
+    std::unordered_map<uint32_t, int64_t> bank_id_to_offset = {{0, 0}};
+    const uint64_t allocatable_l1_size = 1398720;
+    const DeviceAddr interleaved_address_limit = 100432;  // address_limit
+    const uint32_t l1_alignment = 16;
+    const DeviceAddr l1_unreserved_base = 100416;  // offset
+    const bool disable_interleaved = false;
+    BankManager bank_manager(
+        BufferType::L1,
+        bank_id_to_offset,
+        allocatable_l1_size,
+        interleaved_address_limit,
+        l1_alignment,
+        l1_unreserved_base,
+        disable_interleaved,
+        deps);
+
+    // Two consecutive top-down allocations
+    const uint32_t alloc_size_4K = 4096;
+    const auto alloc0_addr0 = bank_manager.allocate_buffer(
+        alloc_size_4K,
+        alloc_size_4K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr0, allocatable_l1_size - alloc_size_4K + l1_unreserved_base);
+
+    const auto alloc0_addr1 = bank_manager.allocate_buffer(
+        alloc_size_4K,
+        alloc_size_4K,
+        /*bottom_up=*/false,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr1, alloc0_addr0 - alloc_size_4K);
+
+    // Two consecutive bottom-up allocations
+    const auto alloc0_addr2 = bank_manager.allocate_buffer(
+        alloc_size_4K,
+        alloc_size_4K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    // With dependent allocators, the clamping logic will find an address above address limit
+    // With independent allocators, regular allocate API will actually fail for this use case
+    // - But in practice, we always allocate top-down so it's not an issue
+    EXPECT_EQ(alloc0_addr2, interleaved_address_limit);
+
+    const auto alloc0_addr3 = bank_manager.allocate_buffer(
+        alloc_size_4K,
+        alloc_size_4K,
+        /*bottom_up=*/true,
+        CoreRangeSet(std::vector<CoreRange>{}),
+        std::nullopt,
+        AllocatorID{0});
+    EXPECT_EQ(alloc0_addr3, alloc0_addr2 + alloc_size_4K);
 }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -342,7 +342,8 @@ std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::available_addresses(
             size_t block_index = free_blocks_segregated_by_size_[i][j];
             if (block_size_[block_index] >= alloc_size) {
                 addresses.push_back(
-                    {block_address_[block_index], block_address_[block_index] + block_size_[block_index]});
+                    {block_address_[block_index] + offset_bytes_,
+                     block_address_[block_index] + block_size_[block_index] + offset_bytes_});
             }
         }
     }
@@ -355,7 +356,8 @@ std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::allocated_addresses(
 
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (meta_block_is_allocated_[i] && block_is_allocated_[i]) {
-            allocated_addresses.emplace_back(block_address_[i], block_address_[i] + block_size_[i]);
+            allocated_addresses.emplace_back(
+                block_address_[i] + offset_bytes_, block_address_[i] + block_size_[i] + offset_bytes_);
         }
     }
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -40,10 +40,19 @@ public:
         SearchPolicy policy = SearchPolicy::BEST);
     void init() override;
 
+    // Returns start and end addresses of available blocks; addresses are absolute addresses with offset added
     std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const override;
 
+    // Returns start and end addresses of allocated blocks; addresses are absolute addresses with offset added
     std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses() const override;
 
+    // Address limit is used as a final check to see if selected address is > address limit.
+    // The selected address is first converted to absolute address by adding offset_bytes_.
+    // Based on usage, it seems like offset_bytes_ is used to offset by address limit so that
+    // absolute address > address limit. Otherwise, bottom-up allocation will always fail without offset.
+    // Eg. In L1 allocator setup:
+    // - address limit (interleaved address limit): 100432
+    // - offset_bytes (l1 unreserved base): 100416
     std::optional<DeviceAddr> allocate(
         DeviceAddr size_bytes, bool bottom_up = true, DeviceAddr address_limit = 0) override;
 


### PR DESCRIPTION
### Ticket
None

### Problem description
`FreeListOpt` APIs that return addresses were not returning absolute addresses. This means, if you consume these addresses and feed them back into `allocate_at_address`,  which takes in absolute addresses, allocator will incorrectly allocate at a lower address. The allocator offset is not exposed, so best solution is to have these APIs also return absolute addresses.

### What's changed
- Add offset_bytes_ to return absolute addresses for APIs
- Add tests for `FreeListOpt` and overlapped bank manager

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18039760549
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes