### PR TITLE
[DM] Fix noc_inline_dw_write_with_state issue and add DM tests to cover it

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -19,6 +19,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/multi_interleaved/test_multi_interleaved.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dram_sharded/test_dram_sharded.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/transaction_id/test_read_after_write.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/direct_write/test_direct_write.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -36,7 +36,9 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 | All to all                  | 300-308              | Write transactions from multiple cores to multiple cores.                               |
 | All from all                | 310-318              | Read transactions from multiple cores to multiple cores.                                |
 | I2S Hardcoded               | 400-405              | Tests interleaved to sharded data movement operations for different memory layouts.     |
+| Inline Direct Write         | 500-501              | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602              | Tests the usage and effects of transaction IDs in NOC transactions.                     |
+
 
 ## Running Tests
 ### C++ Gtests

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/README.md
@@ -1,0 +1,33 @@
+# Direct Write Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of inline direct write transactions between two Tensix cores using both stateful and non-stateful NoC APIs.
+
+## Test Flow
+Two Tensix cores are used: one sender core and one receiver core. The sender kernel performs direct writes to memory locations on the receiver core's L1 memory using either the stateful or non-stateful NoC API. The stateful approach uses `noc_inline_dw_write_set_state` to cache address and/or value information, followed by `noc_inline_dw_write_with_state` calls that can reuse the cached state. The non-stateful approach uses `noc_inline_dw_write` calls that must provide full address and value information for each transaction.
+
+Test attributes such as transaction counts, write patterns, and API approaches as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. The receiver memory is validated after completion to ensure all writes were performed correctly. Additionally, both tests verify the correctness of the writes by reading back the written values and comparing them against expected results.
+
+Test expectations are that validation checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| sender_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
+| receiver_core_coord       | CoreCoord             | Logical coordinates for the receiver core. |
+| num_writes                | uint32_t              | Number of direct write transactions that will be issued. |
+| write_value_base          | uint32_t              | Base value for write data. Values may be incremented from this base. |
+| use_posted_writes         | bool                  | Whether to use posted or non-posted writes. |
+| same_destination          | bool                  | Whether all writes target the same address or different addresses. |
+| use_stateful_approach     | bool                  | Whether to use stateful or non-stateful NoC API. |
+| same_value                | bool                  | Whether to write the same value repeatedly (stateful only optimization). |
+| addr_stride               | uint32_t              | Address increment when writing to different destinations. |
+| noc_id                    | NOC                   | Which NoC to use for the transactions (NOC_0 or NOC_1). |
+
+## Test Cases
+Two different test cases are implemented using the above parameters.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. **Direct Write Performance Comparison (ID: 500)**: Provides a controlled comparison between stateful and non-stateful approaches. It consistently writes different values to the same destination address, testing both posted and non-posted write modes. This establishes a baseline performance comparison demonstrating the advantage of address caching in stateful direct writes.
+
+2. **Direct Write Address Pattern (ID: 501)**: Comprehensively evaluates performance across different usage patterns by testing all combinations of address patterns (same vs different destinations), value patterns (same vs different values), and API approaches (stateful vs non-stateful). The test includes proper usage of the stateful API for `same_value` scenarios where identical values are set once in `set_state` and reused across multiple writes by passing false as the template parameter.

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 
 void kernel_main() {
     // Compile-time arguments - same as stateful version for direct comparison
@@ -48,7 +47,6 @@ void kernel_main() {
             for (uint32_t i = 0; i < num_writes; i++) {
                 uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
                 uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, current_local_addr);
-
                 if (use_posted_writes) {
                     noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
                         dest_noc_addr, write_value_base + i, 0xF, noc_id);

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Compile-time arguments - same as stateful version for direct comparison
+    const uint32_t test_id = get_compile_time_arg_val(0);
+    const uint32_t num_writes = get_compile_time_arg_val(1);
+    const uint32_t write_value_base = get_compile_time_arg_val(2);
+    const uint32_t use_posted_writes = get_compile_time_arg_val(3);
+    const uint32_t same_destination = get_compile_time_arg_val(4);
+    const uint32_t dest_l1_addr = get_compile_time_arg_val(5);
+    const uint32_t addr_stride = get_compile_time_arg_val(6);
+    const uint32_t packed_receiver_coords = get_compile_time_arg_val(7);
+    const uint32_t noc_id = get_compile_time_arg_val(8);
+
+    // Extract receiver coordinates
+    uint32_t receiver_x = (packed_receiver_coords >> 16) & 0xFFFF;
+    uint32_t receiver_y = packed_receiver_coords & 0xFFFF;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        if (same_destination) {
+            // Case 1: All writes to same destination - non-stateful reconfigures each time
+            uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
+
+            for (uint32_t i = 0; i < num_writes; i++) {
+                if (use_posted_writes) {
+                    noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(  // posted=true
+                        dest_noc_addr,
+                        write_value_base + i,
+                        0xF,
+                        noc_id);
+                } else {
+                    noc_inline_dw_write<InlineWriteDst::DEFAULT, false>(  // posted=false
+                        dest_noc_addr,
+                        write_value_base + i,
+                        0xF,
+                        noc_id);
+                }
+            }
+
+        } else {
+            // Case 2: Different destinations - each write has different address
+            for (uint32_t i = 0; i < num_writes; i++) {
+                uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
+                uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, current_local_addr);
+
+                if (use_posted_writes) {
+                    noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(
+                        dest_noc_addr, write_value_base + i, 0xF, noc_id);
+                } else {
+                    noc_inline_dw_write<InlineWriteDst::DEFAULT, false>(
+                        dest_noc_addr, write_value_base + i, 0xF, noc_id);
+                }
+            }
+        }
+
+        // Wait for all writes to complete
+        noc_async_write_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Stateful", 0);  // 0 = non-stateful
+    DeviceTimestampedData("Posted writes", use_posted_writes);
+    DeviceTimestampedData("Number of transactions", num_writes);
+    DeviceTimestampedData("Transaction size in bytes", 32);
+    DeviceTimestampedData("Same destination", same_destination);
+    DeviceTimestampedData("NOC Index", noc_id);
+}

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_non_stateful.cpp
@@ -5,16 +5,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    const uint32_t test_id = get_compile_time_arg_val(0);
-    const uint32_t num_writes = get_compile_time_arg_val(1);
-    const uint32_t write_value_base = get_compile_time_arg_val(2);
-    const uint32_t use_posted_writes = get_compile_time_arg_val(3);
-    const uint32_t same_destination = get_compile_time_arg_val(4);
-    const uint32_t same_value = get_compile_time_arg_val(5);
-    const uint32_t dest_l1_addr = get_compile_time_arg_val(6);
-    const uint32_t addr_stride = get_compile_time_arg_val(7);
-    const uint32_t packed_receiver_coords = get_compile_time_arg_val(8);
-    const uint32_t noc_id = get_compile_time_arg_val(9);
+    constexpr uint32_t test_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_writes = get_compile_time_arg_val(1);
+    constexpr uint32_t write_value_base = get_compile_time_arg_val(2);
+    constexpr uint32_t use_posted_writes = get_compile_time_arg_val(3);
+    constexpr uint32_t same_destination = get_compile_time_arg_val(4);
+    constexpr uint32_t same_value = get_compile_time_arg_val(5);
+    constexpr uint32_t dest_l1_addr = get_compile_time_arg_val(6);
+    constexpr uint32_t addr_stride = get_compile_time_arg_val(7);
+    constexpr uint32_t packed_receiver_coords = get_compile_time_arg_val(8);
+    constexpr uint32_t noc_id = get_compile_time_arg_val(9);
 
     // Extract receiver coordinates
     uint32_t receiver_x = (packed_receiver_coords >> 16) & 0xFFFF;
@@ -22,13 +22,13 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-        if (same_destination) {
+        if constexpr (same_destination) {
             // Case 1: All writes to same destination - non-stateful reconfigures each time
             uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
 
             for (uint32_t i = 0; i < num_writes; i++) {
                 uint32_t write_value = same_value ? write_value_base : (write_value_base + i);
-                if (use_posted_writes) {
+                if constexpr (use_posted_writes) {
                     noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(dest_noc_addr, write_value, 0xF, noc_id);
                 } else {
                     noc_inline_dw_write<InlineWriteDst::DEFAULT, false>(dest_noc_addr, write_value, 0xF, noc_id);
@@ -41,7 +41,7 @@ void kernel_main() {
                 uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
                 uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, current_local_addr);
                 uint32_t write_value = same_value ? write_value_base : (write_value_base + i);
-                if (use_posted_writes) {
+                if constexpr (use_posted_writes) {
                     noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(dest_noc_addr, write_value, 0xF, noc_id);
                 } else {
                     noc_inline_dw_write<InlineWriteDst::DEFAULT, false>(dest_noc_addr, write_value, 0xF, noc_id);

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 
 void kernel_main() {
     // Compile-time arguments
@@ -25,24 +24,18 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV0");
 
         if (same_destination) {
-            // Case 1: All writes to same destination - ideal for stateful approach
             uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
 
             // Setup state once
             if (use_posted_writes) {
-                noc_inline_dw_write_set_state<true, false>(  // posted=true, set_val=false
+                noc_inline_dw_write_set_state<true, false>(
                     dest_noc_addr,
                     0,  // value will be set in with_state calls
                     0xF,
                     write_at_cmd_buf,
                     noc_id);
             } else {
-                noc_inline_dw_write_set_state<false, false>(  // posted=false, set_val=false
-                    dest_noc_addr,
-                    0,
-                    0xF,
-                    write_at_cmd_buf,
-                    noc_id);
+                noc_inline_dw_write_set_state<false, false>(dest_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
             }
 
             // Perform writes - only value changes each time
@@ -70,7 +63,6 @@ void kernel_main() {
                 noc_inline_dw_write_set_state<false, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
             }
 
-            // Perform writes with address updates
             for (uint32_t i = 0; i < num_writes; i++) {
                 uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
 

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "risc_attribs.h"
 
 void kernel_main() {
     constexpr uint32_t test_id = get_compile_time_arg_val(0);
@@ -44,13 +45,13 @@ void kernel_main() {
                 // Perform writes - reuse value from state
                 for (uint32_t i = 0; i < num_writes; i++) {
                     if constexpr (use_posted_writes) {
-                        noc_inline_dw_write_with_state<false, true, true, false, false, true>(
+                        noc_inline_dw_write_with_state<false, true, true, false, false>(
                             0,  // value unused since we reuse from state
                             0,
                             write_at_cmd_buf,
                             noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<false, true, false, false, false, true>(
+                        noc_inline_dw_write_with_state<false, true, false, false, false>(
                             0, 0, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -70,10 +71,10 @@ void kernel_main() {
                 // Perform writes - provide new value each time
                 for (uint32_t i = 0; i < num_writes; i++) {
                     if constexpr (use_posted_writes) {
-                        noc_inline_dw_write_with_state<false, true, true, false, true, true>(
+                        noc_inline_dw_write_with_state<false, true, true, false, true>(
                             write_value_base + i, 0, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<false, true, false, false, true, true>(
+                        noc_inline_dw_write_with_state<false, true, false, false, true>(
                             write_value_base + i, 0, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -98,10 +99,10 @@ void kernel_main() {
                     uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
 
                     if constexpr (use_posted_writes) {
-                        noc_inline_dw_write_with_state<true, true, true, false, false, true>(
+                        noc_inline_dw_write_with_state<true, true, true, false, false>(
                             0, current_local_addr, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<true, true, false, false, false, true>(
+                        noc_inline_dw_write_with_state<true, true, false, false, false>(
                             0, current_local_addr, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -118,10 +119,10 @@ void kernel_main() {
                     uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
 
                     if constexpr (use_posted_writes) {
-                        noc_inline_dw_write_with_state<true, true, true, false, true, true>(
+                        noc_inline_dw_write_with_state<true, true, true, false, true>(
                             write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<true, true, false, false, true, true>(
+                        noc_inline_dw_write_with_state<true, true, false, false, true>(
                             write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
                     }
                 }

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Compile-time arguments
+    const uint32_t test_id = get_compile_time_arg_val(0);
+    const uint32_t num_writes = get_compile_time_arg_val(1);
+    const uint32_t write_value_base = get_compile_time_arg_val(2);
+    const uint32_t use_posted_writes = get_compile_time_arg_val(3);
+    const uint32_t same_destination = get_compile_time_arg_val(4);
+    const uint32_t dest_l1_addr = get_compile_time_arg_val(5);
+    const uint32_t addr_stride = get_compile_time_arg_val(6);
+    const uint32_t packed_receiver_coords = get_compile_time_arg_val(7);
+    const uint32_t noc_id = get_compile_time_arg_val(8);
+
+    // Extract receiver coordinates
+    uint32_t receiver_x = (packed_receiver_coords >> 16) & 0xFFFF;
+    uint32_t receiver_y = packed_receiver_coords & 0xFFFF;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+
+        if (same_destination) {
+            // Case 1: All writes to same destination - ideal for stateful approach
+            uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
+
+            // Setup state once
+            if (use_posted_writes) {
+                noc_inline_dw_write_set_state<true, false>(  // posted=true, set_val=false
+                    dest_noc_addr,
+                    0,  // value will be set in with_state calls
+                    0xF,
+                    write_at_cmd_buf,
+                    noc_id);
+            } else {
+                noc_inline_dw_write_set_state<false, false>(  // posted=false, set_val=false
+                    dest_noc_addr,
+                    0,
+                    0xF,
+                    write_at_cmd_buf,
+                    noc_id);
+            }
+
+            // Perform writes - only value changes each time
+            for (uint32_t i = 0; i < num_writes; i++) {
+                if (use_posted_writes) {
+                    noc_inline_dw_write_with_state<false, true, true, false, true>(
+                        write_value_base + i,  // New value each time
+                        0,                     // addr unused
+                        write_at_cmd_buf,
+                        noc_id);
+                } else {
+                    noc_inline_dw_write_with_state<false, true, false, false, true>(
+                        write_value_base + i, 0, write_at_cmd_buf, noc_id);
+                }
+            }
+
+        } else {
+            // Case 2: Different destinations - update local address each time
+            uint64_t base_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
+
+            // Setup state with base address
+            if (use_posted_writes) {
+                noc_inline_dw_write_set_state<true, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
+            } else {
+                noc_inline_dw_write_set_state<false, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
+            }
+
+            // Perform writes with address updates
+            for (uint32_t i = 0; i < num_writes; i++) {
+                uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
+
+                if (use_posted_writes) {
+                    noc_inline_dw_write_with_state<true, true, true, false, true>(
+                        write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                } else {
+                    noc_inline_dw_write_with_state<true, true, false, false, true>(
+                        write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                }
+            }
+        }
+
+        // Wait for all writes to complete
+        noc_async_write_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Stateful", 1);  // 1 = stateful
+    DeviceTimestampedData("Posted writes", use_posted_writes);
+    DeviceTimestampedData("Number of transactions", num_writes);
+    DeviceTimestampedData("Transaction size in bytes", 32);
+    DeviceTimestampedData("Same destination", same_destination);
+    DeviceTimestampedData("NOC Index", noc_id);
+}

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
@@ -44,13 +44,13 @@ void kernel_main() {
                 // Perform writes - reuse value from state
                 for (uint32_t i = 0; i < num_writes; i++) {
                     if (use_posted_writes) {
-                        noc_inline_dw_write_with_state<false, true, true, false, false>(
+                        noc_inline_dw_write_with_state<false, true, true, false, false, true>(
                             0,  // value unused since we reuse from state
                             0,
                             write_at_cmd_buf,
                             noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<false, true, false, false, false>(
+                        noc_inline_dw_write_with_state<false, true, false, false, false, true>(
                             0, 0, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -70,10 +70,10 @@ void kernel_main() {
                 // Perform writes - provide new value each time
                 for (uint32_t i = 0; i < num_writes; i++) {
                     if (use_posted_writes) {
-                        noc_inline_dw_write_with_state<false, true, true, false, true>(
+                        noc_inline_dw_write_with_state<false, true, true, false, true, true>(
                             write_value_base + i, 0, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<false, true, false, false, true>(
+                        noc_inline_dw_write_with_state<false, true, false, false, true, true>(
                             write_value_base + i, 0, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -98,10 +98,10 @@ void kernel_main() {
                     uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
 
                     if (use_posted_writes) {
-                        noc_inline_dw_write_with_state<true, true, true, false, false>(
+                        noc_inline_dw_write_with_state<true, true, true, false, false, true>(
                             0, current_local_addr, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<true, true, false, false, false>(
+                        noc_inline_dw_write_with_state<true, true, false, false, false, true>(
                             0, current_local_addr, write_at_cmd_buf, noc_id);
                     }
                 }
@@ -118,10 +118,10 @@ void kernel_main() {
                     uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
 
                     if (use_posted_writes) {
-                        noc_inline_dw_write_with_state<true, true, true, false, true>(
+                        noc_inline_dw_write_with_state<true, true, true, false, true, true>(
                             write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
                     } else {
-                        noc_inline_dw_write_with_state<true, true, false, false, true>(
+                        noc_inline_dw_write_with_state<true, true, false, false, true, true>(
                             write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
                     }
                 }

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_stateful.cpp
@@ -5,16 +5,16 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    // Compile-time arguments
     const uint32_t test_id = get_compile_time_arg_val(0);
     const uint32_t num_writes = get_compile_time_arg_val(1);
     const uint32_t write_value_base = get_compile_time_arg_val(2);
     const uint32_t use_posted_writes = get_compile_time_arg_val(3);
     const uint32_t same_destination = get_compile_time_arg_val(4);
-    const uint32_t dest_l1_addr = get_compile_time_arg_val(5);
-    const uint32_t addr_stride = get_compile_time_arg_val(6);
-    const uint32_t packed_receiver_coords = get_compile_time_arg_val(7);
-    const uint32_t noc_id = get_compile_time_arg_val(8);
+    const uint32_t same_value = get_compile_time_arg_val(5);
+    const uint32_t dest_l1_addr = get_compile_time_arg_val(6);
+    const uint32_t addr_stride = get_compile_time_arg_val(7);
+    const uint32_t packed_receiver_coords = get_compile_time_arg_val(8);
+    const uint32_t noc_id = get_compile_time_arg_val(9);
 
     // Extract receiver coordinates
     uint32_t receiver_x = (packed_receiver_coords >> 16) & 0xFFFF;
@@ -27,28 +27,55 @@ void kernel_main() {
             uint64_t dest_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
 
             // Setup state once
-            if (use_posted_writes) {
-                noc_inline_dw_write_set_state<true, false>(
-                    dest_noc_addr,
-                    0,  // value will be set in with_state calls
-                    0xF,
-                    write_at_cmd_buf,
-                    noc_id);
-            } else {
-                noc_inline_dw_write_set_state<false, false>(dest_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
-            }
-
-            // Perform writes - only value changes each time
-            for (uint32_t i = 0; i < num_writes; i++) {
+            if (same_value) {
+                // When writing same value, set it in the state and reuse it
                 if (use_posted_writes) {
-                    noc_inline_dw_write_with_state<false, true, true, false, true>(
-                        write_value_base + i,  // New value each time
-                        0,                     // addr unused
+                    noc_inline_dw_write_set_state<true, true>(
+                        dest_noc_addr,
+                        write_value_base,  // Set the value once in state
+                        0xF,
                         write_at_cmd_buf,
                         noc_id);
                 } else {
-                    noc_inline_dw_write_with_state<false, true, false, false, true>(
-                        write_value_base + i, 0, write_at_cmd_buf, noc_id);
+                    noc_inline_dw_write_set_state<false, true>(
+                        dest_noc_addr, write_value_base, 0xF, write_at_cmd_buf, noc_id);
+                }
+
+                // Perform writes - reuse value from state
+                for (uint32_t i = 0; i < num_writes; i++) {
+                    if (use_posted_writes) {
+                        noc_inline_dw_write_with_state<false, true, true, false, false>(
+                            0,  // value unused since we reuse from state
+                            0,
+                            write_at_cmd_buf,
+                            noc_id);
+                    } else {
+                        noc_inline_dw_write_with_state<false, true, false, false, false>(
+                            0, 0, write_at_cmd_buf, noc_id);
+                    }
+                }
+            } else {
+                // When writing different values, set addr only in state
+                if (use_posted_writes) {
+                    noc_inline_dw_write_set_state<true, false>(
+                        dest_noc_addr,
+                        0,  // value will be provided in each with_state call
+                        0xF,
+                        write_at_cmd_buf,
+                        noc_id);
+                } else {
+                    noc_inline_dw_write_set_state<false, false>(dest_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
+                }
+
+                // Perform writes - provide new value each time
+                for (uint32_t i = 0; i < num_writes; i++) {
+                    if (use_posted_writes) {
+                        noc_inline_dw_write_with_state<false, true, true, false, true>(
+                            write_value_base + i, 0, write_at_cmd_buf, noc_id);
+                    } else {
+                        noc_inline_dw_write_with_state<false, true, false, false, true>(
+                            write_value_base + i, 0, write_at_cmd_buf, noc_id);
+                    }
                 }
             }
 
@@ -56,22 +83,47 @@ void kernel_main() {
             // Case 2: Different destinations - update local address each time
             uint64_t base_noc_addr = get_noc_addr(receiver_x, receiver_y, dest_l1_addr);
 
-            // Setup state with base address
-            if (use_posted_writes) {
-                noc_inline_dw_write_set_state<true, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
-            } else {
-                noc_inline_dw_write_set_state<false, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
-            }
-
-            for (uint32_t i = 0; i < num_writes; i++) {
-                uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
-
+            if (same_value) {
+                // When writing same value to different addresses, set value in state
                 if (use_posted_writes) {
-                    noc_inline_dw_write_with_state<true, true, true, false, true>(
-                        write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                    noc_inline_dw_write_set_state<true, true>(
+                        base_noc_addr, write_value_base, 0xF, write_at_cmd_buf, noc_id);
                 } else {
-                    noc_inline_dw_write_with_state<true, true, false, false, true>(
-                        write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                    noc_inline_dw_write_set_state<false, true>(
+                        base_noc_addr, write_value_base, 0xF, write_at_cmd_buf, noc_id);
+                }
+
+                // Perform writes - provide new address each time, reuse value from state
+                for (uint32_t i = 0; i < num_writes; i++) {
+                    uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
+
+                    if (use_posted_writes) {
+                        noc_inline_dw_write_with_state<true, true, true, false, false>(
+                            0, current_local_addr, write_at_cmd_buf, noc_id);
+                    } else {
+                        noc_inline_dw_write_with_state<true, true, false, false, false>(
+                            0, current_local_addr, write_at_cmd_buf, noc_id);
+                    }
+                }
+            } else {
+                // When writing different values to different addresses, set base addr in state
+                if (use_posted_writes) {
+                    noc_inline_dw_write_set_state<true, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
+                } else {
+                    noc_inline_dw_write_set_state<false, false>(base_noc_addr, 0, 0xF, write_at_cmd_buf, noc_id);
+                }
+
+                // Perform writes - provide new address and new value each time
+                for (uint32_t i = 0; i < num_writes; i++) {
+                    uint32_t current_local_addr = dest_l1_addr + (i * addr_stride);
+
+                    if (use_posted_writes) {
+                        noc_inline_dw_write_with_state<true, true, true, false, true>(
+                            write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                    } else {
+                        noc_inline_dw_write_with_state<true, true, false, false, true>(
+                            write_value_base + i, current_local_addr, write_at_cmd_buf, noc_id);
+                    }
                 }
             }
         }
@@ -81,10 +133,11 @@ void kernel_main() {
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Stateful", 1);  // 1 = stateful
+    DeviceTimestampedData("Stateful", 1);
     DeviceTimestampedData("Posted writes", use_posted_writes);
     DeviceTimestampedData("Number of transactions", num_writes);
     DeviceTimestampedData("Transaction size in bytes", 32);
     DeviceTimestampedData("Same destination", same_destination);
+    DeviceTimestampedData("Same value", same_value);
     DeviceTimestampedData("NOC Index", noc_id);
 }

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -119,7 +119,7 @@ bool run_dm(
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     // Launch the program - Use mesh workload approach
-    auto mesh_workload = distributed::CreateMeshWorkload();
+    auto mesh_workload = distributed::MeshWorkload();
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));  // Single device at (0,0)
     distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "dm_common.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::direct_write {
+
+// Test config for direct write performance comparison
+struct DirectWriteConfig {
+    uint32_t test_id = 0;
+    CoreCoord sender_core_coord = CoreCoord();
+    CoreCoord receiver_core_coord = CoreCoord();
+    uint32_t num_writes = 100;               // Number of direct writes to perform
+    uint32_t write_value_base = 0x12340000;  // Base value for writes
+    bool use_posted_writes = false;          // Posted vs non-posted writes
+    bool same_destination = true;            // All writes to same address vs different addresses
+    bool use_stateful_approach = true;       // Stateful vs non-stateful approach
+    uint32_t dest_l1_addr_offset = 0x20000;  // L1 address offset on receiver
+    uint32_t addr_stride = 4;                // Address increment for different destinations
+    NOC noc_id = NOC::NOC_0;
+};
+
+/// @brief Run direct write test comparing stateful vs non-stateful approaches
+/// @param device Device to run on
+/// @param test_config Test configuration
+/// @return Success status
+bool run_dm(IDevice* device, const DirectWriteConfig& test_config) {
+    // Program
+    Program program = CreateProgram();
+
+    // (Logical) Core coordinates and ranges
+    CoreRangeSet sender_core_set({CoreRange(test_config.sender_core_coord)});
+    CoreRangeSet receiver_core_set({CoreRange(test_config.receiver_core_coord)});
+    CoreRangeSet combined_core_set = sender_core_set.merge<CoreRangeSet>(receiver_core_set);
+
+    // Get L1 Address info
+    L1AddressInfo sender_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.sender_core_coord);
+    L1AddressInfo receiver_l1_info =
+        tt::tt_metal::unit_tests::dm::get_l1_address_and_size(device, test_config.receiver_core_coord);
+
+    // Validate L1 memory
+    if (sender_l1_info.base_address != receiver_l1_info.base_address || sender_l1_info.size != receiver_l1_info.size) {
+        log_error(tt::LogTest, "Mismatch in L1 address or size between sender and receiver cores");
+        return false;
+    }
+
+    // Check if we have enough space for the test
+    uint32_t required_bytes = test_config.same_destination ? 4 : (test_config.num_writes * test_config.addr_stride);
+    if (receiver_l1_info.size < test_config.dest_l1_addr_offset + required_bytes) {
+        log_error(tt::LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    uint32_t l1_base_address = sender_l1_info.base_address;
+
+    // Physical Core Coordinates
+    CoreCoord physical_receiver_core = device->worker_core_from_logical_core(test_config.receiver_core_coord);
+    uint32_t packed_receiver_core_coordinates = physical_receiver_core.x << 16 | (physical_receiver_core.y & 0xFFFF);
+
+    // Compile-time arguments for sender kernel
+    vector<uint32_t> sender_compile_args = {
+        test_config.test_id,
+        test_config.num_writes,
+        test_config.write_value_base,
+        test_config.use_posted_writes ? 1u : 0u,
+        test_config.same_destination ? 1u : 0u,
+        l1_base_address + test_config.dest_l1_addr_offset,  // Destination L1 address
+        test_config.addr_stride,
+        packed_receiver_core_coordinates,
+        static_cast<uint32_t>(test_config.noc_id)};
+
+    // Choose kernel based on approach
+    std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/direct_write/kernels/";
+    std::string sender_kernel_filename =
+        test_config.use_stateful_approach ? "sender_stateful.cpp" : "sender_non_stateful.cpp";
+    std::string sender_kernel_path = kernels_dir + sender_kernel_filename;
+
+    CreateKernel(
+        program,
+        sender_kernel_path,
+        test_config.sender_core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = test_config.noc_id,
+            .compile_args = sender_compile_args});
+
+    // Assign unique id
+    log_info(
+        tt::LogTest,
+        "Running Direct Write Test ID: {}, Approach: {}, Writes: {}",
+        test_config.test_id,
+        test_config.use_stateful_approach ? "Stateful" : "Non-Stateful",
+        test_config.num_writes);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    // Initialize receiver memory to known pattern
+    uint32_t init_words = test_config.same_destination ? 1 : test_config.num_writes;
+    std::vector<uint32_t> init_data(init_words, 0x00000000);  // Initialize to zero
+    tt_metal::detail::WriteToDeviceL1(
+        device, test_config.receiver_core_coord, l1_base_address + test_config.dest_l1_addr_offset, init_data);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    // Launch the program
+    detail::LaunchProgram(device, program);
+
+    // Read back and validate results
+    std::vector<uint32_t> output_data;
+    uint32_t read_bytes = init_words * sizeof(uint32_t);
+    tt_metal::detail::ReadFromDeviceL1(
+        device,
+        test_config.receiver_core_coord,
+        l1_base_address + test_config.dest_l1_addr_offset,
+        read_bytes,
+        output_data);
+
+    // Validation
+    bool pass = true;
+    if (test_config.same_destination) {
+        // All writes went to same location - should have the last written value
+        uint32_t expected_final_value = test_config.write_value_base + test_config.num_writes - 1;
+        if (output_data[0] != expected_final_value) {
+            log_error(
+                tt::LogTest, "Expected final value: 0x{:08x}, Got: 0x{:08x}", expected_final_value, output_data[0]);
+            pass = false;
+        }
+    } else {
+        // Different destinations - check first few values
+        uint32_t check_count =
+            std::min(static_cast<uint32_t>(output_data.size()), std::min(test_config.num_writes, 10u));
+        for (uint32_t i = 0; i < check_count; i++) {
+            uint32_t expected_value = test_config.write_value_base + i;
+            if (output_data[i] != expected_value) {
+                log_error(
+                    tt::LogTest, "Index {}: Expected: 0x{:08x}, Got: 0x{:08x}", i, expected_value, output_data[i]);
+                pass = false;
+            }
+        }
+    }
+
+    if (!pass) {
+        log_error(tt::LogTest, "Direct write test validation failed");
+        log_info(tt::LogTest, "Output data (first 8 words):");
+        for (size_t i = 0; i < std::min(output_data.size(), size_t(8)); i++) {
+            log_info(tt::LogTest, "  [{}]: 0x{:08x}", i, output_data[i]);
+        }
+    }
+
+    return pass;
+}
+
+void performance_comparison_test(
+    ARCH arch_,
+    vector<IDevice*>& devices_,
+    uint32_t num_devices_,
+    uint32_t test_id,
+    CoreCoord sender_core = {0, 0},
+    CoreCoord receiver_core = {0, 1}) {
+    vector<uint32_t> write_counts = {10, 100, 1000};  // Show scaling advantage
+    vector<bool> stateful_options = {false, true};    // Non-stateful vs stateful
+    vector<bool> posted_options = {false, true};      // Non-posted vs posted
+
+    for (uint32_t num_writes : write_counts) {
+        for (bool posted : posted_options) {
+            for (bool stateful : stateful_options) {
+                DirectWriteConfig test_config = {
+                    .test_id = test_id,
+                    .sender_core_coord = sender_core,
+                    .receiver_core_coord = receiver_core,
+                    .num_writes = num_writes,
+                    .use_posted_writes = posted,
+                    .same_destination = true,  // Same dest to show stateful advantage
+                    .use_stateful_approach = stateful};
+
+                for (unsigned int id = 0; id < num_devices_; id++) {
+                    EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+                }
+            }
+        }
+    }
+}
+
+void address_pattern_test(
+    ARCH arch_,
+    vector<IDevice*>& devices_,
+    uint32_t num_devices_,
+    uint32_t test_id,
+    CoreCoord sender_core = {0, 0},
+    CoreCoord receiver_core = {1, 0}) {
+    vector<bool> destination_patterns = {true, false};  // Same vs different destinations
+    vector<bool> stateful_options = {false, true};
+
+    for (bool same_dest : destination_patterns) {
+        for (bool stateful : stateful_options) {
+            // Skip non-stateful with different destinations for performance reasons
+            if (!stateful && !same_dest) {
+                continue;
+            }
+
+            DirectWriteConfig test_config = {
+                .test_id = test_id,
+                .sender_core_coord = sender_core,
+                .receiver_core_coord = receiver_core,
+                .num_writes = 50,
+                .same_destination = same_dest,
+                .use_stateful_approach = stateful};
+
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            }
+        }
+    }
+}
+
+void noc_comparison_test(
+    ARCH arch_,
+    vector<IDevice*>& devices_,
+    uint32_t num_devices_,
+    uint32_t test_id,
+    CoreCoord sender_core = {1, 1},
+    CoreCoord receiver_core = {2, 2}) {
+    vector<NOC> nocs = {NOC::NOC_0, NOC::NOC_1};
+
+    for (NOC noc_id : nocs) {
+        DirectWriteConfig test_config = {
+            .test_id = test_id,
+            .sender_core_coord = sender_core,
+            .receiver_core_coord = receiver_core,
+            .num_writes = 200,
+            .use_posted_writes = true,
+            .use_stateful_approach = true,  // Use best performing approach
+            .noc_id = noc_id};
+
+        for (unsigned int id = 0; id < num_devices_; id++) {
+            EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+        }
+    }
+}
+
+void correctness_test(
+    ARCH arch_,
+    vector<IDevice*>& devices_,
+    uint32_t num_devices_,
+    uint32_t test_id,
+    CoreCoord sender_core = {0, 0},
+    CoreCoord receiver_core = {0, 1}) {
+    // Simple correctness test with known pattern
+    DirectWriteConfig test_config = {
+        .test_id = test_id,
+        .sender_core_coord = sender_core,
+        .receiver_core_coord = receiver_core,
+        .num_writes = 20,
+        .write_value_base = 0xDEADBEE0,  // Easy to recognize pattern
+        .same_destination = false,       // Test different addresses
+        .use_stateful_approach = true};
+
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
+
+}  // namespace unit_tests::dm::direct_write
+
+/* ========== TEST CASES ========== */
+
+TEST_F(DeviceFixture, TensixDirectWritePerformanceComparison) {
+    uint32_t test_id = 500;
+    unit_tests::dm::direct_write::performance_comparison_test(arch_, devices_, num_devices_, test_id);
+}
+
+TEST_F(DeviceFixture, TensixDirectWriteAddressPatternsPacketSizes) {
+    uint32_t test_id = 501;
+    unit_tests::dm::direct_write::address_pattern_test(arch_, devices_, num_devices_, test_id);
+}
+
+TEST_F(DeviceFixture, TensixDirectWriteNOCComparisonPacketSizes) {
+    uint32_t test_id = 502;
+    unit_tests::dm::direct_write::noc_comparison_test(arch_, devices_, num_devices_, test_id);
+}
+
+TEST_F(DeviceFixture, TensixDirectWriteCorrectness) {
+    uint32_t test_id = 503;
+    unit_tests::dm::direct_write::correctness_test(arch_, devices_, num_devices_, test_id);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -154,7 +154,7 @@ bool run_dm(std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device, 
         // Different destinations - check first few values
 
         uint32_t check_count =
-            std::min(static_cast<uint32_t>(output_data.size()), std::min(test_config.num_writes, 10u));
+            std::min({static_cast<uint32_t>(output_data.size()), test_config.num_writes, 10u});
         for (uint32_t i = 0; i < check_count; i++) {
             uint32_t expected_value;
             if (test_config.same_value) {

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -19,8 +19,8 @@ namespace unit_tests::dm::direct_write {
 // Test config for direct write performance comparison
 struct DirectWriteConfig {
     uint32_t test_id = 0;
-    CoreCoord sender_core_coord = CoreCoord();
-    CoreCoord receiver_core_coord = CoreCoord();
+    CoreCoord sender_core_coord;
+    CoreCoord receiver_core_coord;
     uint32_t num_writes = 100;               // Number of direct writes to perform
     uint32_t write_value_base = 0x12340000;  // Base value for writes
     bool use_posted_writes = false;          // Posted vs non-posted writes

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -35,7 +35,8 @@ struct DirectWriteConfig {
 /// @param mesh_device MeshDevice to run on
 /// @param test_config Test configuration
 /// @return Success status
-bool run_dm(std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device, const DirectWriteConfig& test_config) {
+bool run_dm(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, const DirectWriteConfig& test_config) {
     // Get the actual device for this single-device test
     IDevice* device = mesh_device->get_device(0);
 
@@ -184,7 +185,7 @@ bool run_dm(std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device, 
 }
 
 void performance_comparison_test(
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     uint32_t test_id,
     CoreCoord sender_core = {0, 0},
     CoreCoord receiver_core = {1, 1}) {
@@ -211,7 +212,7 @@ void performance_comparison_test(
 }
 
 void address_pattern_test(
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     uint32_t test_id,
     CoreCoord sender_core = {0, 0},
     CoreCoord receiver_core = {1, 1}) {

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -25,7 +25,6 @@ struct DirectWriteConfig {
     bool same_destination = true;            // All writes to same address vs different addresses
     bool use_stateful_approach = true;       // Stateful vs non-stateful approach
     bool same_value = false;                 // Write same value each time vs different values (stateful only)
-    uint32_t dest_l1_addr_offset = 0x20000;  // L1 address offset on receiver
     uint32_t addr_stride = 4;                // Address increment for different destinations
     NOC noc_id = NOC::NOC_0;
 };
@@ -238,8 +237,6 @@ void address_pattern_test(
 }
 
 }  // namespace unit_tests::dm::direct_write
-
-/* ========== TEST CASES ========== */
 
 TEST_F(DeviceFixture, TensixDirectWritePerformanceComparison) {
     // GTEST_SKIP() << "Skipping test";

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -122,7 +122,7 @@ bool run_dm(
     auto mesh_workload = distributed::MeshWorkload();
     auto target_devices =
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));  // Single device at (0,0)
-    distributed::AddProgramToMeshWorkload(mesh_workload, std::move(program), target_devices);
+    mesh_workload.add_program(target_devices, std::move(program));
 
     auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -124,6 +124,9 @@ class Plotter:
                 # For Transaction ID tests, plot both data size vs bandwidth and transaction ID count vs bandwidth
                 self.plot_data_size_vs_bandwidth(axes[0], plot_data[test_id])
                 self.plot_transaction_id_count_vs_bandwidth(axes[1], plot_data[test_id])
+            elif "Direct Write" in test_name:
+                self.plot_durations(axes[0], plot_data[test_id])
+                self.plot_bandwidth_direct_write(axes[1], plot_data[test_id])
             else:  # Packet Sizes
                 self.plot_durations(axes[0], plot_data[test_id])
                 self.plot_data_size_vs_bandwidth(axes[1], plot_data[test_id])
@@ -326,6 +329,30 @@ class Plotter:
         ax.set_ylabel("Bandwidth (bytes/cycle)")
         ax.set_title("Transaction ID Count vs Bandwidth")
         ax.grid()
+    # Direct Write: Num of transactions vs Bandwidth
+    def plot_bandwidth_direct_write(self, ax, data):
+        x_key = "num_transactions"
+        y_key = "bandwidth"
+        series_keys = ["stateful", "posted"]
+
+        title = "Number of Transactions vs Bandwidth"
+        xlabel = "Number of Transactions"
+        ylabel = "Bandwidth (bytes/cycle)"
+
+        self._plot_series(
+            ax=ax,
+            data=data,
+            x_key=x_key,
+            y_key=y_key,
+            series_keys=series_keys,
+            label_format=lambda combo, keys: f"Stateful={combo[0]}, Posted={combo[1]}",
+            title=title,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            xscale="log",
+            xbase=2,
+            add_theoretical_max_bw=False,
+        )
 
     # Multicast Schemes: Grid Dimensions vs Bandwidth
     def plot_bandwidth_multicast(self, ax, data, riscv, noc_index):

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -44,7 +44,10 @@ class Plotter:
             # For virtual channels tests, use two plots (1x2 grid) for NOC 0 and NOC 1
             config["nrows_per_figure"] = 1
             config["ncols_per_figure"] = 2
-
+        if "Direct Write" in test_name:
+            # For direct write tests, use one plot (1x1 grid)
+            config["nrows_per_figure"] = 1
+            config["ncols_per_figure"] = 1
         return config
 
     def plot_dm_stats(self):
@@ -360,7 +363,7 @@ class Plotter:
     def plot_bandwidth_direct_write_address_patern(self, ax, data):
         x_key = "num_transactions"
         y_key = "bandwidth"
-        series_keys = ["stateful", "same_dest"]
+        series_keys = ["stateful", "same_dest", "same_value"]
 
         title = "Number of Transactions vs Bandwidth"
         xlabel = "Number of Transactions"
@@ -372,7 +375,7 @@ class Plotter:
             x_key=x_key,
             y_key=y_key,
             series_keys=series_keys,
-            label_format=lambda combo, keys: f"{'Stateful' if combo[0] else 'Non-stateful'}, {'Same destinations' if combo[1] else 'Different destinations'}",
+            label_format=lambda combo, keys: f"{'Stateful' if combo[0] else 'Non-stateful'}, {'Same destinations' if combo[1] else 'Different destinations'}, {'Same value' if combo[2] else 'Different values'}",
             title=title,
             xlabel=xlabel,
             ylabel=ylabel,

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -333,7 +333,7 @@ class Plotter:
         ax.set_ylabel("Bandwidth (bytes/cycle)")
         ax.set_title("Transaction ID Count vs Bandwidth")
         ax.grid()
-        
+
     # Direct Write: Performance test
     def plot_bandwidth_direct_write_performance(self, ax, data):
         x_key = "num_transactions"

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -130,7 +130,7 @@ class Plotter:
             elif "Direct Write Performance Comparison" in test_name:
                 self.plot_bandwidth_direct_write_performance(axes[0], plot_data[test_id])
             elif "Direct Write Address Pattern" in test_name:
-                self.plot_bandwidth_direct_write_address_patern(axes[0], plot_data[test_id])
+                self.plot_bandwidth_direct_write_address_pattern(axes[0], plot_data[test_id])
             else:  # Packet Sizes
                 self.plot_durations(axes[0], plot_data[test_id])
                 self.plot_data_size_vs_bandwidth(axes[1], plot_data[test_id])
@@ -360,7 +360,7 @@ class Plotter:
         )
 
     # Direct Write: Address pattern
-    def plot_bandwidth_direct_write_address_patern(self, ax, data):
+    def plot_bandwidth_direct_write_address_pattern(self, ax, data):
         x_key = "num_transactions"
         y_key = "bandwidth"
         series_keys = ["stateful", "same_dest", "same_value"]

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -124,9 +124,10 @@ class Plotter:
                 # For Transaction ID tests, plot both data size vs bandwidth and transaction ID count vs bandwidth
                 self.plot_data_size_vs_bandwidth(axes[0], plot_data[test_id])
                 self.plot_transaction_id_count_vs_bandwidth(axes[1], plot_data[test_id])
-            elif "Direct Write" in test_name:
-                self.plot_durations(axes[0], plot_data[test_id])
-                self.plot_bandwidth_direct_write(axes[1], plot_data[test_id])
+            elif "Direct Write Performance Comparison" in test_name:
+                self.plot_bandwidth_direct_write_performance(axes[0], plot_data[test_id])
+            elif "Direct Write Address Pattern" in test_name:
+                self.plot_bandwidth_direct_write_address_patern(axes[0], plot_data[test_id])
             else:  # Packet Sizes
                 self.plot_durations(axes[0], plot_data[test_id])
                 self.plot_data_size_vs_bandwidth(axes[1], plot_data[test_id])
@@ -329,8 +330,9 @@ class Plotter:
         ax.set_ylabel("Bandwidth (bytes/cycle)")
         ax.set_title("Transaction ID Count vs Bandwidth")
         ax.grid()
-    # Direct Write: Num of transactions vs Bandwidth
-    def plot_bandwidth_direct_write(self, ax, data):
+        
+    # Direct Write: Performance test
+    def plot_bandwidth_direct_write_performance(self, ax, data):
         x_key = "num_transactions"
         y_key = "bandwidth"
         series_keys = ["stateful", "posted"]
@@ -345,7 +347,32 @@ class Plotter:
             x_key=x_key,
             y_key=y_key,
             series_keys=series_keys,
-            label_format=lambda combo, keys: f"Stateful={combo[0]}, Posted={combo[1]}",
+            label_format=lambda combo, keys: f"{'Stateful' if combo[0] else 'Non-stateful'}, {'Posted' if combo[1] else 'Non-posted'}",
+            title=title,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            xscale="log",
+            xbase=2,
+            add_theoretical_max_bw=False,
+        )
+
+    # Direct Write: Address pattern
+    def plot_bandwidth_direct_write_address_patern(self, ax, data):
+        x_key = "num_transactions"
+        y_key = "bandwidth"
+        series_keys = ["stateful", "same_dest"]
+
+        title = "Number of Transactions vs Bandwidth"
+        xlabel = "Number of Transactions"
+        ylabel = "Bandwidth (bytes/cycle)"
+
+        self._plot_series(
+            ax=ax,
+            data=data,
+            x_key=x_key,
+            y_key=y_key,
+            series_keys=series_keys,
+            label_format=lambda combo, keys: f"{'Stateful' if combo[0] else 'Non-stateful'}, {'Same destinations' if combo[1] else 'Different destinations'}",
             title=title,
             xlabel=xlabel,
             ylabel=ylabel,

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -439,10 +439,13 @@ tests:
   602:
     name: "Transaction ID - Read After Write One Packet Stateful"
   500:
-    name: "Direct Write Performance Comparison"
+    name: "Inline Direct Write Performance Comparison"
     comment: |
       Compares stateful vs non-stateful NOC inline write performance.
       Shows scaling advantage of stateful approach with increasing write counts.
 
   501:
-    name: "Direct Write Address Pattern"
+    name: "Inline Direct Write Address Pattern"
+    comment: |
+      Evaluates the performance impact of stateful versus stateless approaches under scenarios
+      involving both identical and differing values and destinations.

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -438,3 +438,17 @@ tests:
 
   602:
     name: "Transaction ID - Read After Write One Packet Stateful"
+  500:
+    name: "Direct Write Performance Comparison"
+    comment: |
+      Compares stateful vs non-stateful NOC inline write performance.
+      Shows scaling advantage of stateful approach with increasing write counts.
+
+  501:
+    name: "Direct Write Address Patterns"
+
+  502:
+    name: "Direct Write NOC Comparison"
+
+  503:
+    name: "Direct Write Correctness"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -445,10 +445,4 @@ tests:
       Shows scaling advantage of stateful approach with increasing write counts.
 
   501:
-    name: "Direct Write Address Patterns"
-
-  502:
-    name: "Direct Write NOC Comparison"
-
-  503:
-    name: "Direct Write Correctness"
+    name: "Direct Write Address Pattern"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -12,5 +12,6 @@ direct_write:
   attributes:
     "Posted writes": "posted"
     "Same destination": "same_dest"
+    "Same value": "same_value"
     "NOC Index": "noc_index"
     "Stateful": "stateful"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -8,3 +8,9 @@ virtual_channels:
   attributes:
     "Number of Virtual Channels": "num_virtual_channels"
     "NoC Index": "noc_index"
+direct_write:
+  attributes:
+    "Posted writes": "posted"
+    "Same destination": "same_dest"
+    "NOC Index": "noc_index"
+    "Stateful": "stateful"

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -535,14 +535,14 @@ private:
                     auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
                     noc_inline_dw_write<InlineWriteDst::REG>(noc_sem_addr_, packed_val, 0xf, noc);
                 } else {
-                    noc_inline_dw_write_with_state<true, false, true>(
+                    noc_inline_dw_write_with_state<true, false, true, false, false, false>(
                         0,  // val unused
                         this->edm_buffer_remote_free_slots_update_addr,
                         this->sync_noc_cmd_buf,
                         noc);
                 }
             } else {
-                noc_inline_dw_write_with_state<false, false, true>(
+                noc_inline_dw_write_with_state<false, false, true, false, false, false>(
                     0,  // val unused
                     0,  // addr unused
                     this->sync_noc_cmd_buf,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -535,14 +535,14 @@ private:
                     auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
                     noc_inline_dw_write<InlineWriteDst::REG>(noc_sem_addr_, packed_val, 0xf, noc);
                 } else {
-                    noc_inline_dw_write_with_state<true, false, true, false, false, false>(
+                    noc_inline_dw_write_with_state<true, false, true, false, false, InlineWriteDst::REG>(
                         0,  // val unused
                         this->edm_buffer_remote_free_slots_update_addr,
                         this->sync_noc_cmd_buf,
                         noc);
                 }
             } else {
-                noc_inline_dw_write_with_state<false, false, true, false, false, false>(
+                noc_inline_dw_write_with_state<false, false, true, false, false, InlineWriteDst::REG>(
                     0,  // val unused
                     0,  // addr unused
                     this->sync_noc_cmd_buf,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
@@ -269,14 +269,14 @@ private:
                     auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
                     noc_inline_dw_write<InlineWriteDst::REG>(noc_sem_addr_, packed_val, 0xf, noc);
                 } else {
-                    noc_inline_dw_write_with_state<true, false, true>(
+                    noc_inline_dw_write_with_state<true, false, true, false, false, false>(
                         0,  // val unused
                         this->edm_buffer_remote_free_slots_update_addr,
                         this->sync_noc_cmd_buf,
                         noc);
                 }
             } else {
-                noc_inline_dw_write_with_state<false, false, true>(
+                noc_inline_dw_write_with_state<false, false, true, false, false, false>(
                     0,  // val unused
                     0,  // addr unused
                     this->sync_noc_cmd_buf,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
@@ -269,14 +269,14 @@ private:
                     auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
                     noc_inline_dw_write<InlineWriteDst::REG>(noc_sem_addr_, packed_val, 0xf, noc);
                 } else {
-                    noc_inline_dw_write_with_state<true, false, true, false, false, false>(
+                    noc_inline_dw_write_with_state<true, false, true, false, false, InlineWriteDst::REG>(
                         0,  // val unused
                         this->edm_buffer_remote_free_slots_update_addr,
                         this->sync_noc_cmd_buf,
                         noc);
                 }
             } else {
-                noc_inline_dw_write_with_state<false, false, true, false, false, false>(
+                noc_inline_dw_write_with_state<false, false, true, false, false, InlineWriteDst::REG>(
                     0,  // val unused
                     0,  // addr unused
                     this->sync_noc_cmd_buf,

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1942,18 +1942,18 @@ FORCE_INLINE void noc_inline_dw_write_set_state(
  *
  * Return value: None
  *
- * | Argument                                   | Description                                         | Data type | Valid range   | required |
- * |--------------------------------------------|-----------------------------------------------------|-----------|---------------|----------|
- * | val                                        | The value to be written                             | uint32_t  | Any uint32_t  | True     |
- * | addr                                       | The local address to write to (if not set in state) | uint32_t  | 0..1MB        | False    |
- * | cmd_buf                                    | Command buffer to use for the transaction           | uint8_t   | 0-3           | False    |
- * | noc                                        | NOC to use for the transaction                      | uint8_t   | 0 or 1        | False    |
- * | update_addr_lo (template parameter)        | Whether to update the lower 32 bits of the address  | bool      | true or false | False    |
- * | update_counter (template parameter)        | Whether to update the write counters                | bool      | true or false | False    |
- * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)   | bool      | true or false | False    |
- * | update_addr_hi (template parameter)        | Whether to update the upper 32 bits of the address  | bool      | true or false | False    |
- * | update_val (template parameter)            | Whether to set the value to be written              | bool      | true or false | False    |
- * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true| bool      | true or false | False    |
+ * | Argument                                   | Description                                            | Data type | Valid range   | required |
+ * |--------------------------------------------|--------------------------------------------------------|-----------|---------------|----------|
+ * | val                                        | The value to be written                                | uint32_t  | Any uint32_t  | True     |
+ * | addr                                       | The local address to write to (if not set in state)    | uint32_t  | 0..1MB        | False    |
+ * | cmd_buf                                    | Command buffer to use for the transaction              | uint8_t   | 0-3           | False    |
+ * | noc                                        | NOC to use for the transaction                         | uint8_t   | 0 or 1        | False    |
+ * | update_addr_lo (template parameter)        | Whether to update the lower 32 bits of the address     | bool      | true or false | False    |
+ * | update_counter (template parameter)        | Whether to update the write counters                   | bool      | true or false | False    |
+ * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool      | true or false | False    |
+ * | update_addr_hi (template parameter)        | Whether to update the upper 32 bits of the address     | bool      | true or false | False    |
+ * | update_val (template parameter)            | Whether to set the value to be written                 | bool      | true or false | False    |
+ * | dst_type (template parameter)              | Whether the write is targeting L1 or a Stream Register | InlineWriteDst| DEFAULT, L1, REG | False    |
  */
 // clang-format on
 template <
@@ -1962,7 +1962,7 @@ template <
     bool posted = false,
     bool update_addr_hi = false,
     bool update_val = false,
-    bool update_be_on_addr_lo = true>
+    InlineWriteDst dst_type = InlineWriteDst::DEFAULT>
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
 #ifdef ARCH_BLACKHOLE
@@ -1982,7 +1982,7 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
         update_val,
         posted,
         update_counter_in_callee,
-        update_be_on_addr_lo>(noc, cmd_buf, val, addr);
+        dst_type>(noc, cmd_buf, val, addr);
     WAYPOINT("NWID");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1942,17 +1942,18 @@ FORCE_INLINE void noc_inline_dw_write_set_state(
  *
  * Return value: None
  *
- * | Argument                            | Description                                         | Data type | Valid range   | required |
- * |-------------------------------------|-----------------------------------------------------|-----------|---------------|----------|
- * | val                                 | The value to be written                             | uint32_t  | Any uint32_t  | True     |
- * | addr                                | The local address to write to (if not set in state) | uint32_t  | 0..1MB        | False    |
- * | cmd_buf                             | Command buffer to use for the transaction           | uint8_t   | 0-3           | False    |
- * | noc                                 | NOC to use for the transaction                      | uint8_t   | 0 or 1        | False    |
- * | update_addr_lo (template parameter) | Whether to update the lower 32 bits of the address  | bool      | true or false | False    |
- * | update_counter (template parameter) | Whether to update the write counters                | bool      | true or false | False    |
- * | posted (template parameter)         | Whether the call is posted (i.e. ack requirement)   | bool      | true or false | False    |
- * | update_addr_hi (template parameter) | Whether to update the upper 32 bits of the address  | bool      | true or false | False    |
- * | update_val (template parameter)     | Whether to set the value to be written              | bool      | true or false | False    |
+ * | Argument                                   | Description                                         | Data type | Valid range   | required |
+ * |--------------------------------------------|-----------------------------------------------------|-----------|---------------|----------|
+ * | val                                        | The value to be written                             | uint32_t  | Any uint32_t  | True     |
+ * | addr                                       | The local address to write to (if not set in state) | uint32_t  | 0..1MB        | False    |
+ * | cmd_buf                                    | Command buffer to use for the transaction           | uint8_t   | 0-3           | False    |
+ * | noc                                        | NOC to use for the transaction                      | uint8_t   | 0 or 1        | False    |
+ * | update_addr_lo (template parameter)        | Whether to update the lower 32 bits of the address  | bool      | true or false | False    |
+ * | update_counter (template parameter)        | Whether to update the write counters                | bool      | true or false | False    |
+ * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)   | bool      | true or false | False    |
+ * | update_addr_hi (template parameter)        | Whether to update the upper 32 bits of the address  | bool      | true or false | False    |
+ * | update_val (template parameter)            | Whether to set the value to be written              | bool      | true or false | False    |
+ * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true| bool      | true or false | False    |
  */
 // clang-format on
 template <
@@ -1960,7 +1961,8 @@ template <
     bool update_counter = true,
     bool posted = false,
     bool update_addr_hi = false,
-    bool update_val = false>
+    bool update_val = false,
+    bool update_be_on_addr_lo = true>
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
 #ifdef ARCH_BLACKHOLE
@@ -1979,7 +1981,8 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
         update_addr_hi,
         update_val,
         posted,
-        update_counter_in_callee>(noc, cmd_buf, val, addr);
+        update_counter_in_callee,
+        update_be_on_addr_lo>(noc, cmd_buf, val, addr);
     WAYPOINT("NWID");
 }
 

--- a/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1269,6 +1269,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  * | update_val (template parameter)     | Whether to set the value to be written                 | bool     | true or false                    | False    |
  * | posted (template parameter)         | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
  * | update_counter (template parameter) | Whether to update the write counters                   | bool     | true or false                    | False    |
+ * | dst_type (template parameter)       | Whether the write is targeting L1 or a Stream Register | InlineWriteDst     | DEFAULT, L1, REG       | False    |
  */
 // clang-format on
 template <
@@ -1277,7 +1278,8 @@ template <
     bool update_addr_hi = false,
     bool update_val = false,
     bool posted = false,
-    bool update_counter = true>
+    bool update_counter = true,
+    InlineWriteDst dst_type = InlineWriteDst::DEFAULT>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
@@ -1294,6 +1296,10 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
+        if constexpr (dst_type != InlineWriteDst::REG) {
+            uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
+            NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+        }
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -1090,6 +1090,8 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
+        uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -1065,7 +1065,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  * | update_val (template parameter)            | Whether to set the value to be written                 | bool     | true or false                    | False    |
  * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
  * | update_counter (template parameter)        | Whether to update the write counters                   | bool     | true or false                    | False    |
- * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true   | bool     | true or false                    | False    |
+ * | dst_type (template parameter)              | Whether the write is targeting L1 or a Stream Register | InlineWriteDst     | DEFAULT, L1, REG       | False    |
  */
 // clang-format on
 template <
@@ -1075,7 +1075,7 @@ template <
     bool update_val = false,
     bool posted = false,
     bool update_counter = true,
-    bool update_be_on_addr_lo = false>
+    InlineWriteDst dst_type = InlineWriteDst::DEFAULT>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
@@ -1092,7 +1092,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
-        if constexpr (update_be_on_addr_lo) {
+        if constexpr (dst_type != InlineWriteDst::REG) {
             uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
             NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
         }

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -1054,17 +1054,18 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  *
  * Return value: None
  *
- * | Argument                            | Description                                            | Type     | Valid Range                      | Required |
- * |-------------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
- * | noc                                 | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
- * | cmd_buf                             | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
- * | val                                 | The value to be written                                | uint32_t | Any uint32_t value               | False    |
- * | dest_addr                           | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | False    |
- * | update_addr_lo (template parameter) | Whether to update the lower 32 bits of the address     | bool     | true or false                    | False    |
- * | update_addr_hi (template parameter) | Whether to update the upper 32 bits of the address     | bool     | true or false                    | False    |
- * | update_val (template parameter)     | Whether to set the value to be written                 | bool     | true or false                    | False    |
- * | posted (template parameter)         | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
- * | update_counter (template parameter) | Whether to update the write counters                   | bool     | true or false                    | False    |
+ * | Argument                                   | Description                                            | Type     | Valid Range                      | Required |
+ * |--------------------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
+ * | noc                                        | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
+ * | cmd_buf                                    | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
+ * | val                                        | The value to be written                                | uint32_t | Any uint32_t value               | False    |
+ * | dest_addr                                  | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | False    |
+ * | update_addr_lo (template parameter)        | Whether to update the lower 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_addr_hi (template parameter)        | Whether to update the upper 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_val (template parameter)            | Whether to set the value to be written                 | bool     | true or false                    | False    |
+ * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
+ * | update_counter (template parameter)        | Whether to update the write counters                   | bool     | true or false                    | False    |
+ * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true   | bool     | true or false                    | False    |
  */
 // clang-format on
 template <
@@ -1073,7 +1074,8 @@ template <
     bool update_addr_hi = false,
     bool update_val = false,
     bool posted = false,
-    bool update_counter = true>
+    bool update_counter = true,
+    bool update_be_on_addr_lo = false>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
@@ -1090,8 +1092,10 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
-        uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+        if constexpr (update_be_on_addr_lo) {
+            uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
+            NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+        }
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1194,6 +1194,8 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
+        uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1158,17 +1158,18 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  *
  * Return value: None
  *
- * | Argument                            | Description                                            | Type     | Valid Range                      | Required |
- * |-------------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
- * | noc                                 | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
- * | cmd_buf                             | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
- * | val                                 | The value to be written                                | uint32_t | Any uint32_t value               | False    |
- * | dest_addr                           | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | False    |
- * | update_addr_lo (template parameter) | Whether to update the lower 32 bits of the address     | bool     | true or false                    | False    |
- * | update_addr_hi (template parameter) | Whether to update the upper 32 bits of the address     | bool     | true or false                    | False    |
- * | update_val (template parameter)     | Whether to set the value to be written                 | bool     | true or false                    | False    |
- * | posted (template parameter)         | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
- * | update_counter (template parameter) | Whether to update the write counters                   | bool     | true or false                    | False    |
+ * | Argument                                   | Description                                            | Type     | Valid Range                      | Required |
+ * |--------------------------------------------|--------------------------------------------------------|----------|----------------------------------|----------|
+ * | noc                                        | NOC to use for the transaction                         | uint32_t | 0 or 1                           | True     |
+ * | cmd_buf                                    | Command buffer to use for the transaction              | uint32_t | 0 - 3                            | True     |
+ * | val                                        | The value to be written                                | uint32_t | Any uint32_t value               | False    |
+ * | dest_addr                                  | Encoding of the destination NOC location (x,y)+address | uint64_t | Results of \a get_noc_addr calls | False    |
+ * | update_addr_lo (template parameter)        | Whether to update the lower 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_addr_hi (template parameter)        | Whether to update the upper 32 bits of the address     | bool     | true or false                    | False    |
+ * | update_val (template parameter)            | Whether to set the value to be written                 | bool     | true or false                    | False    |
+ * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
+ * | update_counter (template parameter)        | Whether to update the write counters                   | bool     | true or false                    | False    |
+ * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true   | bool     | true or false                    | False    |
  */
 // clang-format on
 template <
@@ -1177,7 +1178,8 @@ template <
     bool update_addr_hi = false,
     bool update_val = false,
     bool posted = false,
-    bool update_counter = true>
+    bool update_counter = true,
+    bool update_be_on_addr_lo = false>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
@@ -1194,8 +1196,10 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
-        uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
-        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+        if constexpr (update_be_on_addr_lo) {
+            uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
+            NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+        }
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1169,7 +1169,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  * | update_val (template parameter)            | Whether to set the value to be written                 | bool     | true or false                    | False    |
  * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
  * | update_counter (template parameter)        | Whether to update the write counters                   | bool     | true or false                    | False    |
- * | update_be_on_addr_lo (template parameter)  | Whether to update the BE when update_addr_lo is true   | bool     | true or false                    | False    |
+ * | dst_type (template parameter)              | Whether the write is targeting L1 or a Stream Register | InlineWriteDst     | DEFAULT, L1, REG       | False    |
  */
 // clang-format on
 template <
@@ -1196,7 +1196,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
-        if constexpr (update_be_on_addr_lo) {
+        if constexpr (dst_type != InlineWriteDst::REG) {
             uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
             NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
         }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -202,19 +202,12 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(
         WAYPOINT("NISD");
     }
 
-    noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, flags, CQ_NOC_wait, CQ_NOC_send, false, false, false>(
-        noc, dst_addr, val, be);
+    noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, flags, CQ_NOC_wait, CQ_NOC_send>(noc, dst_addr, val, be);
 
     if constexpr (send) {
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc, NCRISC_WR_REG_CMD_BUF);
-        noc_inline_dw_write_with_state<
-            NCRISC_WR_REG_CMD_BUF,
-            CQ_NOC_INLINE_ndvb,
-            CQ_NOC_wait,
-            send,
-            false,
-            false,
-            false>(noc, dst_addr, val, be);
+        noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, CQ_NOC_INLINE_ndvb, CQ_NOC_wait, send>(
+            noc, dst_addr, val, be);
     }
 #endif
 }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -202,11 +202,19 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(
         WAYPOINT("NISD");
     }
 
-    noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, flags, CQ_NOC_wait, CQ_NOC_send>(noc, dst_addr, val, be);
+    noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, flags, CQ_NOC_wait, CQ_NOC_send, false, false, false>(
+        noc, dst_addr, val, be);
 
     if constexpr (send) {
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc, NCRISC_WR_REG_CMD_BUF);
-        noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, CQ_NOC_INLINE_ndvb, CQ_NOC_wait, send>(noc, dst_addr, val, be);
+        noc_inline_dw_write_with_state<
+            NCRISC_WR_REG_CMD_BUF,
+            CQ_NOC_INLINE_ndvb,
+            CQ_NOC_wait,
+            send,
+            false,
+            false,
+            false>(noc, dst_addr, val, be);
     }
 #endif
 }


### PR DESCRIPTION
### Ticket
[Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=123522028&issue=tenstorrent%7Ctt-metal%7C26532)

### Problem description
In `noc_inline_dw_write_with_state`, the `NOC_AT_LEN_BE` register was not being updated. As a result, in certain scenarios, the actual write address differed from the one provided as a method parameter.

### What's changed
**This is a reopened PR because the [previous one](https://github.com/tenstorrent/tt-metal/pull/27905) failed the APC after merging.**

I've added the fix in both blackhole and wormhole. However, as mentioned in the [docs](https://github.com/tenstorrent/tt-isa-documentation/blob/main/BlackholeA0/NoC/MemoryMap.md), on blackhole, this call should be avoided. The fix consists of updating the `NOC_AT_LEN_BE` every time both `update_addr_lo` and `update_be_on_addr_lo` are set. This is done this way because the fabric team is changing the lower part of the address but the offset stays the same. To make sure they don't lose performance on the unnecessary register writes, we added `update_be_on_addr_lo ` which can be disabled if needed. The `NOC_AT_LEN_BE` is updated with the corresponding mask, which is calculated based on the last 5 bits of the address. See [documentation](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/NoC/MemoryMap.md#noc_at_len_be).
I've also added the data movement tests for this api.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [results](https://github.com/tenstorrent/tt-metal/actions/runs/19033730995)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes