### PR TITLE
Change tensor page size in argmax single core kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -116,7 +116,7 @@ operation::ProgramWithCallbacks argmax_single_core(
 
     // Create input CB to read reduction dim worth of data at once
     const uint32_t src_cb_idx = tt::CBIndex::c_0;
-    const uint32_t src_page_size = round_up_to_mul32(red_dim_units * input_unit_size);
+    const uint32_t src_page_size = red_dim_units * input_unit_size;
     tt::tt_metal::CircularBufferConfig src_cb_config =
         tt::tt_metal::CircularBufferConfig(src_page_size, {{src_cb_idx, input_cb_data_format}})
             .set_page_size(src_cb_idx, src_page_size);
@@ -124,7 +124,7 @@ operation::ProgramWithCallbacks argmax_single_core(
 
     // Create output CB based on the output shape's last dimension
     const uint32_t dst_cb_idx = tt::CBIndex::c_1;
-    const uint32_t dst_page_size = round_up_to_mul32(output_last_dim * output_unit_size);
+    const uint32_t dst_page_size = output_last_dim * output_unit_size;
     const tt::tt_metal::CircularBufferConfig dst_db_config =
         tt::tt_metal::CircularBufferConfig(dst_page_size, {{dst_cb_idx, output_cb_data_format}})
             .set_page_size(dst_cb_idx, dst_page_size);


### PR DESCRIPTION
### Ticket
[23001](https://github.com/tenstorrent/tt-metal/issues/23001)
[23000](https://github.com/tenstorrent/tt-metal/issues/23000)

### Problem description
The argmax operation generates wrong output in several argmax sweep test cases.
The root cause of the problem is that invalid tensor page sizes are set in the program factory.
The kernel code iterates over elements of the output tensor: for each output element, all required input elements are read as a single page, then index of the maximal element is found and written to the output tensor also as a single page. What follows, the kernel code requires the src page size to be the size of elements in the reduction dimension, and the dst page size equal to the size of a single output element. The program factory code applied round_up_to_mul32() to the (otherwise correct) page sizes, which was then not handled in the kernel code.

### What's changed
The page sizes are changed (the rounding is removed) to reflect the tensor access pattern in the kernel code.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)