### PR TITLE
RISC_POST_HEARTBEAT is not needed for Blackhole

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1945,10 +1945,13 @@ FORCE_INLINE void noc_semaphore_inc(
 }
 
 inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
+    // Posting heartbeat at this address is only needed for Wormhole
+#if !defined(ARCH_BLACKHOLE)
     invalidate_l1_cache();
     volatile uint32_t* ptr = (volatile uint32_t*)(0x1C);
     heartbeat++;
     ptr[0] = 0xAABB0000 | (heartbeat & 0xFFFF);
+#endif
 }
 
 // clang-format off


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29435

### Problem description
RISC_POST_HEARTBEAT is not needed for Blackhole

### What's changed
Disable using define

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18043578735
BH
https://github.com/tenstorrent/tt-metal/actions/runs/18048679995