### PR TITLE
#26591: Migrate `EnqueueRecordEvent` to `MeshCommandQueue::enqueue_record_event`

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -537,8 +537,9 @@ Unlike OpenCL's command queue which optionally supports out-of-order execution, 
 ```c++
 // Wait for the current tail operation on queue 0 to complete
 // before proceeding on command queue 1
-auto event = EnqueueRecordEvent(device->command_queue(0));
-EnqueueWaitForEvent(device->command_queue(1), event);
+auto event = std::make_shared<Event>();
+device->command_queue(0).enqueue_record_event(event);
+device->command_queue(1).enqueue_wait_for_event(event);
 ```
 
 ### SPMD in Metalium

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -505,13 +505,13 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src0_buf, mul_sub_src0_vec);
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
 
-    MeshEvent write_event = EnqueueRecordEvent(data_movement_cq);
+    MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
 
     ReplayTrace(mesh_device_.get(), kWorkloadCqId, trace_id, false);
 
     // Synchronize
-    MeshEvent trace_event = EnqueueRecordEvent(workload_cq);
+    MeshEvent trace_event = workload_cq.enqueue_record_event();
     data_movement_cq.enqueue_wait_for_event(trace_event);
 
     std::vector<bfloat16> add_dst_vec = {};

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -56,7 +56,7 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
         // Writes on CQ 0
         EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(0), buf, src_vec);
         // Device to Device Synchronization
-        auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
+        auto write_event = mesh_device_->mesh_command_queue(0).enqueue_record_event();
         mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
 
         // Reads on CQ 1
@@ -103,7 +103,7 @@ TEST_F(MeshEventsTest2x4, ShardedAsyncIO) {
             EventSynchronize(write_event);
         } else {
             // Test Device <-> Device synchronization
-            auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
+            auto write_event = mesh_device_->mesh_command_queue(0).enqueue_record_event();
             mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
         }
         // Reads on CQ 1
@@ -164,14 +164,14 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
             EventSynchronize(write_event);
         } else {
             // Test Device <-> Device Synchronization
-            auto write_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(1));
+            auto write_event = mesh_device_->mesh_command_queue(1).enqueue_record_event();
             mesh_device_->mesh_command_queue(0).enqueue_wait_for_event(write_event);
         }
         // Issue workloads on MeshCQ 0
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(0), mesh_workload, false);
         if (iter % 2) {
             // Test Device <-> Device Synchronization
-            auto op_event = EnqueueRecordEvent(mesh_device_->mesh_command_queue(0));
+            auto op_event = mesh_device_->mesh_command_queue(0).enqueue_record_event();
             mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(op_event);
         } else {
             // Test Host <-> Device Synchronization
@@ -231,7 +231,7 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
         std::vector<std::vector<uint32_t>> readback_vecs = {};
 
         mesh_device_->mesh_command_queue(1).enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_0, false);
-        auto event0 = EnqueueRecordEvent(mesh_device_->mesh_command_queue(1), {}, devices_0);
+        auto event0 = mesh_device_->mesh_command_queue(1).enqueue_record_event({}, devices_0);
         mesh_device_->mesh_command_queue(0).enqueue_wait_for_event(event0);
 
         for (const auto& coord : devices_0) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -218,7 +218,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsEventsQueryBasic) {
         mesh_device.get(),
         cq.id(),
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(0, 0)));
-    distributed::EnqueueRecordEvent(cq);
+    cq.enqueue_record_event();
     event_status = distributed::EventQuery(*future_event);
     EXPECT_EQ(event_status, false);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -401,7 +401,7 @@ int main(int argc, char** argv) {
                 start = std::chrono::system_clock::now();
             }
             if (hammer_write_reg_g || hammer_pcie_g) {
-                auto sync_event = tt::tt_metal::distributed::EnqueueRecordEvent(cq);
+                auto sync_event = cq.enqueue_record_event();
 
                 bool done = false;
                 uint32_t addr = 0xfafafafa;

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -102,14 +102,6 @@ void EnqueueReadMeshBuffer(
     mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
 }
 
-// Make the specified MeshCommandQueue record an event.
-// Host is not notified when this event completes.
-// Can be used for CQ to CQ synchronization.
-MeshEvent EnqueueRecordEvent(
-    MeshCommandQueue& mesh_cq,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-    const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
-
 // Make the specified MeshCommandQueue record an event and notify the host when it completes.
 // Can be used for CQ to CQ and host to CQ synchronization.
 MeshEvent EnqueueRecordEventToHost(

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -23,13 +23,6 @@ void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload,
     mesh_cq.enqueue_mesh_workload(mesh_workload, blocking);
 }
 
-MeshEvent EnqueueRecordEvent(
-    MeshCommandQueue& mesh_cq,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
-    const std::optional<MeshCoordinateRange>& device_range) {
-    return mesh_cq.enqueue_record_event(sub_device_ids, device_range);
-}
-
 MeshEvent EnqueueRecordEventToHost(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids,

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -252,12 +252,12 @@ int main() {
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src0_buf, mul_sub_src0_vec);
     EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
     // Synchronize
-    MeshEvent write_event = EnqueueRecordEvent(data_movement_cq);
+    MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
     // =========== Step 8: Run MeshTrace on MeshCQ0 ===========
     ReplayTrace(mesh_device.get(), workload_cq_id, trace_id, false);
     // Synchronize
-    MeshEvent trace_event = EnqueueRecordEvent(workload_cq);
+    MeshEvent trace_event = workload_cq.enqueue_record_event();
     data_movement_cq.enqueue_wait_for_event(trace_event);
     // =========== Step 9: Read Outputs on MeshCQ1 ===========
     std::vector<bfloat16> add_dst_vec = {};

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -52,7 +52,7 @@ void wait_for_event(
 }
 
 tt::tt_metal::distributed::MeshEvent record_event(tt::tt_metal::distributed::MeshCommandQueue& cq) {
-    return tt::tt_metal::distributed::EnqueueRecordEvent(cq);
+    return cq.enqueue_record_event();
 }
 tt::tt_metal::distributed::MeshEvent record_event_to_host(tt::tt_metal::distributed::MeshCommandQueue& cq) {
     return tt::tt_metal::distributed::EnqueueRecordEventToHost(cq);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26591)

### Problem description
N/A

### What's changed

- Migration of `EnqueueRecordEvent` API, contributing to the effort to deprecate/remove `tt_metal/api/tt-metalium/distributed.hpp`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18135357168))
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18135362786))