### PR TITLE
Skip src_ch_id set for tensix extension mode

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -118,6 +118,15 @@ uint32_t get_worker_connected_sender_channel(const eth_chan_directions direction
     return is_2D_routing ? direction : 0;
 }
 
+uint32_t get_vc1_connected_sender_channel(Topology topology) {
+    if (topology == tt::tt_fabric::Topology::Ring) {
+        return FabricEriscDatamoverConfig::num_sender_channels_1d_ring - 1;  // channel 2 (last of 3)
+    } else if (topology == tt::tt_fabric::Topology::Torus) {
+        return FabricEriscDatamoverConfig::num_sender_channels_2d_torus - 1;  // channel 4 (last of 5)
+    }
+    return 0;  // invalid
+}
+
 uint32_t get_worker_or_vc1_connected_sender_channel(const eth_chan_directions direction, Topology topology) {
     uint32_t target_channel = get_worker_connected_sender_channel(direction, topology);
     // if without vc1, return worker channel, otherwise return vc1 channel
@@ -1237,6 +1246,14 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     size_t receiver_channel_num_buffers =
         this->dateline_connection ? this->receiver_channels_num_buffers[1] : this->receiver_channels_num_buffers[0];
 
+    const auto remote_routing_direction =
+        control_plane.get_forwarding_direction(this->peer_fabric_node_id, this->local_fabric_node_id);
+    auto remote_eth_direction =
+        control_plane.routing_direction_to_eth_direction(remote_routing_direction.value_or(RoutingDirection::E));
+    auto remote_worker_sender_channel = get_worker_connected_sender_channel(remote_eth_direction, topology);
+    auto remote_vc1_sender_channel =
+        this->dateline_connection ? remote_worker_sender_channel : get_vc1_connected_sender_channel(topology);
+
     bool update_pkt_hdr_on_rx_ch = true;
     bool fabric_tensix_extension_enabled = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
                                            tt::tt_fabric::FabricTensixConfig::DISABLED;
@@ -1286,7 +1303,10 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         is_handshake_master,
         this->handshake_address,
         this->channel_buffer_size,
-        vc1_has_different_downstream_dest};
+        vc1_has_different_downstream_dest,
+        this->has_tensix_extension,
+        remote_vc1_sender_channel,
+        remote_worker_sender_channel};
 
     const std::vector<uint32_t> main_args_part2 = {
         config.skip_receiver_channel_1_connection,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -227,6 +227,8 @@ struct ReceiverChannelPointers {
 
     FORCE_INLINE uint8_t get_src_chan_id(BufferIndex buffer_index) const { return src_chan_ids[buffer_index.get()]; }
 
+    FORCE_INLINE uint8_t get_src_chan_id() const { return src_chan_ids[0]; }
+
     FORCE_INLINE void init() { reset(); }
 
     FORCE_INLINE void reset() {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -137,8 +137,12 @@ constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 // then the total amount of buffering for that
 constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
 constexpr bool vc1_has_different_downstream_dest = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
+constexpr bool has_tensix_extension = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
+constexpr bool skip_src_ch_id_update = has_tensix_extension;
+constexpr uint32_t remote_vc1_sender_channel = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);
+constexpr size_t remote_worker_sender_channel = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 12);
 
-constexpr size_t SENDER_NUM_BUFFERS_IDX = MAIN_CT_ARGS_START_IDX + 10;
+constexpr size_t SENDER_NUM_BUFFERS_IDX = MAIN_CT_ARGS_START_IDX + 13;
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_NUM_BUFFERS_ARRAY =
     fill_array_with_next_n_args<size_t, SENDER_NUM_BUFFERS_IDX, NUM_SENDER_CHANNELS>();
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -139,10 +139,14 @@ constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_STA
 constexpr bool vc1_has_different_downstream_dest = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
 constexpr bool has_tensix_extension = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
 constexpr bool skip_src_ch_id_update = has_tensix_extension;
-constexpr uint32_t remote_vc1_sender_channel = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);
-constexpr size_t remote_worker_sender_channel = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 12);
 
-constexpr size_t SENDER_NUM_BUFFERS_IDX = MAIN_CT_ARGS_START_IDX + 13;
+constexpr size_t REMOTE_CHANNEL_INFO_START_IDX = MAIN_CT_ARGS_START_IDX + 11;
+constexpr uint32_t remote_vc1_sender_channel =
+    conditional_get_compile_time_arg<skip_src_ch_id_update, REMOTE_CHANNEL_INFO_START_IDX>();
+constexpr size_t remote_worker_sender_channel =
+    conditional_get_compile_time_arg<skip_src_ch_id_update, REMOTE_CHANNEL_INFO_START_IDX + 1>();
+
+constexpr size_t SENDER_NUM_BUFFERS_IDX = REMOTE_CHANNEL_INFO_START_IDX + (skip_src_ch_id_update ? 2 : 0);
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_NUM_BUFFERS_ARRAY =
     fill_array_with_next_n_args<size_t, SENDER_NUM_BUFFERS_IDX, NUM_SENDER_CHANNELS>();
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1858,11 +1858,7 @@ void run_receiver_channel_step_impl(
         if (can_send_completion) {
             uint8_t src_ch_id;
             if constexpr (skip_src_ch_id_update) {
-                if constexpr (receiver_channel == 0) {
-                    src_ch_id = remote_worker_sender_channel;
-                } else {
-                    src_ch_id = remote_vc1_sender_channel;
-                }
+                src_ch_id = receiver_channel_pointers.get_src_chan_id();
             } else {
                 src_ch_id = receiver_channel_pointers.get_src_chan_id(receiver_buffer_index);
             }
@@ -1968,6 +1964,10 @@ void run_fabric_edm_main_loop(
     auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<NUM_RECEIVER_CHANNELS - 1>();
     receiver_channel_pointers_ch0.reset();
     receiver_channel_pointers_ch1.reset();
+    if constexpr (skip_src_ch_id_update) {
+        receiver_channel_pointers_ch0.set_src_chan_id(BufferIndex{0}, remote_worker_sender_channel);
+        receiver_channel_pointers_ch1.set_src_chan_id(BufferIndex{0}, remote_vc1_sender_channel);
+    }
 
     std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established =
         initialize_array<NUM_SENDER_CHANNELS, bool, false>();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -377,7 +377,9 @@ FORCE_INLINE void send_next_data(
     volatile auto* pkt_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(src_addr);
     size_t payload_size_bytes = pkt_header->get_payload_size_including_header();
     auto dest_addr = receiver_buffer_channel.get_cached_next_buffer_slot_addr();
-    pkt_header->src_ch_id = sender_channel_index;
+    if constexpr (!skip_src_ch_id_update) {
+        pkt_header->src_ch_id = sender_channel_index;
+    }
 
     if constexpr (ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA) {
         while (internal_::eth_txq_is_busy(sender_txq_id)) {
@@ -1736,8 +1738,9 @@ void run_receiver_channel_step_impl(
 #if !defined(FABRIC_2D) || !defined(DYNAMIC_ROUTING_ENABLED)
         cached_routing_fields = packet_header->routing_fields;
 #endif
-
-        receiver_channel_pointers.set_src_chan_id(receiver_buffer_index, packet_header->src_ch_id);
+        if constexpr (!skip_src_ch_id_update) {
+            receiver_channel_pointers.set_src_chan_id(receiver_buffer_index, packet_header->src_ch_id);
+        }
         uint32_t hop_cmd;
         bool can_send_to_all_local_chip_receivers;
         if constexpr (is_2d_fabric) {
@@ -1853,9 +1856,18 @@ void run_receiver_channel_step_impl(
             can_send_completion = can_send_completion && !internal_::eth_txq_is_busy(receiver_txq_id);
         }
         if (can_send_completion) {
+            uint8_t src_ch_id;
+            if constexpr (skip_src_ch_id_update) {
+                if constexpr (receiver_channel == 0) {
+                    src_ch_id = remote_worker_sender_channel;
+                } else {
+                    src_ch_id = remote_vc1_sender_channel;
+                }
+            } else {
+                src_ch_id = receiver_channel_pointers.get_src_chan_id(receiver_buffer_index);
+            }
             receiver_send_completion_ack<ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK>(
-                receiver_channel_response_credit_sender,
-                receiver_channel_pointers.get_src_chan_id(receiver_buffer_index));
+                receiver_channel_response_credit_sender, src_ch_id);
             receiver_channel_trid_tracker.clear_trid_at_buffer_slot(receiver_buffer_index);
             completion_counter.increment();
         }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
src_ch_id is used to differentiate sender channels from the receiver side, since in normal mode (no tensix extension) multiple sender channels can send to a single remote receiver channel, we need a flag to know which sender it is.

### What's changed
In tensix mode, we don't need it anymore because we always have the one sender -> one remote receiver mapping.

<img width="517" height="310" alt="Screenshot 2025-09-26 at 4 03 57 PM" src="https://github.com/user-attachments/assets/d113c06e-c92d-4d3c-afee-58d3e0654ec3" />

### Checklist
- [ ] [All post commit] 
- [ ] [Blackhole Post commit] 
- [ ] BH nightly