### PR TITLE
[skip ci] Run extra checks in clang-tidy-light

### DIFF
--- a/.clang-tidy-light
+++ b/.clang-tidy-light
@@ -1,0 +1,2 @@
+cppcoreguidelines-pro-type-cstyle-cast
+cppcoreguidelines-special-member-functions

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -259,6 +259,7 @@ jobs:
       run: |
         grep -v -F -f .clang-tidy-light .clang-tidy > .clang-tidy-new
         mv .clang-tidy-new .clang-tidy
+        cat .clang-tidy
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -255,6 +255,10 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clang-tidy-20 python3.11 python3.11-venv python3.11-dev
         sudo ln -s $(which clang-tidy-20) /usr/local/bin/clang-tidy
         pip install pyyaml # Needed for clang-tidy-diff-20.py
+    - name: Prepare .clang-tidy with extra checks
+      run: |
+        grep -v -F -f .clang-tidy-light .clang-tidy > .clang-tidy-new
+        mv .clang-tidy-new .clang-tidy
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1136,7 +1136,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                 continue;
             }
 
-            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, static_cast<uint8_t>(cores.size()));
+            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, (uint8_t)(cores.size()));
             uint8_t num_reserved_cores = 0;
             for (auto i = 0; i < cores.size(); i++) {
                 if (num_reserved_cores == num_cores_to_reserve) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1136,7 +1136,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                 continue;
             }
 
-            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, (uint8_t)(cores.size()));
+            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, static_cast<uint8_t>(cores.size()));
             uint8_t num_reserved_cores = 0;
             for (auto i = 0; i < cores.size(); i++) {
                 if (num_reserved_cores == num_cores_to_reserve) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -42,20 +42,6 @@
 static constexpr uint32_t HOST_MEM_CHANNELS = 4;
 static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
 
-struct Bad {
-    int* data;
-
-    Bad(int value) : data(new int(value)) {}
-
-    // Destructor is defined
-    ~Bad() { delete data; }
-
-    // Copy constructor is implicitly generated
-    // Copy assignment operator is implicitly generated
-    // Move constructor is implicitly deleted
-    // Move assignment operator is implicitly deleted
-};
-
 namespace {
 
 inline std::string get_soc_description_file(

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -42,6 +42,20 @@
 static constexpr uint32_t HOST_MEM_CHANNELS = 4;
 static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
 
+struct Bad {
+    int* data;
+
+    Bad(int value) : data(new int(value)) {}
+
+    // Destructor is defined
+    ~Bad() { delete data; }
+
+    // Copy constructor is implicitly generated
+    // Copy assignment operator is implicitly generated
+    // Move constructor is implicitly deleted
+    // Move assignment operator is implicitly deleted
+};
+
 namespace {
 
 inline std::string get_soc_description_file(


### PR DESCRIPTION
### Ticket
NA

### Problem description
We still have many checks disabled.
Some of them are important but would be too cumbersome to turn on all at once.

### What's changed
Turn them on in clang-tidy-diff workflow to give feedback on PRs.