### PR TITLE
#26591: Migrate `EnqueueWaitForEvent()` to 'MeshCommandQueue::enqueue_wait_for_event'

### DIFF
--- a/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
+++ b/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
@@ -1174,13 +1174,13 @@ EnqueueWriteBuffer(device_0_cq_1_handle, mul_src_1, random_data_1);
 // Record that inputs were written
 EnqueueRecordEvent(device_0_cq_1_handle, device_0_write_event);
 // Wait until inputs were written
-EnqueueWaitForEvent(device_0_cq_0_handle, device_0_write_event);
+device_0_cq_0_handle.enqueue_wait_for_event(device_0_write_event);
 // Run compute
 EnqueueProgram(device_0_cq_0_handle, mul_program);
 // Record that compute was run and is completed
 EnqueueRecordEvent(device_0_cq_0_handle, device_0_compute_event);
 // Wait until compute has completed
-EnqueueWaitForEvent(device_0_cq_1_handle, device_0_compute_event);
+device_0_cq_1_handle.enqueue_wait_for_event(device_0_compute_event);
 // Read outputs
 EnqueueReadBuffer(device_0_cq_1_handle, mul_dst, mul_readback_data);
 

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -510,13 +510,13 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
 
     MeshEvent write_event = EnqueueRecordEvent(data_movement_cq);
-    EnqueueWaitForEvent(workload_cq, write_event);
+    workload_cq.enqueue_wait_for_event(write_event);
 
     ReplayTrace(mesh_device_.get(), kWorkloadCqId, trace_id, false);
 
     // Synchronize
     MeshEvent trace_event = EnqueueRecordEvent(workload_cq);
-    EnqueueWaitForEvent(data_movement_cq, trace_event);
+    data_movement_cq.enqueue_wait_for_event(trace_event);
 
     std::vector<bfloat16> add_dst_vec = {};
     std::vector<bfloat16> mul_sub_dst_vec = {};

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -57,7 +57,7 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(0), buf, src_vec);
         // Device to Device Synchronization
         auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
-        EnqueueWaitForEvent(mesh_device_->mesh_command_queue(1), write_event);
+        mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
 
         // Reads on CQ 1
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
@@ -104,7 +104,7 @@ TEST_F(MeshEventsTest2x4, ShardedAsyncIO) {
         } else {
             // Test Device <-> Device synchronization
             auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
-            EnqueueWaitForEvent(mesh_device_->mesh_command_queue(1), write_event);
+            mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
         }
         // Reads on CQ 1
         std::vector<uint32_t> dst_vec = {};
@@ -165,14 +165,14 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
         } else {
             // Test Device <-> Device Synchronization
             auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(1));
-            EnqueueWaitForEvent(mesh_device_->mesh_command_queue(0), write_event);
+            mesh_device_->mesh_command_queue(0).enqueue_wait_for_event(write_event);
         }
         // Issue workloads on MeshCQ 0
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(0), mesh_workload, false);
         if (iter % 2) {
             // Test Device <-> Device Synchronization
             auto op_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
-            EnqueueWaitForEvent(mesh_device_->mesh_command_queue(1), op_event);
+            mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(op_event);
         } else {
             // Test Host <-> Device Synchronization
             auto op_event = EnqueueRecordEventToHost(mesh_device_->mesh_command_queue(0));
@@ -232,7 +232,7 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
 
         mesh_device_->mesh_command_queue(1).enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_0, false);
         auto event0 = EnqueueRecordEvent(mesh_device_->mesh_command_queue(1), {}, devices_0);
-        EnqueueWaitForEvent(mesh_device_->mesh_command_queue(0), event0);
+        mesh_device_->mesh_command_queue(0).enqueue_wait_for_event(event0);
 
         for (const auto& coord : devices_0) {
             readback_vecs.push_back({});
@@ -304,12 +304,12 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
         if (i > 0) {
             // Wait for read to complete before writing, since the same
             // buffer is used across iterations
-            EnqueueWaitForEvent(write_cq, read_events.back());
+            write_cq.enqueue_wait_for_event(read_events.back());
         }
         EnqueueWriteMeshBuffer(write_cq, buffer, input_shard_data[i], true);
         write_events.push_back(EnqueueRecordEventToHost(write_cq));
         // Wait for write to complete before reading
-        EnqueueWaitForEvent(read_cq, write_events.back());
+        read_cq.enqueue_wait_for_event(write_events.back());
         read_cq.enqueue_read_shards(read_shards[i], buffer, false);
         read_events.push_back(EnqueueRecordEventToHost(read_cq));
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -165,14 +165,14 @@ TEST_F(UnitMeshCQEventFixture, TestEventsQueueWaitForEventBasic) {
         // Device synchronize every N number of events.
         if (i > 0 && ((i % num_events_between_sync) == 0)) {
             log_debug(tt::LogTest, "Going to WaitForEvent for i: {}", i);
-            distributed::EnqueueWaitForEvent(cq, *event);
+            cq.enqueue_wait_for_event(*event);
         }
     }
 
     // A bunch of bonus syncs where event_id is mod on earlier ID's.
-    distributed::EnqueueWaitForEvent(cq, *sync_events.at(0));
-    distributed::EnqueueWaitForEvent(cq, *sync_events.at(sync_events.size() - 5));
-    distributed::EnqueueWaitForEvent(cq, *sync_events.at(4));
+    cq.enqueue_wait_for_event(*sync_events.at(0));
+    cq.enqueue_wait_for_event(*sync_events.at(sync_events.size() - 5));
+    cq.enqueue_wait_for_event(*sync_events.at(4));
     distributed::Finish(cq);
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
@@ -257,7 +257,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) 
         std::shared_ptr<distributed::MeshBuffer> buf =
             distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
         distributed::WriteShard(cq, buf, page, distributed::MeshCoordinate(0, 0), true);
-        distributed::EnqueueWaitForEvent(cq, *event);
+        cq.enqueue_wait_for_event(*event);
 
         if (i % 10 == 0) {
             distributed::EventSynchronize(*event);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -532,7 +532,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceFixture, TensixTestSubDeviceCQOwnership) {
     EXPECT_THROW(
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), mesh_workload_2, false), std::exception);
     // Waiting on an event before the last program was queued does not allow transferring ownership of sub device 2.
-    distributed::EnqueueWaitForEvent(mesh_device->mesh_command_queue(0), early_event);
+    mesh_device->mesh_command_queue(0).enqueue_wait_for_event(early_event);
     EXPECT_THROW(
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), mesh_workload_2, false), std::exception);
 
@@ -540,7 +540,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceFixture, TensixTestSubDeviceCQOwnership) {
     auto event1 = distributed::EnqueueRecordEventToHost(mesh_device->mesh_command_queue(1), sub_device_ids_for_event);
     auto event2 = distributed::EnqueueRecordEventToHost(mesh_device->mesh_command_queue(1), sub_device_ids_for_event);
     log_info(tt::LogTest, "waiting on event2");
-    distributed::EnqueueWaitForEvent(mesh_device->mesh_command_queue(0), event2);
+    mesh_device->mesh_command_queue(0).enqueue_wait_for_event(event2);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(0), mesh_workload_2, false);
 
     distributed::Synchronize(mesh_device.get(), std::nullopt);

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -119,11 +119,6 @@ MeshEvent EnqueueRecordEventToHost(
     tt::stl::Span<const SubDeviceId> sub_device_ids = {},
     const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
 
-// Make the specified MeshCommandQueue wait for the completion of an event.
-// This operation is non-blocking on host, however the specified command queue
-// will stall until the event is recorded.
-void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event);
-
 // Make the current thread block until the event is recorded by the associated MeshCommandQueue.
 void EventSynchronize(const MeshEvent& event);
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -41,8 +41,6 @@ MeshEvent EnqueueRecordEventToHost(
     return mesh_cq.enqueue_record_event_to_host(sub_device_ids, device_range);
 }
 
-void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event) { mesh_cq.enqueue_wait_for_event(event); }
-
 void EventSynchronize(const MeshEvent& event) {
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         return;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -255,12 +255,12 @@ int main() {
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
     // Synchronize
     MeshEvent write_event = EnqueueRecordEvent(data_movement_cq);
-    EnqueueWaitForEvent(workload_cq, write_event);
+    workload_cq.enqueue_wait_for_event(write_event);
     // =========== Step 8: Run MeshTrace on MeshCQ0 ===========
     ReplayTrace(mesh_device.get(), workload_cq_id, trace_id, false);
     // Synchronize
     MeshEvent trace_event = EnqueueRecordEvent(workload_cq);
-    EnqueueWaitForEvent(data_movement_cq, trace_event);
+    data_movement_cq.enqueue_wait_for_event(trace_event);
     // =========== Step 9: Read Outputs on MeshCQ1 ===========
     std::vector<bfloat16> add_dst_vec = {};
     std::vector<bfloat16> mul_sub_dst_vec = {};

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -48,7 +48,7 @@ void event_synchronize(const tt::tt_metal::distributed::MeshEvent& event) {
 
 void wait_for_event(
     tt::tt_metal::distributed::MeshCommandQueue& cq, const tt::tt_metal::distributed::MeshEvent& event) {
-    tt::tt_metal::distributed::EnqueueWaitForEvent(cq, event);
+    cq.enqueue_wait_for_event(event);
 }
 
 tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq) {

--- a/ttnn/core/events.cpp
+++ b/ttnn/core/events.cpp
@@ -15,7 +15,6 @@
 namespace ttnn::events {
 
 using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
-using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
 using ::tt::tt_metal::distributed::EventSynchronize;
 
 MeshEvent record_mesh_event(
@@ -27,7 +26,7 @@ MeshEvent record_mesh_event(
 }
 
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {
-    EnqueueWaitForEvent(event.device()->mesh_command_queue(*cq_id), event);
+    event.device()->mesh_command_queue(*cq_id).enqueue_wait_for_event(event);
 }
 
 void event_synchronize(const MeshEvent& event) { EventSynchronize(event); }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26591)

### Problem description
N/A

### What's changed

- Migration of`EnqueueWaitForEvent` API, contributing to the effort to deprecate/remove tt_metal/api/tt-metalium/distributed.hpp

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18048878287))
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18100226174))