### PR TITLE
#25340: Correct TensorTopology constructor in host-side ops

### DIFF
--- a/ttnn/api/ttnn/distributed/tensor_topology.hpp
+++ b/ttnn/api/ttnn/distributed/tensor_topology.hpp
@@ -14,7 +14,7 @@ public:
     TensorTopology() :
         distribution_shape_(tt::tt_metal::distributed::MeshShape{1}),
         placements_({tt::tt_metal::distributed::MeshMapperConfig::Replicate{}}),
-        mesh_coords_({tt::tt_metal::distributed::MeshCoordinate{0}}) {}
+        mesh_coords_({tt::tt_metal::distributed::MeshCoordinate{0, 0}}) {}
 
     TensorTopology(
         tt::tt_metal::distributed::MeshShape distribution_shape,
@@ -62,5 +62,7 @@ private:
 
 bool operator==(const TensorTopology& lhs, const TensorTopology& rhs);
 bool operator!=(const TensorTopology& lhs, const TensorTopology& rhs);
+
+std::ostream& operator<<(std::ostream& os, const TensorTopology& tensor_topology);
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/distributed/tensor_topology.hpp
+++ b/ttnn/api/ttnn/distributed/tensor_topology.hpp
@@ -55,8 +55,12 @@ public:
 private:
     tt::tt_metal::distributed::MeshShape distribution_shape_;
     tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements_;
+
     // Physical device coordinates
     std::vector<tt::tt_metal::distributed::MeshCoordinate> mesh_coords_;
 };
+
+bool operator==(const TensorTopology& lhs, const TensorTopology& rhs);
+bool operator!=(const TensorTopology& lhs, const TensorTopology& rhs);
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/distributed/tensor_topology.cpp
+++ b/ttnn/core/distributed/tensor_topology.cpp
@@ -100,4 +100,11 @@ std::optional<tt::tt_metal::distributed::MeshCoordinate> TensorTopology::get_ten
     return std::nullopt;
 }
 
+bool operator==(const TensorTopology& lhs, const TensorTopology& rhs) {
+    return lhs.distribution_shape() == rhs.distribution_shape() && lhs.placements() == rhs.placements() &&
+           lhs.mesh_coords() == rhs.mesh_coords();
+}
+
+bool operator!=(const TensorTopology& lhs, const TensorTopology& rhs) { return !(lhs == rhs); }
+
 }  // namespace tt::tt_metal

--- a/ttnn/core/distributed/tensor_topology.cpp
+++ b/ttnn/core/distributed/tensor_topology.cpp
@@ -107,4 +107,20 @@ bool operator==(const TensorTopology& lhs, const TensorTopology& rhs) {
 
 bool operator!=(const TensorTopology& lhs, const TensorTopology& rhs) { return !(lhs == rhs); }
 
+std::ostream& operator<<(std::ostream& os, const TensorTopology& tensor_topology) {
+    os << "TensorTopology(";
+    os << "distribution_shape=" << tensor_topology.distribution_shape();
+    os << ", placements=" << tensor_topology.placements();
+    os << ", mesh_coords=";
+    for (size_t i = 0; i < tensor_topology.mesh_coords().size(); i++) {
+        const auto& coord = tensor_topology.mesh_coords()[i];
+        if (i > 0) {
+            os << ", ";
+        }
+        os << coord;
+    }
+    os << ")";
+    return os;
+}
+
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#25340

### Problem description
Default `TensorTopology` ctor doesn't do the right thing in the context of host-side ops like pad/unpad/to_layout.

### What's changed
Correct the code, add tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18172576765)
- [x] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18172580094)
- [x] New/Existing tests provide coverage for changes