### PR TITLE
Remove unused boost_thread_pool

### DIFF
--- a/tests/tt_metal/distributed/benchmark_thread_pool.cpp
+++ b/tests/tt_metal/distributed/benchmark_thread_pool.cpp
@@ -44,26 +44,9 @@ static void BM_ThreadPool(benchmark::State& state, ThreadPoolCreator create_thre
     state.SetComplexityN(state.range(0));
 }
 
-static void BM_BoostThreadPool(benchmark::State& state) {
-    BM_ThreadPool(state, [](uint32_t num_threads) { return tt::tt_metal::create_boost_thread_pool(num_threads); });
-}
-
-static void BM_DistributedBoostThreadPool(benchmark::State& state) {
-    BM_ThreadPool(
-        state, [](uint32_t num_threads) { return tt::tt_metal::create_distributed_boost_thread_pool(num_threads); });
-}
-
 static void BM_DeviceBoundThreadPool(benchmark::State& state) {
     BM_ThreadPool(
         state, [](uint32_t num_threads) { return tt::tt_metal::create_device_bound_thread_pool(num_threads); });
 }
-
-BENCHMARK(BM_BoostThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();
-
-BENCHMARK(BM_DistributedBoostThreadPool)
-    ->RangeMultiplier(2)
-    ->Range(1, 1 << 18)
-    ->Complexity(benchmark::oN)
-    ->UseRealTime();
 
 BENCHMARK(BM_DeviceBoundThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <boost/asio.hpp>
-#include <boost/asio/post.hpp>
-#include <boost/asio/thread_pool.hpp>
 #include <cstddef>
 #include <future>
 #include <type_traits>
@@ -271,107 +268,6 @@ namespace thread_pool_impls {
 // Implementations conforming to the ThreadPool interface.
 using threading_primitives::NumaAwareExecutor;
 
-// Boost backed thread-pool.
-class BoostThreadPool : public ThreadPool {
-public:
-    BoostThreadPool(size_t thread_count) : pool_(thread_count) {
-        // Given the current use case, we don't expect to
-        // enqueue more tasks than the number of threads.
-        // Add a factor of safety and modify as needed.
-        futures_.reserve(thread_count * 4);
-        // Bind threads to CPU cores.
-        for (int i = 0; i < thread_count; i++) {
-            auto cpu_id = thread_binding::get_cpu_core_for_physical_device(i);
-            auto task = [cpu_id]() {
-                pthread_t thread = pthread_self();
-                cpu_set_t cpuset;
-                CPU_ZERO(&cpuset);
-                CPU_SET(cpu_id, &cpuset);
-
-                int rc = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
-                if (rc) {
-                    log_warning(
-                        tt::LogMetal,
-                        "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
-                        rc);
-                }
-            };
-            this->enqueue(task, i);
-        }
-        this->wait();
-    }
-
-    ~BoostThreadPool() noexcept override = default;
-
-    void enqueue(std::function<void()>&& f, std::optional<uint32_t> device_idx = std::nullopt) override {
-        std::packaged_task<void()> task(std::move(f));
-        futures_.push_back(task.get_future());
-        boost::asio::post(pool_, [executor = std::move(task)]() mutable { executor(); });
-    }
-
-    void wait() override {
-        for (auto& future : futures_) {
-            future.get();
-        }
-        futures_.clear();
-    }
-
-private:
-    boost::asio::thread_pool pool_;
-    std::vector<std::future<void>> futures_;
-};
-
-// Uses the BoostThreadPool implementation. Maintains a vector of single thread
-// BoostThreadPool objects. This allows submitting tasks to specific workers,
-// allowing an even distribution of work.
-class DistributedBoostThreadPool : public ThreadPool {
-public:
-    DistributedBoostThreadPool(uint32_t thread_count) : num_workers_(thread_count) {
-        workers_.reserve(thread_count);
-
-        for (uint32_t i = 0; i < thread_count; i++) {
-            workers_.emplace_back(std::make_unique<BoostThreadPool>(1));
-        }
-        // Bind threads to CPU cores.
-        for (int i = 0; i < thread_count; i++) {
-            auto cpu_id = thread_binding::get_cpu_core_for_physical_device(i);
-            auto task = [cpu_id]() {
-                pthread_t thread = pthread_self();
-                cpu_set_t cpuset;
-                CPU_ZERO(&cpuset);
-                CPU_SET(cpu_id, &cpuset);
-                int rc = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
-                if (rc) {
-                    log_warning(
-                        tt::LogMetal,
-                        "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
-                        rc);
-                }
-            };
-            this->enqueue(task, i);
-        }
-        this->wait();
-    }
-
-    void enqueue(std::function<void()>&& f, std::optional<uint32_t> device_idx = 0) override {
-        workers_[device_idx.value_or(thread_idx_ % num_workers_)]->enqueue(std::move(f));
-        ++thread_idx_;
-    }
-
-    void wait() override {
-        for (auto& worker : workers_) {
-            worker->wait();
-        }
-    }
-
-private:
-    std::vector<std::unique_ptr<BoostThreadPool>> workers_;
-    // Used to pick threads when device_idx is not specified in the enqueue API
-    uint32_t thread_idx_ = 0;
-    // Store the number of workers to repeated lookups
-    uint32_t num_workers_ = 0;
-};
-
 // Custom Thread-Pool using the threading::Executor class.
 // Allows enqueuing tasks tied to specific devices.
 class DeviceBoundThreadPool : public ThreadPool {
@@ -445,14 +341,6 @@ public:
 };
 
 }  // namespace thread_pool_impls
-
-std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads) {
-    return std::make_shared<thread_pool_impls::BoostThreadPool>(num_threads);
-}
-
-std::shared_ptr<ThreadPool> create_distributed_boost_thread_pool(int num_threads) {
-    return std::make_shared<thread_pool_impls::DistributedBoostThreadPool>(num_threads);
-}
 
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads) {
     return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(num_threads);

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -25,8 +25,6 @@ public:
     virtual void wait() = 0;
 };
 
-std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
-std::shared_ptr<ThreadPool> create_distributed_boost_thread_pool(int num_threads);
 // API accespting the number of threads to spawn in the pool. Will bind each thread to a CPU core, but the
 // binding strategy will not be NUMA aware. Used for testing and benchmarking host-code.
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -84,8 +84,6 @@ std::shared_ptr<ThreadPool> create_default_thread_pool(const std::vector<IDevice
     // Bind the thread-pool to the physical devices being used.
     if (tt::parse_env("TT_MESH_PASS_THROUGH_THREAD_POOL", false) || physical_devices.size() == 1) {
         return create_passthrough_thread_pool();
-    } else if (tt::parse_env("TT_MESH_BOOST_THREAD_POOL", false)) {
-        return create_boost_thread_pool(physical_devices.size());
     } else {
         return create_device_bound_thread_pool(physical_devices);
     }


### PR DESCRIPTION
### Ticket
[Remove Boost thread pool](https://github.com/tenstorrent/tt-metal/issues/27381)

### Problem description
Cleanup: the functionality hasn’t been used so far, so it’s safe to remove it.

### What's changed
Remove BoostThreadPool

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Result](https://github.com/tenstorrent/tt-metal/actions/runs/18110120000)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes