### PR TITLE
add LSan suppression file to cpp-post-commit.yaml

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -82,6 +82,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TT_METAL_HOME: /work
+        LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
### Ticket
n/a

### Problem description
cpp-post-commit fails on ASan build fails with memory leak error in openmpi

### What's changed
add the LSan suppression file that is used in smoke.yaml.

### Checklist
trivial?