### PR TITLE
SFPI v7.2.0

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,7 +18,7 @@ on:
       ttsim-ref:
         required: false
         type: string
-        default: "74455e61626060cd8363cb99c82e28b89856c0e6"
+        default: "b22b5c02f501d5c7ab2dbf9512e9f16cc35f4135"
 
 jobs:
   ttsim-integration:

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -138,9 +138,13 @@ int main() {
 
     // Setup arguments for the kernels in the program.
     // Unlike OpenCL/CUDA, every kernel can have its own set of arguments.
-    SetRuntimeArgs(program, binary_reader_kernel_id, core, {src0_dram_buffer->address(), src1_dram_buffer->address()});
+    SetRuntimeArgs(
+        program,
+        binary_reader_kernel_id,
+        core,
+        {(unsigned)src0_dram_buffer->address(), (unsigned)src1_dram_buffer->address()});
     SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
-    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address()});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {(unsigned)dst_dram_buffer->address()});
 
     // Add the program to the workload and execute it.
     workload.add_program(device_range, std::move(program));

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -142,9 +142,9 @@ int main() {
         program,
         binary_reader_kernel_id,
         core,
-        {(unsigned)src0_dram_buffer->address(), (unsigned)src1_dram_buffer->address()});
+        {(uint32_t)src0_dram_buffer->address(), (uint32_t)src1_dram_buffer->address()});
     SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
-    SetRuntimeArgs(program, unary_writer_kernel_id, core, {(unsigned)dst_dram_buffer->address()});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {(uint32_t)dst_dram_buffer->address()});
 
     // Add the program to the workload and execute it.
     workload.add_program(device_range, std::move(program));

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,13 +1,13 @@
 # set SFPI release version information
 
-sfpi_version=7.1.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
-# sed 's/^\([0-9a-f]*\) \*sfpi_[-.0-9a-zA-Z]*_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_\2_\3_md5=\1/'
-sfpi_aarch64_txz_md5=84349e5d816885a7db0d447a71311b6c
-sfpi_aarch64_deb_md5=ab74092edaf9d8effe22d5c3ee1a6641
-sfpi_aarch64_rpm_md5=33c2221bd643168479ce668e4967c18f
-sfpi_x86_64_txz_md5=92c59298aec2954b1a9c65e5a39cf9af
-sfpi_x86_64_deb_md5=46632ec6aa6c11605447b03284395bfb
-sfpi_x86_64_rpm_md5=10e3b833fddead540ddf6b240dd616c0
+# sed 's/^\([0-9a-f]*\) \*sfpi_\([-.0-9a-zA-Z]*\)_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_version=\2'"\n"'sfpi_\3_\4_md5=\1/' *-build/sfpi_*.md5 | sort -u
+sfpi_aarch64_deb_md5=a67c257092b55af74b16d1ca03305f05
+sfpi_aarch64_rpm_md5=3ec63a0a7b83485867f103c7fd3f5079
+sfpi_aarch64_txz_md5=6f0380cb9d50055e0c31f5b7e96fb638
+sfpi_version=7.2.0
+sfpi_x86_64_deb_md5=df7a206658fc40cf31fe7282343a2752
+sfpi_x86_64_rpm_md5=9634997e6101227dae10bd9701f046e8
+sfpi_x86_64_txz_md5=e408d57cc776d4d51055323c5e29cf02


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18813
https://github.com/tenstorrent/tt-metal/issues/18789

### Problem description
BH has bit and atomic inns

### What's changed
Enable them.
Also don't check ARCH_foo macros in sfpi header file, that interferes with quasar development, which is using BH as a base.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes