### PR TITLE
Allow OP with large number of tensor args under tracy build

### DIFF
--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -473,7 +473,7 @@ inline std::string op_meta_data_serialized_json(
         }
 
         auto msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(4));
-        if (msg.size() > std::numeric_limits<uint16_t>::max()) {
+        if (msg.size() >= std::numeric_limits<uint16_t>::max()) {
             msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
         }
         return msg;

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -472,8 +472,11 @@ inline std::string op_meta_data_serialized_json(
             cached_ops.at(device_id).emplace(program_hash, short_str);
         }
 
-        std::string ser = j.dump(4);
-        return fmt::format("{}{} ->\n{}`", short_str, operation_id, ser);
+        auto msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(4));
+        if (msg.size() > std::numeric_limits<uint16_t>::max()) {
+            msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
+        }
+        return msg;
     } else {
         auto opname = program_hash_to_opname_.find_if_exists({device_id, program_hash});
         runtime_id_to_opname_.insert({device_id, program.get_runtime_id()}, std::move(opname));


### PR DESCRIPTION
### Ticket
#29519

### Problem description
See the above issue.

### What's changed
The large portion of json is actually indentation.
When the json does not exceed the 64K limit, it produces prettified output as-is.
When it exceeds the limit, we replace it to much smaller json by giving `indent=-1`, which triggers compact output mode of nlohmann::json.
It is indeed little hacky, but it allows much large number of tensor args (256~1024 depending on the dump options), which would be enough for the foreseeable future.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes