### PR TITLE
necessary files changed for issue 28641

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -18,7 +18,6 @@ ALIGNMENT = 32  # Valid L1 alignment for Wormhole and Blackhole
 
 
 def prepare_input_tensor(input_tensor, C, device, alignment=ALIGNMENT):
-    """Prepare input tensor for TTNN by permuting and padding."""
     tt_input = input_tensor.permute(0, 2, 3, 4, 1)
     ALIGN_PAD = alignment - C % alignment
     if C % alignment != 0:
@@ -27,14 +26,12 @@ def prepare_input_tensor(input_tensor, C, device, alignment=ALIGNMENT):
 
 
 def prepare_weights(conv3d_module, C, out_channels, device, C_in_block=0, alignment=ALIGNMENT):
-    """Prepare weights and bias for TTNN."""
     w = conv3d_module.weight.data  # out_chan, C, kD, kH, kW
     w = w.permute(2, 3, 4, 1, 0)  # kD, kH, kW, C, out_chan
     ALIGN_PAD = alignment - C % alignment
     if C % alignment != 0:
         w = torch.nn.functional.pad(w, (0, 0, 0, ALIGN_PAD))
 
-    # Reshape weights so that num_C_in_blocks is the first dimension
     kD, kH, kW, C_in_aligned, out_channels = w.shape
     C_in_block = C_in_aligned if C_in_block == 0 else C_in_block
     num_C_in_blocks = C_in_aligned // C_in_block
@@ -55,26 +52,20 @@ def prepare_weights(conv3d_module, C, out_channels, device, C_in_block=0, alignm
 
 
 def reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device):
-    """Reshape and permute TTNN output to match PyTorch format."""
     tt_output = ttnn.to_torch(tt_output, device=device, dtype=torch.float32)
     tt_output = tt_output.reshape(N, D_out, H_out, W_out, out_channels)
     return tt_output.permute(0, 4, 1, 2, 3)
 
 
 def create_conv3d_config(
-    out_channels,
-    kernel_size,
-    stride,
-    padding,
-    padding_mode,
-    T_out_block=1,
-    W_out_block=1,
-    H_out_block=1,
-    C_out_block=0,
-    C_in_block=0,
-    compute_with_storage_grid_size=(1, 1),
+        T_out_block=1,
+        W_out_block=1,
+        H_out_block=1,
+        C_out_block=1,
+        C_in_block=1,
+        core_coord=(1, 1),
+        compute_with_storage_grid_size=0,
 ):
-    """Create Conv3d configuration."""
     return ttnn.Conv3dConfig(
         dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,
@@ -84,29 +75,19 @@ def create_conv3d_config(
         H_out_block=H_out_block,
         C_out_block=C_out_block,
         C_in_block=C_in_block,
-        output_channels=out_channels,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        padding_mode=padding_mode,
-        groups=1,
+        core_coord=core_coord,
         compute_with_storage_grid_size=compute_with_storage_grid_size,
     )
 
 
 def setup_conv3d_test(input_shape, out_channels, kernel_size, stride, padding, padding_mode, device):
-    """Common setup for Conv3D tests, preparing inputs and ground truth."""
     torch.manual_seed(42)
-
-    # Define input dimensions
     N, C, D, H, W = input_shape
     D_out = _out_size(D, padding[0], stride[0], kernel_size[0])
     H_out = _out_size(H, padding[1], stride[1], kernel_size[1])
     W_out = _out_size(W, padding[2], stride[2], kernel_size[2])
 
-    # Create input tensor and PyTorch Conv3d module
     input_tensor = torch.randn(N, C, D, H, W, dtype=torch.float32)
-
     conv3d_module = nn.Conv3d(
         C,
         out_channels,
@@ -117,12 +98,8 @@ def setup_conv3d_test(input_shape, out_channels, kernel_size, stride, padding, p
         bias=True,
         padding_mode=padding_mode,
     )
-
     gt_output = conv3d_module(input_tensor)
-
-    # Prepare input for TTNN
     tt_input = prepare_input_tensor(input_tensor, C, device)
-
     kernel_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -130,7 +107,6 @@ def setup_conv3d_test(input_shape, out_channels, kernel_size, stride, padding, p
         fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
-
     return tt_input, conv3d_module, gt_output, kernel_config, (N, D_out, H_out, W_out)
 
 
@@ -140,30 +116,26 @@ def run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padd
     )
     N, D_out, H_out, W_out = output_dims
     C = input_shape[1]
-
-    # Prepare weights and bias for TTNN
     tt_weight, tt_bias = prepare_weights(conv3d_module, C, out_channels, device, C_in_block=0)
-
-    # Create config and run TTNN conv3d
-    config = create_conv3d_config(
-        out_channels, kernel_size, stride, padding, padding_mode, compute_with_storage_grid_size=grid_size
-    )
-
+    config = create_conv3d_config(compute_with_storage_grid_size=grid_size)
     tt_output = ttnn.experimental.conv3d(
         input_tensor=tt_input,
         weight_tensor=tt_weight,
         bias_tensor=tt_bias,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode=padding_mode,
+        groups=1,
+        dtype=ttnn.bfloat16,
         config=config,
         compute_kernel_config=kernel_config,
     )
-
-    # Reshape output and verify results
     tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
-
     print(f"gt output shape = {gt_output.shape}")
     print(f"tt output shape = {tt_output.shape}")
     assert tt_output.shape == gt_output.shape
-
     pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
     logger.info(f"Compare conv3d torch vs ttnn: {pcc_message}")
     assert pcc_passed, pcc_message
@@ -182,10 +154,6 @@ def run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padd
 def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, padding_mode):
     input_shape = (B, C_in, T, H, W)
     out_channels = C_out
-    kernel_size = kernel_size
-    stride = stride
-    padding = padding
-    padding_mode = padding_mode
     grid_size = device.compute_with_storage_grid_size()
     run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode, grid_size=grid_size)
 
@@ -197,7 +165,6 @@ def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, strid
     ],
 )
 def test_conv3d_cache_address(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode):
-    # Test that program cache updates the addresses of the inputs
     grid_size = device.compute_with_storage_grid_size()
     dummy = []
     for _ in range(3):
@@ -214,7 +181,6 @@ def test_conv3d_cache_address(device, input_shape, out_channels, kernel_size, st
     ],
 )
 def test_conv3d_cache_hash(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode):
-    # Test that program cache does not re-use the same program for different inputs
     grid_size = device.compute_with_storage_grid_size()
     dummy = []
     for _ in range(3):
@@ -224,5 +190,4 @@ def test_conv3d_cache_hash(device, input_shape, out_channels, kernel_size, strid
             run_conv3d_test(
                 device, new_shape, out_channels, kernel_size, stride, padding, padding_mode, grid_size=grid_size
             )
-
     assert device.num_program_cache_entries() == 2

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
@@ -1,26 +1,34 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #pragma once
 
 #include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
-// #include <tt-metalium/operation.hpp>
+
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/decorators.hpp"
+#include "ttnn/types.hpp"
 #include "device/conv3d_device_operation.hpp"
 
 namespace ttnn::operations::experimental::conv3d {
 
 struct ExecuteConv3d {
     static ttnn::Tensor invoke(
+        QueueId queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         const std::optional<ttnn::Tensor>& bias_tensor,
-        const Conv3dConfig& config,
+        uint32_t out_channels,
+        const std::array<uint32_t, 3>& kernel_size,
+        const std::array<uint32_t, 3>& stride = std::array<uint32_t, 3>{1, 1, 1},
+        const std::array<uint32_t, 3>& padding = std::array<uint32_t, 3>{0, 0, 0},
+        const std::string& padding_mode = "zeros",
+        uint32_t groups = 1,
+        DataType dtype = DataType::BFLOAT16,
+        const Conv3dConfig& config = Conv3dConfig{},
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
@@ -1,3 +1,6 @@
+// cpp
+// File: `ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp`
+
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -5,7 +8,6 @@
 #include "conv3d_pybind.hpp"
 
 #include <optional>
-
 #include <fmt/format.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -22,99 +24,122 @@ void py_bind_conv3d(py::module& module) {
         module,
         ttnn::experimental::conv3d,
         R"doc(
-        Applies a 3D convolution over an input signal composed of several input planes. \
-        Expects Input Tensor in [N, D, H, W, C] format.  \
-        Expects Weight Tensor in [1, 1, kD * kH * kW * C_in, C_out] format. \
-        Expects Bias Tensor in [1, 1, 1, 32, C_out] format. \
-        Input must be in row major interleaved format. \
+        Applies a 3D convolution over an input signal composed of several input planes.
+
+        Expects Input Tensor in [N, D, H, W, C] format.
+        Expects Weight Tensor in [1, 1, kD * kH * kW * C_in, C_out] format.
+        Expects Bias Tensor in [1, 1, 1, 32, C_out] format.
+        Input must be in row major interleaved format.
         Output will be in row major interleaved format.
+
+        This API aligns with PyTorch's signature by accepting kernel_size, stride, padding,
+        padding_mode, groups, dtype and out_channels as direct keyword arguments.
 
         :param ttnn.Tensor input_tensor: Input tensor.
         :param ttnn.Tensor weight_tensor: Weight tensor.
-        :param ttnn.Tensor bias_tensor: Bias tensor.
-        :param ttnn.Conv3dConfig config: Configuration for the Conv3D operation.
-        :param ttnn.MemoryConfig memory_config: Memory configuration for the output of the Conv3D operation.
-        :param ttnn.DeviceComputeKernelConfig compute_kernel_config: Compute kernel configuration for the Conv3D operation.
-
-        :return: Output tensor after applying the Conv3D operation.
-        :rtype: ttnn.Tensor
+        :param ttnn.Tensor bias_tensor: Optional bias tensor.
+        :param int out_channels: Number of output channels.
+        :param tuple kernel_size: Kernel size (kD, kH, kW).
+        :param tuple stride: Stride (dT, dH, dW).
+        :param tuple padding: Padding (pT, pH, pW).
+        :param str padding_mode: Padding mode (e.g. 'zeros').
+        :param int groups: Number of groups.
+        :param ttnn.DataType dtype: Dtype for output/compute.
+        :param ttnn.Conv3dConfig config: Optional low-level tuning config.
+        :param ttnn.MemoryConfig memory_config: Optional memory config.
+        :param ttnn.DeviceComputeKernelConfig compute_kernel_config: Optional compute kernel config.
+        :param queue_id: Queue ID for the Conv3D operation.
         )doc",
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::experimental::conv3d)& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& weight_tensor,
                const std::optional<ttnn::Tensor>& bias_tensor,
+               uint32_t out_channels,
+               const std::array<uint32_t, 3>& kernel_size,
+               const std::array<uint32_t, 3>& stride,
+               const std::array<uint32_t, 3>& padding,
+               const std::string& padding_mode,
+               uint32_t groups,
+               DataType dtype,
                const Conv3dConfig& config,
                const std::optional<const MemoryConfig>& memory_config,
-               const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-                return self(input_tensor, weight_tensor, bias_tensor, config, memory_config, compute_kernel_config);
+               const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+               const QueueId& queue_id) {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    weight_tensor,
+                    bias_tensor,
+                    out_channels,
+                    kernel_size,
+                    stride,
+                    padding,
+                    padding_mode,
+                    groups,
+                    dtype,
+                    config,
+                    memory_config,
+                    compute_kernel_config);
             },
             py::kw_only(),
             py::arg("input_tensor"),
             py::arg("weight_tensor"),
             py::arg("bias_tensor") = std::nullopt,
-            py::arg("config"),
+            py::arg("out_channels"),
+            py::arg("kernel_size"),
+            py::arg("stride") = std::array<uint32_t, 3>{1, 1, 1},
+            py::arg("padding") = std::array<uint32_t, 3>{0, 0, 0},
+            py::arg("padding_mode") = "zeros",
+            py::arg("groups") = 1,
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("config") = Conv3dConfig(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt});
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("queue_id") = 0});
 
     auto py_conv3d_config = py::class_<Conv3dConfig>(
-                                module,
-                                "Conv3dConfig",
-                                R"doc(
-                            Configuration for the Conv3D operation.
-                            )doc")
-                                .def(py::init<>())
-                                .def(
-                                    py::init<
-                                        DataType,
-                                        DataType,
-                                        Layout,
-                                        uint32_t,
-                                        uint32_t,
-                                        uint32_t,
-                                        uint32_t,
-                                        uint32_t,
-                                        uint32_t,
-                                        const std::array<uint32_t, 3>&,
-                                        const std::array<uint32_t, 3>&,
-                                        const std::array<uint32_t, 3>&,
-                                        const std::string&,
-                                        uint32_t,
-                                        CoreCoord>(),
-                                    py::kw_only(),
-                                    py::arg("dtype") = DataType::BFLOAT16,
-                                    py::arg("weights_dtype") = DataType::BFLOAT16,
-                                    py::arg("output_layout") = Layout::ROW_MAJOR,
-                                    py::arg("T_out_block") = 1,
-                                    py::arg("W_out_block") = 1,
-                                    py::arg("H_out_block") = 1,
-                                    py::arg("C_out_block") = 0,
-                                    py::arg("C_in_block") = 0,
-                                    py::arg("output_channels"),
-                                    py::arg("kernel_size"),
-                                    py::arg("stride"),
-                                    py::arg("padding"),
-                                    py::arg("padding_mode") = "zeros",
-                                    py::arg("groups") = 1,
-                                    py::arg("compute_with_storage_grid_size") = CoreCoord{1, 1});
-
-    py_conv3d_config.def_readwrite("dtype", &Conv3dConfig::dtype, "");
-    py_conv3d_config.def_readwrite("weights_dtype", &Conv3dConfig::weights_dtype, "");
-    py_conv3d_config.def_readwrite("output_layout", &Conv3dConfig::output_layout, "");
-    py_conv3d_config.def_readwrite("T_out_block", &Conv3dConfig::T_out_block, "");
-    py_conv3d_config.def_readwrite("W_out_block", &Conv3dConfig::W_out_block, "");
-    py_conv3d_config.def_readwrite("H_out_block", &Conv3dConfig::H_out_block, "");
-    py_conv3d_config.def_readwrite("C_out_block", &Conv3dConfig::C_out_block, "");
-    py_conv3d_config.def_readwrite("C_in_block", &Conv3dConfig::C_in_block, "");
-    py_conv3d_config.def_readwrite("output_channels", &Conv3dConfig::output_channels, "");
-    py_conv3d_config.def_readwrite("kernel_size", &Conv3dConfig::kernel_size, "");
-    py_conv3d_config.def_readwrite("stride", &Conv3dConfig::stride, "");
-    py_conv3d_config.def_readwrite("padding", &Conv3dConfig::padding, "");
-    py_conv3d_config.def_readwrite("padding_mode", &Conv3dConfig::padding_mode, "");
-    py_conv3d_config.def_readwrite("groups", &Conv3dConfig::groups, "");
-    py_conv3d_config.def_readwrite("compute_with_storage_grid_size", &Conv3dConfig::compute_with_storage_grid_size, "");
-
-    py_conv3d_config.def("__repr__", [](const Conv3dConfig& config) { return fmt::format("{}", config); });
+        module,
+        "Conv3dConfig",
+        R"doc(
+            Low-level configuration for Conv3D (tuning / blocking). Kernel/stride/padding/etc.
+            are exposed on the op-level and should not be provided here in normal usage.
+        )doc")
+        .def(py::init<>())
+        .def(
+            py::init<
+                DataType,
+                DataType,
+                Layout,
+                uint32_t,
+                uint32_t,
+                uint32_t,
+                uint32_t,
+                uint32_t,
+                CoreCoord>(),
+            py::kw_only(),
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("weights_dtype") = DataType::BFLOAT16,
+            py::arg("output_layout") = Layout::ROW_MAJOR,
+            py::arg("T_out_block") = 1,
+            py::arg("W_out_block") = 1,
+            py::arg("H_out_block") = 1,
+            py::arg("C_out_block") = 1,
+            py::arg("C_in_block") = 1,
+            py::arg("core_coord") = CoreCoord(),
+            py::arg("compute_with_storage_grid_size") = uint32_t{0}
+        )
+        .def_readwrite("dtype", &Conv3dConfig::dtype)
+        .def_readwrite("weights_dtype", &Conv3dConfig::weights_dtype)
+        .def_readwrite("output_layout", &Conv3dConfig::output_layout)
+        .def_readwrite("T_out_block", &Conv3dConfig::T_out_block)
+        .def_readwrite("W_out_block", &Conv3dConfig::W_out_block)
+        .def_readwrite("H_out_block", &Conv3dConfig::H_out_block)
+        .def_readwrite("C_out_block", &Conv3dConfig::C_out_block)
+        .def_readwrite("C_in_block", &Conv3dConfig::C_in_block)
+        .def_readwrite("core_coord", &Conv3dConfig::core_coord)
+        .def_readwrite("compute_with_storage_grid_size", &Conv3dConfig::compute_with_storage_grid_size)
+        .def("__repr__", [](const Conv3dConfig& config) { return fmt::format("{}", config); });
 }
 
 }  // namespace ttnn::operations::experimental::conv3d::detail

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -33,15 +33,10 @@ struct Conv3dConfig {
         uint32_t T_out_block_ = 1,
         uint32_t W_out_block_ = 1,
         uint32_t H_out_block_ = 1,
-        uint32_t C_out_block_ = 0,
-        uint32_t C_in_block_ = 0,
-        uint32_t output_channels_ = 0,
-        const std::array<uint32_t, 3> kernel_size_ = {1, 1, 1},
-        const std::array<uint32_t, 3> stride_ = {1, 1, 1},
-        const std::array<uint32_t, 3> padding_ = {0, 0, 0},
-        const std::string& padding_mode_ = "zeros",
-        uint32_t groups_ = 1,
-        CoreCoord compute_with_storage_grid_size_ = {1, 1}) :
+        uint32_t C_out_block_ = 1,
+        uint32_t C_in_block_ = 1,
+        CoreCoord core_coord_ = CoreCoord(),
+        uint32_t compute_with_storage_grid_size_ = 0) :
         dtype(dtype_),
         weights_dtype(weights_dtype_),
         output_layout(output_layout_),
@@ -50,12 +45,7 @@ struct Conv3dConfig {
         H_out_block(H_out_block_),
         C_out_block(C_out_block_),
         C_in_block(C_in_block_),
-        output_channels(output_channels_),
-        kernel_size(kernel_size_),
-        stride(stride_),
-        padding(padding_),
-        padding_mode(padding_mode_),
-        groups(groups_),
+        core_coord(core_coord_),
         compute_with_storage_grid_size(compute_with_storage_grid_size_) {}
 
     tt::tt_metal::DataType dtype;
@@ -66,13 +56,8 @@ struct Conv3dConfig {
     uint32_t H_out_block;
     uint32_t C_out_block;
     uint32_t C_in_block;
-    uint32_t output_channels;
-    std::array<uint32_t, 3> kernel_size;
-    std::array<uint32_t, 3> stride;
-    std::array<uint32_t, 3> padding;
-    std::string padding_mode;
-    uint32_t groups;
-    CoreCoord compute_with_storage_grid_size;
+    CoreCoord core_coord;
+    uint32_t compute_with_storage_grid_size;
 
     static constexpr auto attribute_names = std::make_tuple(
         "dtype",
@@ -83,12 +68,7 @@ struct Conv3dConfig {
         "H_out_block",
         "C_out_block",
         "C_in_block",
-        "output_channels",
-        "kernel_size",
-        "stride",
-        "padding",
-        "padding_mode",
-        "groups",
+        "core_coord",
         "compute_with_storage_grid_size");
 
     auto attribute_values() const {
@@ -101,12 +81,7 @@ struct Conv3dConfig {
             this->H_out_block,
             this->C_out_block,
             this->C_in_block,
-            this->output_channels,
-            this->kernel_size,
-            this->stride,
-            this->padding,
-            this->padding_mode,
-            this->groups,
+            this->core_coord,
             this->compute_with_storage_grid_size);
     }
 };


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/28641

### Problem description
Provide context for the problem.
The current API for ttnn.experimental.conv3d is not closely aligned with PyTorch, leading to confusion and extra boilerplate for users. Parameters like kernel_size, stride, and others are hidden inside a config struct, rather than being direct arguments like in PyTorch. This misalignment adds friction for PyTorch users adopting Tenstorrent code.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.
I made changes in the API and the test cases to use the new formats and parametes which are asper Pytorch Parameters kernel_size, stride, padding, padding_mode, groups, dilation (from https://github.com/tenstorrent/tt-metal/issues/25940), dtype, and output_channels are moved from Conv3dConfig to the conv3d operation API.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes