### PR TITLE
cppcoreguidelines-virtual-class-destructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,7 +68,6 @@ Checks: >
   -cppcoreguidelines-rvalue-reference-param-not-moved,
   -cppcoreguidelines-special-member-functions,
   -cppcoreguidelines-use-default-member-init,
-  -cppcoreguidelines-virtual-class-destructor,
   -fuchsia-default-arguments-calls,
   -fuchsia-default-arguments-declarations,
   -fuchsia-multiple-inheritance,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -23,13 +23,15 @@ struct CacheTestParams {
 };
 // NOLINTBEGIN(cppcoreguidelines-virtual-class-destructor)
 class RingbufferCacheRandomizedTestsFixture : public ::testing::TestWithParam<CacheTestParams> {
-protected:
-    RingbufferCacheRandomizedTestsFixture() = default;
-    ~RingbufferCacheRandomizedTestsFixture() override = default;
+public:
     RingbufferCacheRandomizedTestsFixture(const RingbufferCacheRandomizedTestsFixture&) = delete;
     RingbufferCacheRandomizedTestsFixture& operator=(const RingbufferCacheRandomizedTestsFixture&) = delete;
     RingbufferCacheRandomizedTestsFixture(RingbufferCacheRandomizedTestsFixture&&) = delete;
     RingbufferCacheRandomizedTestsFixture& operator=(RingbufferCacheRandomizedTestsFixture&&) = delete;
+
+protected:
+    RingbufferCacheRandomizedTestsFixture() = default;
+    ~RingbufferCacheRandomizedTestsFixture() override = default;
 
     std::unique_ptr<RingbufferCacheManager> rb_cache_;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -26,8 +26,8 @@ public:
 
 
 protected:
-    ~RingbufferCacheRandomizedTestsFixture() override = default;
     RingbufferCacheRandomizedTestsFixture() = default;
+    ~RingbufferCacheRandomizedTestsFixture() override = default; // NOLINT(cppcoreguidelines-virtual-class-destructor)
 
     std::unique_ptr<RingbufferCacheManager> rb_cache_;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -23,9 +23,10 @@ struct CacheTestParams {
 };
 class RingbufferCacheRandomizedTestsFixture : public ::testing::TestWithParam<CacheTestParams> {
 public:
-    ~RingbufferCacheRandomizedTestsFixture() override = default;
+
 
 protected:
+    ~RingbufferCacheRandomizedTestsFixture() override = default;
     RingbufferCacheRandomizedTestsFixture() = default;
 
     std::unique_ptr<RingbufferCacheManager> rb_cache_;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -22,9 +22,11 @@ struct CacheTestParams {
     std::pair<int, int> pgm_sizes;
 };
 class RingbufferCacheRandomizedTestsFixture : public ::testing::TestWithParam<CacheTestParams> {
+public:
+    ~RingbufferCacheRandomizedTestsFixture() override = default;
+
 protected:
     RingbufferCacheRandomizedTestsFixture() = default;
-    ~RingbufferCacheRandomizedTestsFixture() override = default;
 
     std::unique_ptr<RingbufferCacheManager> rb_cache_;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -21,13 +21,15 @@ struct CacheTestParams {
     std::pair<int, int> pgm_ids;
     std::pair<int, int> pgm_sizes;
 };
+// NOLINTBEGIN(cppcoreguidelines-virtual-class-destructor)
 class RingbufferCacheRandomizedTestsFixture : public ::testing::TestWithParam<CacheTestParams> {
-public:
-
-
 protected:
     RingbufferCacheRandomizedTestsFixture() = default;
-    ~RingbufferCacheRandomizedTestsFixture() override = default; // NOLINT(cppcoreguidelines-virtual-class-destructor)
+    ~RingbufferCacheRandomizedTestsFixture() override = default;
+    RingbufferCacheRandomizedTestsFixture(const RingbufferCacheRandomizedTestsFixture&) = delete;
+    RingbufferCacheRandomizedTestsFixture& operator=(const RingbufferCacheRandomizedTestsFixture&) = delete;
+    RingbufferCacheRandomizedTestsFixture(RingbufferCacheRandomizedTestsFixture&&) = delete;
+    RingbufferCacheRandomizedTestsFixture& operator=(RingbufferCacheRandomizedTestsFixture&&) = delete;
 
     std::unique_ptr<RingbufferCacheManager> rb_cache_;
 
@@ -47,6 +49,7 @@ protected:
     auto get_valid_entry(size_t idx) const { return rb_cache_->valid_[idx]; }
     constexpr static auto invalid_entry_ = RingbufferCacheManager::invalid_cache_entry_;
 };
+// NOLINTEND(cppcoreguidelines-virtual-class-destructor)
 
 INSTANTIATE_TEST_SUITE_P(
     RingbufferCacheRandomSuite,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -43,6 +43,7 @@ enum class TestWorkerType : uint8_t { SENDER, RECEIVER };
 
 struct TestWorker {
 public:
+    virtual ~TestWorker() = default;
     TestWorker(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void set_kernel_src(const std::string_view& kernel_src);
     void create_kernel(
@@ -65,6 +66,7 @@ protected:
 
 struct TestSender : TestWorker {
 public:
+    ~TestSender() override = default;
     TestSender(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void add_config(TestTrafficSenderConfig config);
     void add_sync_config(TestTrafficSenderConfig sync_config);
@@ -91,6 +93,7 @@ public:
 
 struct TestReceiver : TestWorker {
 public:
+    ~TestReceiver() override = default;
     TestReceiver(
         CoreCoord logical_core,
         TestDevice* test_device_ptr,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -117,6 +117,9 @@ public:
 class IDistributedContextManager {
     virtual uint32_t get_randomized_master_seed() const = 0;
     virtual void barrier() const = 0;
+
+public:
+    virtual ~IDistributedContextManager() = default;
 };
 
 }  // namespace fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -115,11 +115,12 @@ public:
 };
 
 class IDistributedContextManager {
-    virtual uint32_t get_randomized_master_seed() const = 0;
-    virtual void barrier() const = 0;
-
 public:
     virtual ~IDistributedContextManager() = default;
+
+private:
+    virtual uint32_t get_randomized_master_seed() const = 0;
+    virtual void barrier() const = 0;
 };
 
 }  // namespace fabric_tests

--- a/tt_metal/impl/debug/inspector.hpp
+++ b/tt_metal/impl/debug/inspector.hpp
@@ -17,7 +17,7 @@ class MeshWorkloadImpl;
 
 namespace inspector {
 class Data;
-class RpcServer;
+class RpcServer;  // NOLINT(cppcoreguidelines-virtual-class-destructor)
 }
 
 class Inspector {

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -65,6 +65,7 @@ enum class EnqueueCommandType {
 class Command {
 public:
     Command() = default;
+    virtual ~Command() = default;
     virtual void process() {};
     virtual EnqueueCommandType type() = 0;
 };

--- a/tt_metal/impl/dispatch/ringbuffer_cache.hpp
+++ b/tt_metal/impl/dispatch/ringbuffer_cache.hpp
@@ -23,6 +23,7 @@ namespace tt::tt_metal {
  * all the data fits into the cache and gets reuse from locality.
  */
 class RingbufferCacheManager {
+    // NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
     friend class RingbufferCacheRandomizedTestsFixture;  // for unit testing purposes
 
 public:

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -277,6 +277,8 @@ struct LegacyCclTensorSlicer {
 
     virtual void increment(uint32_t num_pages) = 0;
 
+    virtual ~LegacyCclTensorSlicer() = default;
+
     uint32_t input_page_size;
     uint32_t num_rows;
     uint32_t num_cols;
@@ -378,6 +380,7 @@ struct InterleavedTensorWorkerSlice {
 template <class DERIVED_SLICER_T>
 class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
     public:
+    virtual ~RingReduceScatterBaseTensorSlicer() = default;
     RingReduceScatterBaseTensorSlicer(
         Tensor const& input_tensor,
         Tensor const& output_tensor,
@@ -442,6 +445,7 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
 
 class RingReduceScatterTensorSlicer : public RingReduceScatterBaseTensorSlicer<RingReduceScatterTensorSlicer> {
    public:
+    ~RingReduceScatterTensorSlicer() override = default;
     RingReduceScatterTensorSlicer(
         Tensor const& input_tensor,
         Tensor const& output_tensor,
@@ -470,6 +474,7 @@ class RingReduceScatterTensorSlicer : public RingReduceScatterBaseTensorSlicer<R
 // Define a class RingReduceScatterWrappedTensor slicer that inherits from RingReduceScatterBaseTensorSlicer and overwrites the compute_worker_slice_offsets and create_worker_slice_shapes_for_tile_layout functions
 class RingReduceScatterWrappedTensorSlicer : public RingReduceScatterBaseTensorSlicer<RingReduceScatterWrappedTensorSlicer> {
    public:
+    ~RingReduceScatterWrappedTensorSlicer() override = default;
     RingReduceScatterWrappedTensorSlicer(
         Tensor const& input_tensor,
         Tensor const& output_tensor,
@@ -497,6 +502,7 @@ class RingReduceScatterWrappedTensorSlicer : public RingReduceScatterBaseTensorS
 
 class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
    public:
+    ~InterleavedRingAllGatherTensorSlicer() override = default;
     InterleavedRingAllGatherTensorSlicer(
          const Tensor & input_tensor,  const Tensor & output_tensor, int slice_dim, uint32_t slice_idx) :
         LegacyCclTensorSlicer() {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -380,7 +380,7 @@ struct InterleavedTensorWorkerSlice {
 template <class DERIVED_SLICER_T>
 class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
     public:
-    virtual ~RingReduceScatterBaseTensorSlicer() = default;
+    ~RingReduceScatterBaseTensorSlicer() override = default;
     RingReduceScatterBaseTensorSlicer(
         Tensor const& input_tensor,
         Tensor const& output_tensor,


### PR DESCRIPTION
### Ticket
#22758 
Closes #29505 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.html

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual

### What's changed
- Enable check
- Manually address warnings (Please confirm good)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18087086221) CI passes
- [x] New/Existing tests provide coverage for changes
