### PR TITLE
Fix demo, page table creation and misc

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -154,7 +154,9 @@ def test_forward_pass(
         else None
     )
 
-    tt_page_table = MLA.create_page_table(torch_page_table, paged_config, mesh_device)
+    tt_page_table = MLA.create_page_table(
+        page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
+    )
 
     # RoPE setup
     rope_setup = RotarySetup(

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -187,7 +187,9 @@ def test_forward_pass(
         else None
     )
 
-    tt_page_table = MLA.create_page_table(torch_page_table, paged_config, mesh_device)
+    tt_page_table = MLA.create_page_table(
+        page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
+    )
 
     # RoPE setup
     rope_setup = RotarySetup(

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -193,7 +193,8 @@ def test_forward_pass(
     )
 
     tt_page_tables = tuple(
-        MLA.create_page_table(torch_page_table, paged_config, mesh_device) for torch_page_table in torch_page_tables
+        MLA.create_page_table(page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device)
+        for torch_page_table in torch_page_tables
     )
 
     # RoPE setup

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -37,6 +37,12 @@ def reference_model(hf_config):
     indirect=True,
 )
 @pytest.mark.parametrize(
+    "topk_fallback",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
     "mode,seq_len",
     [
         ("decode", 128),
@@ -52,6 +58,7 @@ def test_forward_pass(
     mesh_device,
     ccl,
     set_deterministic_env,
+    topk_fallback,
 ):
     """Test forward pass against reference model."""
     batch_size = 1
@@ -75,7 +82,7 @@ def test_forward_pass(
     weight_config = MoE.convert_weights(hf_config, (state_dict,), tmp_path, mesh_device)
 
     # Generate appropriate config using utility function
-    model_config = get_model_config(MoE, mode, hf_config, mesh_device)
+    model_config = get_model_config(MoE, mode, hf_config, mesh_device, topk_fallback=topk_fallback)
 
     # Create a new model state with CCL
     model_state = MoE.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -314,7 +314,7 @@ class DeepseekGenerator:
         generations: List[List[int]] = [[] for _ in range(len(prompts))]
         for gen_idx in range(max_new_tokens):
             # Decode one step with previous next_tokens
-            logger.info(f"Generating tocken# {gen_idx}/{max_new_tokens}")
+            logger.info(f"Generating token# {gen_idx}/{max_new_tokens}")
             logits = self._decode_step(next_tokens, positions)
             pred_tokens = self._sample_greedy(logits)
             if teacher_forcing is not None:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -17,7 +17,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla import MLA
 from models.demos.deepseek_v3.tt.model import Model
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import MAX_BATCH_SIZE
+from models.demos.deepseek_v3.utils.config_helpers import MAX_BATCH_SIZE, get_weight_config
 from models.demos.deepseek_v3.utils.hf_model_utils import load_model_weights
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import add_inv_scale_to_state_dict
@@ -74,7 +74,8 @@ class DeepseekGenerator:
 
         # Load HF config + tokenizer
         self.hf_config = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
-        self._ensure_max_seq_len(self.hf_config)
+        # self._ensure_max_seq_len(self.hf_config)
+        self.hf_config.max_seq_len = 4096  # TODO: Change this when needed?
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -96,9 +97,13 @@ class DeepseekGenerator:
 
         # Paged attention setup
         self.paged_config = MLA.get_valid_paged_config(self.hf_config.max_seq_len, MAX_BATCH_SIZE, self.dp_factor)
-        self.page_table_tt, _ = MLA.create_page_table(
-            MAX_BATCH_SIZE, dp_factor=self.dp_factor, config=self.paged_config, mesh_device=mesh_device
-        )
+        self.page_tables_tt = [
+            MLA.create_page_table(
+                paged_config=self.paged_config,
+                mesh_device=mesh_device,
+            )
+            for _ in range(self.hf_config.num_hidden_layers)
+        ]
         self.rope = RotarySetup(device=mesh_device, batch_size=MAX_BATCH_SIZE, hf_config=self.hf_config)
 
         # Prepare weights/configs
@@ -125,9 +130,8 @@ class DeepseekGenerator:
         hf_config.max_seq_len = 4096
 
     def _prepare_run_configs(self, cache_dir: str | Path | None) -> None:
-        cache_root = Path(cache_dir) if cache_dir is not None else Path("generated/deepseek_v3")
-        weights_out = cache_root / "weights"
-        weights_out.mkdir(parents=True, exist_ok=True)
+        weight_cache_path = Path(cache_dir) if cache_dir is not None else Path("generated/deepseek_v3")
+        weight_cache_path.mkdir(parents=True, exist_ok=True)
 
         if self.random_weights:
             if self.single_layer and self.single_layer.lower() == "moe":
@@ -144,46 +148,55 @@ class DeepseekGenerator:
                 torch_state,
                 block_shape=self.hf_config.quantization_config["weight_block_size"],
             )
-            stripped = _strip_model_prefix(torch_state)
             model_state = {
                 k: v
-                for k, v in stripped.items()
-                if k.startswith("embed_tokens.")
-                or k.startswith("layers.")
-                or k.startswith("norm.")
+                for k, v in torch_state.items()
+                if k.startswith("model.embed_tokens.")
+                or k.startswith("model.layers.")
+                or k.startswith("model.norm.")
                 or k.startswith("lm_head.")
             }
         else:
-            logger.info("Loading HF weights (this may take a while)...")
+            logger.info(f"Loading HF weights from {self.model_path} (this may take a while)...")
             hf_weights = load_model_weights(self.model_path)
             logger.info("HF weights loaded")
 
-            # Split weight dicts for Model and LMHead
-            stripped = _strip_model_prefix(hf_weights)
-            if "lm_head.weight" not in stripped:
+            if "lm_head.weight" not in hf_weights:
                 raise RuntimeError(
                     "No HF safetensors found in model path or missing 'lm_head.weight'. "
                     "Set DEEPSEEK_V3_HF_MODEL to a directory containing DeepSeek-V3 safetensors, or pass --model-path."
                 )
             model_state = {
                 k: v
-                for k, v in stripped.items()
-                if k.startswith("embed_tokens.")
-                or k.startswith("layers.")
-                or k.startswith("norm.")
+                for k, v in hf_weights.items()
+                if k.startswith("model.embed_tokens.")
+                or k.startswith("model.layers.")
+                or k.startswith("model.norm.")
                 or k.startswith("lm_head.")
             }
         # Convert weights to TT tensors-on-disk and build weight_config
         logger.info("Converting weights to TTNN SavedWeight format (Model)...")
-        self.model_weight_config = Model.convert_weights(
-            self.hf_config, model_state, weights_out / "model_1d", self.mesh_device
-        )  # Build model and head decode configs + states
-        model_decode_cfg = Model.decode_model_config(self.hf_config, self.mesh_device)
-        model_state = Model.create_state(self.hf_config, self.mesh_device, paged_config=self.paged_config, ccl=self.ccl)
-        model_shared_state = Model.create_shared_state(self.hf_config, self.mesh_device)
+        self.model_weight_config = get_weight_config(
+            ModuleClass=Model,
+            hf_config=self.hf_config,
+            state_dicts=(model_state,),
+            weight_cache_path=weight_cache_path,
+            mesh_device=self.mesh_device,
+            force_recalculate=False,
+        )
+        logger.info("Building model decode config...")
+        model_decode_cfg = Model.decode_model_config(hf_config=self.hf_config, mesh_device=self.mesh_device)
+        logger.info("Creating model states...")
+        model_state = Model.create_state(
+            hf_config=self.hf_config, mesh_device=self.mesh_device, paged_config=self.paged_config, ccl=self.ccl
+        )
+        logger.info("Creating model shared states...")
+        model_shared_state = Model.create_shared_state(hf_config=self.hf_config, mesh_device=self.mesh_device)
+        logger.info("Creating model run config...")
         self.model_run_config = create_run_config(
             model_decode_cfg, self.model_weight_config, model_state, model_shared_state
         )
+        logger.info("Model run config created...")
 
     def _tt_from_tokens_step(self, tokens_step: torch.Tensor) -> ttnn.Tensor:
         """Tokens step: [B] -> TTNN tensor [1, 1, B] uint32, replicated to mesh."""
@@ -226,7 +239,11 @@ class DeepseekGenerator:
 
         # Model forward
         logits_tt = Model.forward_decode(
-            tt_tokens, tt_positions, rope_tensors, self.page_table_tt, self.model_run_config
+            tt_tokens,
+            tt_positions,
+            self.model_run_config,
+            rope_tensors,
+            self.page_tables_tt,
         )
         # Gather to host
         logits = ttnn.to_torch(logits_tt, mesh_composer=ttnn.ConcatMeshToTensor(self.mesh_device, dim=3))
@@ -297,6 +314,7 @@ class DeepseekGenerator:
         generations: List[List[int]] = [[] for _ in range(len(prompts))]
         for gen_idx in range(max_new_tokens):
             # Decode one step with previous next_tokens
+            logger.info(f"Generating tocken# {gen_idx}/{max_new_tokens}")
             logits = self._decode_step(next_tokens, positions)
             pred_tokens = self._sample_greedy(logits)
             if teacher_forcing is not None:

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -266,13 +266,10 @@ class LMHead(AbstractModule):
         assert x.memory_config() == cfg["input_memory_config"], f"{x.memory_config()} != {cfg['input_memory_config']}"
 
         mesh_scatter(x, **cfg["mesh_scatter"])
-
-        print("running linear")
-        print(f"{x.shape=}, {cfg['linear']['input_tensor_b'].shape=}")
         output = ttnn.linear(x, **cfg["linear"])
 
-        # Debug print removed
         assert output.memory_config() == cfg["output_memory_config"]
+
         return output
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -406,7 +406,6 @@ class MoEGate(AbstractModule):
         use_bitonic_sort: bool,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         # convert ttnn mesh tensor to torch tensor
-        logger.info(f"topk_fallback_op: input shape: {input.shape}")
         torch_input = ttnn.to_torch(
             input,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),

--- a/models/demos/deepseek_v3/tt/moe_gate.py
+++ b/models/demos/deepseek_v3/tt/moe_gate.py
@@ -130,7 +130,7 @@ class MoEGate(AbstractModule):
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
         mode: str,
-        topk_fallback: bool = True,
+        topk_fallback: bool = False,
         use_bitonic_sort: bool = True,
     ) -> ModelDecodeConfig | ModelPrefillConfig:
         """Generate decode configuration for this module.
@@ -224,7 +224,7 @@ class MoEGate(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        topk_fallback: bool = True,
+        topk_fallback: bool = False,
         use_bitonic_sort: bool = True,
     ) -> ModelDecodeConfig:
         return cls.model_config(hf_config, mesh_device, "decode", topk_fallback, use_bitonic_sort)
@@ -234,7 +234,7 @@ class MoEGate(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
-        topk_fallback: bool = True,
+        topk_fallback: bool = False,
         use_bitonic_sort: bool = True,
     ) -> ModelPrefillConfig:
         return cls.model_config(hf_config, mesh_device, "prefill", topk_fallback, use_bitonic_sort)
@@ -406,6 +406,7 @@ class MoEGate(AbstractModule):
         use_bitonic_sort: bool,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         # convert ttnn mesh tensor to torch tensor
+        logger.info(f"topk_fallback_op: input shape: {input.shape}")
         torch_input = ttnn.to_torch(
             input,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -828,6 +828,7 @@ def get_weight_config(
     mesh_device: ttnn.Device,
     force_recalculate: bool,
 ):
+    weight_cache_path = weight_cache_path / f"{hf_config.num_hidden_layers}_layers"
     config_path = weight_cache_path / "config.json"
     weight_path = weight_cache_path / "weights"
     for _ in range(1):
@@ -841,6 +842,7 @@ def get_weight_config(
         logger.info(f"Using weights cached at {weight_cache_path}")
         return weight_config
 
+    logger.info(f"Caching weights at {weight_cache_path}")
     weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
     json.dump(weight_config, config_path.open("w"), cls=WeightConfigEncoder)
     return weight_config

--- a/models/demos/deepseek_v3/utils/run_config.py
+++ b/models/demos/deepseek_v3/utils/run_config.py
@@ -8,8 +8,6 @@ from enum import Enum
 from types import NoneType
 from typing import Any, overload
 
-from loguru import logger
-
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, OpConfigBase, SavedWeight
 
@@ -97,8 +95,6 @@ def create_run_config(model_config, weight_config, *model_states):
         search_for_mesh_device=False,
         mb_mesh_device=None,
     )
-
-    logger.info(f"run config: {_convert_run_config_to_pretty_print(run_config)}")
 
     return run_config
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29486

### What's changed
- Change create_page_table to create page instead of just converting supplied one
- Make changes to other places with API change of create_page_table
- Change get_weight_config for weights naming and add more logs
- Change generator.py to align with other changes and make sure demo works.

Prompt: "Summarize the history of RISC architectures."
Generated o/p (100 tokens): "Okay, the user asked for a summary of RISC architecture history. Let me start by recalling the basics. RISC stands for Reduced Instruction Set Computer, right? It's a type of microprocessor design that simplifies instructions to boost performance. But why did this become important? Probably because early computers had complex instructions that were hard to manage.

Hmm, the user might be a student or someone interested in computer science. They might need this for an exam, a project, or just personal curiosity."



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes