### PR TITLE
Fix timeout detection for n300 device

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -427,6 +427,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         loop_and_wait_with_timeout(fetch_operation_body, fetch_wait_condition, fetch_on_timeout, timeout_duration);
     };
 
+    wait_for_fetch_q_space();
     // Wrap FetchQ if possible
     uint32_t prefetch_q_base = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::UNRESERVED);

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -398,20 +398,36 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     // Helper to wait for fetch queue space, if needed
     uint32_t fence;
+    std::atomic<bool> fetch_q_exit_condition{false};
     auto wait_for_fetch_q_space = [&]() {
         if (this->prefetch_q_dev_ptrs[cq_id] != this->prefetch_q_dev_fences[cq_id]) {
             return;
         }
         ZoneScopedN("wait_for_fetch_q_space");
-        // Loop until space frees up
-        while (this->prefetch_q_dev_ptrs[cq_id] == this->prefetch_q_dev_fences[cq_id]) {
+
+        // Body of the operation
+        auto fetch_operation_body = [&]() {
             tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                 &fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
-        }
-    };
+        };
 
-    wait_for_fetch_q_space();
+        // Condition to check if should continue waiting
+        auto fetch_wait_condition = [&]() -> bool {
+            return this->prefetch_q_dev_ptrs[cq_id] == this->prefetch_q_dev_fences[cq_id];
+        };
+
+        // Handler for timeout
+        auto fetch_on_timeout = [&]() {
+            fetch_q_exit_condition.store(true);
+            TT_THROW("TIMEOUT: device timeout in fetch queue wait, potential hang detected");
+        };
+
+        auto timeout_duration =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations();
+
+        loop_and_wait_with_timeout(fetch_operation_body, fetch_wait_condition, fetch_on_timeout, timeout_duration);
+    };
 
     // Wrap FetchQ if possible
     uint32_t prefetch_q_base = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -398,7 +398,6 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     // Helper to wait for fetch queue space, if needed
     uint32_t fence;
-    std::atomic<bool> fetch_q_exit_condition{false};
     auto wait_for_fetch_q_space = [&]() {
         if (this->prefetch_q_dev_ptrs[cq_id] != this->prefetch_q_dev_fences[cq_id]) {
             return;
@@ -419,7 +418,6 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
         // Handler for timeout
         auto fetch_on_timeout = [&]() {
-            fetch_q_exit_condition.store(true);
             TT_THROW("TIMEOUT: device timeout in fetch queue wait, potential hang detected");
         };
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/29652)

### Problem description
The host was expecting the queues to be released, but since the device was in a hang state, that was never happening

### What's changed
Added a way to detect when we timeout while waiting for queues to be released. This was not happening in N150

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes