### PR TITLE
[skip ci] Prep TT-Train to consume TT-Metalium & TT-NN from packages

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -28,7 +28,8 @@ CPMAddPackage(
 CPMAddPackage(
     NAME yaml-cpp
     GITHUB_REPOSITORY jbeder/yaml-cpp
-    GIT_TAG 0.8.0
+    GIT_TAG
+        2f86d13775d119edbb69af52e5f566fd65c6953b # 0.8.0 + patches
     OPTIONS
         "YAML_CPP_BUILD_TESTS OFF"
         "YAML_CPP_BUILD_TOOLS OFF"

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -376,9 +376,8 @@ target_link_libraries(
         z
         pthread
         atomic
-        Metalium::Metal
-        Metalium::TTNN
-        Metalium::TTNNCPP
+        TT::Metalium
+        TTNN::TTNN
         Python3::Python
         fmt::fmt-header-only
         enchantum::enchantum

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -9,9 +9,6 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-volatile"
 #pragma GCC diagnostic ignored "-Wdeprecated-this-capture"
 
-#include <cpp/ttnn/operations/core/core.hpp>                                                               // NOLINT
-#include <cpp/ttnn/operations/moreh/moreh_softmax/moreh_softmax.hpp>                                       // NOLINT
-#include <cpp/ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp>                     // NOLINT
 #include <hostdevcommon/common_values.hpp>                                                                 // NOLINT
 #include <tt-metalium/base_types.hpp>                                                                      // NOLINT
 #include <tt-metalium/bfloat16.hpp>                                                                        // NOLINT
@@ -32,6 +29,7 @@
 #include <ttnn/distributed/types.hpp>                                                                      // NOLINT
 #include <ttnn/operations/copy/typecast/typecast.hpp>                                                      // NOLINT
 #include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>                                   // NOLINT
+#include <ttnn/operations/core/core.hpp>                                                                   // NOLINT
 #include <ttnn/operations/core/to_dtype/to_dtype_op.hpp>                                                   // NOLINT
 #include <ttnn/operations/creation.hpp>                                                                    // NOLINT
 #include <ttnn/operations/data_movement/concat/concat.hpp>                                                 // NOLINT
@@ -70,6 +68,8 @@
 #include <ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp>                               // NOLINT
 #include <ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.hpp>                                         // NOLINT
 #include <ttnn/operations/moreh/moreh_nll_loss_backward/moreh_nll_loss_backward.hpp>                       // NOLINT
+#include <ttnn/operations/moreh/moreh_softmax/moreh_softmax.hpp>                                           // NOLINT
+#include <ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp>                         // NOLINT
 #include <ttnn/operations/moreh/moreh_sum/moreh_sum.hpp>                                                   // NOLINT
 #include <ttnn/operations/normalization/softmax/softmax.hpp>                                               // NOLINT
 #include <ttnn/operations/rand/rand.hpp>                                                                   // NOLINT

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -402,6 +402,7 @@ list(
 
 add_library(ttnncpp SHARED)
 add_library(TTNN::CPP ALIAS ttnncpp)
+add_library(TTNN::TTNN ALIAS ttnncpp)
 add_library(Metalium::TTNNCPP ALIAS ttnncpp) # backwards compatibility. FIXME: remove
 
 target_compile_definitions(ttnncpp PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some prep work to make it easier to build TT-Train from pre-built TT-NN packages.

### What's changed
* Brought YAML CPP in line with what is pulled in from the monorepo - interesting bit is an update to CMake to maintain compatibility with modern versions.
* Used the TT-NN & TT-Metalium target names that are aligned with what is available in packages.
* Fixed some #include paths to be resolvable when building from packages.