### PR TITLE
#27841 #29427 Gemma3 repeat batch fix

### DIFF
--- a/models/demos/gemma3/demo/text_demo.py
+++ b/models/demos/gemma3/demo/text_demo.py
@@ -887,7 +887,7 @@ def test_demo_text(
                     k_cache, v_cache = layer.attention.layer_past
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
-
+            generator.prev_page_table = None
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
 
         logger.info("Starting prefill warmup...")


### PR DESCRIPTION
### Ticket
#27841 #29427 

### Problem description
- The cause of hang is caused by failing to reset the inputs in between repeat batches. This is due to the logic introduced in the generator around `prev_page_table` that controls when we copy the tensors from host memory to device memory. Namely, the page table, the tokens, the current position and the rope index.

### What's changed
- A straightforward fix is to explicitly reset the `prev_page_table` after each repeat batch in our `simple_text_demo.py`.
Summarize the changes made and its impact.

### Checklist