### PR TITLE
[skip ci] Re-enable BH LB Llama-3.1-8B-Instruct vLLM in CI

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -73,19 +73,18 @@ jobs:
             multimodal: false,
             owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
-          # {
-          #   Removing this until #26734 is resolved
-          #   name: "[BH-RB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
-          #   multimodal: false,
-          #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # },
+          {
+            name: "[BH-RB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-rackbox,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 8}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
           {
             name: "[WH-GLX] Llama-3.3-70B-Instruct",
             model: "meta-llama/Llama-3.3-70B-Instruct",


### PR DESCRIPTION
### Ticket
Now that https://github.com/tenstorrent/tt-metal/issues/26734 has been closed, we can re-enable this test in CI

### Checklist
On dispatch vLLM nightly tests run here: https://github.com/tenstorrent/tt-metal/actions/runs/18048236997