### PR TITLE
Missing reference on range-for loop prevents GCC 12 build. 

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -622,7 +622,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_logical_chip_to_physical_chi
         auto eth_coords_per_chip =
             tt::tt_metal::MetalContext::instance().get_cluster().get_all_chip_ethernet_coordinates();
         std::unordered_map<int, chip_id_t> eth_coord_y_for_gateway_chips = {};
-        for (const auto [chip_id, eth_coord] : eth_coords_per_chip) {
+        for (const auto& [chip_id, eth_coord] : eth_coords_per_chip) {
             if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(chip_id) == BoardType::N150) {
                 eth_coord_y_for_gateway_chips[eth_coord.y] = chip_id;
             }


### PR DESCRIPTION
### Ticket

### Problem description

Building tt-metal on Debian with GCC 12 fails due to missing reference in the range-for loop:

```
FAILED: [code=1] tt_metal/fabric/CMakeFiles/fabric.dir/control_plane.cpp.o 
/usr/bin/g++-12 -DENCHANTUM_ENABLE_MSVC_SPEEDUP=1 -DFMT_HEADER_ONLY=1 -DSPDLOG_FMT_EXTERNAL -DSPDLOG_FWRITE_UNLOCKED -DTRACY_IMPORTS -DTRACY_TIMER_FALLBACK -DTT_ENABLE_LIGHT_METAL_TRACE=1 -DYAML_CPP_STATIC_DEFINE -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/api -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/api/tt-metalium -I/root/.conan2/p/b/tt-me593a045a0ad73/b/.conan-build/Release/tt_metal/api -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/fabric -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/llrt -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/hw/inc -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/hw -I/root/.conan2/p/b/tt-me593a045a0ad73/b -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/hostdevcommon/api -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/impl -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/impl/debug -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/impl/profiler -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/include -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/common -I/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_stl/. -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.conan-build/Release/tt_metal/fabric -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/third_party/umd/device/api -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include -isystem /root/.conan2/p/b/hwloc15cadbc24a011/p/include -isystem /root/.conan2/p/b/libnu0c9844c5ea64f/p/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/enchantum/2fb7ab238e36c101b9848892ddb6382276b65837/enchantum/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/yaml-cpp/0_8_0_upstream_patched/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0 -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/tt-logger/48ec77b63c35cf84c47678990aa3603b492d0c7c/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/third_party/umd/src/firmware/riscv -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/simd-everywhere/b3b426f78574ef837b17f42e86bab88314c5e4db -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/taskflow/52063f60902bfeb362fa4616b1394ab5efe30994 -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/third_party/tracy/public -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/flatbuffers/2c4062bffa52fa4157b1b4deeae73395df475fda/include -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/protobuf/015fab22471269b76cc86d83a230da3c050068ba/src -m64 -O3 -std=c++20 -fPIC -march=x86-64-v3 -fPIC -fvisibility-inlines-hidden -Wall -Werror -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-unused-function -fpch-preprocess -Wno-array-bounds -Wno-deprecated -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-narrowing -Wno-non-template-friend -Wno-parentheses -Wno-pragmas -Wno-reorder -Wno-restrict -Wno-sign-compare -Wno-strict-aliasing -Wno-stringop-overflow -Wno-stringop-overread -Wno-unused-local-typedefs -Wno-volatile -Wno-pessimizing-move -Wno-dangling-reference -Wno-overloaded-virtual -Wno-int-to-pointer-cast -isystem /root/.conan2/p/b/tt-me593a045a0ad73/b/.cpmcache/taskflow/52063f60902bfeb362fa4616b1394ab5efe30994 -Winvalid-pch -include /root/.conan2/p/b/tt-me593a045a0ad73/b/.conan-build/Release/CMakeFiles/metal_common_pch.dir/cmake_pch.hxx -MD -MT tt_metal/fabric/CMakeFiles/fabric.dir/control_plane.cpp.o -MF tt_metal/fabric/CMakeFiles/fabric.dir/control_plane.cpp.o.d -o tt_metal/fabric/CMakeFiles/fabric.dir/control_plane.cpp.o -c /root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/fabric/control_plane.cpp
/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/fabric/control_plane.cpp: In member function ‘std::map<tt::tt_fabric::FabricNodeId, int> tt::tt_fabric::ControlPlane::get_logical_chip_to_physical_chip_mapping(const std::string&)’:
/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/fabric/control_plane.cpp:620:25: error: loop variable ‘<structured bindings>’ creates a copy from type ‘const std::pair<const int, tt::umd::eth_coord_t>’ [-Werror=range-loop-construct]
  620 |         for (const auto [chip_id, eth_coord] : eth_coords_per_chip) {
      |                         ^~~~~~~~~~~~~~~~~~~~
/root/.conan2/p/b/tt-me593a045a0ad73/b/tt_metal/fabric/control_plane.cpp:620:25: note: use reference type to prevent copying
  620 |         for (const auto [chip_id, eth_coord] : eth_coords_per_chip) {
      |                         ^~~~~~~~~~~~~~~~~~~~
      |                         &
At global scope:
```

### What's changed

- Add missing const reference to resolve the build error. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes