### PR TITLE
[POOL] Halo kernel having errors in alignment on NOC transactions detected by watcher

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -143,15 +143,12 @@ static std::vector<Tensor> pool2d_invoke(
         num_cores_nhw = conv::get_num_cores_nhw_from_parallel_config(parallel_config);
         num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
 
-        // This is the code path of the non sharded input tensor, this means that input channels
-        // can be whatever number here so we need to have the shard_width aligned to the l1 memory alignment
-        // which is 16, in case shard_width is multiple of 16 or 32 we will take largest number possible. We are
-        // aligning it by changing the padded shape of the tensor.
-        uint32_t input_channels_alignment = is_in_tiled ? tt::constants::TILE_WIDTH : 16U;
-        if (input_tensor.memory_config().is_sharded() && input_tensor.layout() == Layout::ROW_MAJOR) {
-            const uint32_t shard_width = input_tensor.memory_config().shard_spec()->shape[1];
-            input_channels_alignment = (shard_width % tt::constants::TILE_WIDTH == 0) ? tt::constants::TILE_WIDTH : 16U;
-        }
+        uint32_t input_channels_alignment = conv::get_input_channels_alignment(
+            shard_layout,
+            input_tensor.layout(),
+            input_tensor.memory_config().buffer_type(),
+            false,
+            input_tensor.memory_config());
 
         ttnn::Shape input_tensor_shape = input_tensor.padded_shape();
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -144,11 +144,7 @@ static std::vector<Tensor> pool2d_invoke(
         num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
 
         uint32_t input_channels_alignment = conv::get_input_channels_alignment(
-            shard_layout,
-            input_tensor.layout(),
-            input_tensor.memory_config().buffer_type(),
-            false,
-            input_tensor.memory_config());
+            shard_layout, input_tensor.layout(), BufferType::L1, false, input_tensor.memory_config());
 
         ttnn::Shape input_tensor_shape = input_tensor.padded_shape();
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -145,14 +145,12 @@ static std::vector<Tensor> pool2d_invoke(
 
         // This is the code path of the non sharded input tensor, this means that input channels
         // can be whatever number here so we need to have the shard_width aligned to the l1 memory alignment
-        // which is 8, in case shard_width is multiple of 16 or 32 we will take largest number possible. We are aligning
-        // it by changing the padded shape of the tensor.
-        uint32_t input_channels_alignment = is_in_tiled ? tt::constants::TILE_WIDTH : 8U;
+        // which is 16, in case shard_width is multiple of 16 or 32 we will take largest number possible. We are
+        // aligning it by changing the padded shape of the tensor.
+        uint32_t input_channels_alignment = is_in_tiled ? tt::constants::TILE_WIDTH : 16U;
         if (input_tensor.memory_config().is_sharded() && input_tensor.layout() == Layout::ROW_MAJOR) {
             const uint32_t shard_width = input_tensor.memory_config().shard_spec()->shape[1];
-            input_channels_alignment = (shard_width % tt::constants::TILE_WIDTH == 0) ? tt::constants::TILE_WIDTH
-                                       : (shard_width % 16 == 0)                      ? 16U
-                                                                                      : 8U;
+            input_channels_alignment = (shard_width % tt::constants::TILE_WIDTH == 0) ? tt::constants::TILE_WIDTH : 16U;
         }
 
         ttnn::Shape input_tensor_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -307,7 +307,7 @@ void kernel_main() {
             fill_with_val<num_elements_to_fill, pad_val>(get_write_ptr(pad_cb_id));
 
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
-            constexpr uint32_t padding_region_size = stick_nbytes / elem_nbytes;
+            constexpr uint32_t padding_region_size = std::max(stick_nbytes, stick_nbytes / elem_nbytes);
             copy_padding<padding_config_cb_id, out_cb_id, stick_nbytes, padding_region_size>(padding_l1_addr);
         }
     }


### PR DESCRIPTION
### Ticket
[29024](https://github.com/tenstorrent/tt-metal/issues/29024)

### Problem description
The action of getting the APC green with watcher enabled required correcting the error induced by incorrect alignments in halo kernels

### What's changed
1. Resolving the watcher detected issues in pools when channels < 8 were aligned to 8 instead of 16 
2. Rebase conflict incorrectly resolved, where recently added change with padded tensor for block floats was bypassed now is corrected

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18499345273)
- [ ] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/18499359059)
- [ ] [Nightly tt-metal L2 tests ](https://github.com/tenstorrent/tt-metal/actions/runs/18499373840)
- [ ] [APC Select with watcher enabled](https://github.com/tenstorrent/tt-metal/actions/runs/18499393027)
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/18499412504)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/18499436920)