### PR TITLE
CMake: enable compile warning as error, disable some 3rd party warnings

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,6 +28,11 @@ function(ensureboosttarget boostTarget)
     endif()
 endfunction()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(BOOST_EXTRA_CXX_FLAGS "-Wno-aggressive-loop-optimizations -Wno-stringop-overflow")
+    set(BOOST_EXTRA_C_FLAGS "-Wno-aggressive-loop-optimizations -Wno-stringop-overflow")
+endif()
+
 CPMAddPackage(
     NAME Boost
     VERSION 1.86.0
@@ -40,6 +45,8 @@ CPMAddPackage(
         "BOOST_SKIP_INSTALL_RULES ON"
         "BUILD_SHARED_LIBS OFF"
         "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio\\\;lockfree"
+        "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${BOOST_EXTRA_CXX_FLAGS}"
+        "CMAKE_C_FLAGS ${CMAKE_C_FLAGS} ${BOOST_EXTRA_C_FLAGS}"
     FIND_PACKAGE_ARGUMENTS "CONFIG REQUIRED"
 )
 
@@ -55,6 +62,12 @@ ensureboosttarget(interprocess)
 # protobuf
 ############################################################################################################################
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(PROTOBUF_EXTRA_CXX_FLAGS "-Wno-deprecated-declarations -Wno-invalid-noreturn")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(PROTOBUF_EXTRA_CXX_FLAGS "-Wno-stringop-overflow")
+endif()
+
 CPMAddPackage(
     NAME protobuf
     GITHUB_REPOSITORY protocolbuffers/protobuf
@@ -63,7 +76,7 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "protobuf_BUILD_TESTS OFF"
-        "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-invalid-noreturn"
+        "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${PROTOBUF_EXTRA_CXX_FLAGS}"
         "protobuf_INSTALL OFF"
         "BUILD_TESTING OFF"
         "protobuf_BUILD_EXAMPLES OFF"
@@ -328,6 +341,12 @@ CPMAddPackage(
 ####################################################################################################################
 # Cap'n Proto : https://github.com/capnproto/capnproto
 ####################################################################################################################
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CAPNPROTO_EXTRA_CXX_FLAGS "-Wno-deprecated-this-capture")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CAPNPROTO_EXTRA_CXX_FLAGS "-Wno-maybe-uninitialized -Wno-deprecated")
+endif()
+
 CPMAddPackage(
     NAME capnproto
     GITHUB_REPOSITORY capnproto/capnproto
@@ -340,5 +359,6 @@ CPMAddPackage(
         "CAPNP_LITE OFF"
         "BUILD_SHARED_LIBS OFF"
         "CMAKE_CXX_EXTENSIONS ON"
+        "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${CAPNPROTO_EXTRA_CXX_FLAGS}"
     CUSTOM_CACHE_KEY "1_2_0_patched"
 )

--- a/tt-train/CMakeLists.txt
+++ b/tt-train/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.18..3.30)
 include(cmake/compilers.cmake)
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 if(DEFINED ENV{CMAKE_C_COMPILER} AND DEFINED ENV{CMAKE_CXX_COMPILER})
     message(STATUS "Setting C and C++ compiler from environment variables")


### PR DESCRIPTION
### Problem description
Ensure that all things built are done so with compile warnings treated as errors

### What's changed
*Set CMAKE_COMPILE_WARNING_AS_ERROR to ON in root CMakeLists.txt
*Disable some warnings in third_party CMakeLists.txt

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes