### PR TITLE
Revert #27152: Add int32 support for add_sfpu (#27759)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -51,7 +51,6 @@ target_sources(
     unit_tests_ttnn_basic
     PRIVATE
         test_add.cpp
-        test_add_int.cpp
         test_broadcast_to.cpp
         test_generic_op.cpp
         test_graph_add.cpp

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -76,20 +76,5 @@ void calculate_rsub(uint32_t param) {
     return;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
-    int int_scalar = scalar;
-
-    // Load value scalar to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // Using mov to preserve the scalar value after each iteration
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 4);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_7, 0);
-        sfpi::dst_reg++;
-    }
-}
-
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -12,21 +12,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t param1, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, param1);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
-}
-
-template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -12,7 +12,10 @@
 #include "noc_nonblocking_api.h"
 #include "sfpi.h"
 
-namespace ckernel::sfpu {
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
 
 enum {
     ADD = 0,
@@ -24,11 +27,11 @@ enum {
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
 void calculate_binop_with_scalar(uint32_t param) {
-    const sfpi::vFloat parameter = Converter::as_float(param);
+    const vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = 0.0f;
+        vFloat val = dst_reg[0];
+        vFloat result = 0.0f;
 
         if constexpr (BINOP_MODE == ADD) {
             result = val + parameter;
@@ -43,8 +46,8 @@ void calculate_binop_with_scalar(uint32_t param) {
             result = parameter - val;
         }
 
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
+        dst_reg[0] = result;
+        dst_reg++;
     }
 }
 
@@ -74,18 +77,5 @@ void calculate_rsub(uint32_t param) {
     return;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
-    int int_scalar = scalar;
-    // Load value param to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // Using mov to preserve the scalar value after each iteration
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 4);
-        TTI_SFPSTORE(p_sfpu::LREG1, INT32, ADDR_MOD_3, 0);
-        sfpi::dst_reg++;
-    }
-}
-
-}  // namespace ckernel::sfpu
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -12,21 +12,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
+    uint dst_index, uint32_t param1, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, param1);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
-}
-
-template <bool APPROXIMATE, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
-    uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
@@ -20,10 +20,10 @@ namespace ckernel {
  * | Argument       | Description                                                                | Type     | Valid Range                                                 | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------------|----------|
  * | tile_index     | The index of the tile in DST register buffer to perform requested operation| uint32_t | Must be less than the size of the DST register buffer       | True     |
- * | mode           | 0, 1, 2, 3, and 4                                                          | uint32_t | 0, 1, 2, 3, 4 corresponding to add, mul, sub, div, and rsub | True     |
+ * | mode           | 0, 1, 2, 3, and 4                                                          | uint32_t | 0, 1, 2, 3, 4 corresponding to add, mul, sub, div, and rsub | True     |         
  * | param1         | fp32 value scalar encoded as uint32                                        | uint32_t | Must be less than the size of the DST register buffer       | True     |
  */
-// clang-format on
+ // clang-format on
 enum { ADD_UNARY = 0, SUB_UNARY = 1, MUL_UNARY = 2, DIV_UNARY = 3, RSUB_UNARY = 4 };
 ALWI void add_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY>(idst, param1)));
@@ -43,25 +43,6 @@ ALWI void div_unary_tile(uint32_t idst, uint32_t param1) {
 
 ALWI void rsub_unary_tile(uint32_t idst, uint32_t param1) {
     MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY>(idst, param1)));
-}
-
-// clang-format off
-/**
-* Performs element-wise add operation with int32 scalar. The DST
-* register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
-* compute engine.
-*
-* Return value: None
-*
-* | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
-* |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
-* | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
-* | param1          | int32 value scalar encoded as uint32                                       | uint32_t | Must be less than the size of the DST register buffer | True     |
-*/
-// clang-format on
-
-ALWI void add_unary_tile_int32(uint32_t idst, uint32_t param1) {
-    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32<APPROX, 8>(idst, param1)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -103,18 +103,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
     std::pair<std::string, std::string> op_init_and_name;
     TT_FATAL(is_parametrized_type(op_type), "operator should support at least one parameter", "Error");
     // TODO don't cast T to float when precision needs to be preserved
-    const T param0_raw = params[0];
-    float param0 = static_cast<float>(params[0]);
+    float param0 = params[0];
     switch (op_type) {
         case UnaryOpType::FILL:
-            if (input_dtype == DataType::INT32) {
-                op_init_and_name = {
-                    "fill_tile_init();",
-                    fmt::format(
-                        "fill_tile_int({}, {}u);", idst, std::bit_cast<uint32_t>(static_cast<int32_t>(param0_raw)))};
-            } else if (input_dtype == DataType::UINT32) {
-                op_init_and_name = {
-                    "fill_tile_init();", fmt::format("fill_tile_int({}, {}u);", idst, (uint)param0_raw)};
+            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+                op_init_and_name = {"fill_tile_init();", fmt::format("fill_tile_int({}, {}u);", idst, (uint)params[0])};
             } else {
                 // Note: bit casted to int float is used to properly pass nan/+-inf
                 op_init_and_name = {
@@ -278,25 +271,9 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 fmt::format("sub_unary_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
             break;
         case UnaryOpType::ADD_UNARY_SFPU:
-            TT_FATAL(
-                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32) {
-                op_init_and_name = {
-                    "binop_with_scalar_tile_init();",
-                    fmt::format(
-                        "add_unary_tile_int32({}, {}u);",
-                        idst,
-                        std::bit_cast<uint32_t>(static_cast<int32_t>(param0_raw)))};
-            } else if (input_dtype == DataType::UINT32) {
-                op_init_and_name = {
-                    "binop_with_scalar_tile_init();",
-                    // TODO: Use uint32_t tile API here once implemented
-                    fmt::format("add_unary_tile_int32({}, {}u);", idst, (uint)param0_raw)};
-            } else {
-                op_init_and_name = {
-                    "binop_with_scalar_tile_init();",
-                    fmt::format("add_unary_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
-            }
+            op_init_and_name = {
+                "binop_with_scalar_tile_init();",
+                fmt::format("add_unary_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
             break;
         case UnaryOpType::MUL_UNARY_SFPU:
             op_init_and_name = {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -208,6 +208,7 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::RELU_MAX>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::RELU_MIN>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::REMAINDER>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::FMOD>;
+template struct ExecuteUnaryWithFloatParameter<UnaryOpType::FILL>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_GT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_LT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_NE>;
@@ -230,12 +231,6 @@ template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::
     const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::MAXIMUM>::invoke<int32_t>(
-    const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
-
-template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::FILL>::invoke<float>(
-    const Tensor&, const float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
-
-template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::FILL>::invoke<int32_t>(
     const Tensor&, const int32_t, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 Tensor Sigmoid_accurate::invoke(
@@ -523,7 +518,10 @@ Tensor SymmetricBinop<unary_op_type, T>::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        input_tensor, {EltwiseUnaryWithParam(unary_op_type, (param))}, memory_config, optional_output_tensor);
+        input_tensor,
+        {UnaryWithParam(unary_op_type, static_cast<float>(param))},
+        memory_config,
+        optional_output_tensor);
 }
 
 template <UnaryOpType unary_op_type, typename T>
@@ -533,7 +531,10 @@ Tensor SymmetricBinop<unary_op_type, T>::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        input_tensor, {EltwiseUnaryWithParam(unary_op_type, (param))}, memory_config, optional_output_tensor);
+        input_tensor,
+        {UnaryWithParam(unary_op_type, static_cast<float>(param))},
+        memory_config,
+        optional_output_tensor);
 }
 
 // Explicit template instantiation
@@ -547,7 +548,10 @@ Tensor AsymmetricBinop<unary_op_type, unary_op_rev_type>::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        input_tensor, {EltwiseUnaryWithParam{unary_op_type, (param)}}, memory_config, optional_output_tensor);
+        input_tensor,
+        {UnaryWithParam(unary_op_type, static_cast<float>(param))},
+        memory_config,
+        optional_output_tensor);
 }
 
 template <UnaryOpType unary_op_type, UnaryOpType unary_op_rev_type>
@@ -557,7 +561,10 @@ Tensor AsymmetricBinop<unary_op_type, unary_op_rev_type>::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
-        input_tensor, {EltwiseUnaryWithParam{unary_op_rev_type, (param)}}, memory_config, optional_output_tensor);
+        input_tensor,
+        {UnaryWithParam(unary_op_rev_type, static_cast<float>(param))},
+        memory_config,
+        optional_output_tensor);
 }
 
 template struct AsymmetricBinop<UnaryOpType::SUB_UNARY_SFPU, UnaryOpType::RSUB>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -423,6 +423,7 @@ REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(leaky_relu, LEAKY_RELU);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(relu_max, RELU_MAX);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(relu_min, RELU_MIN);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(unary_remainder, REMAINDER);
+REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(fill, FILL);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(gt_unary, UNARY_GT);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(lt_unary, UNARY_LT);
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(ne_unary, UNARY_NE);
@@ -459,9 +460,7 @@ constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::o
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
 
 constexpr auto selu = ttnn::register_operation<"ttnn::selu", ttnn::operations::unary::Selu>();
-constexpr auto fill = ttnn::register_operation<
-    "ttnn::fill",
-    ttnn::operations::unary::ExecuteUnaryWithVariantFloatIntParameter<ttnn::operations::unary::UnaryOpType::FILL>>();
+
 constexpr auto sigmoid_accurate =
     ttnn::register_operation<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
 constexpr auto log_sigmoid = ttnn::register_operation<"ttnn::log_sigmoid", ttnn::operations::unary::LogSigmoid>();


### PR DESCRIPTION
Slack discussion: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1758806246368379

### Problem description
T3K unit test is failing from this commit: https://github.com/tenstorrent/tt-metal/commit/0993736ddec2d292e36f0d15102f6510b75f371e

### What's changed
Revert changes from this commit: https://github.com/tenstorrent/tt-metal/commit/0993736ddec2d292e36f0d15102f6510b75f371e

### Checklist
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/18100480230
- [ ] T3K unit test: https://github.com/tenstorrent/tt-metal/actions/runs/18100489334