### PR TITLE
[skip ci] Generate reports for failed jobs in Single-card model perf …

### DIFF
--- a/.github/actions/single-card-perf-test/action.yml
+++ b/.github/actions/single-card-perf-test/action.yml
@@ -33,4 +33,6 @@ runs:
         install_wheel: true
         run_args: |
           ${{ inputs.commands }}
+          status=$?
           env python3 models/perf/merge_perf_results.py REPORT
+          exit $status

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -78,6 +78,12 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
     [[maybe_unused]] auto control_plane = make_control_plane(tg_mesh_graph_desc_path);
 }
 
+TEST_F(ControlPlaneFixture, TestN150ControlPlaneInit) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    EXPECT_EQ(control_plane.get_user_physical_mesh_ids().size(), 1);
+}
+
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_meshes = control_plane.get_user_physical_mesh_ids();


### PR DESCRIPTION
…(#29440)

Link to Github Issue:
https://github.com/tenstorrent/tt-metal/issues/29439

Generate reports for failed jobs in Single-card model perf

Single-card model-perf passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18021329678

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes