### PR TITLE
Fix packet size overflow in all broadcast op

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
@@ -240,6 +240,8 @@ def run_all_broadcast_impl(
         (8, 1, [256, 3328], ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
         (4, 1, [1, 69, 4000], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
         (8, 1, [10, 8320], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (2, 1, [11, 10, 32784], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (4, 1, [1, 2, 16300], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
@@ -390,6 +390,15 @@ def test_all_broadcast_trace(
             None,
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ),
+        (
+            4,
+            [1, 1, 32, 32768],
+            (32, 1024),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
     ],
 )
 @pytest.mark.parametrize("num_links", [1])

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -97,7 +97,6 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     const size_t packet_size_bytes =
         tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : MAX_PACKET_SIZE_BYTES;
     size_t max_packet_size = packet_size_bytes;
-    // uint32_t num_packets_per_row = std::ceil(static_cast<double>(row_size) / max_packet_size);
     uint32_t l1_scratch_cb_page_size_bytes = input_tensor.buffer()->aligned_page_size();
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
     uint32_t cb_num_pages = 3 * num_pages_per_packet;  // tripple buffering

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -93,7 +93,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     }
 
     // L1 Scratch CB Creation
-    size_t MAX_PACKET_SIZE_BYTES = tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : 4 * 1088;
+    DataType dtype = input_tensor.dtype();
+    const uint32_t fabric_max_packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+    const uint32_t MAX_PACKET_SIZE_BYTES =
+        dtype == DataType::BFLOAT16 ? std::bit_floor(fabric_max_packet_size_bytes) : fabric_max_packet_size_bytes;
     const size_t packet_size_bytes =
         tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : MAX_PACKET_SIZE_BYTES;
     size_t max_packet_size = packet_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -93,7 +93,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     }
 
     // L1 Scratch CB Creation
-    constexpr size_t MAX_PACKET_SIZE_BYTES = 4 * 1088;
+    size_t MAX_PACKET_SIZE_BYTES = tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : 4 * 1088;
     const size_t packet_size_bytes =
         tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : MAX_PACKET_SIZE_BYTES;
     size_t max_packet_size = packet_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/device/all_broadcast_async_program.cpp
@@ -93,9 +93,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
     }
 
     // L1 Scratch CB Creation
-    const size_t packet_size_bytes = tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : 4096;
+    constexpr size_t MAX_PACKET_SIZE_BYTES = 4 * 1088;
+    const size_t packet_size_bytes =
+        tilized ? tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes() : MAX_PACKET_SIZE_BYTES;
     size_t max_packet_size = packet_size_bytes;
-    uint32_t num_packets_per_row = std::ceil(static_cast<double>(row_size) / max_packet_size);
+    // uint32_t num_packets_per_row = std::ceil(static_cast<double>(row_size) / max_packet_size);
     uint32_t l1_scratch_cb_page_size_bytes = input_tensor.buffer()->aligned_page_size();
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
     uint32_t cb_num_pages = 3 * num_pages_per_packet;  // tripple buffering
@@ -106,10 +108,13 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
             .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
 
     uint32_t buffer_page_size = page_size;
+    uint32_t num_packets_per_page =
+        static_cast<uint32_t>(std::ceil(static_cast<double>(buffer_page_size) / max_packet_size));
     if (!tilized) {
         if (num_width_shards > 1) {
             buffer_page_size = input_tensor.memory_config().shard_spec()->shape[1] * input_tensor.element_size();
         }
+
         uint32_t num_rows_per_packet = (max_packet_size / buffer_page_size >= 2) ? 2 : 1;
         cb_src0_config =
             tt::tt_metal::CircularBufferConfig(3 * buffer_page_size * num_rows_per_packet, {{src0_cb_index, df}})
@@ -134,7 +139,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
             buffer_page_size,                                   // page_size
             row_size,                                           // row_size
             (max_packet_size / buffer_page_size >= 2) ? 2 : 1,  // num_rows_per_packet
-        };
+            num_packets_per_page,                               // num_packets_per_page
+            max_packet_size};
     }
 
     std::vector<uint32_t> writer_compile_args = {
@@ -152,7 +158,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_broadcast_async_multicore(
             row_size,
             max_packet_size,
             (max_packet_size / buffer_page_size >= 2) ? 2 : 1,  // num_rows_per_packet
-            num_packets_per_row,                                // num_packets_per_row
+            num_packets_per_page,                               // num_packets_per_row
             num_targets_forward,                                // num_targets_forward_direction
             num_targets_backward,                               // num_targets_backward_direction
         };


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/29349

### Problem description
t3k_gemma3_tests is using a packet size of 65568, which is larger than the maximum packet payload size (4 * 1088)

### What's changed
In this PR, we modify all broadcast op to use a maximum packet size of 4 * 1088

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18102882186
- [x] Galaxy nightly tests https://github.com/tenstorrent/tt-metal/actions/runs/18103055499
- [x] T3K demo tests (fixing gemma3) https://github.com/tenstorrent/tt-metal/actions/runs/18137557069/job/51620739964
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes