### PR TITLE
#0: [skip ci] Run upstream container tests on POR BH multi-card systems

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -220,11 +220,12 @@ jobs:
       - ${{ matrix.bh-config.runner-label }}
       - in-service
       - cloud-virtual-machine
+      - pipeline-perf
     steps:
       - name: Run image
         timeout-minutes: 30
         env:
-          LLAMA_DIR: ${{ contains(runner.name, 'tt-metal-ci') && !contains(runner.name, 'qb') && '/mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct' || '/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct' }}
+          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -219,7 +219,6 @@ jobs:
     runs-on:
       - ${{ matrix.bh-config.runner-label }}
       - in-service
-      - cloud-virtual-machine
       - pipeline-perf
     steps:
       - name: Run image


### PR DESCRIPTION
### Ticket
None

### Problem description


### What's changed
Switch from sim HW to POR HW:
Add `pipeline-perf` tag and remove `cloud-virtual-machine`
Use local stored weights

### Checklist
- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/18133958055/job/51609827234