### PR TITLE
Fix watcher assert in paged_update writer kernel for missing atomic barrier

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -126,5 +126,6 @@ void kernel_main() {
         // send signal to start compute
         const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(send_core_x, send_core_y, semaphore_addr);
         noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+        noc_async_atomic_barrier();
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/29525)

This pull request introduces a minor update to the cache writer kernel in the dataflow operation. The change adds a call to `noc_async_atomic_barrier()` after incrementing the semaphore, which helps ensure proper synchronization after signaling the start of compute.

The watcher assert for missing atomic barrier only occurs with `share_cache=True`

* Synchronization improvement:
  * Added a call to `noc_async_atomic_barrier()` after incrementing the semaphore in `kernel_main()` within `writer_update_cache_interleaved_start_id.cpp` to improve atomic operation consistency.
### Checklist
- [ ] [All post commit with Watcher enabled](https://github.com/tenstorrent/tt-metal/actions/runs/18106019729) CI passes
- [x] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/18113184523/job/51544111439) CI Passes