### PR TITLE
Add Upsample wrapper and DRAM Slicing support to TT-CNN

### DIFF
--- a/models/tt_cnn/tests/test_builder.py
+++ b/models/tt_cnn/tests/test_builder.py
@@ -29,19 +29,65 @@ DEVICE_PARAMS = {"l1_small_size": 32768}
 PCC_THRESHOLD = 0.999
 
 INPUT_SIZES = [(8, 8), (16, 8)]
+SLICE_INPUT_SIZES = [(256, 128)]
 
 CHANNEL_CONFIGS = [
     {"in_channels": 8, "out_channels": 16},
     {"in_channels": 16, "out_channels": 16},
 ]
 
+SLICE_CHANNEL_CONFIGS = [
+    {"in_channels": 64, "out_channels": 128},
+    {"in_channels": 128, "out_channels": 64},
+]
+
+SLICE_CONFIGS = [
+    {"type": "no_slice", "num_slices": 0},
+    {"type": "height_slice", "num_slices": 2},
+    {"type": "width_slice", "num_slices": 2},
+    {"type": "channel_slice", "num_slices": 4},
+]
+
 BATCH_SIZES = [1, 2]
 
 KERNEL_CONFIGS = [{"kernel_size": 3, "padding": 1}, {"kernel_size": 5, "padding": 2}]
 
+POOL_CONFIGS = [
+    {"kernel_size": 2, "padding": 0, "ceil_mode": True},
+    {"kernel_size": 4, "padding": 0, "ceil_mode": False},
+]
+
+UPSAMPLE_CONFIGS = [
+    {"scale_factor": 2, "mode": "bilinear"},
+    {"scale_factor": (2, 3), "mode": "nearest"},
+    {"scale_factor": 4, "mode": "nearest"},
+]
+
 
 def create_conv2d_input_tensor(configuration: Conv2dConfiguration):
     shape = (configuration.batch_size, configuration.in_channels, configuration.input_height, configuration.input_width)
+    nchw = torch.randn(shape, dtype=torch.bfloat16).float()
+
+    nhwc = torch.permute(nchw, (0, 2, 3, 1))
+    nhwc = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    return nchw, nhwc
+
+
+def create_pool2d_input_tensor(configuration: MaxPool2dConfiguration):
+    shape = (configuration.batch_size, configuration.channels, configuration.input_height, configuration.input_width)
+    nchw = torch.randn(shape, dtype=torch.bfloat16).float()
+
+    nhwc = torch.permute(nchw, (0, 2, 3, 1)).reshape(
+        1, 1, configuration.batch_size * configuration.input_height * configuration.input_width, configuration.channels
+    )
+    nhwc = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    return nchw, nhwc
+
+
+def create_upsample_input_tensor(configuration: UpsampleConfiguration):
+    shape = (configuration.batch_size, configuration.channels, configuration.input_height, configuration.input_width)
     nchw = torch.randn(shape, dtype=torch.bfloat16).float()
 
     nhwc = torch.permute(nchw, (0, 2, 3, 1))
@@ -135,39 +181,11 @@ def test_conv2d(input_size, channel_config, batch_size, kernel_config, sharding_
     )
 
 
-def create_pool2d_input_tensor(configuration: MaxPool2dConfiguration):
-    shape = (configuration.batch_size, configuration.channels, configuration.input_height, configuration.input_width)
-    nchw = torch.randn(shape, dtype=torch.bfloat16).float()
-
-    nhwc = torch.permute(nchw, (0, 2, 3, 1)).reshape(
-        1, 1, configuration.batch_size * configuration.input_height * configuration.input_width, configuration.channels
-    )
-    nhwc = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-
-    return nchw, nhwc
-
-
-def create_upsample_input_tensor(configuration: UpsampleConfiguration):
-    shape = (configuration.batch_size, configuration.channels, configuration.input_height, configuration.input_width)
-    nchw = torch.randn(shape, dtype=torch.bfloat16).float()
-
-    nhwc = torch.permute(nchw, (0, 2, 3, 1))
-    nhwc = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-
-    return nchw, nhwc
-
-
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
 @pytest.mark.parametrize("input_size", INPUT_SIZES)  # Use first 2 sizes
 @pytest.mark.parametrize("channels", [16, 8])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)  # Use first 2 batch sizes
-@pytest.mark.parametrize(
-    "pool_config",
-    [
-        {"kernel_size": 2, "padding": 0, "ceil_mode": True},
-        {"kernel_size": 4, "padding": 0, "ceil_mode": False},
-    ],
-)
+@pytest.mark.parametrize("pool_config", POOL_CONFIGS)
 def test_pool2d(input_size, channels, batch_size, pool_config, device):
     input_height, input_width = input_size
     kernel_size, padding, ceil_mode = pool_config["kernel_size"], pool_config["padding"], pool_config["ceil_mode"]
@@ -273,6 +291,52 @@ def test_downblock(input_size, batch_size, device):
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("input_size", INPUT_SIZES)
+@pytest.mark.parametrize("channels", [16, 8])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("upsample_config", UPSAMPLE_CONFIGS)
+def test_upsample(input_size, channels, batch_size, upsample_config, device):
+    input_height, input_width = input_size
+    scale_factor, mode = upsample_config["scale_factor"], upsample_config["mode"]
+
+    # Skip bilinear upsampling if channels is not divisible by 32
+    if mode == "bilinear":
+        if channels % 32 != 0:
+            pytest.skip(f"Bilinear upsampling requires channels ({channels}) to be divisible by 32")
+
+    configuration = UpsampleConfiguration(
+        input_height=input_height,
+        input_width=input_width,
+        channels=channels,
+        batch_size=batch_size,
+        scale_factor=scale_factor,
+        mode=mode,
+    )
+
+    torch_input_tensor, ttnn_input_tensor = create_upsample_input_tensor(configuration)
+
+    layer = TtUpsample(configuration, device)
+
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
+    ttnn_output_tensor = layer(ttnn_input_tensor)
+
+    torch_output_tensor = torch.nn.functional.interpolate(
+        torch_input_tensor,
+        scale_factor=configuration.scale_factor,
+        mode=configuration.mode,
+    )
+
+    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
+    assert_with_pcc(
+        torch_output_tensor,
+        ttnn.to_torch(ttnn_output_tensor)
+        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
+        .permute(0, 3, 1, 2),
+        PCC_THRESHOLD,
+    )
+
+
+@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
 @pytest.mark.parametrize("input_size", INPUT_SIZES[:1])
 @pytest.mark.parametrize("channel_config", CHANNEL_CONFIGS[:1])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES[:1])
@@ -326,54 +390,6 @@ def test_conv2d_configuration_from_torch_layer(input_size, channel_config, batch
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-def test_upsample_validation_errors(device):
-    """Test that validation errors are raised correctly for Upsample configuration"""
-
-    # Test that height/width slicing raises error
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=HeightSliceStrategyConfiguration(num_slices=2),
-        )
-
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-        )
-
-    # Test that channels not divisible by num_slices raises error
-    with pytest.raises(ValueError, match="must be divisible by number of slices"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=15,  # Not divisible by 4
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=ChannelSliceStrategyConfiguration(num_slices=4),
-        )
-
-    # Test invalid mode
-    with pytest.raises(ValueError, match="Mode must be one of"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            mode="invalid_mode",
-        )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
 @pytest.mark.parametrize("input_size", INPUT_SIZES[:1])
 @pytest.mark.parametrize("channels", [16, 8])
 @pytest.mark.parametrize("batch_size", BATCH_SIZES[:1])
@@ -422,51 +438,55 @@ def test_pool2d_configuration_from_torch_layer(input_size, channels, batch_size,
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-def test_upsample_validation_errors(device):
-    """Test that validation errors are raised correctly for Upsample configuration"""
+@pytest.mark.parametrize("input_size", INPUT_SIZES[:1])
+@pytest.mark.parametrize("channels", [16])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES[:1])
+@pytest.mark.parametrize(
+    "torch_layer_config",
+    [
+        {"scale_factor": 2, "mode": "nearest"},
+        {"scale_factor": (2, 3), "mode": "nearest"},
+        {"scale_factor": 4, "mode": "nearest"},
+    ],
+)
+def test_upsample_configuration_from_torch_layer(input_size, channels, batch_size, torch_layer_config, device):
+    input_height, input_width = input_size
 
-    # Test that height/width slicing raises error
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=HeightSliceStrategyConfiguration(num_slices=2),
-        )
+    torch_layer = torch.nn.Upsample(**torch_layer_config)
 
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-        )
+    configuration = UpsampleConfiguration.from_torch(
+        torch_layer=torch_layer,
+        input_height=input_height,
+        input_width=input_width,
+        batch_size=batch_size,
+        channels=channels,
+    )
 
-    # Test that channels not divisible by num_slices raises error
-    with pytest.raises(ValueError, match="must be divisible by number of slices"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=15,  # Not divisible by 4
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=ChannelSliceStrategyConfiguration(num_slices=4),
-        )
+    assert configuration.scale_factor == (
+        torch_layer.scale_factor
+        if isinstance(torch_layer.scale_factor, tuple)
+        else (torch_layer.scale_factor, torch_layer.scale_factor)
+    )
+    assert configuration.mode == torch_layer.mode
 
-    # Test invalid mode
-    with pytest.raises(ValueError, match="Mode must be one of"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            mode="invalid_mode",
-        )
+    tt_layer = TtUpsample(configuration, device)
+
+    torch_input = torch.randn(batch_size, channels, input_height, input_width)
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute(0, 2, 3, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+
+    ttnn_output = tt_layer(ttnn_input)
+    torch_output = torch_layer(torch_input)
+
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+    output_height, output_width = torch_output.shape[-2:]
+    ttnn_output_torch = ttnn_output_torch.reshape(batch_size, output_height, output_width, channels).permute(0, 3, 1, 2)
+
+    assert_with_pcc(torch_output, ttnn_output_torch, PCC_THRESHOLD)
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
@@ -526,128 +546,6 @@ def test_conv2d_configuration_from_model_args(input_size, channel_config, batch_
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-def test_upsample_validation_errors(device):
-    """Test that validation errors are raised correctly for Upsample configuration"""
-
-    # Test that height/width slicing raises error
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=HeightSliceStrategyConfiguration(num_slices=2),
-        )
-
-    with pytest.raises(ValueError, match="Height and Width slicing are not supported"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-        )
-
-    # Test that channels not divisible by num_slices raises error
-    with pytest.raises(ValueError, match="must be divisible by number of slices"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=15,  # Not divisible by 4
-            batch_size=1,
-            scale_factor=2,
-            slice_strategy=ChannelSliceStrategyConfiguration(num_slices=4),
-        )
-
-    # Test invalid mode
-    with pytest.raises(ValueError, match="Mode must be one of"):
-        UpsampleConfiguration(
-            input_height=16,
-            input_width=16,
-            channels=16,
-            batch_size=1,
-            scale_factor=2,
-            mode="invalid_mode",
-        )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(32, 32)])
-@pytest.mark.parametrize("channels", [16])  # Must be divisible by num_slices for channel slicing
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize(
-    "slice_config",
-    [
-        {"type": "no_slice", "num_slices": 0},
-        {"type": "height_slice", "num_slices": 2},
-        {"type": "width_slice", "num_slices": 2},
-        {"type": "channel_slice", "num_slices": 4},
-    ],
-)
-def test_conv2d_slicing_strategies(input_size, channels, batch_size, slice_config, device):
-    """Test Conv2D with different slicing strategies"""
-    input_height, input_width = input_size
-    in_channels = channels
-    out_channels = channels
-
-    # Create slice strategy based on config
-    if slice_config["type"] == "no_slice":
-        slice_strategy = None
-    elif slice_config["type"] == "height_slice":
-        slice_strategy = HeightSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
-    elif slice_config["type"] == "width_slice":
-        slice_strategy = WidthSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
-    elif slice_config["type"] == "channel_slice":
-        slice_strategy = ChannelSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
-    else:
-        raise ValueError(f"Unknown slice type: {slice_config['type']}")
-
-    configuration = Conv2dConfiguration.with_random_weights(
-        input_height=input_height,
-        input_width=input_width,
-        in_channels=in_channels,
-        out_channels=out_channels,
-        batch_size=batch_size,
-        kernel_size=(3, 3),
-        padding=(1, 1),
-        slice_strategy=slice_strategy,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
-
-    # Test with slicing
-    layer = TtConv2d(configuration, device)
-
-    # For slicing tests, ensure input is on device with DRAM memory config
-    if slice_config["type"] != "no_slice":
-        ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    ttnn_output_tensor = layer(ttnn_input_tensor)
-
-    # Reference implementation without slicing
-    torch_output_tensor = torch.nn.functional.conv2d(
-        torch_input_tensor,
-        ttnn.to_torch(configuration.weight),
-        ttnn.to_torch(configuration.bias).reshape(-1) if configuration.bias is not None else None,
-        stride=configuration.stride,
-        padding=configuration.padding,
-        dilation=configuration.dilation,
-        groups=configuration.groups,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.out_channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
 def test_conv2d_slicing_validation_errors(device):
     """Test that validation errors are raised correctly for Conv2D slicing"""
 
@@ -657,122 +555,7 @@ def test_conv2d_slicing_validation_errors(device):
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(128, 128)])
-@pytest.mark.parametrize("channels", [64])  # Must be divisible by num_slices
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("num_slices", [2, 4])
-def test_conv2d_channel_slicing_detailed(input_size, channels, batch_size, num_slices, device):
-    """Test Conv2D channel slicing in detail"""
-    input_height, input_width = input_size
-
-    # Create configuration with channel slicing
-    slice_strategy = ChannelSliceStrategyConfiguration(num_slices=num_slices)
-    configuration = Conv2dConfiguration.with_random_weights(
-        input_height=input_height,
-        input_width=input_width,
-        in_channels=channels,
-        out_channels=channels,
-        batch_size=batch_size,
-        kernel_size=(3, 3),
-        padding=(1, 1),
-        slice_strategy=slice_strategy,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
-
-    # Test with channel slicing
-    layer = TtConv2d(configuration, device)
-
-    # Verify that weight_slices are created for channel slicing
-    assert hasattr(layer, "weight_slices"), "Layer should have weight_slices attribute"
-
-    # For channel slicing, ensure input is on device with DRAM memory config
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    if slice_strategy.get_num_slices() > 0:
-        # For channel slicing, weight_slices should be populated after first call
-        ttnn_output_tensor = layer(ttnn_input_tensor)
-        # Note: weight_slices are populated during the first forward pass for channel slicing
-    else:
-        ttnn_output_tensor = layer(ttnn_input_tensor)
-        assert len(layer.weight_slices) == 0, "No weight slices should be created for non-channel slicing"
-
-    # Reference implementation
-    torch_output_tensor = torch.nn.functional.conv2d(
-        torch_input_tensor,
-        ttnn.to_torch(configuration.weight),
-        ttnn.to_torch(configuration.bias).reshape(-1) if configuration.bias is not None else None,
-        stride=configuration.stride,
-        padding=configuration.padding,
-        dilation=configuration.dilation,
-        groups=configuration.groups,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [N, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.out_channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(32, 32)])
-@pytest.mark.parametrize("channels", [16])  # Must be divisible by num_slices for channel slicing
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("kernel_size", [2, 3])
-@pytest.mark.parametrize("num_slices", [2, 4])
-def test_maxpool2d_channel_slicing(input_size, channels, batch_size, kernel_size, num_slices, device):
-    """Test MaxPool2d with channel slicing support"""
-    input_height, input_width = input_size
-
-    # Create configuration with channel slicing
-    slice_strategy = ChannelSliceStrategyConfiguration(num_slices=num_slices)
-    configuration = MaxPool2dConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        kernel_size=(kernel_size, kernel_size),
-        stride=(kernel_size, kernel_size),  # Non-overlapping pooling
-        padding=(0, 0),
-        slice_strategy=slice_strategy,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_pool2d_input_tensor(configuration)
-
-    # Test with channel slicing
-    layer = TtMaxPool2d(configuration, device)
-
-    # For channel slicing, ensure input is on device with DRAM memory config
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    ttnn_output_tensor = layer(ttnn_input_tensor)
-
-    # Reference implementation without slicing
-    torch_output_tensor = torch.nn.functional.max_pool2d(
-        torch_input_tensor,
-        kernel_size=configuration.kernel_size,
-        stride=configuration.stride,
-        padding=configuration.padding,
-        dilation=configuration.dilation,
-        ceil_mode=configuration.ceil_mode,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-def test_maxpool2d_slicing_validation_errors(device):
+def test_pool2d_slicing_validation_errors(device):
     """Test that validation errors are raised correctly for MaxPool2d slicing"""
 
     # Test that height/width slicing raises error
@@ -809,216 +592,7 @@ def test_maxpool2d_slicing_validation_errors(device):
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(64, 64)])
-@pytest.mark.parametrize("channels", [32])  # Must be divisible by num_slices
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("num_slices", [2, 4])
-def test_maxpool2d_channel_slicing_detailed(input_size, channels, batch_size, num_slices, device):
-    """Test MaxPool2d channel slicing in detail"""
-    input_height, input_width = input_size
-
-    # Create configuration with channel slicing
-    slice_strategy = ChannelSliceStrategyConfiguration(num_slices=num_slices)
-    configuration = MaxPool2dConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        kernel_size=(2, 2),
-        stride=(2, 2),
-        padding=(0, 0),
-        slice_strategy=slice_strategy,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_pool2d_input_tensor(configuration)
-
-    # Test with channel slicing
-    layer = TtMaxPool2d(configuration, device)
-
-    # Verify that channel slicing is detected
-    assert layer.use_channel_slicing, "Channel slicing should be enabled"
-    assert layer.num_slices == num_slices, f"Expected {num_slices} slices"
-    assert layer.channels_per_slice == channels // num_slices, f"Expected {channels // num_slices} channels per slice"
-
-    # For channel slicing, ensure input is on device with DRAM memory config
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    ttnn_output_tensor = layer(ttnn_input_tensor)
-
-    # Reference implementation
-    torch_output_tensor = torch.nn.functional.max_pool2d(
-        torch_input_tensor,
-        kernel_size=configuration.kernel_size,
-        stride=configuration.stride,
-        padding=configuration.padding,
-        dilation=configuration.dilation,
-        ceil_mode=configuration.ceil_mode,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(32, 32)])
-@pytest.mark.parametrize("channels", [16])
-@pytest.mark.parametrize("batch_size", [1])
-def test_maxpool2d_no_slicing_vs_channel_slicing(input_size, channels, batch_size, device):
-    """Test that MaxPool2d produces same results with and without channel slicing"""
-    input_height, input_width = input_size
-
-    # Configuration without slicing
-    config_no_slice = MaxPool2dConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        kernel_size=(2, 2),
-        stride=(2, 2),
-        padding=(0, 0),
-    )
-
-    # Configuration with channel slicing
-    config_with_slice = MaxPool2dConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        kernel_size=(2, 2),
-        stride=(2, 2),
-        padding=(0, 0),
-        slice_strategy=ChannelSliceStrategyConfiguration(num_slices=4),
-    )
-
-    # Create same input for both
-    torch_input_tensor, ttnn_input_tensor = create_pool2d_input_tensor(config_no_slice)
-
-    # Test without slicing
-    layer_no_slice = TtMaxPool2d(config_no_slice, device)
-    ttnn_input_no_slice = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    ttnn_output_no_slice = layer_no_slice(ttnn_input_no_slice)
-
-    # Test with slicing
-    layer_with_slice = TtMaxPool2d(config_with_slice, device)
-    ttnn_input_with_slice = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    ttnn_output_with_slice = layer_with_slice(ttnn_input_with_slice)
-
-    # Compare outputs - they should be identical
-    assert_with_pcc(
-        ttnn.to_torch(ttnn_output_no_slice),
-        ttnn.to_torch(ttnn_output_with_slice),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", INPUT_SIZES)
-@pytest.mark.parametrize("channels", [16, 8])
-@pytest.mark.parametrize("batch_size", BATCH_SIZES)
-@pytest.mark.parametrize(
-    "upsample_config",
-    [
-        {"scale_factor": 2, "mode": "nearest"},
-        {"scale_factor": (2, 3), "mode": "nearest"},
-        {"scale_factor": 4, "mode": "nearest"},
-    ],
-)
-def test_upsample(input_size, channels, batch_size, upsample_config, device):
-    input_height, input_width = input_size
-    scale_factor, mode = upsample_config["scale_factor"], upsample_config["mode"]
-
-    configuration = UpsampleConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        scale_factor=scale_factor,
-        mode=mode,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_upsample_input_tensor(configuration)
-
-    layer = TtUpsample(configuration, device)
-
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
-    ttnn_output_tensor = layer(ttnn_input_tensor)
-
-    torch_output_tensor = torch.nn.functional.interpolate(
-        torch_input_tensor,
-        scale_factor=configuration.scale_factor,
-        mode=configuration.mode,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", INPUT_SIZES[:1])
-@pytest.mark.parametrize("channels", [16])
-@pytest.mark.parametrize("batch_size", BATCH_SIZES[:1])
-@pytest.mark.parametrize(
-    "torch_layer_config",
-    [
-        {"scale_factor": 2, "mode": "nearest"},
-        {"scale_factor": (2, 3), "mode": "nearest"},
-        {"scale_factor": 4, "mode": "nearest"},
-    ],
-)
-def test_upsample_configuration_from_torch_layer(input_size, channels, batch_size, torch_layer_config, device):
-    input_height, input_width = input_size
-
-    torch_layer = torch.nn.Upsample(**torch_layer_config)
-
-    configuration = UpsampleConfiguration.from_torch(
-        torch_layer=torch_layer,
-        input_height=input_height,
-        input_width=input_width,
-        batch_size=batch_size,
-        channels=channels,
-    )
-
-    assert configuration.scale_factor == (
-        torch_layer.scale_factor
-        if isinstance(torch_layer.scale_factor, tuple)
-        else (torch_layer.scale_factor, torch_layer.scale_factor)
-    )
-    assert configuration.mode == torch_layer.mode
-
-    tt_layer = TtUpsample(configuration, device)
-
-    torch_input = torch.randn(batch_size, channels, input_height, input_width)
-    ttnn_input = ttnn.from_torch(
-        torch_input.permute(0, 2, 3, 1),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-    )
-
-    ttnn_output = tt_layer(ttnn_input)
-    torch_output = torch_layer(torch_input)
-
-    ttnn_output_torch = ttnn.to_torch(ttnn_output)
-    output_height, output_width = torch_output.shape[-2:]
-    ttnn_output_torch = ttnn_output_torch.reshape(batch_size, output_height, output_width, channels).permute(0, 3, 1, 2)
-
-    assert_with_pcc(torch_output, ttnn_output_torch, PCC_THRESHOLD)
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-def test_upsample_validation_errors(device):
+def test_upsample_slicing_validation_errors(device):
     """Test that validation errors are raised correctly for Upsample configuration"""
 
     # Test that height/width slicing raises error
@@ -1062,40 +636,202 @@ def test_upsample_validation_errors(device):
             batch_size=1,
             scale_factor=2,
             mode="invalid_mode",
-        )  # Additional upsample tests to be appended to test_builder.py
+        )
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(32, 32)])
-@pytest.mark.parametrize("channels", [16])  # Must be divisible by num_slices for channel slicing
-@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("input_size", SLICE_INPUT_SIZES)
+@pytest.mark.parametrize("channels", SLICE_CHANNEL_CONFIGS)  # Must be divisible by num_slices for channel slicing
+@pytest.mark.parametrize("batch_size", [1])  # Only use batch size 1 for slicing tests
 @pytest.mark.parametrize(
     "slice_config",
-    [
-        {"type": "no_slice", "num_slices": 0},
-        {"type": "channel_slice", "num_slices": 4},
-    ],
+    SLICE_CONFIGS,
 )
-@pytest.mark.parametrize("scale_factor", [2, (2, 3)])
-def test_upsample_slicing_strategies(input_size, channels, batch_size, slice_config, scale_factor, device):
-    """Test Upsample with different slicing strategies"""
+def test_conv2d_slicing_strategies(input_size, channels, batch_size, slice_config, device):
+    """Test Conv2D with different slicing strategies"""
     input_height, input_width = input_size
+    in_channels = channels["in_channels"]
+    out_channels = channels["out_channels"]
+
+    # Create slice strategy based on config
+    if slice_config["type"] == "no_slice":
+        slice_strategy = None
+    elif slice_config["type"] == "height_slice":
+        slice_strategy = HeightSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
+    elif slice_config["type"] == "width_slice":
+        slice_strategy = WidthSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
+    elif slice_config["type"] == "channel_slice":
+        slice_strategy = ChannelSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
+    else:
+        raise ValueError(f"Unknown slice type: {slice_config['type']}")
+
+    configuration = Conv2dConfiguration.with_random_weights(
+        input_height=input_height,
+        input_width=input_width,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=batch_size,
+        kernel_size=(3, 3),
+        padding=(1, 1),
+        slice_strategy=slice_strategy,
+    )
+
+    torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
+
+    # Test with slicing
+    layer = TtConv2d(configuration, device)
+
+    # Verify that weight_slices are created for channel slicing
+    assert hasattr(layer, "weight_slices"), "Layer should have weight_slices attribute"
+
+    # For slicing tests, ensure input is on device with DRAM memory config
+    if slice_config["type"] != "no_slice":
+        ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    if slice_config["type"] == "channel_slice":
+        # For channel slicing, weight_slices should be populated after first call
+        ttnn_output_tensor = layer(ttnn_input_tensor)
+        # Note: weight_slices are populated during the first forward pass for channel slicing
+    else:
+        # For non-channel slicing (no_slice, height_slice, width_slice), no weight slices should be created
+        ttnn_output_tensor = layer(ttnn_input_tensor)
+        assert len(layer.weight_slices) == 0, "No weight slices should be created for non-channel slicing"
+
+    # Reference implementation without slicing
+    torch_output_tensor = torch.nn.functional.conv2d(
+        torch_input_tensor,
+        ttnn.to_torch(configuration.weight),
+        ttnn.to_torch(configuration.bias).reshape(-1) if configuration.bias is not None else None,
+        stride=configuration.stride,
+        padding=configuration.padding,
+        dilation=configuration.dilation,
+        groups=configuration.groups,
+    )
+
+    output_height, output_width = torch_output_tensor.shape[-2:]  # [N, C, H, W]
+    assert_with_pcc(
+        torch_output_tensor,
+        ttnn.to_torch(ttnn_output_tensor)
+        .reshape(configuration.batch_size, output_height, output_width, configuration.out_channels)
+        .permute(0, 3, 1, 2),
+        PCC_THRESHOLD,
+    )
+
+
+@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("input_size", SLICE_INPUT_SIZES)
+@pytest.mark.parametrize("channels", SLICE_CHANNEL_CONFIGS)  # Must be divisible by num_slices for channel slicing
+@pytest.mark.parametrize("batch_size", [1])  # Only use batch size 1 for slicing tests
+@pytest.mark.parametrize("pool_config", POOL_CONFIGS)
+@pytest.mark.parametrize(
+    "slice_config",
+    SLICE_CONFIGS,
+)
+def test_maxpool2d_slicing_strategies(input_size, channels, batch_size, pool_config, slice_config, device):
+    """Test MaxPool2d with different slicing strategies"""
+    input_height, input_width = input_size
+    # For MaxPool2d, we use the out_channels from the channel config
+    num_channels = channels["out_channels"]
+    kernel_size, padding, ceil_mode = pool_config["kernel_size"], pool_config["padding"], pool_config["ceil_mode"]
 
     # Create slice strategy based on config
     if slice_config["type"] == "no_slice":
         slice_strategy = None
     elif slice_config["type"] == "channel_slice":
         slice_strategy = ChannelSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
+    elif slice_config["type"] in ["height_slice", "width_slice"]:
+        pytest.skip(f"{slice_config['type']} slicing is not supported for MaxPool2d")
     else:
         raise ValueError(f"Unknown slice type: {slice_config['type']}")
+
+    configuration = MaxPool2dConfiguration(
+        input_height=input_height,
+        input_width=input_width,
+        channels=num_channels,
+        batch_size=batch_size,
+        kernel_size=(kernel_size, kernel_size),
+        padding=(padding, padding),
+        ceil_mode=ceil_mode,
+        slice_strategy=slice_strategy,
+    )
+
+    torch_input_tensor, ttnn_input_tensor = create_pool2d_input_tensor(configuration)
+
+    # Test with slicing
+    layer = TtMaxPool2d(configuration, device)
+
+    # For slicing tests, ensure input is on device with DRAM memory config
+    if slice_config["type"] != "no_slice":
+        ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    else:
+        ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
+
+    ttnn_output_tensor = layer(ttnn_input_tensor)
+
+    # Reference implementation without slicing
+    torch_output_tensor = torch.nn.functional.max_pool2d(
+        torch_input_tensor,
+        kernel_size=configuration.kernel_size,
+        stride=configuration.stride,
+        padding=configuration.padding,
+        dilation=configuration.dilation,
+        ceil_mode=configuration.ceil_mode,
+    )
+
+    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
+    assert_with_pcc(
+        torch_output_tensor,
+        ttnn.to_torch(ttnn_output_tensor)
+        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
+        .permute(0, 3, 1, 2),
+        PCC_THRESHOLD,
+    )
+
+
+@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("input_size", SLICE_INPUT_SIZES)
+@pytest.mark.parametrize("channels", SLICE_CHANNEL_CONFIGS)  # Must be divisible by num_slices for channel slicing
+@pytest.mark.parametrize("batch_size", [1])  # Only use batch size 1 for slicing tests
+@pytest.mark.parametrize("upsample_config", UPSAMPLE_CONFIGS)
+@pytest.mark.parametrize(
+    "slice_config",
+    SLICE_CONFIGS,
+)
+def test_upsample_slicing_strategies(input_size, channels, batch_size, upsample_config, slice_config, device):
+    """Test Upsample with different slicing strategies"""
+    input_height, input_width = input_size
+    # For Upsample, we use the out_channels from the channel config
+    num_channels = channels["out_channels"]
+    scale_factor, mode = upsample_config["scale_factor"], upsample_config["mode"]
+
+    # Create slice strategy based on config
+    if slice_config["type"] == "no_slice":
+        slice_strategy = None
+    elif slice_config["type"] == "channel_slice":
+        slice_strategy = ChannelSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
+    elif slice_config["type"] in ["height_slice", "width_slice"]:
+        pytest.skip(f"{slice_config['type']} slicing is not supported for Upsample")
+    else:
+        raise ValueError(f"Unknown slice type: {slice_config['type']}")
+
+    # Skip bilinear upsampling if channels or channels per slice is not divisible by 32
+    if mode == "bilinear":
+        if num_channels % 32 != 0:
+            pytest.skip(f"Bilinear upsampling requires channels ({num_channels}) to be divisible by 32")
+        if slice_strategy is not None and isinstance(slice_strategy, ChannelSliceStrategyConfiguration):
+            channels_per_slice = num_channels // slice_strategy.get_num_slices()
+            if channels_per_slice % 32 != 0:
+                pytest.skip(
+                    f"Bilinear upsampling requires channels per slice ({channels_per_slice}) to be divisible by 32"
+                )
 
     configuration = UpsampleConfiguration(
         input_height=input_height,
         input_width=input_width,
-        channels=channels,
+        channels=num_channels,
         batch_size=batch_size,
         scale_factor=scale_factor,
-        mode="nearest",
+        mode=mode,
         slice_strategy=slice_strategy,
     )
 
@@ -1125,110 +861,5 @@ def test_upsample_slicing_strategies(input_size, channels, batch_size, slice_con
         ttnn.to_torch(ttnn_output_tensor)
         .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
         .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(64, 64)])
-@pytest.mark.parametrize("channels", [32])  # Must be divisible by num_slices
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("num_slices", [2, 4])
-@pytest.mark.parametrize("scale_factor", [2, (2, 3)])
-def test_upsample_channel_slicing_detailed(input_size, channels, batch_size, num_slices, scale_factor, device):
-    """Test Upsample channel slicing in detail"""
-    input_height, input_width = input_size
-
-    # Create configuration with channel slicing
-    slice_strategy = ChannelSliceStrategyConfiguration(num_slices=num_slices)
-    configuration = UpsampleConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        scale_factor=scale_factor,
-        mode="nearest",
-        slice_strategy=slice_strategy,
-    )
-
-    torch_input_tensor, ttnn_input_tensor = create_upsample_input_tensor(configuration)
-
-    # Test with channel slicing
-    layer = TtUpsample(configuration, device)
-
-    # Verify that channel slicing is detected
-    assert layer.use_channel_slicing, "Channel slicing should be enabled"
-    assert layer.num_slices == num_slices, f"Expected {num_slices} slices"
-    assert layer.channels_per_slice == channels // num_slices, f"Expected {channels // num_slices} channels per slice"
-
-    # For channel slicing, ensure input is on device with DRAM memory config
-    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    ttnn_output_tensor = layer(ttnn_input_tensor)
-
-    # Reference implementation
-    torch_output_tensor = torch.nn.functional.interpolate(
-        torch_input_tensor,
-        scale_factor=configuration.scale_factor,
-        mode=configuration.mode,
-    )
-
-    output_height, output_width = torch_output_tensor.shape[-2:]  # [B, C, H, W]
-    assert_with_pcc(
-        torch_output_tensor,
-        ttnn.to_torch(ttnn_output_tensor)
-        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
-        .permute(0, 3, 1, 2),
-        PCC_THRESHOLD,
-    )
-
-
-@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
-@pytest.mark.parametrize("input_size", [(32, 32)])
-@pytest.mark.parametrize("channels", [16])
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("scale_factor", [2])
-def test_upsample_no_slicing_vs_channel_slicing(input_size, channels, batch_size, scale_factor, device):
-    """Test that Upsample produces same results with and without channel slicing"""
-    input_height, input_width = input_size
-
-    # Configuration without slicing
-    config_no_slice = UpsampleConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        scale_factor=scale_factor,
-        mode="nearest",
-    )
-
-    # Configuration with channel slicing
-    config_with_slice = UpsampleConfiguration(
-        input_height=input_height,
-        input_width=input_width,
-        channels=channels,
-        batch_size=batch_size,
-        scale_factor=scale_factor,
-        mode="nearest",
-        slice_strategy=ChannelSliceStrategyConfiguration(num_slices=4),
-    )
-
-    # Create same input for both
-    torch_input_tensor, ttnn_input_tensor = create_upsample_input_tensor(config_no_slice)
-
-    # Test without slicing
-    layer_no_slice = TtUpsample(config_no_slice, device)
-    ttnn_input_no_slice = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    ttnn_output_no_slice = layer_no_slice(ttnn_input_no_slice)
-
-    # Test with slicing
-    layer_with_slice = TtUpsample(config_with_slice, device)
-    ttnn_input_with_slice = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    ttnn_output_with_slice = layer_with_slice(ttnn_input_with_slice)
-
-    # Compare outputs - they should be identical
-    assert_with_pcc(
-        ttnn.to_torch(ttnn_output_no_slice),
-        ttnn.to_torch(ttnn_output_with_slice),
         PCC_THRESHOLD,
     )

