### PR TITLE
Increased timeout for L2 nightly tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -54,7 +54,7 @@ on:
         description: 'Test timeout in minutes'
         required: false
         type: number
-        default: 120
+        default: 150
 
 
 jobs:


### PR DESCRIPTION
### Problem description
Nightly L2 pipeline being red on main due to timeout triggered. Conv tests were actually running that long, with the reasonable amount per test so the investigation showed that it wasn't due to the hang. 

### What's changed
To unblock the pipeline I increased timeout for nightly pipeline for now. Conv test clean up is planned.