### PR TITLE
[skip ci] Clarify the role of Src{A,B} in doc

### DIFF
--- a/docs/source/tt-metalium/tt_metal/advanced_topics/compute_engines_and_dataflow_within_tensix.rst
+++ b/docs/source/tt-metalium/tt_metal/advanced_topics/compute_engines_and_dataflow_within_tensix.rst
@@ -26,12 +26,18 @@ Several key components work together to perform computations within Tensix:
 
 The compute engines rely on four main register sets:
 
-1. **SrcA**: The first source register set for the matrix engine.
-2. **SrcB**: The second source register set for the matrix engine.
+1. **SrcA**: The first source register of the matrix engine.
+2. **SrcB**: The second source register of the matrix engine.
 3. **Dst**: The destination register set for the matrix engine, also used by the vector engine. This register set is exposed in the higher-level API.
 4. **LReg**: Internal registers within the SFPU for holding vector data during computation.
 
 The following image illustrates the connection between the different components and the registers they can access.
+
+.. note::
+
+    The register names are historical and may not clearly reflect their roles. The matrix engine (FPU) was developed before the vector engine (SFPU), and the names ``SrcA``, ``SrcB``, and ``Dst`` were chosen based on their use in matrix operations: ``SrcA`` and ``SrcB`` as source operands, and ``Dst`` as the destination. These names remained unchanged when the vector engine was added.
+
+    ``SrcA`` and ``SrcB`` are physical registers inside the matrix engine. The names might suggest references to memory locations, but they are just hardware registers used for computation. And unlike ``Dst``, ``SrcA`` and ``SrcB`` are single registers, not a register set.
 
 .. note::
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
In Discord community users are confused about the role of SrcA/B due to it looking like a reference to register instead of being a physical register.

> I mean like, in the RISCV-spec rs1 is used to refer to any register operand

### What's changed
Clarify wording

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes