### PR TITLE
Remove hw/inc from include path for host code.

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_bit_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_bit_utils.cpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <memory>
 
-#include "bit_utils.h"
+#include "tt_metal/hw/inc/bit_utils.h"
 
 TEST(Host, ExtractBitArray) {
     uint32_t src[4] = {0x12345678, 0x9abcdef0, 0x13579bdf, 0x2468ace0};

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -149,6 +149,8 @@ target_sources(
         accessor/test_tensor_accessor.cpp
         accessor/test_tensor_accessor_on_device.cpp
 )
+# needs access to "compile_time_args.h"
+target_link_libraries(unit_tests_ttnn_accessor PRIVATE Metalium::Metal::Hardware)
 setup_ttnn_test_target(unit_tests_ttnn_accessor)
 
 # unit_tests_ttnn_tensor

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
     llrt
     PUBLIC
         umd::device
-        Metalium::Metal::Hardware
+        TT::Metalium::HostDevCommon
     PRIVATE
         HAL::1xx
         Tracy::TracyClient


### PR DESCRIPTION
### Ticket
n/a

### Problem description
This is not needed after "dev_msgs.h" has been [removed](https://github.com/tenstorrent/tt-metal/issues/28083) from host code.  "dev_msgs.h" no longer compiles in host environment.  It's better to remove the unnecessary include path.

We should encourage using hostdevcommon for code shared between host and device.

### What's changed
remove hw/inc from include path and fix the few violations.

### Checklist
Change is trival enough that a passing build is sufficient.