--- a/models/tt_cnn/tests/test_builder.py
+++ b/models/tt_cnn/tests/test_builder.py
@@ -15,7 +15,6 @@ from models.tt_cnn.tt.builder import (
     HeightShardedStrategyConfiguration,
     HeightSliceStrategyConfiguration,
     MaxPool2dConfiguration,
-    NoSliceStrategyConfiguration,
     ShardedStrategyConfiguration,
     TtConv2d,
     TtMaxPool2d,
@@ -595,7 +594,7 @@ def test_conv2d_slicing_strategies(input_size, channels, batch_size, slice_confi
 
     # Create slice strategy based on config
     if slice_config["type"] == "no_slice":
-        slice_strategy = NoSliceStrategyConfiguration()
+        slice_strategy = None
     elif slice_config["type"] == "height_slice":
         slice_strategy = HeightSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
     elif slice_config["type"] == "width_slice":
@@ -655,10 +654,6 @@ def test_conv2d_slicing_validation_errors(device):
     # Test channel slicing with non-divisible channels
     with pytest.raises(ValueError, match="Channel slicing requires num_slices > 1"):
         ChannelSliceStrategyConfiguration(num_slices=1)
-
-    # Test no slice with non-zero num_slices
-    with pytest.raises(ValueError, match="Non-zero num_slices is not allowed for no slice strategy"):
-        NoSliceStrategyConfiguration(num_slices=2)
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
@@ -1088,7 +1083,7 @@ def test_upsample_slicing_strategies(input_size, channels, batch_size, slice_con
 
     # Create slice strategy based on config
     if slice_config["type"] == "no_slice":
-        slice_strategy = NoSliceStrategyConfiguration()
+        slice_strategy = None
     elif slice_config["type"] == "channel_slice":
         slice_strategy = ChannelSliceStrategyConfiguration(num_slices=slice_config["num_slices"])
     else:

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -11,7 +11,61 @@ from ttnn.model_preprocessing import Conv2dArgs
 import ttnn
 
 
-@dataclass(frozen=True)
+@dataclass
+class SliceStrategyConfiguration:
+    num_slices: int = 0
+
+    def get_slice_type(self):
+        ...
+
+    def get_num_slices(self):
+        return self.num_slices
+
+
+# Currently, channel slicing is not natively supported by the Conv2D operation and must be done manually
+# For now, we identify channel slicing by having a num_slices > 0 with a slice_type of None
+# Normally, num_slices of 0 for a not None slice_type means auto-slice, so we don't have that feature for channel slice
+# Once Conv2D supports channel slicing natively, we should be able to support it without API changes
+@dataclass
+class NoSliceStrategyConfiguration(SliceStrategyConfiguration):
+    def get_slice_type(self):
+        return None
+
+    def __post_init__(self):
+        if self.num_slices != 0:
+            raise ValueError(f"Non-zero num_slices is not allowed for no slice strategy")
+
+
+@dataclass
+class HeightSliceStrategyConfiguration(SliceStrategyConfiguration):
+    def get_slice_type(self):
+        return ttnn.Conv2dSliceHeight
+
+
+@dataclass
+class WidthSliceStrategyConfiguration(SliceStrategyConfiguration):
+    def get_slice_type(self):
+        return ttnn.Conv2dSliceWidth
+
+
+@dataclass
+class ChannelSliceStrategyConfiguration(SliceStrategyConfiguration):
+    def get_slice_type(self):
+        return None
+
+    def __post_init__(self):
+        if self.num_slices <= 1:
+            raise ValueError(f"Channel slicing requires num_slices > 1")
+
+
+SliceStrategy = Union[
+    NoSliceStrategyConfiguration,
+    HeightSliceStrategyConfiguration,
+    WidthSliceStrategyConfiguration,
+    ChannelSliceStrategyConfiguration,
+]
+
+
 class ShardedStrategyConfiguration:
     def get_tensor_memory_layout(self):
         ...
@@ -105,6 +159,7 @@ class Conv2dConfiguration:
     output_layout: ttnn.Layout = ttnn.TILE_LAYOUT
 
     sharding_strategy: ShardedStrategyConfiguration = AutoShardedStrategyConfiguration()
+    slice_strategy: SliceStrategyConfiguration = NoSliceStrategyConfiguration()
 
     math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.LoFi
     fp32_dest_acc_en: bool = False
@@ -267,6 +322,22 @@ class MaxPool2dConfiguration:
     deallocate_input: bool = False
     reallocate_halo_output: bool = True
 
+    slice_strategy: SliceStrategyConfiguration = NoSliceStrategyConfiguration()
+
+    def __post_init__(self):
+        # Validate that only channel slicing is supported for MaxPool2d
+        if isinstance(self.slice_strategy, (HeightSliceStrategyConfiguration, WidthSliceStrategyConfiguration)):
+            raise ValueError(
+                "Height and Width slicing are not supported for MaxPool2d. Only channel slicing is supported."
+            )
+
+        # Validate channel slicing configuration
+        if isinstance(self.slice_strategy, ChannelSliceStrategyConfiguration):
+            if self.channels % self.slice_strategy.get_num_slices() != 0:
+                raise ValueError(
+                    f"Number of channels ({self.channels}) must be divisible by number of slices ({self.slice_strategy.get_num_slices()})"
+                )
+
     @classmethod
     def from_torch(
         cls,
@@ -294,7 +365,66 @@ class MaxPool2dConfiguration:
         )
 
 
-LayerConfiguration = Union[Conv2dConfiguration, MaxPool2dConfiguration]
+@dataclass(frozen=True)
+class UpsampleConfiguration:
+    input_height: int
+    input_width: int
+    channels: int
+    batch_size: int
+    scale_factor: Union[int, Tuple[int, int]]
+    mode: str = "nearest"
+
+    slice_strategy: SliceStrategyConfiguration = NoSliceStrategyConfiguration()
+
+    def __post_init__(self):
+        # Validate that only channel slicing is supported for Upsample
+        if isinstance(self.slice_strategy, (HeightSliceStrategyConfiguration, WidthSliceStrategyConfiguration)):
+            raise ValueError(
+                "Height and Width slicing are not supported for Upsample. Only channel slicing is supported."
+            )
+
+        # Validate channel slicing configuration
+        if isinstance(self.slice_strategy, ChannelSliceStrategyConfiguration):
+            if self.channels % self.slice_strategy.get_num_slices() != 0:
+                raise ValueError(
+                    f"Number of channels ({self.channels}) must be divisible by number of slices ({self.slice_strategy.get_num_slices()})"
+                )
+
+        # Normalize scale_factor to tuple
+        if isinstance(self.scale_factor, (int, float)):
+            object.__setattr__(self, "scale_factor", (self.scale_factor, self.scale_factor))
+
+        # Validate mode
+        supported_modes = {"nearest", "bilinear"}
+        if self.mode not in supported_modes:
+            raise ValueError(f"Mode must be one of {supported_modes}, got '{self.mode}'")
+
+    @classmethod
+    def from_torch(
+        cls,
+        torch_layer: torch.nn.Upsample,
+        input_height: int,
+        input_width: int,
+        batch_size: int,
+        channels: int,
+        **kwargs,
+    ):
+        scale_factor = torch_layer.scale_factor
+        if isinstance(scale_factor, (list, tuple)):
+            scale_factor = tuple(scale_factor)
+        mode = torch_layer.mode
+        return cls(
+            input_height=input_height,
+            input_width=input_width,
+            channels=channels,
+            batch_size=batch_size,
+            scale_factor=scale_factor,
+            mode=mode,
+            **kwargs,
+        )
+
+
+LayerConfiguration = Union[Conv2dConfiguration, MaxPool2dConfiguration, UpsampleConfiguration]
 
 
 def sharding_strategy_to_conv2d_config(sharding_strategy: ShardingStrategy):
@@ -353,6 +483,15 @@ def to_compute_config(configuration: Conv2dConfiguration, device: ttnn.Device):
     )
 
 
+def to_slice_config(configuration: Conv2dConfiguration):
+    if configuration.slice_strategy.get_slice_type() is None:
+        return None
+    return ttnn.Conv2dSliceConfig(
+        slice_type=configuration.slice_strategy.get_slice_type(),
+        num_slices=configuration.slice_strategy.get_num_slices(),
+    )
+
+
 class TtConv2d:
     def __init__(
         self,
@@ -362,11 +501,51 @@ class TtConv2d:
         self.configuration = configuration
         self.conv2d_config = to_conv2d_config(configuration)
         self.compute_config = to_compute_config(configuration, device)
+        self.slice_config = to_slice_config(configuration)
 
         self.device = device
 
         self.weight = configuration.weight
         self.bias = configuration.bias
+
+        # Initialize weight_slices as empty list
+        self.weight_slices = []
+
+        # Check for channel slicing
+        if self.slice_config is None and configuration.slice_strategy.get_num_slices() > 0:
+            split_in_channels = configuration.in_channels // configuration.slice_strategy.get_num_slices()
+
+            # slice weights - this should only run on first inference
+            if ttnn.is_tensor_storage_on_device(self.weight):
+                # Weights are on device - use ttnn.slice
+                for i in range(configuration.slice_strategy.get_num_slices()):
+                    start_idx = i * split_in_channels
+                    end_idx = (i + 1) * split_in_channels
+                    weight_slice = ttnn.slice(
+                        self.weight,
+                        [0, start_idx, 0, 0],
+                        [
+                            configuration.out_channels,
+                            end_idx,
+                            configuration.kernel_size[0],
+                            configuration.kernel_size[1],
+                        ],
+                    )
+                    self.weight_slices.append(weight_slice)
+            else:
+                # Weights are on host - convert to torch, slice, then convert back to TTNN
+                torch_weight = ttnn.to_torch(self.weight)
+                for i in range(configuration.slice_strategy.get_num_slices()):
+                    start_idx = i * split_in_channels
+                    end_idx = (i + 1) * split_in_channels
+                    torch_slice = torch_weight[:, start_idx:end_idx, :, :]
+                    # This TTNN tensor will remain on host until pulled by Conv2D
+                    weight_slice = ttnn.from_torch(torch_slice, dtype=self.weight.dtype, layout=self.weight.layout)
+                    self.weight_slices.append(weight_slice)
+
+            # bias needs to be on device for channel slicing due to ttnn.add requirements
+            if not ttnn.is_tensor_storage_on_device(self.bias):
+                self.bias = ttnn.to_device(self.bias, self.device)
 
         if not isinstance(self.weight, ttnn.Tensor):
             raise ValueError(f"Weight tensor should be of type ttnn.Tensor (was {type(self.weight)}")
@@ -389,18 +568,82 @@ class TtConv2d:
             "dtype": self.configuration.output_dtype,
             "device": self.device,
             "conv_config": self.conv2d_config,
+            "slice_config": self.slice_config,
         }
 
     def __call__(self, x):
-        x, [self.weight, self.bias] = ttnn.conv2d(
-            input_tensor=x,
-            weight_tensor=self.weight,
-            bias_tensor=self.bias,
-            return_output_dim=False,
-            return_weights_and_bias=True,
-            compute_config=self.compute_config,
-            **self.get_conv2d_kwargs(),
-        )
+        if not self.weight_slices:
+            # No slicing
+            x, [self.weight, self.bias] = ttnn.conv2d(
+                input_tensor=x,
+                weight_tensor=self.weight,
+                bias_tensor=self.bias,
+                return_output_dim=False,
+                return_weights_and_bias=True,
+                compute_config=self.compute_config,
+                **self.get_conv2d_kwargs(),
+            )
+        else:
+            # slice input
+            input_slices = []
+            for i in range(self.configuration.slice_strategy.get_num_slices()):
+                input_slices.append(
+                    ttnn.slice(
+                        x,
+                        [
+                            0,
+                            0,
+                            0,
+                            i * self.configuration.in_channels // self.configuration.slice_strategy.get_num_slices(),
+                        ],
+                        [
+                            self.configuration.batch_size,
+                            self.configuration.input_height,
+                            self.configuration.input_width,
+                            (i + 1)
+                            * self.configuration.in_channels
+                            // self.configuration.slice_strategy.get_num_slices(),
+                        ],
+                    )
+                )
+
+            # perform conv2d on each slice
+            accumulated_output = None
+            channels_per_slice = self.configuration.in_channels // self.configuration.slice_strategy.get_num_slices()
+
+            for i in range(self.configuration.slice_strategy.get_num_slices()):
+                # Create kwargs with correct in_channels for this slice
+                slice_kwargs = self.get_conv2d_kwargs()
+                slice_kwargs["in_channels"] = channels_per_slice
+
+                output_slice, self.weight_slices[i] = ttnn.conv2d(
+                    input_tensor=input_slices[i],
+                    weight_tensor=self.weight_slices[i],
+                    bias_tensor=None,
+                    return_output_dim=False,
+                    return_weights_and_bias=True,
+                    compute_config=self.compute_config,
+                    **slice_kwargs,
+                )
+                # Without this, some edge case convs OOM
+                output_slice = ttnn.move(output_slice)
+                if i == 0:
+                    accumulated_output = ttnn.to_memory_config(output_slice, ttnn.DRAM_MEMORY_CONFIG)
+                else:
+                    accumulated_output = ttnn.add(output_slice, accumulated_output, output_tensor=accumulated_output)
+                output_slice.deallocate(True)
+
+            # Apply bias
+            if self.bias is not None:
+                # ttnn.add will fail if layout is not tile or dtype doesn't match
+                # this should only run on first inference
+                if self.bias.layout != ttnn.TILE_LAYOUT or self.bias.dtype != accumulated_output.dtype:
+                    self.bias = ttnn.to_layout(self.bias, ttnn.TILE_LAYOUT, dtype=accumulated_output.dtype)
+
+                accumulated_output = ttnn.add(accumulated_output, self.bias, output_tensor=accumulated_output)
+
+            x = accumulated_output
+
         return x
 
 
@@ -409,20 +652,147 @@ class TtMaxPool2d:
         self.configuration = configuration
         self.device = device
 
+        # Check for channel slicing
+        self.use_channel_slicing = isinstance(configuration.slice_strategy, ChannelSliceStrategyConfiguration)
+
+        if self.use_channel_slicing:
+            self.num_slices = configuration.slice_strategy.get_num_slices()
+            self.channels_per_slice = configuration.channels // self.num_slices
+
+    def get_maxpool2d_kwargs(self):
+        return {
+            "batch_size": self.configuration.batch_size,
+            "input_h": self.configuration.input_height,
+            "input_w": self.configuration.input_width,
+            "kernel_size": self.configuration.kernel_size,
+            "stride": self.configuration.stride,
+            "padding": self.configuration.padding,
+            "dilation": self.configuration.dilation,
+            "ceil_mode": self.configuration.ceil_mode,
+            "in_place_halo": self.configuration.in_place,
+            "deallocate_input": self.configuration.deallocate_input,
+            "reallocate_halo_output": self.configuration.reallocate_halo_output,
+        }
+
     def __call__(self, x):
-        x = ttnn.max_pool2d(
-            input_tensor=x,
-            batch_size=self.configuration.batch_size,
-            input_h=self.configuration.input_height,
-            input_w=self.configuration.input_width,
-            channels=self.configuration.channels,
-            kernel_size=self.configuration.kernel_size,
-            stride=self.configuration.stride,
-            padding=self.configuration.padding,
-            dilation=self.configuration.dilation,
-            ceil_mode=self.configuration.ceil_mode,
-            in_place_halo=self.configuration.in_place,
-            deallocate_input=self.configuration.deallocate_input,
-            reallocate_halo_output=self.configuration.reallocate_halo_output,
-        )
+        if not self.use_channel_slicing:
+            # No slicing
+            x = ttnn.max_pool2d(
+                input_tensor=x,
+                channels=self.configuration.channels,
+                **self.get_maxpool2d_kwargs(),
+            )
+        else:
+            # Slice input tensor along channel dimension
+            input_slices = []
+            for i in range(self.num_slices):
+                start_channel = i * self.channels_per_slice
+                end_channel = (i + 1) * self.channels_per_slice
+
+                input_slice = ttnn.slice(
+                    x,
+                    [0, 0, 0, start_channel],
+                    [
+                        1,
+                        1,
+                        self.configuration.batch_size
+                        * self.configuration.input_height
+                        * self.configuration.input_width,
+                        end_channel,
+                    ],
+                )
+                input_slices.append(input_slice)
+
+            # Perform max pooling on each slice
+            output_slices = []
+            for i in range(self.num_slices):
+                output_slice = ttnn.max_pool2d(
+                    input_tensor=input_slices[i],
+                    channels=self.channels_per_slice,
+                    **self.get_maxpool2d_kwargs(),
+                )
+                # Output slice to DRAM
+                output_slice = ttnn.to_memory_config(output_slice, ttnn.DRAM_MEMORY_CONFIG)
+                output_slices.append(output_slice)
+
+            # Concatenate output slices along channel dimension
+            x = ttnn.concat(output_slices, dim=3)
+
+            # Clean up intermediate tensors
+            for slice_tensor in input_slices + output_slices:
+                slice_tensor.deallocate(True)
+
+        return x
+
+
+class TtUpsample:
+    def __init__(self, configuration: UpsampleConfiguration, device: ttnn.Device):
+        self.configuration = configuration
+        self.device = device
+
+        # Check for channel slicing
+        self.use_channel_slicing = isinstance(configuration.slice_strategy, ChannelSliceStrategyConfiguration)
+
+        if self.use_channel_slicing:
+            self.num_slices = configuration.slice_strategy.get_num_slices()
+            self.channels_per_slice = configuration.channels // self.num_slices
+
+    def get_upsample_kwargs(self):
+        # Convert scale_factor to the format expected by ttnn.upsample
+        scale_factor = self.configuration.scale_factor
+        if isinstance(scale_factor, tuple) and len(scale_factor) == 2:
+            # Convert to list of integers as expected by ttnn
+            scale_factor = [int(scale_factor[0]), int(scale_factor[1])]
+        elif isinstance(scale_factor, (int, float)):
+            scale_factor = int(scale_factor)
+
+        return {
+            "scale_factor": scale_factor,
+            "mode": self.configuration.mode,
+        }
+
+    def __call__(self, x):
+        if not self.use_channel_slicing:
+            # No slicing
+            x = ttnn.upsample(
+                input_tensor=x,
+                **self.get_upsample_kwargs(),
+            )
+        else:
+            # Slice input tensor along channel dimension
+            input_slices = []
+            for i in range(self.num_slices):
+                start_channel = i * self.channels_per_slice
+                end_channel = (i + 1) * self.channels_per_slice
+
+                input_slice = ttnn.slice(
+                    x,
+                    [0, 0, 0, start_channel],
+                    [
+                        self.configuration.batch_size,
+                        self.configuration.input_height,
+                        self.configuration.input_width,
+                        end_channel,
+                    ],
+                )
+                input_slices.append(input_slice)
+
+            # Perform upsampling on each slice
+            output_slices = []
+            for i in range(self.num_slices):
+                output_slice = ttnn.upsample(
+                    input_tensor=input_slices[i],
+                    **self.get_upsample_kwargs(),
+                )
+                # Output slice to DRAM
+                output_slice = ttnn.to_memory_config(output_slice, ttnn.DRAM_MEMORY_CONFIG)
+                output_slices.append(output_slice)
+
+            # Concatenate output slices along channel dimension
+            x = ttnn.concat(output_slices, dim=3)
+
+            # Clean up intermediate tensors
+            for slice_tensor in input_slices + output_slices:
+                slice_tensor.deallocate(True)
+
         return x

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -53,6 +53,7 @@ SliceStrategy = Union[
 ]
 
 
+@dataclass(frozen=True)
 class ShardedStrategyConfiguration:
     def get_tensor_memory_layout(self):
         ...
@@ -381,10 +382,6 @@ class UpsampleConfiguration:
                     f"Number of channels ({self.channels}) must be divisible by number of slices ({self.slice_strategy.get_num_slices()})"
                 )
 
-        # Normalize scale_factor to tuple
-        if isinstance(self.scale_factor, (int, float)):
-            object.__setattr__(self, "scale_factor", (self.scale_factor, self.scale_factor))
-
         # Validate mode
         supported_modes = {"nearest", "bilinear"}
         if self.mode not in supported_modes:
@@ -403,6 +400,9 @@ class UpsampleConfiguration:
         scale_factor = torch_layer.scale_factor
         if isinstance(scale_factor, (list, tuple)):
             scale_factor = tuple(scale_factor)
+        elif isinstance(scale_factor, (int, float)):
+            # Normalize single number to tuple for consistency
+            scale_factor = (scale_factor, scale_factor)
         mode = torch_layer.mode
         return cls(
             input_height=input_height,

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -45,6 +45,7 @@ class ChannelSliceStrategyConfiguration(SliceStrategyConfiguration):
 
     def __post_init__(self):
         if self.num_slices <= 1:
+            # for height and width slicing passing 0 will result in auto-slice, but for channel slice it's not implemented
             raise ValueError(f"Channel slicing requires num_slices > 1")
 
 

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -474,15 +474,15 @@ def to_compute_config(configuration: Conv2dConfiguration, device: ttnn.Device):
     )
 
 
-def to_slice_config(configuration: Conv2dConfiguration):
-    if configuration.slice_strategy is None:
+def to_slice_config(slice_strategy: Optional[SliceStrategy]):
+    if slice_strategy is None:
         return None
     # Channel slicing uses the predefined Conv2dL1FullSliceConfig
-    if isinstance(configuration.slice_strategy, ChannelSliceStrategyConfiguration):
+    if isinstance(slice_strategy, ChannelSliceStrategyConfiguration):
         return ttnn.Conv2dL1FullSliceConfig
     return ttnn.Conv2dSliceConfig(
-        slice_type=configuration.slice_strategy.get_slice_type(),
-        num_slices=configuration.slice_strategy.get_num_slices(),
+        slice_type=slice_strategy.get_slice_type(),
+        num_slices=slice_strategy.get_num_slices(),
     )
 
 
@@ -495,7 +495,7 @@ class TtConv2d:
         self.configuration = configuration
         self.conv2d_config = to_conv2d_config(configuration)
         self.compute_config = to_compute_config(configuration, device)
-        self.slice_config = to_slice_config(configuration)
+        self.slice_config = to_slice_config(configuration.slice_strategy)
 
         self.device = device
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29509)

### Problem description
We want to migrate Panoptic-DeepLab to TT-CNN to use a set of common wrappers instead of rolling our own. At the moment, however, we rely on those wrappers to handle DRAM slicing for convolutions, max pool and upsample (we are very L1 constrained).

This PR adds Upsample and DRAM slicing support to TT-CNN so that we may migrate.

### What's changed
- New wrapper for Upsample
- DRAM slicing support for Conv2D (width, height, channel sliced), MaxPool2D (channel sliced), Upsample (channel sliced)
- Unit test coverage

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes