### PR TITLE
Add  Performance assertion statement for e2e pipeline

### DIFF
--- a/models/demos/segformer/README.md
+++ b/models/demos/segformer/README.md
@@ -33,7 +33,7 @@ Semantic segmentation: [source](https://huggingface.co/nvidia/segformer-b0-finet
 
 ### Performant Model with Trace+2CQ
 #### Single Device (BS=1):
-- end-2-end perf is 105 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- end-2-end perf is 106 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
 Use the following command to run Model performant running with Trace+2CQ
 ```

--- a/models/demos/segformer/README.md
+++ b/models/demos/segformer/README.md
@@ -35,6 +35,8 @@ Semantic segmentation: [source](https://huggingface.co/nvidia/segformer-b0-finet
 #### Single Device (BS=1):
 - end-2-end perf is 106 FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
+*Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/segformer/tests/perf/test_e2e_performant.py#L58) for the e2e perf from the code.*
+
 Use the following command to run Model performant running with Trace+2CQ
 ```
 pytest models/demos/segformer/tests/perf/test_e2e_performant.py::test_segformer_e2e
@@ -43,10 +45,13 @@ pytest models/demos/segformer/tests/perf/test_e2e_performant.py::test_segformer_
 #### Multi Device (DP=2, n300):
 - end-2-end perf is 182 FPS
 
+*Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/segformer/tests/perf/test_e2e_performant.py#L78) for the e2e perf from the code.*
+
 Use the following command to run Model performant running with Trace+2CQ
 ```
 pytest models/demos/segformer/tests/perf/test_e2e_performant.py::test_segformer_e2e_dp
 ```
+
 
 ### Segformer Semantic Segmentation Performant Demo
 - This script downloads 30 validation images and their annotations of [ADE20K](https://www.kaggle.com/datasets/awsaf49/ade20k-dataset) Dataset.

--- a/models/demos/segformer/tests/perf/test_e2e_performant.py
+++ b/models/demos/segformer/tests/perf/test_e2e_performant.py
@@ -55,7 +55,7 @@ def run_segformer_trace_2cqs_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        106 if ttnn.get_num_devices() < 2 else 99,
+        104 if ttnn.get_num_devices() < 2 else 97,
     ],
 )
 def test_segformer_e2e(device, batch_size, model_location_generator, expected_inference_throughput):
@@ -75,7 +75,7 @@ def test_segformer_e2e(device, batch_size, model_location_generator, expected_in
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        148,
+        146,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/ufld_v2/README.md
+++ b/models/demos/ufld_v2/README.md
@@ -23,13 +23,13 @@ Use the following command to run the model:
 ### Performant Model with Trace+2CQ
 
 #### Single Device (BS=1):
-- end-2-end perf is `365` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- end-2-end perf is `366` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
   ```
   pytest --disable-warnings models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py::test_ufldv2_e2e_performant
   ```
 #### Multi Device (DP=2, N300):
-- end-2-end perf is `572` FPS
+- end-2-end perf is `632` FPS
 
   ```
   pytest --disable-warnings models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py::test_ufldv2_e2e_performant_dp

--- a/models/demos/ufld_v2/README.md
+++ b/models/demos/ufld_v2/README.md
@@ -25,11 +25,15 @@ Use the following command to run the model:
 #### Single Device (BS=1):
 - end-2-end perf is `366` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py#L68) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py::test_ufldv2_e2e_performant
   ```
 #### Multi Device (DP=2, N300):
 - end-2-end perf is `632` FPS
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py#L90) for the e2e perf from the code.
 
   ```
   pytest --disable-warnings models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py::test_ufldv2_e2e_performant_dp

--- a/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
@@ -65,7 +65,7 @@ def run_ufldv2_e2e(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        366 if ttnn.get_num_devices() < 2 else 319,
+        364 if ttnn.get_num_devices() < 2 else 317,
     ],
 )
 def test_ufldv2_e2e_performant(device, batch_size, model_location_generator, expected_inference_throughput):
@@ -87,7 +87,7 @@ def test_ufldv2_e2e_performant(device, batch_size, model_location_generator, exp
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        632,
+        630,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
@@ -65,7 +65,7 @@ def run_ufldv2_e2e(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        364 if ttnn.get_num_devices() < 2 else 312,
+        364 if ttnn.get_num_devices() < 2 else 317,
     ],
 )
 def test_ufldv2_e2e_performant(device, batch_size, model_location_generator, expected_inference_throughput):

--- a/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/perf/test_ufld_v2_e2e_performant.py
@@ -65,7 +65,7 @@ def run_ufldv2_e2e(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        364 if ttnn.get_num_devices() < 2 else 317,
+        364 if ttnn.get_num_devices() < 2 else 312,
     ],
 )
 def test_ufldv2_e2e_performant(device, batch_size, model_location_generator, expected_inference_throughput):

--- a/models/demos/yolov10x/README.md
+++ b/models/demos/yolov10x/README.md
@@ -28,7 +28,7 @@ pytest --disable-warnings models/demos/yolov10x/tests/pcc/test_ttnn_yolov10x.py:
   ```
 
 #### Multi Device (DP=2, n300):
-- For `640x640`, end-2-end perf is `83` FPS.
+- For `640x640`, end-2-end perf is `91` FPS.
 
   ```bash
   pytest --disable-warnings models/demos/yolov10x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov10x/README.md
+++ b/models/demos/yolov10x/README.md
@@ -23,12 +23,16 @@ pytest --disable-warnings models/demos/yolov10x/tests/pcc/test_ttnn_yolov10x.py:
 #### Single Device (BS=1):
 - For `640x640`, end-2-end perf is `48` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov10x/tests/perf/test_e2e_performant.py#L84) for the e2e perf from the code.
+
   ```bash
   pytest --disable-warnings models/demos/yolov10x/tests/perf/test_e2e_performant.py::test_e2e_performant
   ```
 
 #### Multi Device (DP=2, n300):
 - For `640x640`, end-2-end perf is `91` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov10x/tests/perf/test_e2e_performant.py#L126) for the e2e perf from the code.
 
   ```bash
   pytest --disable-warnings models/demos/yolov10x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov10x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov10x/tests/perf/test_e2e_performant.py
@@ -81,7 +81,7 @@ def run_yolov10x_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        48 if ttnn.get_num_devices() < 2 else 46,
+        46 if ttnn.get_num_devices() < 2 else 44,
     ],
 )
 def test_e2e_performant(
@@ -123,7 +123,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        90,
+        89,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov11/README.md
+++ b/models/demos/yolov11/README.md
@@ -19,14 +19,14 @@ pytest --disable-warnings models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py::t
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `179` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640`, end-2-end perf is `184` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 ```
 pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
 
 ### Performant Demo with Trace+2CQ
 #### Multi Device (DP=2, N300):
-- For `640x640`, end-2-end perf is `290` FPS :
+- For `640x640`, end-2-end perf is `297` FPS :
   ```
   pytest --disable-warnings models/demos/yolov11/tests/test_e2e_performant.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov11/README.md
+++ b/models/demos/yolov11/README.md
@@ -20,6 +20,9 @@ pytest --disable-warnings models/demos/yolov11/tests/pcc/test_ttnn_yolov11.py::t
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
 - For `640x640`, end-2-end perf is `184` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov11/tests/perf/test_e2e_performant.py#L83) for the e2e perf from the code.
+
 ```
 pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
@@ -27,6 +30,9 @@ pytest --disable-warnings models/demos/yolov11/tests/perf/test_e2e_performant.py
 ### Performant Demo with Trace+2CQ
 #### Multi Device (DP=2, N300):
 - For `640x640`, end-2-end perf is `297` FPS :
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov11/tests/perf/test_e2e_performant.py#L128) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/yolov11/tests/test_e2e_performant.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov11/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov11/tests/perf/test_e2e_performant.py
@@ -80,7 +80,7 @@ def run_yolov11_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        184 if ttnn.get_num_devices() < 2 else 152,
+        182 if ttnn.get_num_devices() < 2 else 150,
     ],
 )
 def test_e2e_performant(
@@ -125,7 +125,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        297,
+        295,
     ],
 )
 def test_e2e_performant_dp(

--- a/models/demos/yolov11/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov11/tests/perf/test_e2e_performant.py
@@ -22,6 +22,7 @@ def run_yolov11_inference(
     weight_dtype,
     model_location_generator,
     resolution,
+    expected_inference_throughput,
 ):
     inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
 
@@ -55,6 +56,10 @@ def run_yolov11_inference(
         f"Model: ttnn_yolov11 - batch_size: {batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size / inference_time_avg)}"
     )
 
+    assert (
+        round(batch_size / inference_time_avg) >= expected_inference_throughput
+    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {round(batch_size/inference_time_avg)} fps"
+
 
 @pytest.mark.parametrize(
     "batch_size_per_device, act_dtype, weight_dtype",
@@ -72,6 +77,12 @@ def run_yolov11_inference(
     [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        184 if ttnn.get_num_devices() < 2 else 152,
+    ],
+)
 def test_e2e_performant(
     device,
     batch_size_per_device,
@@ -79,6 +90,7 @@ def test_e2e_performant(
     weight_dtype,
     model_location_generator,
     resolution,
+    expected_inference_throughput,
     reset_seeds,
 ):
     run_yolov11_inference(
@@ -88,6 +100,7 @@ def test_e2e_performant(
         weight_dtype,
         resolution=resolution,
         model_location_generator=model_location_generator,
+        expected_inference_throughput=expected_inference_throughput,
     )
 
 
@@ -109,6 +122,12 @@ def test_e2e_performant(
     [{"l1_small_size": YOLOV11_L1_SMALL_SIZE, "trace_region_size": 23887872, "num_command_queues": 2}],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        297,
+    ],
+)
 def test_e2e_performant_dp(
     mesh_device,
     batch_size_per_device,
@@ -116,8 +135,12 @@ def test_e2e_performant_dp(
     weight_dtype,
     model_location_generator,
     resolution,
+    expected_inference_throughput,
     reset_seeds,
 ):
+    if ttnn.get_num_devices() < 2:
+        pytest.skip()
+
     run_yolov11_inference(
         mesh_device,
         batch_size_per_device,
@@ -125,4 +148,5 @@ def test_e2e_performant_dp(
         weight_dtype,
         model_location_generator,
         resolution,
+        expected_inference_throughput=expected_inference_throughput,
     )

--- a/models/demos/yolov11m/README.md
+++ b/models/demos/yolov11m/README.md
@@ -19,14 +19,14 @@ pytest --disable-warnings models/demos/yolov11m/tests/pcc/test_ttnn_yolov11.py::
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640`, end-2-end perf is `95` FPS :
+- For `640x640`, end-2-end perf is `87` FPS :
 ```
 pytest --disable-warnings models/demos/yolov11m/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
 
 ### Performant Demo with Trace+2CQ
 #### Multi Device (DP=2, N300):
-- For `640x640`, end-2-end perf is `TBD` FPS :
+- For `640x640`, end-2-end perf is `154` FPS :
   ```
   pytest --disable-warnings models/demos/yolov11m/perf/tests/test_e2e_performant.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov11m/README.md
+++ b/models/demos/yolov11m/README.md
@@ -20,6 +20,9 @@ pytest --disable-warnings models/demos/yolov11m/tests/pcc/test_ttnn_yolov11.py::
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
 - For `640x640`, end-2-end perf is `87` FPS :
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov11m/tests/perf/test_e2e_performant.py#L84) for the e2e perf from the code.
+
 ```
 pytest --disable-warnings models/demos/yolov11m/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
@@ -27,6 +30,9 @@ pytest --disable-warnings models/demos/yolov11m/tests/perf/test_e2e_performant.p
 ### Performant Demo with Trace+2CQ
 #### Multi Device (DP=2, N300):
 - For `640x640`, end-2-end perf is `154` FPS :
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov11m/tests/perf/test_e2e_performant.py#L122) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/yolov11m/perf/tests/test_e2e_performant.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov11m/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov11m/tests/perf/test_e2e_performant.py
@@ -81,7 +81,7 @@ def run_yolov11_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        87 if ttnn.get_num_devices() < 2 else 79,
+        85 if ttnn.get_num_devices() < 2 else 77,
     ],
 )
 def test_e2e_performant(
@@ -125,7 +125,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        154,
+        152,
     ],
 )
 def test_e2e_performant_dp(

--- a/models/demos/yolov12x/README.md
+++ b/models/demos/yolov12x/README.md
@@ -31,7 +31,7 @@ pytest --disable-warnings models/demos/yolov12x/tests/pcc/test_ttnn_yolov12x.py:
 
 #### Multi Device (DP=2, N300):
 
-- For `640x640`, end-2-end perf is `28` FPS :
+- For `640x640`, end-2-end perf is `27` FPS :
 
   ```
   pytest --disable-warnings models/demos/yolov12x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov12x/README.md
+++ b/models/demos/yolov12x/README.md
@@ -25,6 +25,8 @@ pytest --disable-warnings models/demos/yolov12x/tests/pcc/test_ttnn_yolov12x.py:
 
 - For `640x640`, end-2-end perf is `14` FPS :
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov12x/tests/perf/test_e2e_performant.py#L69) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/yolov12x/tests/perf/test_e2e_performant.py::test_e2e_performant
   ```
@@ -32,6 +34,8 @@ pytest --disable-warnings models/demos/yolov12x/tests/pcc/test_ttnn_yolov12x.py:
 #### Multi Device (DP=2, N300):
 
 - For `640x640`, end-2-end perf is `27` FPS :
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov12x/tests/perf/test_e2e_performant.py#L98) for the e2e perf from the code.
 
   ```
   pytest --disable-warnings models/demos/yolov12x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov12x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov12x/tests/perf/test_e2e_performant.py
@@ -66,7 +66,7 @@ def run_yolov12x_inference(device, batch_size_per_device, resolution, expected_i
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        14 if ttnn.get_num_devices() < 2 else 14,
+        12 if ttnn.get_num_devices() < 2 else 12,
     ],
 )
 def test_e2e_performant(device, batch_size_per_device, resolution, expected_inference_throughput):
@@ -95,7 +95,7 @@ def test_e2e_performant(device, batch_size_per_device, resolution, expected_infe
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        27,
+        25,
     ],
 )
 def test_e2e_performant_dp(mesh_device, batch_size_per_device, resolution, expected_inference_throughput):

--- a/models/demos/yolov5x/README.md
+++ b/models/demos/yolov5x/README.md
@@ -25,6 +25,8 @@ pytest --disable-warnings models/demos/yolov5x/tests/pcc/test_ttnn_yolov5x.py::t
 
 - For `640x640`, end-2-end perf is `67` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov5x/tests/perf/test_e2e_performant.py#L81) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/yolov5x/tests/perf/test_e2e_performant.py::test_e2e_performant
   ```
@@ -32,6 +34,8 @@ pytest --disable-warnings models/demos/yolov5x/tests/pcc/test_ttnn_yolov5x.py::t
 #### Multi Device (DP=2, N300) :
 
 - For `640x640`, end-2-end perf is `126` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov5x/tests/perf/test_e2e_performant.py#L124) for the e2e perf from the code.
 
   ```
   pytest --disable-warnings models/demos/yolov5x/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/demos/yolov5x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov5x/tests/perf/test_e2e_performant.py
@@ -78,7 +78,7 @@ def run_yolov5x_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        68 if ttnn.get_num_devices() < 2 else 50,
+        66 if ttnn.get_num_devices() < 2 else 48,
     ],
 )
 @pytest.mark.models_performance_bare_metal
@@ -121,7 +121,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        100,
+        98,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov5x/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov5x/tests/perf/test_e2e_performant.py
@@ -78,7 +78,7 @@ def run_yolov5x_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        66 if ttnn.get_num_devices() < 2 else 48,
+        66 if ttnn.get_num_devices() < 2 else 62,
     ],
 )
 @pytest.mark.models_performance_bare_metal
@@ -121,7 +121,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        98,
+        124,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov6l/README.md
+++ b/models/demos/yolov6l/README.md
@@ -25,6 +25,8 @@ pytest --disable-warnings models/demos/yolov6l/tests/pcc/test_ttnn_yolov6l.py
 
 - For `640x640`, end-2-end perf is `103` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov6l/tests/perf/test_e2e_performant.py#L106) for the e2e perf from the code.
+
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l
   ```
@@ -32,6 +34,8 @@ pytest --disable-warnings models/demos/yolov6l/tests/pcc/test_ttnn_yolov6l.py
 #### Multi Device (DP=2, N300) :
 
 - For `640x640`, end-2-end perf is `181` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov6l/tests/perf/test_e2e_performant.py#L148) for the e2e perf from the code.
 
   ```
   pytest --disable-warnings models/demos/yolov6l/tests/perf/test_e2e_performant.py::test_perf_yolov6l_dp

--- a/models/demos/yolov6l/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov6l/tests/perf/test_e2e_performant.py
@@ -103,7 +103,7 @@ def run_yolov6_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        103 if ttnn.get_num_devices() < 2 else 94,
+        101 if ttnn.get_num_devices() < 2 else 92,
     ],
 )
 def test_perf_yolov6l(
@@ -145,7 +145,7 @@ def test_perf_yolov6l(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        181,
+        179,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov6l/tests/perf/test_e2e_performant.py
@@ -28,6 +28,7 @@ def run_yolov6_inference(
     weight_dtype,
     resolution,
     model_location_generator,
+    expected_inference_throughput,
 ):
     disable_persistent_kernel_cache()
 
@@ -78,6 +79,9 @@ def run_yolov6_inference(
         comments="",
         inference_time_cpu=0.0,
     )
+    assert (
+        round(batch_size / inference_time) >= expected_inference_throughput
+    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {round(batch_size/inference_time)} fps"
 
 
 @run_for_wormhole_b0()
@@ -96,6 +100,12 @@ def run_yolov6_inference(
         (640, 640),
     ],
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        103 if ttnn.get_num_devices() < 2 else 94,
+    ],
+)
 def test_perf_yolov6l(
     device,
     batch_size_per_device,
@@ -103,6 +113,7 @@ def test_perf_yolov6l(
     weight_dtype,
     resolution,
     model_location_generator,
+    expected_inference_throughput,
 ):
     run_yolov6_inference(
         device,
@@ -111,6 +122,7 @@ def test_perf_yolov6l(
         weight_dtype,
         resolution,
         model_location_generator=model_location_generator,
+        expected_inference_throughput=expected_inference_throughput,
     )
 
 
@@ -130,6 +142,12 @@ def test_perf_yolov6l(
         (640, 640),
     ],
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        181,
+    ],
+)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_perf_yolov6l_dp(
@@ -139,7 +157,11 @@ def test_perf_yolov6l_dp(
     weight_dtype,
     resolution,
     model_location_generator,
+    expected_inference_throughput,
 ):
+    if ttnn.get_num_devices() < 2:
+        pytest.skip()
+
     run_yolov6_inference(
         mesh_device,
         batch_size_per_device,
@@ -147,4 +169,5 @@ def test_perf_yolov6l_dp(
         weight_dtype,
         resolution,
         model_location_generator=model_location_generator,
+        expected_inference_throughput=expected_inference_throughput,
     )

--- a/models/demos/yolov8s/README.md
+++ b/models/demos/yolov8s/README.md
@@ -21,13 +21,13 @@ pytest --disable-warnings models/demos/yolov8s/tests/pcc/test_yolov8s.py::test_y
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- end-2-end perf is `211` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- end-2-end perf is `214` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
 ```
 pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py
 ```
 
 #### Multi Device (DP=2, n300):
-- end-2-end perf is `355` FPS
+- end-2-end perf is `368` FPS
 ```
 pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py::test_run_yolov8s_trace_2cqs_dp_inference[wormhole_b0-1-device_params0]
 ```

--- a/models/demos/yolov8s/README.md
+++ b/models/demos/yolov8s/README.md
@@ -22,12 +22,18 @@ pytest --disable-warnings models/demos/yolov8s/tests/pcc/test_yolov8s.py::test_y
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
 - end-2-end perf is `214` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov8s/tests/perf/test_e2e_performant.py#L70) for the e2e perf from the code.
+
 ```
 pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py
 ```
 
 #### Multi Device (DP=2, n300):
 - end-2-end perf is `368` FPS
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov8s/tests/perf/test_e2e_performant.py#L99) for the e2e perf from the code.
+
 ```
 pytest --disable-warnings models/demos/yolov8s/tests/perf/test_e2e_performant.py::test_run_yolov8s_trace_2cqs_dp_inference[wormhole_b0-1-device_params0]
 ```

--- a/models/demos/yolov8s/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8s/tests/perf/test_e2e_performant.py
@@ -67,7 +67,7 @@ def run_yolov8s(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        214 if ttnn.get_num_devices() < 2 else 187,
+        212 if ttnn.get_num_devices() < 2 else 185,
     ],
 )
 def test_run_yolov8s_trace_2cqs_inference(
@@ -96,7 +96,7 @@ def test_run_yolov8s_trace_2cqs_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        368,
+        366,
     ],
 )
 def test_run_yolov8s_trace_2cqs_dp_inference(

--- a/models/demos/yolov8s/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8s/tests/perf/test_e2e_performant.py
@@ -67,7 +67,7 @@ def run_yolov8s(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        212 if ttnn.get_num_devices() < 2 else 185,
+        212 if ttnn.get_num_devices() < 2 else 160,
     ],
 )
 def test_run_yolov8s_trace_2cqs_inference(

--- a/models/demos/yolov8s/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8s/tests/perf/test_e2e_performant.py
@@ -67,7 +67,7 @@ def run_yolov8s(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        212 if ttnn.get_num_devices() < 2 else 160,
+        212 if ttnn.get_num_devices() < 2 else 185,
     ],
 )
 def test_run_yolov8s_trace_2cqs_inference(

--- a/models/demos/yolov8s_world/README.md
+++ b/models/demos/yolov8s_world/README.md
@@ -22,12 +22,18 @@ pytest --disable-warnings models/demos/yolov8s_world/tests/pcc/test_ttnn_yolov8s
 ### Model Performant with Trace+2CQ
 #### Single Device (BS=1):
 - For `640x640`, end-2-end perf is `105` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov8s_world/tests/perf/test_e2e_performant.py#L107) for the e2e perf from the code.
+
   ```bash
   pytest --disable-warnings models/demos/yolov8s_world/tests/perf/test_e2e_performant.py::test_perf_yolov8s_world
   ```
 
 #### Multi Device (DP=2, N300):
 - For `640x640`, end-2-end perf is `189` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov8s_world/tests/perf/test_e2e_performant.py#L149) for the e2e perf from the code.
+
   ```bash
   pytest --disable-warnings models/demos/yolov8s_world/tests/perf/test_e2e_performant.py::test_perf_yolov8s_world_dp
   ```

--- a/models/demos/yolov8s_world/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov8s_world/tests/perf/test_e2e_performant.py
@@ -104,7 +104,7 @@ def run_yolov8s_world_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        105 if ttnn.get_num_devices() < 2 else 96,
+        103 if ttnn.get_num_devices() < 2 else 94,
     ],
 )
 def test_perf_yolov8s_world(
@@ -146,7 +146,7 @@ def test_perf_yolov8s_world(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        189,
+        187,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov9c/README.md
+++ b/models/demos/yolov9c/README.md
@@ -78,12 +78,12 @@ Note: To test the demo with your own images, replace images with `models/demos/y
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640` - `Segmentation`, end-2-end perf is `51` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640` - `Segmentation`, end-2-end perf is `26` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py::test_e2e_performant
   ```
 
-- For `640x640` - `Detection`, end-2-end perf is `82` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640` - `Detection`, end-2-end perf is `42` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py::test_e2e_performant
   ```

--- a/models/demos/yolov9c/README.md
+++ b/models/demos/yolov9c/README.md
@@ -78,12 +78,12 @@ Note: To test the demo with your own images, replace images with `models/demos/y
 
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
-- For `640x640` - `Segmentation`, end-2-end perf is `26` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640` - `Segmentation`, end-2-end perf is `51` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py::test_e2e_performant
   ```
 
-- For `640x640` - `Detection`, end-2-end perf is `42` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+- For `640x640` - `Detection`, end-2-end perf is `82` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py::test_e2e_performant
   ```

--- a/models/demos/yolov9c/README.md
+++ b/models/demos/yolov9c/README.md
@@ -94,7 +94,7 @@ Note: To test the demo with your own images, replace images with `models/demos/y
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py::test_e2e_performant_dp
   ```
 
-- For `640x640` - `Detection`, end-2-end perf is `131` FPS.
+- For `640x640` - `Detection`, end-2-end perf is `142` FPS.
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov9c/README.md
+++ b/models/demos/yolov9c/README.md
@@ -79,22 +79,34 @@ Note: To test the demo with your own images, replace images with `models/demos/y
 ### Model performant running with Trace+2CQ
 #### Single Device (BS=1):
 - For `640x640` - `Segmentation`, end-2-end perf is `51` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py#L32) for the e2e perf from the code.
+
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py::test_e2e_performant
   ```
 
 - For `640x640` - `Detection`, end-2-end perf is `82` FPS (**On N150**), _On N300 single device, the FPS will be low as it uses ethernet dispatch_
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py#L84) for the e2e perf from the code.
+
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py::test_e2e_performant
   ```
 
 #### Multi Device (DP=2, n300):
 - For `640x640` - `Segmentation`, end-2-end perf is `92` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py#L64) for the e2e perf from the code.
+
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py::test_e2e_performant_dp
   ```
 
 - For `640x640` - `Detection`, end-2-end perf is `142` FPS.
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py#L116) for the e2e perf from the code.
+
   ```bash
   pytest models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py::test_e2e_performant_dp
   ```

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
@@ -81,7 +81,7 @@ def run_yolov9c_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        82 if ttnn.get_num_devices() < 2 else 72,
+        80 if ttnn.get_num_devices() < 2 else 70,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):
@@ -113,7 +113,7 @@ def test_e2e_performant(model_location_generator, device, batch_size, resolution
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        142,
+        140,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
@@ -81,7 +81,7 @@ def run_yolov9c_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        80 if ttnn.get_num_devices() < 2 else 70,
+        40 if ttnn.get_num_devices() < 2 else 34,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_detect.py
@@ -81,7 +81,7 @@ def run_yolov9c_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        40 if ttnn.get_num_devices() < 2 else 34,
+        80 if ttnn.get_num_devices() < 2 else 70,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
@@ -29,7 +29,7 @@ from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        52 if ttnn.get_num_devices() < 2 else 47,
+        50 if ttnn.get_num_devices() < 2 else 45,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):
@@ -61,7 +61,7 @@ def test_e2e_performant(model_location_generator, device, batch_size, resolution
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        94,
+        92,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
@@ -29,7 +29,7 @@ from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        50 if ttnn.get_num_devices() < 2 else 45,
+        24 if ttnn.get_num_devices() < 2 else 22,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
@@ -29,7 +29,7 @@ from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        24 if ttnn.get_num_devices() < 2 else 22,
+        50 if ttnn.get_num_devices() < 2 else 45,
     ],
 )
 def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):

--- a/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
+++ b/models/demos/yolov9c/tests/perf/test_e2e_performant_segment.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+import ttnn
 from models.common.utility_functions import run_for_wormhole_b0
 from models.demos.yolov9c.common import YOLOV9C_L1_SMALL_SIZE
 from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov9c_inference
@@ -25,18 +26,20 @@ from models.demos.yolov9c.tests.perf.test_e2e_performant_detect import run_yolov
         ),
     ],
 )
-def test_e2e_performant(
-    model_location_generator,
-    device,
-    batch_size,
-    resolution,
-):
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        52 if ttnn.get_num_devices() < 2 else 47,
+    ],
+)
+def test_e2e_performant(model_location_generator, device, batch_size, resolution, expected_inference_throughput):
     run_yolov9c_inference(
         model_location_generator,
         device,
         batch_size,
         resolution,
         model_task="segment",
+        expected_inference_throughput=expected_inference_throughput,
     )
 
 
@@ -55,18 +58,25 @@ def test_e2e_performant(
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        94,
+    ],
+)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_dp(
-    model_location_generator,
-    mesh_device,
-    batch_size,
-    resolution,
+    model_location_generator, mesh_device, batch_size, resolution, expected_inference_throughput
 ):
+    if ttnn.get_num_devices() < 2:
+        pytest.skip()
+
     run_yolov9c_inference(
         model_location_generator,
         mesh_device,
         batch_size,
         resolution,
         model_task="segment",
+        expected_inference_throughput=expected_inference_throughput,
     )

--- a/models/experimental/efficientnetb0/README.md
+++ b/models/experimental/efficientnetb0/README.md
@@ -26,7 +26,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Single Device (BS=1)
 
-- For `224x224`, end-2-end perf is `157` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
+- For `224x224`, end-2-end perf is `160` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
 
   ```sh
@@ -35,7 +35,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Multi Device (DP=2, N300)
 
-- For `224x224`, end-2-end perf is `250` FPS :
+- For `224x224`, end-2-end perf is `263` FPS :
 
   ```sh
   pytest models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/experimental/efficientnetb0/README.md
+++ b/models/experimental/efficientnetb0/README.md
@@ -26,7 +26,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Single Device (BS=1)
 
-- For `224x224`, end-2-end perf is `160` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
+- For `224x224`, end-2-end perf is `80` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
 
   ```sh
@@ -35,7 +35,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Multi Device (DP=2, N300)
 
-- For `224x224`, end-2-end perf is `263` FPS :
+- For `224x224`, end-2-end perf is `232` FPS :
 
   ```sh
   pytest models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/experimental/efficientnetb0/README.md
+++ b/models/experimental/efficientnetb0/README.md
@@ -26,7 +26,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Single Device (BS=1)
 
-- For `224x224`, end-2-end perf is `80` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
+- For `224x224`, end-2-end perf is `160` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
 
   ```sh
@@ -35,7 +35,7 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 #### Multi Device (DP=2, N300)
 
-- For `224x224`, end-2-end perf is `232` FPS :
+- For `224x224`, end-2-end perf is `263` FPS :
 
   ```sh
   pytest models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/experimental/efficientnetb0/README.md
+++ b/models/experimental/efficientnetb0/README.md
@@ -28,6 +28,8 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 
 - For `224x224`, end-2-end perf is `160` FPS(**On N150**), On N300 single device, the FPS will be low as it uses ethernet dispatch.
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py#L81) for the e2e perf from the code.
+
 
   ```sh
   pytest models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py::test_e2e_performant
@@ -36,6 +38,8 @@ EfficientNet-B0 is a lightweight and efficient convolutional neural network arch
 #### Multi Device (DP=2, N300)
 
 - For `224x224`, end-2-end perf is `263` FPS :
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py#L117) for the e2e perf from the code.
 
   ```sh
   pytest models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
@@ -78,7 +78,7 @@ def run_efficientnetb0_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        158 if ttnn.get_num_devices() < 2 else 132,
+        78 if ttnn.get_num_devices() < 2 else 64,
     ],
 )
 @pytest.mark.models_performance_bare_metal
@@ -114,7 +114,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        261,
+        230,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
@@ -78,7 +78,7 @@ def run_efficientnetb0_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        160 if ttnn.get_num_devices() < 2 else 134,
+        158 if ttnn.get_num_devices() < 2 else 132,
     ],
 )
 @pytest.mark.models_performance_bare_metal
@@ -114,7 +114,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        263,
+        261,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
@@ -21,6 +21,7 @@ def run_efficientnetb0_inference(
     resolution,
     act_dtype=ttnn.bfloat16,
     weight_dtype=ttnn.bfloat16,
+    expected_inference_throughput=None,
 ):
     inputs_mesh_mapper, weights_mesh_mapper, outputs_mesh_composer = get_mesh_mappers(device)
     performant_runner = EfficientNetb0PerformantRunner(
@@ -55,6 +56,10 @@ def run_efficientnetb0_inference(
         f"Model: ttnn_efficientnetb0 - batch_size: {batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size / inference_time_avg)}"
     )
 
+    assert (
+        round(batch_size / inference_time_avg) >= expected_inference_throughput
+    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {round(batch_size/inference_time_avg)} fps"
+
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
@@ -70,15 +75,16 @@ def run_efficientnetb0_inference(
         (224, 224),
     ],
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        160 if ttnn.get_num_devices() < 2 else 134,
+    ],
+)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_e2e_performant(
-    model_location_generator,
-    device,
-    batch_size,
-    act_dtype,
-    weight_dtype,
-    resolution,
+    model_location_generator, device, batch_size, act_dtype, weight_dtype, resolution, expected_inference_throughput
 ):
     run_efficientnetb0_inference(
         model_location_generator,
@@ -87,6 +93,7 @@ def test_e2e_performant(
         resolution,
         act_dtype=ttnn.bfloat16,
         weight_dtype=ttnn.bfloat16,
+        expected_inference_throughput=expected_inference_throughput,
     )
 
 
@@ -104,6 +111,12 @@ def test_e2e_performant(
         (224, 224),
     ],
 )
+@pytest.mark.parametrize(
+    "expected_inference_throughput",
+    [
+        263,
+    ],
+)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_e2e_performant_dp(
@@ -113,7 +126,11 @@ def test_e2e_performant_dp(
     act_dtype,
     weight_dtype,
     resolution,
+    expected_inference_throughput,
 ):
+    if ttnn.get_num_devices() < 2:
+        pytest.skip()
+
     run_efficientnetb0_inference(
         model_location_generator,
         mesh_device,
@@ -121,4 +138,5 @@ def test_e2e_performant_dp(
         resolution,
         act_dtype=ttnn.bfloat16,
         weight_dtype=ttnn.bfloat16,
+        expected_inference_throughput=expected_inference_throughput,
     )

--- a/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_e2e_performant.py
@@ -78,7 +78,7 @@ def run_efficientnetb0_inference(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        78 if ttnn.get_num_devices() < 2 else 64,
+        158 if ttnn.get_num_devices() < 2 else 132,
     ],
 )
 @pytest.mark.models_performance_bare_metal
@@ -114,7 +114,7 @@ def test_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        230,
+        261,
     ],
 )
 @pytest.mark.models_performance_bare_metal

--- a/models/experimental/vovnet/README.md
+++ b/models/experimental/vovnet/README.md
@@ -24,7 +24,7 @@ Wormhole (n150, n300)
 
 #### Single Device (BS=1):
 
-- For `224x224`, end-2-end perf is `127` FPS
+- For `224x224`, end-2-end perf is `146` FPS
 
   ```
   pytest models/experimental/vovnet/tests/perf/test_e2e_performant.py::test_vovnet_e2e_performant
@@ -32,7 +32,7 @@ Wormhole (n150, n300)
 
 #### Multi Device (DP=2, N300):
 
-- For `224x224`, end-2-end perf is `245` FPS
+- For `224x224`, end-2-end perf is `270` FPS
 
   ```
   pytest models/experimental/vovnet/tests/perf/test_e2e_performant.py::test_vovnet_e2e_performant_dp

--- a/models/experimental/vovnet/README.md
+++ b/models/experimental/vovnet/README.md
@@ -26,6 +26,8 @@ Wormhole (n150, n300)
 
 - For `224x224`, end-2-end perf is `146` FPS
 
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/experimental/vovnet/tests/perf/test_e2e_performant.py#L97) for the e2e perf from the code.
+
   ```
   pytest models/experimental/vovnet/tests/perf/test_e2e_performant.py::test_vovnet_e2e_performant
   ```
@@ -33,6 +35,8 @@ Wormhole (n150, n300)
 #### Multi Device (DP=2, N300):
 
 - For `224x224`, end-2-end perf is `236` FPS
+
+Note: Check [here](https://github.com/tenstorrent/tt-metal/blob/punith/add_assert_e2e/models/experimental/vovnet/tests/perf/test_e2e_performant.py#L140) for the e2e perf from the code.
 
   ```
   pytest models/experimental/vovnet/tests/perf/test_e2e_performant.py::test_vovnet_e2e_performant_dp

--- a/models/experimental/vovnet/README.md
+++ b/models/experimental/vovnet/README.md
@@ -32,7 +32,7 @@ Wormhole (n150, n300)
 
 #### Multi Device (DP=2, N300):
 
-- For `224x224`, end-2-end perf is `270` FPS
+- For `224x224`, end-2-end perf is `236` FPS
 
   ```
   pytest models/experimental/vovnet/tests/perf/test_e2e_performant.py::test_vovnet_e2e_performant_dp

--- a/models/experimental/vovnet/tests/perf/test_e2e_performant.py
+++ b/models/experimental/vovnet/tests/perf/test_e2e_performant.py
@@ -71,8 +71,8 @@ def run_e2e_performant(
     )
 
     assert (
-        round(batch_size / inference_time_avg) >= expected_inference_throughput
-    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {round(batch_size/inference_time_avg)} fps"
+        round(total_batch_size / inference_time_avg) >= expected_inference_throughput
+    ), f"Expected end-to-end performance to exceed {expected_inference_throughput} fps but was {round(total_batch_size/inference_time_avg)} fps"
 
 
 @pytest.mark.parametrize(

--- a/models/experimental/vovnet/tests/perf/test_e2e_performant.py
+++ b/models/experimental/vovnet/tests/perf/test_e2e_performant.py
@@ -94,7 +94,7 @@ def run_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        146 if ttnn.get_num_devices() < 2 else 140,
+        144 if ttnn.get_num_devices() < 2 else 138,
     ],
 )
 def test_vovnet_e2e_performant(
@@ -137,7 +137,7 @@ def test_vovnet_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        270,
+        268,
     ],
 )
 def test_vovnet_e2e_performant_dp(

--- a/models/experimental/vovnet/tests/perf/test_e2e_performant.py
+++ b/models/experimental/vovnet/tests/perf/test_e2e_performant.py
@@ -137,7 +137,7 @@ def test_vovnet_e2e_performant(
 @pytest.mark.parametrize(
     "expected_inference_throughput",
     [
-        268,
+        234,
     ],
 )
 def test_vovnet_e2e_performant_dp(


### PR DESCRIPTION
### Problem description
Assert e2e pipeline if inference_time_Avg(FPS) is less than expected inference time(FPS).


### What's changed
Models - Yolov5x, yolov6l, yolov8s, yolov8s_world, yolov9c, yolov10x, yolov11, yolov11m, yolov12x, efficientnetb0,segformer,ufldv2 and vovnet.
- Asserted e2e pipeline if inference_time_Avg(FPS) is less than expected inference time(FPS) - for both n150 and n300 conditions.
- Skipped e2e DP for single device(n150). 
- Kept a threshold of -2 for FPS.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18123747339) CI passes (if applicable)