### PR TITLE
Bumped expected mamba perf

### DIFF
--- a/models/demos/wormhole/mamba/tests/test_mamba_perf.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_perf.py
@@ -136,7 +136,7 @@ def test_mamba_perf_e2e(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, expected_layer_duration_ms",
-    ((32, 1.630),),
+    ((32, 1.596),),
 )
 def test_mamba_perf_device(batch, expected_layer_duration_ms):
     subdir = "ttnn_mamba"


### PR DESCRIPTION
### Problem description
Mamba is failing on [device perf CI](https://github.com/tenstorrent/tt-metal/actions/runs/18084001077/job/51452059026#step:19:127)
Expected perf needs to be bumped

### What's changed
- bumped perf by lowering `expected_layer_duration_ms`