### PR TITLE
Increased timeout for L2 nightly tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -21,7 +21,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 120
+        default: 150
       run_conv_tests:
         required: false
         type: boolean

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -83,7 +83,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      timeout: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
+      timeout: ${{ (github.event_name == 'schedule' && 150) || fromJSON(inputs.timeout) }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Problem description
Nightly failing due to convolutions tests taking longer than timeout.

### What's changed
Increased timeout for scheduled jobs as well. First attempt was not changing all thetimeouts needed.