### PR TITLE
[skip ci]#29420: SDXL CI fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -388,7 +388,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
     "prompt",
     (("An astronaut riding a green horse"),),
 )
-@pytest.mark.timeout(2000)
+@pytest.mark.timeout(3000)
 def test_unet_loop(
     device,
     is_ci_env,


### PR DESCRIPTION
### Ticket
#29420 
### What's changed
Timeout on the unet loop test is increased to 50 minutes, to be safe we don't confuse test taking a bit longer with a hang.
### Checklist
Skipping CI runs