### PR TITLE
Add transfer-only mode to TT-CNN pipeline API

### DIFF
--- a/models/tt_cnn/README.md
+++ b/models/tt_cnn/README.md
@@ -140,6 +140,20 @@ config = PipelineConfig(
 - **Queue Usage**: CQ0 for operations only, CQ1 for both input writes and output reads
 - **Requirements**: `dram_output_memory_config` for persistent output tensors, requires a minimum of two inputs for effective pipelining, complex event synchronization
 
+#### Transfer Only Mode
+```python
+config = PipelineConfig(
+    ...,
+    transfer_only_mode=True  # Skip all model operations
+)
+```
+- **Use when**: Testing theoretical maximum throughput by measuring pure memory transfer overhead
+- **Executor**: `TransferOnlyExecutor`
+- **Behavior**:
+  - Runs model **once** during compilation to determine output schema
+  - **Skips all model operations** during execution
+  - Only performs device transfers
+
 #### DRAM Memory Configuration
 Many pipeline configurations require memory configs for the persistent tensors that the pipeline automatically allocates and manages during execution. To automatically select optimal DRAM configs given your input shape, use the following utility:
 


### PR DESCRIPTION
### Summary

Adds a transfer-only mode to the TT-CNN pipeline API for measuring pure input/output transfer overhead without model execution.

This mode is useful for measuring theoretical maximum throughput for a particular device and model by isolating input/output transfer overhead from model operations, which can be helpful for determining whether a model is bound by I/O or device.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] New/Existing tests provide coverage for changes