### PR TITLE
Update perf numbers for swin_s and swin_v2

### DIFF
--- a/models/experimental/swin_s/README.md
+++ b/models/experimental/swin_s/README.md
@@ -26,7 +26,7 @@ pytest models/experimental/swin_s/tests/pcc/test_ttnn_swin_transformer.py
 ```sh
 pytest models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant
 ```
-- end-2-end perf is 6 FPS
+- end-2-end perf is 11 FPS
 
 ### Multi Device (DP=2, N300):
 
@@ -34,7 +34,7 @@ pytest models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_pe
 ```sh
 pytest  models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant_dp
 ```
-- end-2-end perf is 13 FPS
+- end-2-end perf is 23 FPS
 
 ## Performant demo with Trace+2CQ
 

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_s", 6.7),
+        (1, "Swin_s", 11.5),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/swin_v2/README.md
+++ b/models/experimental/swin_v2/README.md
@@ -23,14 +23,14 @@ Swin Transformer v2 builds upon the original Swin Transformer to tackle key chal
 
 #### Single Device (BS=1):
 
-- For `512x512` resolution, end-2-end perf is `7` FPS
+- For `512x512` resolution, end-2-end perf is `16` FPS
 
     ```sh
     pytest models/experimental/swin_v2/tests/perf/test_e2e_performant.py::test_e2e_performant
     ```
 #### Multi Device (DP=2, N300):
 
-- For `512x512` resolution, end-2-end perf is `14` FPS
+- For `512x512` resolution, end-2-end perf is `32` FPS
 
     ```sh
     pytest models/experimental/swin_v2/tests/perf/test_e2e_performant.py::test_e2e_performant_dp

--- a/models/experimental/swin_v2/tests/perf/test_perf.py
+++ b/models/experimental/swin_v2/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_v2", 5.95),
+        (1, "Swin_v2", 16.6),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
Update the e2e and device perf numbers for swin_s and swin_v2 models on latest main

### What's changed
Updated the e2e and device perf numbers for swin_s and swin_v2 models on latest main

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18124254402) Passed
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18124325282) Passed
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18124291658) Passed