### PR TITLE
Improve execution speed of new exp approximation ( + bump tt-sim version) (#26988)

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,7 +18,7 @@ on:
       ttsim-ref:
         required: false
         type: string
-        default: "b22b5c02f501d5c7ab2dbf9512e9f16cc35f4135"
+        default: "c684bf3f9bc3e28ed69a1b94623bcb018007f13e"
 
 jobs:
   ttsim-integration:

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,7 +18,7 @@ on:
       ttsim-ref:
         required: false
         type: string
-        default: "c684bf3f9bc3e28ed69a1b94623bcb018007f13e"
+        default: "b22b5c02f501d5c7ab2dbf9512e9f16cc35f4135"
 
 jobs:
   ttsim-integration:

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,7 +18,7 @@ on:
       ttsim-ref:
         required: false
         type: string
-        default: "3a188c2c3fb89fce8a7b10037bd480b829cb00a8"
+        default: "c684bf3f9bc3e28ed69a1b94623bcb018007f13e"
 
 jobs:
   ttsim-integration:

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,7 +18,7 @@ on:
       ttsim-ref:
         required: false
         type: string
-        default: "b22b5c02f501d5c7ab2dbf9512e9f16cc35f4135"
+        default: "3a188c2c3fb89fce8a7b10037bd480b829cb00a8"
 
 jobs:
   ttsim-integration:

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -14,7 +14,6 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     v_elseif(exp > 30)  // overflow occurs above this range
     {
         // set to int32 max value in case of overflow
-        // This should be 0x7fff ffff  => is it 2 SFPLOADI ?
         result = std::numeric_limits<int32_t>::max();
     }
     v_else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -14,6 +14,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
     v_elseif(exp > 30)  // overflow occurs above this range
     {
         // set to int32 max value in case of overflow
+        // This should be 0x7fff ffff  => is it 2 SFPLOADI ?
         result = std::numeric_limits<int32_t>::max();
     }
     v_else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -45,18 +45,19 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConst0;
     // Intermediary values can overflow if abs(val) is above 88.5f, which leads to output increasing again instead
     // of staying at 0 (or becoming finite on large inputs). This overflow happens when `| log2(e) * val | > 127.0f`,
-    // which correspond to `|val| > 88.5f` To avoid this, we clamp absolute value to 88.5f (and restore sign if negative
-    // input)
-    sfpi::vFloat val_positive = setsgn(val, 0);
-    sfpi::vFloat clamp_threshold = sfpi::vFloat(88.5f);
-    vec_min_max(val_positive, clamp_threshold);
-    val = setsgn(val_positive, val);
+    // which correspond to `|val| > 88.5f`
+    // Intermediary values can overflow if values exceeds 88.72283935546875 or -88.72283172607421875
+    // To prevent this, we clamp -88.5 < x < 89
+    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
+    sfpi::vFloat thresh_high = sfpi::vFloat(89);
+    sfpi::vFloat thresh_low = sfpi::vFloat(-88.5);
+    vec_min_max(thresh_low, val);
+    vec_min_max(val, thresh_high);
 
     // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
     // z = (bias + x * factor * N_m; where:
     // factor = 0x00b8aa3b (computed through log(e))
     // bias = 0x3f800000
-    // Is sfpi::vFloat(0x3f800000) getting optimized ?
     sfpi::vInt z = _float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
     sfpi::vInt zii = exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent
     sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));    // Extract mantissa

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -43,8 +43,10 @@ sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConst0;
-    // Intermediary values can overflow if input value is below -88.0f, which leads to output increasing again instead
-    // of staying at 0. This overflow happens when `log2(e) * val < 127.0f`, which correspond to `val < 88.0f`
+    // Intermediary values can overflow if abs(val) is above 88.5f, which leads to output increasing again instead
+    // of staying at 0 (or becoming finite on large inputs). This overflow happens when `| log2(e) * val | > 127.0f`,
+    // which correspond to `|val| > 88.5f` To avoid this, we clamp absolute value to 88.5f (and restore sign if negative
+    // input)
     sfpi::vFloat val_positive = setsgn(val, 0);
     sfpi::vFloat clamp_threshold = sfpi::vFloat(88.5f);
     vec_min_max(val_positive, clamp_threshold);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -75,7 +75,6 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     zif = _float_to_int32_exp21f_(d2 * d3);
 
     // Restore exponent
-    // Is this compiling properly to 1 instruction (vs. add + setexp)
     zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), zii));  // restore exponent
 
     y = sfpi::reinterpret<sfpi::vFloat>(zii);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -50,7 +50,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // To prevent this, we clamp -88.5 < x < 89
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
     sfpi::vFloat threshold_high = sfpi::vFloat(89);
-    sfpi::vFloat thresold_low = sfpi::vFloat(-88.5);
+    sfpi::vFloat threshold_low = sfpi::vFloat(-88.5);
     vec_min_max(threshold_low, val);
     vec_min_max(val, threshold_high);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -21,7 +21,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  */
 sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
-    sfpi::vInt man = exman8(val);
+    sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     sfpi::vInt shift = exp - 23;
     man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
     return man;
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
-        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part that )
+        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
 
     // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
     // This uses a 2nd degree polynomial adjustment of the fractional part

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -49,10 +49,10 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // Intermediary values can overflow if values exceeds 88.72283935546875 or -88.72283172607421875
     // To prevent this, we clamp -88.5 < x < 89
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
-    sfpi::vFloat thresh_high = sfpi::vFloat(89);
-    sfpi::vFloat thresh_low = sfpi::vFloat(-88.5);
-    vec_min_max(thresh_low, val);
-    vec_min_max(val, thresh_high);
+    sfpi::vFloat threshold_high = sfpi::vFloat(89);
+    sfpi::vFloat thresold_low = sfpi::vFloat(-88.5);
+    vec_min_max(threshold_low, val);
+    vec_min_max(val, threshold_high);
 
     // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
     // z = (bias + x * factor * N_m; where:

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "sfpu/ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_conversions.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -31,41 +32,43 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     // Intermediary values can overflow if input value is below -88.0f, which leads to output increasing again instead
     // of staying at 0. This overflow happens when `log2(e) * val < 127.0f`, which correspond to `val < 88.0f`
-    v_if(val > -88.0f) {
-        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-        // z = (bias + x * factor * N_m; where:
-        // factor = 0x00b8aa3b (computed through log(e))
-        // bias = 0x3f800000
-        sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
-        // Polynomial coefficients for approximation of exp on [1; 2]
-        constexpr float POLY_D1 = 0.40196114e-7f;
-        constexpr int POLY_D2 = 0xf94ee7;
-        constexpr int POLY_D3 = 0x560e;
-
-        sfpi::vFloat d1 = sfpi::vFloat(POLY_D1);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + zif, 0);
-        d2 = d1 * d2;
-        zif = sfpu::_float_to_int32_(d2 * d3);
-
-        // Restore exponent
-        zii = sfpi::reinterpret<sfpi::vInt>(
-            sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
-
-        y = sfpi::reinterpret<sfpi::vFloat>(zii);
-
-        if constexpr (!is_fp32_dest_acc_en) {
-            // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
-            // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
-            // rather than 81 (which would have been correct).
-            // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
-        }
-    }
+    v_if(val > -88.0f) { val = -88.0f; }
     v_endif;
+
+    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+    // z = (bias + x * factor * N_m; where:
+    // factor = 0x00b8aa3b (computed through log(e))
+    // bias = 0x3f800000
+    sfpi::vInt z = sfpu::_float_to_int32_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
+    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+
+    // Polynomial coefficients for approximation of exp on [1; 2]
+    constexpr float POLY_D1 = 0.40196114e-7f;
+    constexpr int POLY_D2 = 0xf94ee7;
+    constexpr int POLY_D3 = 0x560e;
+
+    sfpi::vFloat d1 = sfpi::vFloat(POLY_D1);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + zif, 0);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + zif, 0);
+    d2 = d1 * d2;
+    zif = sfpu::_float_to_int32_positive_(d2 * d3);
+
+    // Restore exponent
+    zii = sfpi::reinterpret<sfpi::vInt>(
+        sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
+
+    y = sfpi::reinterpret<sfpi::vFloat>(zii);
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+        // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+        // rather than 81 (which would have been correct).
+        // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
+        y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
+    }
+
     return y;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -49,10 +49,10 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // Intermediary values can overflow if values exceeds 88.72283935546875 or -88.72283172607421875
     // To prevent this, we clamp -88.5 < x < 89
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
-    sfpi::vFloat thresh_high = sfpi::vFloat(89);
-    sfpi::vFloat thresh_low = sfpi::vFloat(-88.5);
-    vec_min_max(thresh_low, val);
-    vec_min_max(val, thresh_high);
+    sfpi::vFloat threshold_high = sfpi::vFloat(89);
+    sfpi::vFloat threshold_low = sfpi::vFloat(-88.5);
+    vec_min_max(threshold_low, val);
+    vec_min_max(val, threshold_high);
 
     // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
     // z = (bias + x * factor * N_m; where:

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -58,26 +58,36 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // z = (bias + x * factor * N_m; where:
     // factor = 0x00b8aa3b (computed through log(e))
     // bias = 0x3f800000
+    //
+    // Fundamentally, this computes exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
+    // - z_i = trunc(x / ln2) (integer part)
+    // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
     sfpi::vInt z = _float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
-    sfpi::vInt zii = exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent
-    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+    sfpi::vInt exponential_part =
+        exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vInt fractional_part =
+        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part that )
 
-    // Polynomial coefficients for approximation of exp on [1; 2]
+    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
+    // This uses a 2nd degree polynomial adjustment of the fractional part
     constexpr float POLY_D1 = 0.40196114e-7f;
     constexpr int POLY_D2 = 0xf94ee7;
     constexpr int POLY_D3 = 0x560e;
 
+    // Compute polynomial through Horner's method
     sfpi::vFloat d1 = sfpi::vFloat(POLY_D1);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + zif, 0);
+    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(POLY_D2) + fractional_part, 0);
+    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + fractional_part, 0);
     d2 = d1 * d2;
 
-    zif = _float_to_int32_exp21f_(d2 * d3);
+    // Compute 2**(adjusted fractional part) through float -> int conversion
+    fractional_part = _float_to_int32_exp21f_(d2 * d3);
 
-    // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), zii));  // restore exponent
+    // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
+    exponential_part = sfpi::reinterpret<sfpi::vInt>(
+        sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(fractional_part), exponential_part));  // restore exponent
 
-    y = sfpi::reinterpret<sfpi::vFloat>(zii);
+    y = sfpi::reinterpret<sfpi::vFloat>(exponential_part);
 
     if constexpr (!is_fp32_dest_acc_en) {
         // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -43,8 +43,10 @@ sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConst0;
-    // Intermediary values can overflow if input value is below -88.0f, which leads to output increasing again instead
-    // of staying at 0. This overflow happens when `log2(e) * val < 127.0f`, which correspond to `val < 88.0f`
+    // Intermediary values can overflow if abs(val) is above 88.5f, which leads to output increasing again instead
+    // of staying at 0 (or becoming finite on large inputs). This overflow happens when `| log2(e) * val | > 127.0f`,
+    // which correspond to `|val| > 88.5f` To avoid this, we clamp absolute value to 88.5f (and restore sign if negative
+    // input)
     sfpi::vFloat val_positive = setsgn(val, 0);
     sfpi::vFloat clamp_threshold = sfpi::vFloat(88.5f);
     vec_min_max(val_positive, clamp_threshold);
@@ -54,7 +56,6 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // z = (bias + x * factor * N_m; where:
     // factor = 0x00b8aa3b (computed through log(e))
     // bias = 0x3f800000
-    // Is sfpi::vFloat(0x3f800000) getting optimized ?
     sfpi::vInt z = _float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
     sfpi::vInt zii = exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent
     sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -75,7 +75,6 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     zif = _float_to_int32_exp21f_(d2 * d3);
 
     // Restore exponent
-    // Is this compiling properly to 1 instruction (vs. add + setexp)
     zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), zii));  // restore exponent
 
     y = sfpi::reinterpret<sfpi::vFloat>(zii);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -21,7 +21,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  */
 sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
-    sfpi::vInt man = exman8(val);
+    sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     sfpi::vInt shift = exp - 23;
     man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
     return man;
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
-        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part that )
+        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
 
     // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
     // This uses a 2nd degree polynomial adjustment of the fractional part

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -47,12 +47,11 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // of staying at 0. This overflow happens when `log2(e) * val < 127.0f`, which correspond to `val < 88.0f`
     // Would it be possible to call minmax ?
     // could also add SKIP_POSITIVE_CHECK here.
-    // TODO: Could compute abs (setsgn) and clamp to 88.8f in a single branch / SFPSWAP
-    v_if(val < -88.0f) { val = -88.f; }
-    v_endif;
 
-    v_if(val > 88.8f) { val = 88.8f; }
-    v_endif;
+    sfpi::vFloat val_positive = setsgn(val, 0);
+    sfpi::vFloat clamp_threshold = sfpi::vFloat(88.8f);
+    vec_min_max(val_positive, clamp_threshold);
+    val = setsgn(val_positive, val);
 
     // Idea: Loop unrolling + Loop splitting to reduce overhead of loading constants
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -19,7 +19,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  * With exp21f function, some of these cases never happen (e.g. negative exponent, overflow)
  * This allow for a branch free (and much smaller algorithm) to compute integer value
  */
-sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
+sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
     sfpi::vInt man = exman8(val);
     sfpi::vInt shift = exp - 23;


### PR DESCRIPTION
### Ticket
#26988

### Problem description
The accurate version of `ttnn.exp` had room for improvement with regards to its execution speed. 

### What's changed

This PR optimizes ttnn.exp for execution speed. Output values are the same as before (< 1 ULP error on bfloat16). 
The improvement version is ~2 times faster than on main.

Also bumped tt-sim version to support SFPSWAP and fix failing PR gate

#### Execution time improvement 

The following results have been obtained by looping 1 million time on SPFU Kernel (i.e. overhead ~ negligible)

Note: fast+approx exp approximation has been added as reference point.

On wormhole

dtype | Name | Cycles/Point | Cycles/Tile | Speed-up
-- | -- | -- | -- | --
bfloat16 | `main`, accurate  | 2.56 | 2624.000332 |  
bfloat16 | **This PR**, accurate | 1.31 | 1344.000567 | 1.95
bfloat16 | fast+approx | 0.13 | 128 | 20.5

On Blackhole

dtype | Name | Cycles/Point | Cycles/Tile | Speed-up
-- | -- | -- | -- | --
bfloat16 | `main`, accurate  | 1.3 | 1328.00 |  
bfloat16 | **This PR**, accurate | 1.31 | 672.00 | 1.98
bfloat16 | fast+approx | 0.05 | 52.00 | 25.5

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) : https://github.com/tenstorrent/tt-metal/actions/runs/18059745096
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) : https://github.com/tenstorrent/tt-metal/actions/runs/18060758279 [(failed tests also on main)](https://github.com/tenstorrent/tt-metal/actions/runs/18090130259)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18060770602
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml)  https://github.com/tenstorrent/tt-metal/actions/runs/18060781318 ( [failed tests also on main](https://github.com/tenstorrent/tt-metal/actions/runs/18060793931/job/51397000523) )
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18060791842 CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). 
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18060800234
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18093177666 CI passes, if applicable, because of current Llama work [(failed tests also on main)](https://github.com/tenstorrent/tt-metal/actions/runs/18066861460)
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18060809647  CI passes (if applicable, since this is run on push to main) [(failed tests also on main)](https://github.com/tenstorrent/tt-metal/actions/runs/18091272505)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18060819873 CI passes (if applicable, since this is required for release) [(failed tests also on main)](https://github.com/tenstorrent/tt-metal/actions/runs/18081979216)
- [ ] New/Existing tests provide coverage for changes