### PR TITLE
Add TP Llama 8b to BH multicard CI, rename RB to LB in vLLM CI

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -31,6 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
+          - name: "llama3.1-8b ${{ inputs.runner-label }} performance"
+            arch: blackhole
+            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 1
+            owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.1-8b ${{ inputs.runner-label }} data-parallel=${{ inputs.num_devices }} performance"
             arch: blackhole
             cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel ${{ inputs.num_devices }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -74,7 +74,7 @@ jobs:
             owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
           },
           {
-            name: "[BH-RB] Llama-3.1-8B-Instruct",
+            name: "[BH-LB] Llama-3.1-8B-Instruct",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 35,
             benchmark-timeout: 10,
@@ -82,6 +82,30 @@ jobs:
             mesh-device: P150x8,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 8}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-LB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-rackbox,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 1}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-LB] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-rackbox,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 1}",
             multimodal: false,
             owner_id: U08GELBB1AP, # Ambrose Ling
           },

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -86,30 +86,6 @@ jobs:
             owner_id: U08GELBB1AP, # Ambrose Ling
           },
           {
-            name: "[BH-LB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: bh-rackbox,
-            mesh-device: P150x8,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 1}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-LB] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: bh-rackbox,
-            mesh-device: P150x8,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 1}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
             name: "[WH-GLX] Llama-3.3-70B-Instruct",
             model: "meta-llama/Llama-3.3-70B-Instruct",
             server-timeout: 35,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29360?issue=tenstorrent%7Ctt-metal%7C29363
https://github.com/tenstorrent/tt-metal/issues/24441

### Problem description
As eth link instability issues are resolved, TP=8 configurations on LB can be added to BH demo and vLLM CI for customer completeness checks 

### What's changed
- Added TP=8 RB llama 8b and llama 70b test to vLLM 
- Added TP tests groups for llama 8b for all multi card demo tests


### Checklist
- [BH multi card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18165477280)
- [BH vllm nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/18165488161)