### PR TITLE
Linear - Update Golden Function for Fused Activations

### DIFF
--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -113,7 +113,7 @@ def _golden_function(
         output_tensor = _get_golden_activation_function(program_config_activation)(output_tensor)
 
     # Then do the composite op activation function if it is requested as well
-    if activation == "gelu" or activation == "gelu_approx":
+    if activation in ("gelu", "gelu_approx"):
         output_tensor = torch.nn.functional.gelu(output_tensor)
     elif activation == "relu":
         output_tensor = torch.nn.functional.relu(output_tensor)

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -63,7 +63,7 @@ def _golden_function(
         output_tensor = _get_golden_activation_function(program_config_activation)(output_tensor)
 
     # Then do the composite op activation function if it is requested as well
-    if activation == "gelu" or activation == "gelu_approx":
+    if activation in ("gelu", "gelu_approx"):
         output_tensor = torch.nn.functional.gelu(output_tensor)
     elif activation == "relu":
         output_tensor = torch.nn.functional.relu(output_tensor)

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -17,8 +17,37 @@ MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig = (
 )
 
 
+def _get_golden_activation_function(activation):
+    import torch
+
+    golden_activations_map = {
+        ttnn.UnaryOpType.RELU: torch.nn.functional.relu,
+        ttnn.UnaryOpType.SILU: torch.nn.functional.silu,
+        ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
+        ttnn.UnaryOpType.SIGMOID: torch.nn.functional.sigmoid,
+        ttnn.UnaryOpType.TANH: torch.nn.functional.tanh,
+        ttnn.UnaryOpType.LOG: torch.log,
+        ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,
+        ttnn.UnaryOpType.GELU: torch.nn.functional.gelu,
+        ttnn.UnaryOpType.SQRT: torch.sqrt,
+    }
+
+    if activation in golden_activations_map:
+        return golden_activations_map[activation]
+    else:
+        raise RuntimeError(f"{activation} is not supported as activation function")
+
+
 def _golden_function(
-    input_tensor_a, input_tensor_b, transpose_a=False, transpose_b=False, *, bias=None, activation=None, **kwargs
+    input_tensor_a,
+    input_tensor_b,
+    transpose_a=False,
+    transpose_b=False,
+    *,
+    bias=None,
+    activation=None,
+    program_config=None,
+    **kwargs,
 ):
     import torch
 
@@ -28,7 +57,13 @@ def _golden_function(
         input_tensor_b = input_tensor_b.transpose(-1, -2)
     output_tensor = input_tensor_a @ input_tensor_b.to(input_tensor_a.dtype)
 
-    if activation == "gelu":
+    # First check if there is a fused activation in the program config
+    if program_config is not None and hasattr(program_config, "fused_activation") and program_config.fused_activation:
+        program_config_activation = program_config.fused_activation.op_type
+        output_tensor = _get_golden_activation_function(program_config_activation)(output_tensor)
+
+    # Then do the composite op activation function if it is requested as well
+    if activation == "gelu" or activation == "gelu_approx":
         output_tensor = torch.nn.functional.gelu(output_tensor)
     elif activation == "relu":
         output_tensor = torch.nn.functional.relu(output_tensor)
@@ -73,26 +108,9 @@ def _golden_function(
         output_tensor += bias
 
     # First check if there is a fused activation in the program config
-    if program_config:
-        program_config_activation = program_config.fused_activation
-        if program_config_activation:
-            program_config_activation = program_config_activation.op_type
-
-            golden_activations_map = {
-                ttnn.UnaryOpType.RELU: torch.nn.functional.relu,
-                ttnn.UnaryOpType.SILU: torch.nn.functional.silu,
-                ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
-                ttnn.UnaryOpType.SIGMOID: torch.nn.functional.sigmoid,
-                ttnn.UnaryOpType.TANH: torch.nn.functional.tanh,
-                ttnn.UnaryOpType.LOG: torch.log,
-                ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,
-                ttnn.UnaryOpType.GELU: torch.nn.functional.gelu,
-                ttnn.UnaryOpType.SQRT: torch.sqrt,
-            }
-            if program_config_activation in golden_activations_map:
-                output_tensor = golden_activations_map[program_config_activation](output_tensor)
-            else:
-                raise RuntimeError(f"{program_config_activation} is not supported as activation function")
+    if program_config is not None and hasattr(program_config, "fused_activation") and program_config.fused_activation:
+        program_config_activation = program_config.fused_activation.op_type
+        output_tensor = _get_golden_activation_function(program_config_activation)(output_tensor)
 
     # Then do the composite op activation function if it is requested as well
     if activation == "gelu" or activation == "gelu_approx":


### PR DESCRIPTION
### Ticket
#29334

### Problem description
Running SDXL with `enable_comparison_mode` reported poor PCC on `ttnn.linear` calls. After investigation, this is because the golden function only checks for the composite op activation, while the op can actually perform a fused activation in addition to the composite activation.

### What's changed
Updated golden function to perform the fused activation in addition to the composite activation, thereby mirroring the ops behaviour. Update is made to both the linear and the matmul golden functions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18047929199)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18047931314) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes