### PR TITLE
lower unet multi device perf

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -236,7 +236,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, num_runs, iterations, expected_compile_time, expected_throughput", ((1, 4, 12, 256, 30.0, 2700.0),)
+    "batch, groups, num_runs, iterations, expected_compile_time, expected_throughput", ((1, 4, 12, 256, 30.0, 2680.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,


### PR DESCRIPTION
### Problem description
Unet multi device e2e perf is a bit flaky. Doesn't seem like an actual regression, since it happens occasionally and doesn't persist. Examples:
- https://github.com/tenstorrent/tt-metal/actions/runs/18116778119/job/51554232874
- https://github.com/tenstorrent/tt-metal/actions/runs/18109212643/job/51531802545

When it fails, it impacts all other tests in the same job - unet single device and stable diffusion 1.4. Started a thread in pipelines channel about resolving the issue with impacting other tests.


### What's changed
Lower the bound. Observe if the flakiness happens on the single device tests.

### Checklist
Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/18127543366