### PR TITLE
#29577: Add `MeshDeviceView` methods in terms of FabricNodeIDs

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -196,7 +196,7 @@ TEST_F(MeshDeviceView2x4Test, ViewGetDevicesInRange) {
     EXPECT_THAT(devices, SizeIs(4));
 
     // Get 1x4 row
-    MeshCoordinateRange row_range(MeshCoordinate{0, 0}, MeshCoordinate(1, 4));
+    MeshCoordinateRange row_range(MeshCoordinate{0, 0}, MeshCoordinate(1, 3));
     auto row_devices = view.get_devices(row_range);
     EXPECT_THAT(row_devices, SizeIs(4));
 }

--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -123,5 +123,265 @@ TEST_F(MeshDeviceView2x4Test, MeshId) {
     EXPECT_EQ(view.mesh_id(), tt::tt_fabric::MeshId(0));
 }
 
+TEST_F(MeshDeviceView2x4Test, ViewBasicProperties) {
+    const auto& view = mesh_device_->get_view();
+
+    EXPECT_FALSE(view.empty());
+    EXPECT_EQ(view.size(), 8);
+    EXPECT_EQ(view.num_devices(), 8);
+    EXPECT_EQ(view.shape(), MeshShape(2, 4));
+    EXPECT_TRUE(view.is_mesh_2d());
+    EXPECT_EQ(view.num_rows(), 2);
+    EXPECT_EQ(view.num_cols(), 4);
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewContains) {
+    const auto& view = mesh_device_->get_view();
+
+    EXPECT_TRUE(view.contains(MeshCoordinate{0, 0}));
+    EXPECT_TRUE(view.contains(MeshCoordinate{1, 3}));
+    EXPECT_TRUE(view.contains(MeshCoordinate{0, 2}));
+
+    EXPECT_FALSE(view.contains(MeshCoordinate{2, 0}));
+    EXPECT_FALSE(view.contains(MeshCoordinate{0, 4}));
+    EXPECT_FALSE(view.contains(MeshCoordinate{3, 3}));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetDevice) {
+    const auto& view = mesh_device_->get_view();
+
+    auto* device_00 = view.get_device(MeshCoordinate{0, 0});
+    auto* device_13 = view.get_device(MeshCoordinate{1, 3});
+
+    EXPECT_NE(device_00, nullptr);
+    EXPECT_NE(device_13, nullptr);
+    EXPECT_NE(device_00->id(), device_13->id());
+
+    // Out of bounds returns nullptr
+    EXPECT_EQ(view.get_device(MeshCoordinate{2, 0}), nullptr);
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeId) {
+    const auto& view = mesh_device_->get_view();
+
+    auto fabric_id_00 = view.get_fabric_node_id(MeshCoordinate{0, 0});
+    auto fabric_id_13 = view.get_fabric_node_id(MeshCoordinate{1, 3});
+
+    EXPECT_NE(fabric_id_00, fabric_id_13);
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.get_fabric_node_id(MeshCoordinate{2, 0}));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetDevices) {
+    const auto& view = mesh_device_->get_view();
+
+    auto all_devices = view.get_devices();
+    EXPECT_THAT(all_devices, SizeIs(8));
+
+    // Verify all devices are unique
+    std::set<chip_id_t> device_ids;
+    for (auto* device : all_devices) {
+        device_ids.insert(device->id());
+    }
+    EXPECT_EQ(device_ids.size(), 8);
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetDevicesInRange) {
+    const auto& view = mesh_device_->get_view();
+
+    // Get 2x2 subregion
+    MeshCoordinateRange range(MeshCoordinate{0, 0}, MeshCoordinate(1, 1));
+    auto devices = view.get_devices(range);
+    EXPECT_THAT(devices, SizeIs(4));
+
+    // Get 1x4 row
+    MeshCoordinateRange row_range(MeshCoordinate{0, 0}, MeshCoordinate(1, 4));
+    auto row_devices = view.get_devices(row_range);
+    EXPECT_THAT(row_devices, SizeIs(4));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIds) {
+    const auto& view = mesh_device_->get_view();
+
+    auto all_fabric_ids = view.get_fabric_node_ids();
+    EXPECT_THAT(all_fabric_ids, SizeIs(8));
+
+    // Verify all fabric node IDs are unique
+    std::set<tt::tt_fabric::FabricNodeId> fabric_ids_set;
+    for (const auto& fabric_id : all_fabric_ids) {
+        fabric_ids_set.insert(fabric_id);
+    }
+    EXPECT_EQ(fabric_ids_set.size(), 8);
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIdsInRange) {
+    const auto& view = mesh_device_->get_view();
+
+    MeshCoordinateRange range(MeshCoordinate{0, 0}, MeshCoordinate(1, 1));
+    auto fabric_ids = view.get_fabric_node_ids(range);
+    EXPECT_THAT(fabric_ids, SizeIs(4));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetDevicesOnRow) {
+    const auto& view = mesh_device_->get_view();
+
+    auto row_0_devices = view.get_devices_on_row(0);
+    EXPECT_THAT(row_0_devices, SizeIs(4));
+
+    auto row_1_devices = view.get_devices_on_row(1);
+    EXPECT_THAT(row_1_devices, SizeIs(4));
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.get_devices_on_row(2));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetDevicesOnColumn) {
+    const auto& view = mesh_device_->get_view();
+
+    auto col_0_devices = view.get_devices_on_column(0);
+    EXPECT_THAT(col_0_devices, SizeIs(2));
+
+    auto col_3_devices = view.get_devices_on_column(3);
+    EXPECT_THAT(col_3_devices, SizeIs(2));
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.get_devices_on_column(4));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIdsOnRow) {
+    const auto& view = mesh_device_->get_view();
+
+    auto row_0_fabric_ids = view.get_fabric_node_ids_on_row(0);
+    EXPECT_THAT(row_0_fabric_ids, SizeIs(4));
+
+    auto row_1_fabric_ids = view.get_fabric_node_ids_on_row(1);
+    EXPECT_THAT(row_1_fabric_ids, SizeIs(4));
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.get_fabric_node_ids_on_row(2));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIdsOnColumn) {
+    const auto& view = mesh_device_->get_view();
+
+    auto col_0_fabric_ids = view.get_fabric_node_ids_on_column(0);
+    EXPECT_THAT(col_0_fabric_ids, SizeIs(2));
+
+    auto col_3_fabric_ids = view.get_fabric_node_ids_on_column(3);
+    EXPECT_THAT(col_3_fabric_ids, SizeIs(2));
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.get_fabric_node_ids_on_column(4));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewFindDevice) {
+    const auto& view = mesh_device_->get_view();
+
+    auto* device = view.get_device(MeshCoordinate{1, 2});
+    ASSERT_NE(device, nullptr);
+
+    auto coord = view.find_device(device->id());
+    EXPECT_EQ(coord, MeshCoordinate(1, 2));
+
+    // Non-existent device throws
+    EXPECT_ANY_THROW((void)view.find_device(9999));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewLineCoordinates) {
+    const auto& view = mesh_device_->get_view();
+
+    auto line_coords = view.get_line_coordinates();
+    EXPECT_THAT(line_coords, SizeIs(8));
+
+    // Verify zigzag pattern: row 0 left-to-right, row 1 right-to-left
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(0, 3));
+    EXPECT_EQ(line_coords[4], MeshCoordinate(1, 3));
+    EXPECT_EQ(line_coords[5], MeshCoordinate(1, 2));
+    EXPECT_EQ(line_coords[6], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[7], MeshCoordinate(1, 0));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewRingCoordinates) {
+    const auto& view = mesh_device_->get_view();
+
+    auto ring_coords = view.get_ring_coordinates();
+    EXPECT_THAT(ring_coords, SizeIs(8));
+
+    // Verify ring traversal (clockwise from top-left)
+    EXPECT_EQ(ring_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(ring_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(ring_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(ring_coords[3], MeshCoordinate(0, 3));
+    EXPECT_EQ(ring_coords[4], MeshCoordinate(1, 3));
+    EXPECT_EQ(ring_coords[5], MeshCoordinate(1, 2));
+    EXPECT_EQ(ring_coords[6], MeshCoordinate(1, 1));
+    EXPECT_EQ(ring_coords[7], MeshCoordinate(1, 0));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewIsLocal) {
+    const auto& view = mesh_device_->get_view();
+
+    // All devices should be local in single-host tests
+    EXPECT_TRUE(view.is_local(MeshCoordinate{0, 0}));
+    EXPECT_TRUE(view.is_local(MeshCoordinate{1, 3}));
+
+    // Out of bounds throws
+    EXPECT_ANY_THROW((void)view.is_local(MeshCoordinate{2, 0}));
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewIterator) {
+    const auto& view = mesh_device_->get_view();
+
+    std::vector<IDevice*> iterated_devices;
+    for (auto device : view) {
+        iterated_devices.push_back(*device);
+    }
+
+    EXPECT_THAT(iterated_devices, SizeIs(8));
+
+    // Should match get_devices()
+    auto all_devices = view.get_devices();
+    EXPECT_EQ(iterated_devices, all_devices);
+}
+
+TEST_F(MeshDeviceView2x4Test, ViewMeshId) {
+    const auto& view = mesh_device_->get_view();
+
+    auto mesh_id = view.mesh_id();
+
+    // All fabric node IDs should have the same mesh ID
+    for (const auto& fabric_id : view.get_fabric_node_ids()) {
+        EXPECT_EQ(fabric_id.mesh_id, mesh_id);
+    }
+}
+
+TEST_F(MeshDeviceView2x4Test, View2DMethodsThrowOnNon2DMesh) {
+    std::vector<IDevice*> devices;
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+    for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
+        devices.push_back(mesh_device_->get_view().get_device(coord));
+        fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
+    }
+
+    MeshDeviceView view_1d(MeshShape(8), devices, fabric_node_ids);
+
+    EXPECT_ANY_THROW((void)view_1d.num_rows());
+    EXPECT_ANY_THROW((void)view_1d.num_cols());
+    EXPECT_ANY_THROW((void)view_1d.get_devices_on_row(0));
+    EXPECT_ANY_THROW((void)view_1d.get_devices_on_column(0));
+    EXPECT_ANY_THROW((void)view_1d.get_fabric_node_ids_on_row(0));
+    EXPECT_ANY_THROW((void)view_1d.get_fabric_node_ids_on_column(0));
+    EXPECT_ANY_THROW((void)view_1d.get_line_coordinates());
+    EXPECT_ANY_THROW((void)view_1d.get_ring_coordinates());
+    EXPECT_ANY_THROW((void)view_1d.get_line_devices());
+    EXPECT_ANY_THROW((void)view_1d.get_ring_devices());
+    EXPECT_ANY_THROW((void)view_1d.get_line_fabric_node_ids());
+    EXPECT_ANY_THROW((void)view_1d.get_ring_fabric_node_ids());
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -196,7 +196,7 @@ TEST_F(MeshDeviceView2x4Test, ViewGetDevicesInRange) {
     EXPECT_THAT(devices, SizeIs(4));
 
     // Get 1x4 row
-    MeshCoordinateRange row_range(MeshCoordinate{0, 0}, MeshCoordinate(1, 3));
+    MeshCoordinateRange row_range(MeshCoordinate{0, 0}, MeshCoordinate(0, 3));
     auto row_devices = view.get_devices(row_range);
     EXPECT_THAT(row_devices, SizeIs(4));
 }

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -130,9 +130,6 @@ private:
     void mark_allocations_unsafe();
     void mark_allocations_safe();
 
-    // Returns the devices in row-major order for the new mesh shape
-    std::vector<IDevice*> get_row_major_devices(const MeshShape& new_shape) const;
-
     std::shared_ptr<MeshTraceBuffer>& create_mesh_trace(const MeshTraceId& trace_id);
 
     std::lock_guard<std::mutex> lock_api() { return std::lock_guard<std::mutex>(api_mutex_); }

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -42,9 +42,6 @@ class MeshDevice;
 
 class MeshDeviceView {
 public:
-    using DeviceView = std::vector<IDevice*>;
-    using DeviceViews = std::vector<std::vector<IDevice*>>;
-
     // Constructors for MeshDeviceView for fully and partially local meshes.
     explicit MeshDeviceView(
         const MeshShape& shape,
@@ -56,9 +53,10 @@ public:
         const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids);
 
     // Get devices spanning the region defined by `range` in row-major order with start/end coordinates inclusive
-    [[nodiscard]] DeviceView get_devices(const MeshCoordinateRange& range) const;
-    [[nodiscard]] DeviceView get_devices(const MeshShape& submesh_shape) const;
-    [[nodiscard]] DeviceView get_devices() const;
+    [[nodiscard]] std::vector<IDevice*> get_devices(const MeshCoordinateRange& range) const;
+    [[nodiscard]] std::vector<IDevice*> get_devices() const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids(const MeshCoordinateRange& range) const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids() const;
     [[nodiscard]] size_t num_devices() const;
 
     [[nodiscard]] bool empty() const noexcept;
@@ -85,10 +83,10 @@ public:
     [[nodiscard]] bool is_mesh_2d() const;
     [[nodiscard]] size_t num_rows() const;
     [[nodiscard]] size_t num_cols() const;
-    [[nodiscard]] DeviceView get_devices_on_row(size_t row) const;
-    [[nodiscard]] DeviceView get_devices_on_column(size_t col) const;
-    [[nodiscard]] DeviceViews get_row_views() const;
-    [[nodiscard]] DeviceViews get_column_views() const;
+    [[nodiscard]] std::vector<IDevice*> get_devices_on_row(size_t row) const;
+    [[nodiscard]] std::vector<IDevice*> get_devices_on_column(size_t col) const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_on_row(size_t row) const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_on_column(size_t col) const;
 
     // These utility methods linearize the set of devices in a mesh into a line or ring.
     // Linearizing a mesh into a line asserts the condition that device[i-1] is connected to device[i].
@@ -108,6 +106,8 @@ public:
     [[nodiscard]] std::vector<MeshCoordinate> get_ring_coordinates() const;
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;
     [[nodiscard]] std::vector<IDevice*> get_line_devices() const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_ring_fabric_node_ids() const;
+    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_line_fabric_node_ids() const;
 
     // Returns true if the view is fully local, i.e. all devices in the view are local.
     // Throws if the coordinate is out of bounds of this view.

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -31,6 +31,16 @@ std::vector<IDevice*> get_devices_from_coordinates(
     return devices;
 }
 
+std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_from_coordinates(
+    const MeshDeviceView& mesh, const std::vector<MeshCoordinate>& coords) {
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+    fabric_node_ids.reserve(coords.size());
+    for (const auto& coord : coords) {
+        fabric_node_ids.push_back(mesh.get_fabric_node_id(coord));
+    }
+    return fabric_node_ids;
+}
+
 }  // namespace
 
 MeshDeviceView::MeshDeviceView(
@@ -62,16 +72,27 @@ MeshDeviceView::MeshDeviceView(
     }
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
-    DeviceView devices_in_region;
+std::vector<IDevice*> MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
+    std::vector<IDevice*> devices_in_region;
     for (const auto& coord : range) {
         devices_.at(coord).if_local([&devices_in_region](const auto& device) { devices_in_region.push_back(device); });
     }
     return devices_in_region;
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshShape& submesh_shape) const {
-    return get_devices(MeshCoordinateRange(submesh_shape));
+std::vector<IDevice*> MeshDeviceView::get_devices() const { return extract_locals(devices_.values()); }
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids(const MeshCoordinateRange& range) const {
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids_in_region;
+    fabric_node_ids_in_region.reserve(range.shape().mesh_size());
+    for (const auto& coord : range) {
+        fabric_node_ids_in_region.push_back(get_fabric_node_id(coord));
+    }
+    return fabric_node_ids_in_region;
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids() const {
+    return fabric_node_ids_.values();
 }
 
 std::vector<IDevice*> MeshDeviceView::get_devices_on_row(size_t row) const {
@@ -98,24 +119,26 @@ std::vector<IDevice*> MeshDeviceView::get_devices_on_column(size_t col) const {
     return col_devices;
 }
 
-std::vector<std::vector<IDevice*>> MeshDeviceView::get_row_views() const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_row(size_t row) const {
     TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
-    std::vector<std::vector<IDevice*>> row_views;
-    row_views.reserve(shape_2d_->height());
-    for (size_t row = 0; row < shape_2d_->height(); ++row) {
-        row_views.push_back(get_devices_on_row(row));
+    TT_FATAL(row < shape_2d_->height(), "Row index out of bounds: {}", row);
+    std::vector<tt::tt_fabric::FabricNodeId> row_fabric_node_ids;
+    row_fabric_node_ids.reserve(shape_2d_->width());
+    for (int col = 0; col < shape_2d_->width(); ++col) {
+        row_fabric_node_ids.push_back(get_fabric_node_id(MeshCoordinate(row, col)));
     }
-    return row_views;
+    return row_fabric_node_ids;
 }
 
-std::vector<std::vector<IDevice*>> MeshDeviceView::get_column_views() const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_column(size_t col) const {
     TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
-    std::vector<std::vector<IDevice*>> column_views;
-    column_views.reserve(shape_2d_->width());
-    for (size_t col = 0; col < shape_2d_->width(); ++col) {
-        column_views.push_back(get_devices_on_column(col));
+    TT_FATAL(col < shape_2d_->width(), "Column index out of bounds: {}", col);
+    std::vector<tt::tt_fabric::FabricNodeId> col_fabric_node_ids;
+    col_fabric_node_ids.reserve(shape_2d_->height());
+    for (int row = 0; row < shape_2d_->height(); ++row) {
+        col_fabric_node_ids.push_back(get_fabric_node_id(MeshCoordinate(row, col)));
     }
-    return column_views;
+    return col_fabric_node_ids;
 }
 
 bool MeshDeviceView::empty() const noexcept { return devices_.shape().mesh_size() == 0; }
@@ -243,7 +266,13 @@ std::vector<IDevice*> MeshDeviceView::get_ring_devices() const {
     return get_devices_from_coordinates(*this, get_ring_coordinates());
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices() const { return extract_locals(devices_.values()); }
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_line_fabric_node_ids() const {
+    return get_fabric_node_ids_from_coordinates(*this, get_line_coordinates());
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_ring_fabric_node_ids() const {
+    return get_fabric_node_ids_from_coordinates(*this, get_ring_coordinates());
+}
 
 bool MeshDeviceView::is_local(const MeshCoordinate& coord) const {
     TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
@@ -81,8 +81,7 @@ Fabric1DRoute fabric_1d_routing(
         const auto neighbor_coord = sender_coord.get_neighbor(mesh_shape, (is_forward ? 1 : -1), dim, boundary_mode);
 
         TT_FATAL(neighbor_coord.has_value(), "Can't find neighbor for {}", sender_coord);
-        const auto next_fabric_id = mesh_device->get_fabric_node_id(neighbor_coord.value());
-        return next_fabric_id;
+        return mesh_device->get_fabric_node_id(*neighbor_coord);
     };
 
     if (topology == ::ttnn::ccl::Topology::Ring) {


### PR DESCRIPTION
### Ticket
#29577

### Problem description
CCLs now require computations done in terms of fabric node IDs.

### What's changed
Add methods that mirror existing logic with chip ID / `IDevice*`, but in terms of `FabricNodeId`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18107665563)
- [x] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18107667571)