### PR TITLE
[skip ci] Use pipeline-perf runner for BH nightly loudbox demos

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -57,7 +57,7 @@ jobs:
             num_devices: 2
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 8
     with:
       runner-label: ${{ matrix.test-group.runner-label }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Update label to be consistent with  https://github.com/tenstorrent/tt-metal/blob/main/.github/workflows/blackhole-multi-card-demo-tests.yaml

### What's changed
Change `pipeline-functional` to `pipeline-perf`