### PR TITLE
Increase default L2 nightly pipeline timeout to 10 minutes

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -54,7 +54,7 @@ on:
 
 # This is a fallback timeout for tests that are not marked with pytest.mark.timeout(xxx)
 env:
-  TEST_BUDGET_SECONDS: 300
+  TEST_BUDGET_SECONDS: 600
 
 jobs:
   ttnn-conv-tests:


### PR DESCRIPTION
### Problem description
One test was constantly failing since it was taking 6-7 minutes. Here is the [link](https://github.com/tenstorrent/tt-metal/actions/runs/18070200681/job/51419178113)

### What's changed
Increased timeout to 10 minutes

### Checklist
- [ ] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/18099178673) CI in progress