### PR TITLE
Add Native Dim 1 & 2 Support to RS-Ring

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -243,14 +243,11 @@ def run_reduce_scatter_impl(
         # Dim 1 tests
         ([2, 24, 256, 256], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([2, 16, 56, 56], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([2, 8, 256, 256], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([2, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Dim 2 tests
         ([2, 4, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([8, 1, 512, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([4, 1, 1024, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([1, 1, 1024, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([2, 1, 2048, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
-        ([1, 1, 4096, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([4, 1, 1024, 340], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 512, 512], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Dim 3 tests
         ([2, 4, 1024, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
@@ -274,9 +271,6 @@ def run_reduce_scatter_impl(
         "scatter_dim_2_test_one",
         "scatter_dim_2_test_two",
         "scatter_dim_2_test_three",
-        "scatter_dim_2_test_four",
-        "scatter_dim_2_test_five",
-        "scatter_dim_2_test_six",
         "non_zero_dim_1",
         "padded_dim_2_test_one",
         "padded_dim_2_test_two",

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -240,6 +240,14 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "rs_input_shape, dim, layout, rs_input_dtype",
     [
+        # Dim 2 tests
+        ([2, 4, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([8, 1, 512, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([4, 1, 1024, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 1024, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([2, 1, 2048, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([1, 1, 4096, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        # Dim 3 tests
         ([2, 4, 1024, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
@@ -256,6 +264,12 @@ def run_reduce_scatter_impl(
         ([1, 1, 29, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
+        "scatter_dim_2_test_one",
+        "scatter_dim_2_test_two",
+        "scatter_dim_2_test_three",
+        "scatter_dim_2_test_four",
+        "scatter_dim_2_test_five",
+        "scatter_dim_2_test_six",
         "non_zero_dim_1",
         "padded_dim_2_test_one",
         "padded_dim_2_test_two",
@@ -367,7 +381,7 @@ def test_reduce_scatter_async(
         ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),
-        # # Scatter on dim 3
+        # Scatter on dim 3
         ([1, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 1, 128, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
         ([16, 16, 8, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -240,6 +240,10 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "rs_input_shape, dim, layout, rs_input_dtype",
     [
+        # Dim 1 tests
+        ([2, 24, 256, 256], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([2, 16, 56, 56], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        ([2, 8, 256, 256], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         # Dim 2 tests
         ([2, 4, 1024, 1024], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([8, 1, 512, 2560], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
@@ -264,6 +268,9 @@ def run_reduce_scatter_impl(
         ([1, 1, 29, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
+        "scatter_dim_1_test_one",
+        "scatter_dim_1_test_two",
+        "scatter_dim_1_test_three",
         "scatter_dim_2_test_one",
         "scatter_dim_2_test_two",
         "scatter_dim_2_test_three",

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -240,6 +240,7 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "rs_input_shape, dim, layout, rs_input_dtype",
     [
+        ([2, 4, 1024, 1024], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
         ([8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
@@ -255,6 +256,7 @@ def run_reduce_scatter_impl(
         ([1, 1, 29, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
+        "non_zero_dim_1",
         "padded_dim_2_test_one",
         "padded_dim_2_test_two",
         "batch_8",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -136,7 +136,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool composite_all_gather =
         composite_common::use_composite_all_gather(padded_tensor, composite_dim, out_memory_config);
     bool composite_reduce_scatter =
-        composite_common::use_composite_reduce_scatter(padded_tensor, composite_dim, std::nullopt);
+        composite_common::use_composite_reduce_scatter(padded_tensor, topology, composite_dim, std::nullopt);
 
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim)) {
         // All reduce = all gather + local reduce
@@ -249,7 +249,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool composite_all_gather =
         composite_common::use_composite_all_gather(padded_tensor, composite_dim, out_memory_config);
     bool composite_reduce_scatter =
-        composite_common::use_composite_reduce_scatter(padded_tensor, composite_dim, cluster_axis);
+        composite_common::use_composite_reduce_scatter(padded_tensor, topology, composite_dim, cluster_axis);
 
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim)) {
         // All reduce = all gather + local reduce

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -6,9 +6,11 @@
 
 namespace composite_common {
 
-// TODO: (GR) This will need to add topology as a parameter
 bool use_composite_reduce_scatter(
-    const ttnn::Tensor& input_tensor, const int32_t dim, std::optional<uint32_t> cluster_axis) {
+    const ttnn::Tensor& input_tensor,
+    ttnn::ccl::Topology topology,
+    const int32_t dim,
+    std::optional<uint32_t> cluster_axis) {
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
@@ -17,6 +19,11 @@ bool use_composite_reduce_scatter(
     int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+
+    // This is the same conditional topology update done inside the native op
+    if (num_devices == 2) {
+        topology = ttnn::ccl::Topology::Linear;
+    }
 
     // Must scatter evenly
     auto input_shape = input_tensor.logical_shape();
@@ -29,9 +36,18 @@ bool use_composite_reduce_scatter(
         return true;
     }
 
-    // Use composite if scattering on a dim that isn't 2 or 3
-    if (scatter_dim != 1 && scatter_dim != 2 && scatter_dim != 3) {
-        return true;
+    // Use composite if we don't support scattering on the provided dim
+    // with the provided topology
+    if (topology == ttnn::ccl::Topology::Linear) {
+        if (scatter_dim != 3) {
+            return true;
+        }
+    } else if (topology == ttnn::ccl::Topology::Ring) {
+        if (scatter_dim != 1 && scatter_dim != 2 && scatter_dim != 3) {
+            return true;
+        }
+    } else {
+        TT_FATAL(false, "reduce_scatter_minimal_async only supports linear or ring topology");
     }
 
     // Use composite if tiled and scattering on padded dim 2 or 3

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.cpp
@@ -30,7 +30,7 @@ bool use_composite_reduce_scatter(
     }
 
     // Use composite if scattering on a dim that isn't 2 or 3
-    if (scatter_dim != 2 && scatter_dim != 3) {
+    if (scatter_dim != 1 && scatter_dim != 2 && scatter_dim != 3) {
         return true;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common.hpp
@@ -24,7 +24,8 @@
 
 namespace composite_common {
 
-bool use_composite_reduce_scatter(const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis);
+bool use_composite_reduce_scatter(
+    const ttnn::Tensor& input_tensor, ttnn::ccl::Topology topology, int32_t dim, std::optional<uint32_t> cluster_axis);
 bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const ttnn::MemoryConfig& output_mem_config);
 bool use_composite_all_gather(
     const ttnn::Tensor& input_tensor, int32_t dim, const std::optional<ttnn::MemoryConfig>& memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -136,117 +136,122 @@ void kernel_main() {
                 actual_slice_idx = slice_idx >= (int)ring_size ? (uint32_t)slice_idx - ring_size : (uint32_t)slice_idx;
             }
 
+            chunk_count = 0;
+
             uint32_t input_tile_id_start = actual_slice_idx * slice_Wt + batch_offset;
             uint32_t intermediate_tile_id_start = actual_slice_idx * slice_Wt;
-            uint32_t stride_Wt = input_tensor_Wt;
-            uint32_t pages_read_in_row = start_pages_read_in_row;
-            uint32_t row_offset = start_row_offset;
-            uint32_t intermediate_pages_read_in_row = pages_read_in_row;
-            uint32_t intermediate_row_offset = row_offset;
-            uint32_t tiles_read = start_tiles_read;
-            uint32_t tiles_to_read = start_tiles_to_read;
+            for (uint32_t c = 0; c < input_tensor_C; ++c) {
+                uint32_t input_pages_read_in_row = start_pages_read_in_row;
+                uint32_t input_row_offset = start_row_offset;
 
-            if constexpr (!direction) {
-                uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-                for (uint32_t k = 0; k < backwards_offset; ++k) {
-                    pages_read_in_row++;
-                    if (pages_read_in_row == slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = pages_read_in_row - slice_Wt;
-                    }
-                }
+                uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
+                uint32_t intermediate_row_offset = input_row_offset;
 
-                tiles_read += backwards_offset;
-                intermediate_pages_read_in_row = pages_read_in_row;
-                intermediate_row_offset = row_offset;
-            }
+                uint32_t tiles_read = start_tiles_read / input_tensor_C;
+                uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
 
-            /**
-             * Interleave forward and backward ring reads
-             * forward handles even tiles, backward handles odd tiles
-             * after ring_size-1 steps, we've transferred all tiles
-             */
-            chunk_count = 0;
-            while (tiles_read < tiles_to_read) {
-                if (do_reduce && (chunk_count % chunks_per_sync == 0)) {
-                    noc_semaphore_wait_min(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
-                    sem_target++;
-                }
-                chunk_count++;
-
-                uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
-
-                uint32_t tiles_to_read_in_current_direction = 0;
-                if constexpr (direction) {
-                    tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
-                } else {
-                    tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
-                }
-
-                cb_reserve_back(cb_in0, tile_granularity);
-                uint32_t l1_write_addr = get_write_ptr(cb_in0);
-                for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
-                    uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
-                    uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
-                    l1_write_addr += page_size;
-                    tiles_read++;
-
-                    pages_read_in_row++;
-                    if (pages_read_in_row == slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = 0;
-                    }
-                }
-
-                if (do_reduce) {
-                    // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
-                    cb_reserve_back(cb_intermediate_id, tile_granularity);
-                    uint32_t intermediate_l1_write_addr = get_write_ptr(cb_intermediate_id);
-                    for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
-                        uint32_t intermediate_tile_id =
-                            intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                        uint64_t intermediate_noc_read_addr =
-                            get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
-                        noc_async_read(intermediate_noc_read_addr, intermediate_l1_write_addr, page_size);
-                        intermediate_l1_write_addr += page_size;
-
-                        intermediate_pages_read_in_row++;
-                        if (intermediate_pages_read_in_row == slice_Wt) {
-                            intermediate_row_offset += stride_Wt;
-                            intermediate_pages_read_in_row = 0;
+                if constexpr (!direction) {
+                    uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
+                    for (uint32_t k = 0; k < backwards_offset; ++k) {
+                        input_pages_read_in_row++;
+                        if (input_pages_read_in_row == slice_Wt) {
+                            input_row_offset += input_tensor_Wt;
+                            input_pages_read_in_row -= slice_Wt;
                         }
+                    }
+
+                    tiles_read += backwards_offset;
+                    intermediate_pages_read_in_row = input_pages_read_in_row;
+                    intermediate_row_offset = input_row_offset;
+                }
+
+                /**
+                 * Interleave forward and backward ring reads
+                 * forward handles even tiles, backward handles odd tiles
+                 * after ring_size-1 steps, we've transferred all tiles
+                 */
+                while (tiles_read < tiles_to_read) {
+                    if (do_reduce && (chunk_count % chunks_per_sync == 0)) {
+                        noc_semaphore_wait_min(
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
+                        sem_target++;
+                    }
+                    chunk_count++;
+
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+
+                    uint32_t tiles_to_read_in_current_direction = 0;
+                    if constexpr (direction) {
+                        tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
+                    } else {
+                        tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
+                    }
+
+                    cb_reserve_back(cb_in0, tile_granularity);
+                    uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
+                        uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
+                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        l1_write_addr += page_size;
+                        tiles_read++;
+
+                        input_pages_read_in_row++;
+                        if (input_pages_read_in_row == slice_Wt) {
+                            input_row_offset += input_tensor_Wt;
+                            input_pages_read_in_row -= slice_Wt;
+                        }
+                    }
+
+                    if (do_reduce) {
+                        // read the next intermediate slice out of the intermediate buffer, and put it in intermediate
+                        // CB
+                        cb_reserve_back(cb_intermediate_id, tile_granularity);
+                        uint32_t intermediate_l1_write_addr = get_write_ptr(cb_intermediate_id);
+                        for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
+                            uint32_t intermediate_tile_id =
+                                intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
+                            uint64_t intermediate_noc_read_addr =
+                                get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
+                            noc_async_read(intermediate_noc_read_addr, intermediate_l1_write_addr, page_size);
+                            intermediate_l1_write_addr += page_size;
+
+                            intermediate_pages_read_in_row++;
+                            if (intermediate_pages_read_in_row == slice_Wt) {
+                                intermediate_row_offset += input_tensor_Wt;
+                                intermediate_pages_read_in_row -= slice_Wt;
+                            }
+                        }
+
+                        noc_async_read_barrier();
+                        cb_push_back(cb_intermediate_id, tile_granularity);
                     }
 
                     noc_async_read_barrier();
-                    cb_push_back(cb_intermediate_id, tile_granularity);
-                }
+                    cb_push_back(cb_in0, tile_granularity);
 
-                noc_async_read_barrier();
-                cb_push_back(cb_in0, tile_granularity);
-
-                // Skip the tiles going the other direction
-                tiles_remaining_to_read = tiles_to_read - tiles_read;
-                if (tiles_remaining_to_read > 0) {
-                    uint32_t tiles_to_read_in_other_direction = 0;
-                    if constexpr (!direction) {
-                        tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
-                    } else {
-                        tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read, tile_granularity);
-                    }
-
-                    for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
-                        pages_read_in_row++;
-                        if (pages_read_in_row == slice_Wt) {
-                            row_offset += stride_Wt;
-                            pages_read_in_row = pages_read_in_row - slice_Wt;
+                    // Skip the tiles going the other direction
+                    tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    if (tiles_remaining_to_read > 0) {
+                        uint32_t tiles_to_read_in_other_direction = 0;
+                        if constexpr (!direction) {
+                            tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
+                        } else {
+                            tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read, tile_granularity);
                         }
-                    }
 
-                    tiles_read += tiles_to_read_in_other_direction;
-                    intermediate_pages_read_in_row = pages_read_in_row;
-                    intermediate_row_offset = row_offset;
+                        for (uint32_t k = 0; k < tiles_to_read_in_other_direction; ++k) {
+                            input_pages_read_in_row++;
+                            if (input_pages_read_in_row == slice_Wt) {
+                                input_row_offset += input_tensor_Wt;
+                                input_pages_read_in_row -= slice_Wt;
+                            }
+                        }
+
+                        tiles_read += tiles_to_read_in_other_direction;
+                        intermediate_pages_read_in_row = input_pages_read_in_row;
+                        intermediate_row_offset = input_row_offset;
+                    }
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -36,6 +36,7 @@ constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
 constexpr uint32_t fuse_op = get_compile_time_arg_val(16);
 constexpr bool direction = get_compile_time_arg_val(17);
 constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(18);
+constexpr uint32_t dim = get_compile_time_arg_val(19);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -53,7 +54,7 @@ void kernel_main() {
     int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr uint32_t ct_idx = 19;
+    constexpr uint32_t ct_idx = 20;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -138,8 +139,15 @@ void kernel_main() {
             }
 
             chunk_count = 0;
-            uint32_t input_tile_id_start = actual_slice_idx * slice_Wt + batch_offset;
-            uint32_t intermediate_tile_id_start = actual_slice_idx * slice_Wt;
+            uint32_t input_tile_id_start;
+            uint32_t intermediate_tile_id_start;
+            if constexpr (dim == 3) {
+                input_tile_id_start = actual_slice_idx * slice_Wt + batch_offset;
+                intermediate_tile_id_start = actual_slice_idx * slice_Wt;
+            } else if constexpr (dim == 2) {
+                input_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt + batch_offset;
+                intermediate_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
+            }
             for (uint32_t c = 0; c < input_tensor_C; ++c) {
                 uint32_t input_pages_read_in_row = start_pages_read_in_row;
                 uint32_t input_row_offset = start_row_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -18,18 +18,24 @@ using tt::tt_metal::BufferType;
 ///////////////////////////////////////////////////
 
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
-constexpr uint32_t cb_input_id = get_compile_time_arg_val(1);
-constexpr uint32_t cb_intermediate_id = get_compile_time_arg_val(2);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(3);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
-constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(5);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(6);
+constexpr uint32_t ring_size = get_compile_time_arg_val(1);
+constexpr uint32_t cb_input_id = get_compile_time_arg_val(2);
+constexpr uint32_t cb_intermediate_id = get_compile_time_arg_val(3);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(4);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(5);
+constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(6);
 constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(7);
-constexpr uint32_t ring_size = get_compile_time_arg_val(8);
-constexpr uint32_t num_batches = get_compile_time_arg_val(9);
-constexpr uint32_t fuse_op = get_compile_time_arg_val(10);
-constexpr bool direction = get_compile_time_arg_val(11);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(12);
+constexpr uint32_t input_tensor_B = get_compile_time_arg_val(8);
+constexpr uint32_t input_tensor_C = get_compile_time_arg_val(9);
+constexpr uint32_t input_tensor_Ht = get_compile_time_arg_val(10);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(11);
+constexpr uint32_t slice_B = get_compile_time_arg_val(12);
+constexpr uint32_t slice_C = get_compile_time_arg_val(13);
+constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
+constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
+constexpr uint32_t fuse_op = get_compile_time_arg_val(16);
+constexpr bool direction = get_compile_time_arg_val(17);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(18);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -41,17 +47,13 @@ void kernel_main() {
     address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    size_t batch_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t link = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_links = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t slice_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
     int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr uint32_t ct_idx = 13;
+    constexpr uint32_t ct_idx = 19;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -111,7 +113,7 @@ void kernel_main() {
     uint32_t chunk_count = 0;
     uint32_t sem_target = 0;
 
-    for (uint32_t b = 0; b < num_batches; b++) {
+    for (uint32_t b = 0; b < input_tensor_B; b++) {
         if constexpr (fuse_op) {
             matmul_receiver.wait_for_matmul_batch(b);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -140,13 +140,13 @@ void kernel_main() {
 
             uint32_t input_tile_id_start = actual_slice_idx * slice_Wt + batch_offset;
             uint32_t intermediate_tile_id_start = actual_slice_idx * slice_Wt;
+
+            uint32_t input_pages_read_in_row = start_pages_read_in_row;
+            uint32_t input_row_offset = start_row_offset;
+
+            uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
+            uint32_t intermediate_row_offset = input_row_offset;
             for (uint32_t c = 0; c < input_tensor_C; ++c) {
-                uint32_t input_pages_read_in_row = start_pages_read_in_row;
-                uint32_t input_row_offset = start_row_offset;
-
-                uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
-                uint32_t intermediate_row_offset = input_row_offset;
-
                 uint32_t tiles_read = start_tiles_read / input_tensor_C;
                 uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -147,8 +147,13 @@ void kernel_main() {
             } else if constexpr (dim == 2) {
                 input_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt + batch_offset;
                 intermediate_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
+            } else if constexpr (dim == 1) {
+                input_tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C + batch_offset;
+                intermediate_tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C;
+            } else {
+                ASSERT(false);
             }
-            for (uint32_t c = 0; c < input_tensor_C; ++c) {
+            for (uint32_t c = 0; c < slice_C; ++c) {
                 uint32_t input_pages_read_in_row = start_pages_read_in_row;
                 uint32_t input_row_offset = start_row_offset;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -235,14 +235,14 @@ void kernel_main() {
             // If not the last slice, write what's on cb_output_id forward
             uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
             if (i < (ring_size - 1)) {
+                uint32_t tile_id_start = actual_slice_idx * slice_Wt;
+                uint32_t pages_read_in_row = start_pages_read_in_row;
+                uint32_t row_offset = start_row_offset;
+
                 chunk_count = 0;
                 for (uint32_t c = 0; c < input_tensor_C; ++c) {
                     uint32_t tiles_read = start_tiles_read / input_tensor_C;
                     uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
-
-                    uint32_t tile_id_start = actual_slice_idx * slice_Wt;
-                    uint32_t pages_read_in_row = start_pages_read_in_row;
-                    uint32_t row_offset = start_row_offset;
 
                     if constexpr (!direction) {
                         uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
@@ -375,10 +375,11 @@ void kernel_main() {
             } else {
                 // Otherwise, on the last slice, write it to output buffer
                 for (uint32_t c = 0; c < input_tensor_C; ++c) {
+                    uint32_t tile_id_start = batch_slice_offset + c * batch_slice_num_pages / input_tensor_C;
+
                     uint32_t tiles_read = start_tiles_read / input_tensor_C;
                     uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
 
-                    uint32_t tile_id_start = batch_slice_offset;
                     if constexpr (!direction) {
                         tiles_read += std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -235,14 +235,16 @@ void kernel_main() {
             // If not the last slice, write what's on cb_output_id forward
             uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
             if (i < (ring_size - 1)) {
-                uint32_t tile_id_start = actual_slice_idx * slice_Wt;
-                uint32_t pages_read_in_row = start_pages_read_in_row;
-                uint32_t row_offset = start_row_offset;
-
                 chunk_count = 0;
                 for (uint32_t c = 0; c < input_tensor_C; ++c) {
-                    uint32_t tiles_read = start_tiles_read / input_tensor_C;
-                    uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
+                    uint32_t tile_id_start =
+                        actual_slice_idx * slice_Wt + c * (batch_slice_num_pages * ring_size) / input_tensor_C;
+
+                    uint32_t pages_read_in_row = start_pages_read_in_row;
+                    uint32_t row_offset = start_row_offset;
+
+                    uint32_t tiles_read = start_tiles_read;
+                    uint32_t tiles_to_read = start_tiles_to_read;
 
                     if constexpr (!direction) {
                         uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
@@ -377,8 +379,8 @@ void kernel_main() {
                 for (uint32_t c = 0; c < input_tensor_C; ++c) {
                     uint32_t tile_id_start = batch_slice_offset + c * batch_slice_num_pages / input_tensor_C;
 
-                    uint32_t tiles_read = start_tiles_read / input_tensor_C;
-                    uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
+                    uint32_t tiles_read = start_tiles_read;
+                    uint32_t tiles_to_read = start_tiles_to_read;
 
                     if constexpr (!direction) {
                         tiles_read += std::min((tiles_to_read - tiles_read) / 2, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -27,35 +27,41 @@ using namespace tt::tt_fabric::linear::experimental;
 ///////////////////////////////////////////////////
 
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
-constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(1);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(2);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
-constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(4);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(5);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(6);
-constexpr uint32_t ring_size = get_compile_time_arg_val(7);
-constexpr uint32_t num_batches = get_compile_time_arg_val(8);
-constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(9);
-constexpr bool direction = get_compile_time_arg_val(10);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(11);
+constexpr uint32_t ring_size = get_compile_time_arg_val(1);
+constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(2);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(3);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
+constexpr uint32_t page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(6);
+constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(7);
+constexpr uint32_t input_tensor_B = get_compile_time_arg_val(8);
+constexpr uint32_t input_tensor_C = get_compile_time_arg_val(9);
+constexpr uint32_t input_tensor_Ht = get_compile_time_arg_val(10);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(11);
+constexpr uint32_t slice_B = get_compile_time_arg_val(12);
+constexpr uint32_t slice_C = get_compile_time_arg_val(13);
+constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
+constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
+constexpr bool direction = get_compile_time_arg_val(16);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(17);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(12);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(13);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(14);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(15);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(16);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(17);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(18);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(19);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(20);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(22);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(24);
+constexpr bool is_termination_master = get_compile_time_arg_val(18);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<25>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<25 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -69,10 +75,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t batch_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t link = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_links = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t slice_Wt = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
     int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
@@ -91,7 +94,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        25 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -115,7 +118,7 @@ void kernel_main() {
 #else
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
     constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
-    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
+    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -138,7 +141,7 @@ void kernel_main() {
     arg_idx += output_rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
-    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
+    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, page_size);
 #endif
 
     auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
@@ -205,7 +208,7 @@ void kernel_main() {
         page_size * 2);
 
     fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
-        pkt_unicast_hdr, static_cast<uint8_t>(unicast_route_info.distance_in_hops), nullptr, intermediate_page_size);
+        pkt_unicast_hdr, static_cast<uint8_t>(unicast_route_info.distance_in_hops), nullptr, page_size);
 
     fabric_unicast_noc_unicast_atomic_inc_set_state<
         UnicastAtomicIncUpdateMask::Wrap | UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
@@ -217,7 +220,7 @@ void kernel_main() {
             32});
 
     uint32_t chunk_count = 0;
-    for (uint32_t b = 0; b < num_batches; b++) {
+    for (uint32_t b = 0; b < input_tensor_B; b++) {
         int slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
 
         uint32_t batch_slice_offset = batch_slice_num_pages * b;
@@ -307,7 +310,7 @@ void kernel_main() {
                                     pkt_unicast_hdr,
                                     l1_read_addr,
                                     NocUnicastCommandHeader{noc_address0});
-                                l1_read_addr += intermediate_page_size;
+                                l1_read_addr += page_size;
                                 tiles_read++;
                                 tiles_read_in_current_direction++;
                                 break;
@@ -386,8 +389,8 @@ void kernel_main() {
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t tile_id = tile_id_start + tiles_read;
                         uint64_t local_noc_addr = get_noc_addr(tile_id, output_addrgen);
-                        noc_async_write(l1_read_addr, local_noc_addr, intermediate_page_size);
-                        l1_read_addr += intermediate_page_size;
+                        noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                        l1_read_addr += page_size;
                         tiles_read++;
                     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -44,24 +44,25 @@ constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
 constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
 constexpr bool direction = get_compile_time_arg_val(16);
 constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(17);
+constexpr uint32_t dim = get_compile_time_arg_val(18);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(18);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
+constexpr bool is_termination_master = get_compile_time_arg_val(19);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(20);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(21);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(22);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(24);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(28);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(29);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(30);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(31);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<32>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<32 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -94,7 +95,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        32 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -236,9 +237,14 @@ void kernel_main() {
             uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
             if (i < (ring_size - 1)) {
                 chunk_count = 0;
-
                 constexpr uint32_t input_channel_num_pages = (batch_slice_num_pages * ring_size) / input_tensor_C;
-                uint32_t tile_id_start = actual_slice_idx * slice_Wt;
+
+                uint32_t tile_id_start;
+                if constexpr (dim == 3) {
+                    tile_id_start = actual_slice_idx * slice_Wt;
+                } else if constexpr (dim == 2) {
+                    tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
+                }
                 for (uint32_t c = 0; c < input_tensor_C; ++c) {
                     uint32_t pages_read_in_row = start_pages_read_in_row;
                     uint32_t row_offset = start_row_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -33,36 +33,35 @@ constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(3);
 constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
 constexpr uint32_t page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_tiles_to_write_per_packet = get_compile_time_arg_val(6);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(7);
-constexpr uint32_t input_tensor_B = get_compile_time_arg_val(8);
-constexpr uint32_t input_tensor_C = get_compile_time_arg_val(9);
-constexpr uint32_t input_tensor_Ht = get_compile_time_arg_val(10);
+constexpr uint32_t output_batch_num_pages = get_compile_time_arg_val(7);
+constexpr uint32_t input_channel_num_pages = get_compile_time_arg_val(8);
+constexpr uint32_t output_channel_num_pages = get_compile_time_arg_val(9);
+constexpr uint32_t input_tensor_B = get_compile_time_arg_val(10);
 constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(11);
-constexpr uint32_t slice_B = get_compile_time_arg_val(12);
-constexpr uint32_t slice_C = get_compile_time_arg_val(13);
-constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
-constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
-constexpr bool direction = get_compile_time_arg_val(16);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(17);
-constexpr uint32_t dim = get_compile_time_arg_val(18);
+constexpr uint32_t slice_C = get_compile_time_arg_val(12);
+constexpr uint32_t slice_Ht = get_compile_time_arg_val(13);
+constexpr uint32_t slice_Wt = get_compile_time_arg_val(14);
+constexpr bool direction = get_compile_time_arg_val(15);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
+constexpr uint32_t dim = get_compile_time_arg_val(17);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(21);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(28);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(29);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(31);
+constexpr bool is_termination_master = get_compile_time_arg_val(18);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<32>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<32 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -95,7 +94,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        32 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -224,7 +223,7 @@ void kernel_main() {
     for (uint32_t b = 0; b < input_tensor_B; b++) {
         int slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
 
-        uint32_t batch_slice_offset = batch_slice_num_pages * b;
+        uint32_t batch_slice_offset = output_batch_num_pages * b;
         for (uint32_t i = 0; i < ring_size; ++i) {
             uint32_t actual_slice_idx;
             if constexpr (direction) {
@@ -237,7 +236,6 @@ void kernel_main() {
             uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
             if (i < (ring_size - 1)) {
                 chunk_count = 0;
-                constexpr uint32_t input_channel_num_pages = (batch_slice_num_pages * ring_size) / input_tensor_C;
 
                 uint32_t tile_id_start;
                 if constexpr (dim == 3) {
@@ -296,6 +294,7 @@ void kernel_main() {
                             }
                             auto noc_address0 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(
                                 intermediate_addrgen, tile_one_id, 0);
+
                             // Will have more cases once scatter-write supports more than 2 distinct addresses
                             switch (tiles_to_put_in_current_packet) {
                                 case 2: {
@@ -387,7 +386,6 @@ void kernel_main() {
                 noc_async_writes_flushed();
             } else {
                 // Otherwise, on the last slice, write it to output buffer
-                constexpr uint32_t output_channel_num_pages = batch_slice_num_pages / slice_C;
                 uint32_t tile_id_start = batch_slice_offset;
                 for (uint32_t c = 0; c < slice_C; ++c) {
                     uint32_t tiles_read = start_tiles_read;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -244,8 +244,12 @@ void kernel_main() {
                     tile_id_start = actual_slice_idx * slice_Wt;
                 } else if constexpr (dim == 2) {
                     tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
+                } else if constexpr (dim == 1) {
+                    tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C;
+                } else {
+                    ASSERT(false);
                 }
-                for (uint32_t c = 0; c < input_tensor_C; ++c) {
+                for (uint32_t c = 0; c < slice_C; ++c) {
                     uint32_t pages_read_in_row = start_pages_read_in_row;
                     uint32_t row_offset = start_row_offset;
 
@@ -383,9 +387,9 @@ void kernel_main() {
                 noc_async_writes_flushed();
             } else {
                 // Otherwise, on the last slice, write it to output buffer
-                constexpr uint32_t output_channel_num_pages = batch_slice_num_pages / input_tensor_C;
+                constexpr uint32_t output_channel_num_pages = batch_slice_num_pages / slice_C;
                 uint32_t tile_id_start = batch_slice_offset;
-                for (uint32_t c = 0; c < input_tensor_C; ++c) {
+                for (uint32_t c = 0; c < slice_C; ++c) {
                     uint32_t tiles_read = start_tiles_read;
                     uint32_t tiles_to_read = start_tiles_to_read;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -30,8 +30,8 @@ void MAIN {
         for (uint32_t i = 0; i < ring_size - 1; i++) {  // Don't reduce on the first slice
 
             for (uint32_t c = 0; c < input_tensor_C; c++) {
-                uint32_t tiles_read = start_tiles_read / input_tensor_C;
-                uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
+                uint32_t tiles_read = start_tiles_read;
+                uint32_t tiles_to_read = start_tiles_to_read;
 
                 if constexpr (!direction) {
                     uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -13,59 +13,63 @@ void MAIN {
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t ring_size = get_compile_time_arg_val(4);
-    constexpr uint32_t num_batches = get_compile_time_arg_val(5);
-    constexpr bool direction = get_compile_time_arg_val(6);
+    constexpr uint32_t input_tensor_B = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_C = get_compile_time_arg_val(6);
+    constexpr bool direction = get_compile_time_arg_val(7);
 
     uint32_t arg_idx = 0;
 
     uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);
 
-    for (uint32_t b = 0; b < num_batches; b++) {
+    for (uint32_t b = 0; b < input_tensor_B; b++) {
         for (uint32_t i = 0; i < ring_size - 1; i++) {  // Don't reduce on the first slice
-            uint32_t tiles_read = start_tiles_read;
 
-            if constexpr (!direction) {
-                uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-                tiles_read += backwards_offset;
-            }
+            for (uint32_t c = 0; c < input_tensor_C; c++) {
+                uint32_t tiles_read = start_tiles_read / input_tensor_C;
+                uint32_t tiles_to_read = start_tiles_to_read / input_tensor_C;
 
-            // Wait for input data once before beginning processing
-            while (tiles_read < tiles_to_read) {
-                uint32_t num_pages_to_read = 0;
-                if constexpr (direction) {
-                    num_pages_to_read = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
-                } else {
-                    num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                if constexpr (!direction) {
+                    uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
+                    tiles_read += backwards_offset;
                 }
-                cb_wait_front(input_cb_id, tile_granularity);
-                // Reserve output space once before processing
-                cb_wait_front(intermediate_cb, tile_granularity);
-                cb_reserve_back(output_cb, tile_granularity);
-                acquire_dst();
-                for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
-                    add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
-                    pack_tile(tile_id, output_cb);
-                }
-                release_dst();
-                cb_pop_front(input_cb_id, tile_granularity);
-                cb_pop_front(intermediate_cb, tile_granularity);
-                cb_push_back(output_cb, tile_granularity);
-                tiles_read += num_pages_to_read;
 
-                // Skip the tiles going the other direction
-                if (tiles_read < tiles_to_read) {
-                    num_pages_to_read = 0;
-                    if constexpr (!direction) {
+                // Wait for input data once before beginning processing
+                while (tiles_read < tiles_to_read) {
+                    uint32_t num_pages_to_read = 0;
+                    if constexpr (direction) {
                         num_pages_to_read = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                     } else {
                         num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
                     }
+                    cb_wait_front(input_cb_id, tile_granularity);
+                    cb_wait_front(intermediate_cb, tile_granularity);
+                    cb_reserve_back(output_cb, tile_granularity);
+                    acquire_dst();
+                    for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
+                        add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
+                        pack_tile(tile_id, output_cb);
+                    }
+                    release_dst();
+                    cb_pop_front(input_cb_id, tile_granularity);
+                    cb_pop_front(intermediate_cb, tile_granularity);
+                    cb_push_back(output_cb, tile_granularity);
                     tiles_read += num_pages_to_read;
+
+                    // Skip the tiles going the other direction
+                    if (tiles_read < tiles_to_read) {
+                        num_pages_to_read = 0;
+                        if constexpr (!direction) {
+                            num_pages_to_read = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
+                        } else {
+                            num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                        }
+                        tiles_read += num_pages_to_read;
+                    }
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -18,7 +18,6 @@ void MAIN {
     constexpr bool direction = get_compile_time_arg_val(7);
 
     uint32_t arg_idx = 0;
-
     uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -14,7 +14,7 @@ void MAIN {
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t ring_size = get_compile_time_arg_val(4);
     constexpr uint32_t input_tensor_B = get_compile_time_arg_val(5);
-    constexpr uint32_t input_tensor_C = get_compile_time_arg_val(6);
+    constexpr uint32_t slice_C = get_compile_time_arg_val(6);
     constexpr bool direction = get_compile_time_arg_val(7);
 
     uint32_t arg_idx = 0;
@@ -29,7 +29,7 @@ void MAIN {
     for (uint32_t b = 0; b < input_tensor_B; b++) {
         // Don't reduce on the first slice
         for (uint32_t i = 0; i < ring_size - 1; i++) {
-            for (uint32_t c = 0; c < input_tensor_C; c++) {
+            for (uint32_t c = 0; c < slice_C; c++) {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t tiles_to_read = start_tiles_to_read;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -11,16 +11,14 @@ void MAIN {
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t intermediate_cb = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(3);
-    constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(5);
-    constexpr uint32_t num_batches = get_compile_time_arg_val(6);
-    constexpr bool direction = get_compile_time_arg_val(7);
+    constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(4);
+    constexpr uint32_t num_batches = get_compile_time_arg_val(5);
+    constexpr bool direction = get_compile_time_arg_val(6);
 
     uint32_t arg_idx = 0;
 
     uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t tiles_read = start_tiles_read;
     uint32_t tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
     // Initialize binary operations - use the same constants consistently
@@ -29,6 +27,8 @@ void MAIN {
 
     for (uint32_t b = 0; b < num_batches; b++) {
         for (uint32_t i = 0; i < ring_size - 1; i++) {  // Don't reduce on the first slice
+            uint32_t tiles_read = start_tiles_read;
+
             if constexpr (!direction) {
                 uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                 tiles_read += backwards_offset;
@@ -68,8 +68,6 @@ void MAIN {
                     tiles_read += num_pages_to_read;
                 }
             }
-
-            tiles_read = start_tiles_read;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -27,8 +27,8 @@ void MAIN {
     add_tiles_init(input_cb_id, intermediate_cb, false);
 
     for (uint32_t b = 0; b < input_tensor_B; b++) {
-        for (uint32_t i = 0; i < ring_size - 1; i++) {  // Don't reduce on the first slice
-
+        // Don't reduce on the first slice
+        for (uint32_t i = 0; i < ring_size - 1; i++) {
             for (uint32_t c = 0; c < input_tensor_C; c++) {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t tiles_to_read = start_tiles_to_read;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -11,7 +11,6 @@
 
 namespace ttnn {
 
-// TODO: (GR) Dim and topology specific validation
 void ReduceScatterMinimalAsync::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     TT_FATAL(input_tensors.size() == 1, "Error, Input tensor size should be 1 but has {}", input_tensors.size());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -11,6 +11,7 @@
 
 namespace ttnn {
 
+// TODO: (GR) Dim and topology specific validation
 void ReduceScatterMinimalAsync::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     TT_FATAL(input_tensors.size() == 1, "Error, Input tensor size should be 1 but has {}", input_tensors.size());
@@ -23,8 +24,8 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
         "reduce_scatter_minimal_async currently requires aligned pages");
 
     TT_FATAL(
-        this->dim == 3 || this->dim == 2,
-        "reduce_scatter_minimal_async currently only supports reducing on dim 2 or 3");
+        this->dim == 3 || this->dim == 2 || this->dim == 1,
+        "reduce_scatter_minimal_async currently only supports reducing on dim 1, 2, or 3");
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -23,9 +23,17 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
         page_size % input_tensors[0].buffer()->alignment() == 0,
         "reduce_scatter_minimal_async currently requires aligned pages");
 
-    TT_FATAL(
-        this->dim == 3 || this->dim == 2 || this->dim == 1,
-        "reduce_scatter_minimal_async currently only supports reducing on dim 1, 2, or 3");
+    if (topology == ccl::Topology::Linear) {
+        TT_FATAL(
+            this->dim == 3,
+            "reduce_scatter_minimal_async line topology implementation only supports scattering on dim 3");
+    } else if (topology == ccl::Topology::Ring) {
+        TT_FATAL(
+            this->dim == 1 || this->dim == 2 || this->dim == 3,
+            "reduce_scatter_minimal_async ring topology implementation only supports scattering on dim 1, 2, or 3");
+    } else {
+        TT_FATAL(false, "reduce_scatter_minimal_async only supports linear or ring topology");
+    }
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(
@@ -33,15 +41,17 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
         "Operands to reduce_scatter_minimal_async need to be allocated in buffers on device!");
     TT_FATAL(this->num_links > 0, "Error, num_links should be more than 0 but has {}", this->num_links);
 
-    const auto& input_shape = input_tensor.padded_shape();
-    uint32_t tile_size = this->dim == 2 ? tt::constants::TILE_HEIGHT : tt::constants::TILE_WIDTH;
-    TT_FATAL(
-        (input_shape[this->dim] / tile_size) % this->ring_size == 0,
-        "Error, The number of tiles at input tensor dimension {} should be divisible by ring_size but the number of "
-        "tiles is {} and the ring_size is {}",
-        this->dim,
-        input_shape[this->dim] / tile_size,
-        this->ring_size);
+    if (this->dim == 2 || this->dim == 3) {
+        const auto& input_shape = input_tensor.padded_shape();
+        uint32_t tile_size = this->dim == 2 ? tt::constants::TILE_HEIGHT : tt::constants::TILE_WIDTH;
+        TT_FATAL(
+            (input_shape[this->dim] / tile_size) % this->ring_size == 0,
+            "Error, The number of tiles at input tensor dimension {} should be divisible by ring_size but the number "
+            "of tiles is {} and the ring_size is {}",
+            this->dim,
+            input_shape[this->dim] / tile_size,
+            this->ring_size);
+    }
 
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -544,7 +544,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                      num_mux_cores_per_direction_per_link + worker];
                 opposite_core_coord = mesh_device->worker_core_from_logical_core(supplemental_core);
 
-                uint32_t worker_id = link * num_workers_per_direction + worker;
+                uint32_t worker_id = (link * num_workers_per_direction) + worker;
                 uint32_t num_workers = num_links * num_workers_per_direction;
 
                 uint32_t start_tiles_read = worker_id * output_channel_num_pages / num_workers;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -548,8 +548,8 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                 uint32_t start_tiles_read = worker_id * batch_slice_num_pages / input_tensor_C / num_workers;
                 uint32_t start_tiles_to_read = (worker_id + 1) * batch_slice_num_pages / input_tensor_C / num_workers;
 
-                uint32_t start_pages_read_in_row = start_tiles_read % (slice_Wt);
-                uint32_t start_row_offset = start_tiles_read / (slice_Wt)*input_tensor_Wt;
+                uint32_t start_pages_read_in_row = start_tiles_read % slice_Wt;
+                uint32_t start_row_offset = start_tiles_read / slice_Wt * input_tensor_Wt;
 
                 uint32_t chunks_per_sync_val =
                     chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
@@ -579,6 +579,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                     fuse_op,                 // fused op
                     dir,                     // direction
                     chunks_per_sync_val,     // chunks_per_sync
+                    dim,                     // dim
                 };
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
@@ -644,6 +645,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                     slice_Wt,                       // slice_Wt
                     dir,                            // direction
                     chunks_per_sync_val,            // chunks_per_sync
+                    dim,                            // dim
                 };
                 append_fabric_mux_connection_ct_args(
                     worker == 0,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -545,15 +545,18 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                 uint32_t worker_id = link * num_workers_per_direction + worker;
                 uint32_t num_workers = num_links * num_workers_per_direction;
 
-                uint32_t start_tiles_read = worker_id * batch_slice_num_pages / num_workers;
-                uint32_t start_tiles_to_read = (worker_id + 1) * batch_slice_num_pages / num_workers;
+                uint32_t start_tiles_read = worker_id * batch_slice_num_pages / input_tensor_C / num_workers;
+                uint32_t start_tiles_to_read = (worker_id + 1) * batch_slice_num_pages / input_tensor_C / num_workers;
 
                 uint32_t start_pages_read_in_row = start_tiles_read % (slice_Wt);
-                uint32_t start_row_offset = start_tiles_read / (input_tensor_Wt / ring_size) * input_tensor_Wt;
+                uint32_t start_row_offset = start_tiles_read / (slice_Wt)*input_tensor_Wt;
 
                 uint32_t chunks_per_sync_val =
                     chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
-                        topology, start_tiles_to_read, start_tiles_read, tile_granularity));
+                        topology,
+                        start_tiles_to_read * input_tensor_C,
+                        start_tiles_read * input_tensor_C,
+                        tile_granularity));
                 log_trace(tt::LogOp, "DEBUG: chunks_per_sync_val: {}", chunks_per_sync_val);
 
                 std::vector<uint32_t> sender_reader_compile_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -717,6 +717,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                     tile_granularity,
                     ring_size,
                     input_tensor_B,
+                    input_tensor_C,
                     dir};
 
                 auto sender_reduce_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -109,7 +109,7 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
     log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
-    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
+    if (composite_common::use_composite_reduce_scatter(input_tensor, topology, dim, cluster_axis)) {
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_reduce_scatter(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27204)

### Problem description
Native RS only supported dim 3, so we were using a composite version of the op to handle dim 0, 1, 2

### What's changed
- Add native support for dim 1 & 2 for the ring implementation, and update the composite branching logic
  - Will add dim 1 & 2 support to the line implementation in a separate PR
- The way the native version is currently implemented (both line and ring), it can't be altered to support dim 0
  - Both implementations process the input in batches (to allow fusing with matmul)
  - So when the first batch arrives, you can't send multiple slices around the ring in parallel (since an input batch is a slice)

### Pipelines
- APC https://github.com/tenstorrent/tt-metal/actions/runs/18084423055
- BH APC https://github.com/tenstorrent/tt-metal/actions/runs/18084425988
- Galaxy Quick https://github.com/tenstorrent/tt-metal/actions/runs/18084431848
- Galaxy Demo https://github.com/tenstorrent/tt-metal/actions/runs/18084433043
- T3K Unit https://github.com/tenstorrent/tt-metal/actions/runs/18084437005
- T3K Demo https://github.com/tenstorrent/tt-metal/actions/runs/18084438054
- T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/18084439520


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes