### PR TITLE
Inspector RPC startup tests

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -52,6 +52,7 @@ jobs:
           - name: debug_tools and device and dispatch
             cmd: |
               ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=$GTEST_FILTER
+              ./build/test/tt_metal/unit_tests_inspector --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_device --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=$GTEST_FILTER
           - name: llk

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -67,6 +67,7 @@ jobs:
             cmd: |
               { [ "$GTEST_FILTER" = "*NIGHTLY_*" ]; } && echo "Skipping run_tools_tests.sh (nightly filter: $GTEST_FILTER)" || ./tests/scripts/run_tools_tests.sh
               ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=$GTEST_FILTER
+              ./build/test/tt_metal/unit_tests_inspector --gtest_filter=$GTEST_FILTER
           - name: ttnn tensor accessor
             cmd: "./build/test/ttnn/unit_tests_ttnn_accessor --gtest_filter=$GTEST_FILTER"
           - name: data movement

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -84,6 +84,7 @@ add_custom_target(
         unit_tests_api
         unit_tests_data_movement
         unit_tests_debug_tools
+        unit_tests_inspector
         unit_tests_device
         unit_tests_dispatch
         unit_tests_eth

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -12,7 +12,6 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_raise_wait.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize_delays.cpp
@@ -23,48 +22,78 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_waypoint.cpp
 )
 
-function(create_unit_test_executable)
-    set(exec_name unit_tests_debug_tools)
+# Create the test executable
+add_executable(unit_tests_debug_tools ${UNIT_TESTS_DEBUG_TOOLS_SRC})
 
-    # Create the test executable
-    add_executable(${exec_name} ${UNIT_TESTS_DEBUG_TOOLS_SRC})
+# Enable unity build for the executable
+TT_ENABLE_UNITY_BUILD(unit_tests_debug_tools)
 
-    # Enable unity build for the executable
-    TT_ENABLE_UNITY_BUILD(${exec_name})
+# Link libraries
+target_link_libraries(unit_tests_debug_tools PRIVATE test_metal_common_libs)
 
-    # Link libraries
-    target_link_libraries(
-        ${exec_name}
-        PRIVATE
-            test_metal_common_libs
-            Metalium::Metal::Impl
-            capnp
-            capnp-rpc
-            numa
-    )
+# Set include directories
+target_include_directories(
+    unit_tests_debug_tools
+    BEFORE
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
 
-    # Set KJ_NO_EXCEPTIONS=0 to enable exceptions in Cap'n Proto code due to a detection bug with g++-12.
-    target_compile_options(${exec_name} PRIVATE -DKJ_NO_EXCEPTIONS=0)
+# Set runtime output directory
+set_target_properties(
+    unit_tests_debug_tools
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
 
-    # Set include directories
-    target_include_directories(
-        ${exec_name}
-        BEFORE
-        PRIVATE
-            "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
-            ${PROJECT_SOURCE_DIR}/tests
-            ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
-            ${CMAKE_CURRENT_SOURCE_DIR}
-            ${CMAKE_CURRENT_SOURCE_DIR}/common
-    )
 
-    # Set runtime output directory
-    set_target_properties(
-        ${exec_name}
-        PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY
-                ${PROJECT_BINARY_DIR}/test/tt_metal
-    )
-endfunction()
 
-create_unit_test_executable()
+
+set(UNIT_TESTS_INSPECTOR_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp
+)
+
+# Create the test executable
+add_executable(unit_tests_inspector ${UNIT_TESTS_INSPECTOR_SRC})
+
+# Enable unity build for the executable
+TT_ENABLE_UNITY_BUILD(unit_tests_inspector)
+
+# Link libraries
+target_link_libraries(
+    unit_tests_inspector
+    PRIVATE
+        test_metal_common_libs
+        Metalium::Metal::Impl
+        capnp
+        capnp-rpc
+        numa
+)
+
+# Set KJ_NO_EXCEPTIONS=0 to enable exceptions in Cap'n Proto code due to a detection bug with g++-12.
+target_compile_options(unit_tests_inspector PRIVATE -DKJ_NO_EXCEPTIONS=0)
+
+# Set include directories
+target_include_directories(
+    unit_tests_inspector
+    BEFORE
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+
+# Set runtime output directory
+set_target_properties(
+    unit_tests_inspector
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -22,38 +22,43 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_waypoint.cpp
 )
 
-# Create the test executable
-add_executable(unit_tests_debug_tools ${UNIT_TESTS_DEBUG_TOOLS_SRC})
+function(create_unit_test_executable)
+    set(exec_name unit_tests_debug_tools)
 
-# Enable unity build for the executable
-TT_ENABLE_UNITY_BUILD(unit_tests_debug_tools)
+    # Create the test executable
+    add_executable(${exec_name} ${UNIT_TESTS_DEBUG_TOOLS_SRC})
 
-# Link libraries
-target_link_libraries(unit_tests_debug_tools PRIVATE test_metal_common_libs)
+    # Enable unity build for the executable
+    TT_ENABLE_UNITY_BUILD(${exec_name})
 
-# Set include directories
-target_include_directories(
-    unit_tests_debug_tools
-    BEFORE
-    PRIVATE
-        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
-        ${PROJECT_SOURCE_DIR}/tests
-        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/common
-)
+    # Link libraries
+    target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)
 
-# Set runtime output directory
-set_target_properties(
-    unit_tests_debug_tools
-    PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY
-            ${PROJECT_BINARY_DIR}/test/tt_metal
-)
+    # Set include directories
+    target_include_directories(
+        ${exec_name}
+        BEFORE
+        PRIVATE
+            "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+            ${PROJECT_SOURCE_DIR}/tests
+            ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}/common
+    )
+
+    # Set runtime output directory
+    set_target_properties(
+        ${exec_name}
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${PROJECT_BINARY_DIR}/test/tt_metal
+    )
+endfunction()
+
+create_unit_test_executable()
 
 
-
-
+# Inspector unit tests
 set(UNIT_TESTS_INSPECTOR_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp
 )

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -57,11 +57,8 @@ endfunction()
 
 create_unit_test_executable()
 
-
 # Inspector unit tests
-set(UNIT_TESTS_INSPECTOR_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp
-)
+set(UNIT_TESTS_INSPECTOR_SRC ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp)
 
 # Create the test executable
 add_executable(unit_tests_inspector ${UNIT_TESTS_INSPECTOR_SRC})

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_raise_wait.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/inspector/test_rpc_startup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize_delays.cpp
@@ -32,7 +33,18 @@ function(create_unit_test_executable)
     TT_ENABLE_UNITY_BUILD(${exec_name})
 
     # Link libraries
-    target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)
+    target_link_libraries(
+        ${exec_name}
+        PRIVATE
+            test_metal_common_libs
+            Metalium::Metal::Impl
+            capnp
+            capnp-rpc
+            numa
+    )
+
+    # Set KJ_NO_EXCEPTIONS=0 to enable exceptions in Cap'n Proto code due to a detection bug with g++-12.
+    target_compile_options(${exec_name} PRIVATE -DKJ_NO_EXCEPTIONS=0)
 
     # Set include directories
     target_include_directories(

--- a/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <gtest/gtest.h>
+#include <impl/debug/inspector/rpc_server_controller.hpp>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+
+class InspectorFixture : public ::testing::Test {
+  protected:
+    // Helper to find a free port
+    int find_free_port() {
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock < 0) return 0;
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = INADDR_ANY;
+        addr.sin_port = 0; // Let OS pick
+        if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+            close(sock);
+            return 0;
+        }
+        socklen_t len = sizeof(addr);
+        if (getsockname(sock, (struct sockaddr*)&addr, &len) == -1) {
+            close(sock);
+            return 0;
+        }
+        int port = ntohs(addr.sin_port);
+        close(sock);
+        return port;
+    }
+};
+
+TEST_F(InspectorFixture, WrongHostnameFailure) {
+    tt::tt_metal::inspector::RpcServerController controller;
+    EXPECT_ANY_THROW(controller.start("265.265.265.265", 12345));
+    EXPECT_ANY_THROW(controller.start("how-is-this-possible.invalid-hostname.my-nonexisting.company.aiqwe", 12345));
+}
+
+TEST_F(InspectorFixture, SecondServerDoesntStart) {
+    tt::tt_metal::inspector::RpcServerController controller_success;
+    int free_port = find_free_port();
+    EXPECT_NO_THROW(controller_success.start("localhost", free_port));
+
+    tt::tt_metal::inspector::RpcServerController controller_fail;
+    EXPECT_ANY_THROW(controller_fail.start("localhost", free_port));
+}
+
+TEST_F(InspectorFixture, StartTwoServersOnDifferentPorts) {
+    tt::tt_metal::inspector::RpcServerController controller1;
+    EXPECT_NO_THROW(controller1.start("localhost", find_free_port()));
+
+    tt::tt_metal::inspector::RpcServerController controller2;
+    EXPECT_NO_THROW(controller2.start("localhost", find_free_port()));
+}

--- a/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <gtest/gtest.h>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -342,3 +342,8 @@ CPMAddPackage(
         "CMAKE_CXX_EXTENSIONS ON"
     CUSTOM_CACHE_KEY "1_2_0_patched"
 )
+
+if(capnproto_ADDED)
+    target_compile_options(kj-async PRIVATE -Wno-deprecated-this-capture)
+    target_compile_options(kj-http PRIVATE -Wno-deprecated-this-capture)
+endif()

--- a/tt_metal/impl/debug/inspector/rpc_server_controller.cpp
+++ b/tt_metal/impl/debug/inspector/rpc_server_controller.cpp
@@ -33,6 +33,7 @@ void RpcServerController::start(const std::string& host, uint16_t port) {
 
     should_stop = false;
     is_running = true;
+    server_start_finished = false;
     server_thread = std::thread(&RpcServerController::run_server, this);
 
     // Wait for server to start or fail


### PR DESCRIPTION
Adding Inspector RPC unit tests that verify safe startup (that nothing will crash during startup, but gracefully throw exception).
Disabling capnp warnings that come from building external dependency.

Previous PR was triggering some weird double release bug that comes with linking `Metalium::Metal::Impl` into `unit_tests_debug_tools`. This PR splits these tests into two executables.