### PR TITLE
Export KernelDescriptor's SourceType to python

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/test_generic_op.py
@@ -78,14 +78,16 @@ def test_eltwise_exp(device):
 
     reader_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        core_ranges=core_grid,
+        source_type=ttnn.SourceType.FILE_PATH,
+        core_ranges=core_grid,        
         compile_time_args=reader_compile_time_args,
         runtime_args=[[reader_rt_args]],
         config=ttnn.ReaderConfigDescriptor(),
     )
     writer_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        core_ranges=core_grid,
+        source_type=ttnn.SourceType.FILE_PATH,
+        core_ranges=core_grid,        
         compile_time_args=writer_compile_time_args,
         runtime_args=[[writer_rt_args]],
         config=ttnn.WriterConfigDescriptor(),
@@ -94,6 +96,7 @@ def test_eltwise_exp(device):
     sfpu_defines = [("SFPU_OP_EXP_INCLUDE", "1"), ("SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);")]
     compute_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="tt_metal/kernels/compute/eltwise_sfpu.cpp",
+        #source_type=ttnn.SourceType.FILE_PATH, expecting this is the default value
         core_ranges=core_grid,
         compile_time_args=compute_compile_time_args,
         defines=sfpu_defines,

--- a/tests/ttnn/unit_tests/operations/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/test_generic_op.py
@@ -78,16 +78,16 @@ def test_eltwise_exp(device):
 
     reader_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
-        source_type=ttnn.SourceType.FILE_PATH,
-        core_ranges=core_grid,        
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
         compile_time_args=reader_compile_time_args,
         runtime_args=[[reader_rt_args]],
         config=ttnn.ReaderConfigDescriptor(),
     )
     writer_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        source_type=ttnn.SourceType.FILE_PATH,
-        core_ranges=core_grid,        
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_grid,
         compile_time_args=writer_compile_time_args,
         runtime_args=[[writer_rt_args]],
         config=ttnn.WriterConfigDescriptor(),
@@ -96,7 +96,7 @@ def test_eltwise_exp(device):
     sfpu_defines = [("SFPU_OP_EXP_INCLUDE", "1"), ("SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);")]
     compute_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="tt_metal/kernels/compute/eltwise_sfpu.cpp",
-        #source_type=ttnn.SourceType.FILE_PATH, expecting this is the default value
+        # source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH, expecting this to be the default value
         core_ranges=core_grid,
         compile_time_args=compute_compile_time_args,
         defines=sfpu_defines,

--- a/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
@@ -157,13 +157,23 @@ void py_module_types(py::module& module) {
             &tt::tt_metal::ComputeConfigDescriptor::math_approx_mode,
             "Approximation mode for mathematical operations");
 
-    export_enum<tt::tt_metal::KernelDescriptor::SourceType>(module, "SourceType");
-    py::class_<tt::tt_metal::KernelDescriptor>(module, "KernelDescriptor", R"pbdoc(
+    py::class_<tt::tt_metal::KernelDescriptor> kernel_descriptor_class(module, "KernelDescriptor", R"pbdoc(
         Descriptor for a computational kernel.
 
         Contains all the information needed to compile and execute a kernel,
         including source code, compilation options, runtime arguments, and configuration.
+    )pbdoc");
+
+    // Bind SourceType as a nested enum within KernelDescriptor
+    py::enum_<tt::tt_metal::KernelDescriptor::SourceType>(kernel_descriptor_class, "SourceType", R"pbdoc(
+        Source type for kernel source code.
+
+        Defines whether the kernel source is provided as a file path or inline source code.
     )pbdoc")
+        .value("FILE_PATH", tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH, "Kernel source is a file path")
+        .value("SOURCE_CODE", tt::tt_metal::KernelDescriptor::SourceType::SOURCE_CODE, "Kernel source is inline code");
+
+    kernel_descriptor_class
         .def(py::init<>(), R"pbdoc(
             Default constructor for KernelDescriptor.
         )pbdoc")

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -213,7 +213,6 @@ from ttnn.types import (
     BinaryOpType,
     BcastOpMath,
     BcastOpDim,
-    SourceType,
     CBFormatDescriptor,
     CBDescriptor,
     ReaderConfigDescriptor,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -213,6 +213,7 @@ from ttnn.types import (
     BinaryOpType,
     BcastOpMath,
     BcastOpDim,
+    SourceType,
     CBFormatDescriptor,
     CBDescriptor,
     ReaderConfigDescriptor,


### PR DESCRIPTION
### Ticket
None

### Problem description
SourceType enum was not properly exported to TT-NN py lib

### What's changed
Adding the export

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18054606125) CI passes
- [x] New/Existing tests provide coverage for changes
