### PR TITLE
Move device profiler dump from MetalContext::teardown() to DevicePool::close_devices()

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -203,6 +203,8 @@ void MetalContext::initialize(
     }
 }
 
+// IMPORTANT: This function is registered as an atexit handler. Creating threads during program termination may cause
+// undefined behavior. Do not create threads in this function or any functions it calls.
 void MetalContext::teardown() {
     ZoneScoped;
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -230,7 +230,6 @@ void MetalContext::teardown() {
     }
 
     if (profiler_state_manager_) {
-        profiler_state_manager_->cleanup_device_profilers();
         profiler_state_manager_.reset();
     }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -898,6 +898,10 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
 
     if (getDeviceProfilerState()) {
+        // Device profiling data is dumped here instead of MetalContext::teardown() because MetalContext::teardown() is
+        // called as a std::atexit() function, and ProfilerStateManager::cleanup_device_profilers() cannot be safely
+        // called from a std::atexit() function because it creates new threads, which is unsafe during program
+        // termination.
         tt::tt_metal::MetalContext::instance().profiler_state_manager()->cleanup_device_profilers();
     }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -30,6 +30,8 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal_profiler.hpp>
+#include "impl/profiler/profiler_state.hpp"
+#include "impl/profiler/profiler_state_manager.hpp"
 #include <tt-metalium/fabric.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -894,6 +896,10 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     }
 
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+
+    if (getDeviceProfilerState()) {
+        tt::tt_metal::MetalContext::instance().profiler_state_manager()->cleanup_device_profilers();
+    }
 
     return pass;
 }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -208,6 +208,8 @@ std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>> getSortedDevice
     const std::map<CoreCoord, std::map<tracy::RiscType, std::set<tracy::TTDeviceMarker>>>&
         device_markers_per_core_risc_map,
     ThreadPool& thread_pool) {
+    ZoneScoped;
+
     uint32_t total_num_markers = 0;
     auto middle = device_markers_per_core_risc_map.begin();
     std::advance(middle, device_markers_per_core_risc_map.size() / 2);
@@ -1806,6 +1808,8 @@ bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
 
 void DeviceProfiler::writeDeviceResultsToFiles() const {
 #if defined(TRACY_ENABLE)
+    ZoneScoped;
+
     std::scoped_lock lock(tt::tt_metal::MetalContext::instance().profiler_state_manager()->file_write_mutex);
 
     const std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
@@ -1820,6 +1824,8 @@ void DeviceProfiler::writeDeviceResultsToFiles() const {
 void DeviceProfiler::pushTracyDeviceResults(
     std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
+    ZoneScoped;
+
     // If this device is root, it may have new sync info updated with syncDeviceHost
     for (auto& [core, info] : device_core_sync_info) {
         if (isSyncInfoNewer(device_sync_info, info)) {


### PR DESCRIPTION
### Ticket
#28224 

`ProfilerStateManager::cleanup_device_profilers()` creates new threads to dump device profiling data, and because `MetalContext::teardown()` is registered with `std::atexit()`, when `teardown()` calls `cleanup_device_profilers()` during process termination, there is some sort of undefined behaviour with how threads creating during teardown interact with Tracy, leading to the GUI showing a `Zone is ended twice` error.

This PR moves the device profiling data dump to happen at the end of `DevicePool::close_devices()` to ensure that all device data is dumped only after all the devices have been closed, and avoids the undefined behaviour with creating threads inside `std::atexit()` handler functions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18049893739)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/18110893020)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18100726499)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18110888389)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/18100734099)
- [x] New/Existing tests provide coverage for changes