### PR TITLE
Revert "#28628: use non-legacy LayerNorm program config settings (#28630)"

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -197,7 +197,7 @@ def test_forward_pass(
 
     # Check output PCC
     logger.info("Validating output")
-    pcc_required = 0.9899
+    pcc_required = 0.99
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
 
     logger.info(f"Mode: {mode}, Seq len: {seq_len}, Batch size: {batch_size}")

--- a/models/demos/falcon7b_common/tt/model_config.py
+++ b/models/demos/falcon7b_common/tt/model_config.py
@@ -148,8 +148,6 @@ def get_ln_block_sharded_config(height_dim, hidden_dim):
         block_h=num_tiles_per_core_h,
         block_w=num_tiles_per_core_w,
         inplace=True,
-        legacy_reduction=True,
-        legacy_rsqrt=True,
     )
 
     return ln_block_sharded_mem_config, ln_block_sharded_prog_config, ln_block_sharded_compute_kernel_config

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
@@ -73,7 +73,7 @@ class basic_transformer_block:
             end_grid = ttnn.CoreCoord(7, 3)
 
         sharded_mem_cfg = ttnn.get_memory_config(hidden_states)
-        program_config = ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True)
+        program_config = ttnn.LayerNormDefaultProgramConfig()
 
         old_hidden_states = hidden_states
         hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -67,14 +67,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
  * | Function   | —    | No parameters                                    |  —   |      —      |    —     |
  */
 // clang-format on
-template <bool enforce_fp32_accumulation = false>
-ALWI void reduce_uninit() {
-    if constexpr (enforce_fp32_accumulation) {
-        MATH((tensix_sync()));
-        MATH((reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0)));
-    }
-    PACK((llk_pack_reduce_mask_clear()));
-}
+ALWI void reduce_uninit() { PACK((llk_pack_reduce_mask_clear())); }
 
 // clang-format off
 /**

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -102,7 +102,7 @@ void MAIN {
 #endif
         tile_regs_commit();
         pack_tile(dst0, cb_ex);
-        reduce_uninit<FLOAT32_REDUCTION>();
+        reduce_uninit();
         tile_regs_release();
         cb_push_back(cb_ex, onetile);
         // End of
@@ -176,7 +176,7 @@ void MAIN {
             }
             cb_pop_front(cb_xmm, blk);
             cb_reserve_back(cb_ex2, onetile);
-            reduce_uninit<FLOAT32_REDUCTION>();
+            reduce_uninit();
             tile_regs_commit();
             pack_tile(dst0, cb_ex2);
             cb_push_back(cb_ex2, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -15,8 +15,8 @@ enum class LayerNormType { LAYERNORM, RMSNORM };
 enum class DistributedLayerNormStage { NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER };
 
 struct LayerNormDefaultProgramConfig {
-    bool legacy_reduction = false;
-    bool legacy_rsqrt = false;
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
     bool use_welford = false;
 };
 struct LayerNormShardedMultiCoreProgramConfig {
@@ -25,8 +25,8 @@ struct LayerNormShardedMultiCoreProgramConfig {
     std::size_t block_h{};
     std::size_t block_w{};
     bool inplace{};
-    bool legacy_reduction = false;
-    bool legacy_rsqrt = false;
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
 };
 
 using LayerNormProgramConfig = std::variant<LayerNormDefaultProgramConfig, LayerNormShardedMultiCoreProgramConfig>;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -17,8 +17,8 @@ void bind_normalization_layernorm_program_config(py::module& module) {
         .def(
             py::init<bool, bool, bool>(),
             py::kw_only(),
-            py::arg("legacy_reduction").noconvert() = false,
-            py::arg("legacy_rsqrt").noconvert() = false,
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true,
             py::arg("use_welford").noconvert() = false)
         .def("__repr__", [](const LayerNormDefaultProgramConfig& config) { return fmt::format("{}", config); });
 
@@ -31,8 +31,8 @@ void bind_normalization_layernorm_program_config(py::module& module) {
             py::arg("block_h").noconvert(),
             py::arg("block_w").noconvert(),
             py::arg("inplace").noconvert(),
-            py::arg("legacy_reduction").noconvert() = false,
-            py::arg("legacy_rsqrt").noconvert() = false)
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true)
         .def(
             "__repr__", [](const LayerNormShardedMultiCoreProgramConfig& config) { return fmt::format("{}", config); });
 }


### PR DESCRIPTION
### Problem description
Multiple test related to SDXL failed in latest runs in Metal CI:

**(Single-card) Frequent model and ttnn tests**
- [fd-nightly / Nightly N150 stable_diffusion_xl_base](https://github.com/tenstorrent/tt-metal/actions/runs/18119372354/job/51561447224#logs)
- [fd-nightly / Nightly N300 stable_diffusion_xl_base](https://github.com/tenstorrent/tt-metal/actions/runs/18119372354/job/51561447280#logs)
Pcc check for tests/nightly/single_card/stable_diffusion_xl_base/test_module_tt_crossattnupblock.py::test_crossattnup failes - for both jobs

**Nightly tt-metal L2 tests**
- [tt-metal-l2-tests (wormhole_b0, N150) / ttnn nightly sdxl tests wormhole_b0 N150](https://github.com/tenstorrent/tt-metal/actions/runs/18103959598/job/51514451103#logs)
- [tt-metal-l2-tests (wormhole_b0, N300) / ttnn nightly sdxl tests wormhole_b0 N300](https://github.com/tenstorrent/tt-metal/actions/runs/18103959598/job/51514451108#logs)
Pcc check for models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py::test_unet_loop, fails for both jobs
________________________________________
We did bisect locally and and found out that (#28630) breaks PCCs

### What's changed
This reverts commit 44b16a4129b4b1f9245aa8733094f7287898ffcd

### Checklist
- [ ] [All post commit]
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/18131655324)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18131595091)

