### PR TITLE
Updating core grid to minimize prefetcher interference in rmsnorm in Llama 70B

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
+++ b/models/demos/llama3_70b_galaxy/tt/distributed_norm.py
@@ -15,7 +15,7 @@ class DistributedNorm(LightweightModule):
         self.ccl_topology = ccl_topology
 
         if TG:
-            core_grid_ln, grid_offset = (8, 2), ttnn.CoreCoord(1, 0)
+            core_grid_ln, grid_offset = (8, 2), ttnn.CoreCoord(2, 0)
             core_range = ttnn.CoreRange(
                 grid_offset, ttnn.CoreCoord(core_grid_ln[1] + grid_offset.x - 1, core_grid_ln[0] + grid_offset.y - 1)
             )

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -38,7 +38,7 @@ def run_rms_trace(
     use_new_version=True,
     profiler=BenchmarkProfiler(),
 ):
-    ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 1))})
+    ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 7))})
     worker_sub_device = ttnn.SubDevice(
         [
             ccl_sub_device_crs,
@@ -69,7 +69,7 @@ def run_rms_trace(
     )
 
     layer_norm_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=(8, 2),
+        compute_with_storage_grid_size=(2, 8),
         subblock_w=1,
         block_h=1,
         block_w=(size_per_device // num_cores) // 32,
@@ -83,7 +83,7 @@ def run_rms_trace(
             32,
             128,
         ),
-        core_grid=input_shard_grid,
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -571,7 +571,7 @@ def test_tg_trace_rms_fuse(
         (
             4,
             8192,
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 7))}),
             ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(


### PR DESCRIPTION
### Ticket
#29138

### Problem description
There is some difference between model test perf and unit test perf that was being investigated. Some of this difference has been attributed to prefetcher interference, which this PR seeks to minimize. Other parts include the unit test not completely reflecting the model test, ie. unit test using a horizontal core grid over a vertical core grid, as in model, and the unit test having a 8x2 core grid for all gather as opposed to one core.

### What's changed
Shifted the vertical core grid one to the right in the model to minimize prefetcher interference. Saves +0.3us per RMS norm op, total 0.6us. Unit tests are also updated to reflect model implementation.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18106113146) CI passes
- [x] [Galaxy all](https://github.com/tenstorrent/tt-metal/actions/runs/18109215123) CI passes