### PR TITLE
Move bfloat8/4 headers to tt_metal namespace.

### DIFF
--- a/tests/tt_metal/test_utils/bfloat_utils.hpp
+++ b/tests/tt_metal/test_utils/bfloat_utils.hpp
@@ -64,7 +64,7 @@ inline std::vector<uint32_t> create_constant_vector_of_bfp8(uint32_t num_bytes, 
     }
 
     std::vector<uint32_t> packed_result =
-        pack_as_bfp8_tiles(ttsl::make_const_span(fp32_vec), /*row_major_input=*/true, is_exp_a);
+        tt::tt_metal::pack_as_bfp8_tiles(ttsl::make_const_span(fp32_vec), /*row_major_input=*/true, is_exp_a);
 
     TT_ASSERT(packed_result.size() == packed_data_size);
 

--- a/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 using namespace tt;
+using namespace tt::tt_metal;
 
 int main(int argc, char** argv) {
     bool pass = true;

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -152,8 +152,8 @@ int main(int argc, char** argv) {
         for (int i = 0; i < 32; i++) {
             vec.at(i * 32 + i) = (float)1;
         }
-        std::vector<uint32_t> weights =
-            pack_as_bfp8_tiles(tt::stl::make_const_span(vec), /*row_major_input=*/true, /*is_exp_a=*/false);
+        std::vector<uint32_t> weights = tt::tt_metal::pack_as_bfp8_tiles(
+            tt::stl::make_const_span(vec), /*row_major_input=*/true, /*is_exp_a=*/false);
 
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 

--- a/tt_metal/api/tt-metalium/bfloat4.hpp
+++ b/tt_metal/api/tt-metalium/bfloat4.hpp
@@ -11,20 +11,7 @@
 #include <optional>
 #include <vector>
 
-constexpr int log2(int n) {
-    int log = 0;
-    while (n >>= 1) {
-        ++log;
-    }
-    return log;
-}
-
-[[deprecated("Use pack_as_bfp4_tiles instead.")]]
-std::vector<uint32_t> pack_fp32_vec_as_bfp4_tiles(
-    tt::stl::Span<const float> fp32_vec,
-    bool row_major_input,
-    bool is_exp_a,
-    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+namespace tt::tt_metal {
 
 template <typename T>
 std::vector<uint32_t> pack_as_bfp4_tiles(
@@ -38,3 +25,5 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     bool row_major_output,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+
+};  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/bfloat8.hpp
+++ b/tt_metal/api/tt-metalium/bfloat8.hpp
@@ -11,12 +11,7 @@
 #include <optional>
 #include <vector>
 
-[[deprecated("Use pack_as_bfp8_tiles instead.")]]
-std::vector<uint32_t> pack_fp32_vec_as_bfp8_tiles(
-    tt::stl::Span<const float> fp32_vec,
-    bool row_major_input,
-    bool is_exp_a,
-    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+namespace tt::tt_metal {
 
 template <typename T>
 std::vector<uint32_t> pack_as_bfp8_tiles(
@@ -30,3 +25,5 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     bool row_major_output,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+
+};  // namespace tt::tt_metal

--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -20,14 +20,7 @@
 #include "tracy/Tracy.hpp"
 #include "tt_backend_api_types.hpp"
 
-std::vector<uint32_t> pack_fp32_vec_as_bfp8_tiles(
-    tt::stl::Span<const float> fp32_vec,
-    bool row_major_input,
-    bool is_exp_a,
-    const std::optional<tt::tt_metal::Tile>& tile) {
-    return pack_as_bfp_tiles<tt::DataFormat::Bfp8_b>(fp32_vec, row_major_input, is_exp_a, tile);
-}
-
+namespace tt::tt_metal {
 template <typename T>
 std::vector<uint32_t> pack_as_bfp8_tiles(
     tt::stl::Span<const T> data, bool row_major_input, bool is_exp_a, const std::optional<tt::tt_metal::Tile>& tile) {
@@ -184,7 +177,8 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
                         // Flush denormals to zero
                         // Check if shift > exp and mantissa is not zero
                         simde__m256i mask_shift_gt_exp = simde_mm256_cmpgt_epi32(shift_cnt, exp_vector);
-                        simde__m256i mask_nonzero_mantissa = simde_mm256_xor_si256(select_mask, simde_mm256_set1_epi32(-1));
+                        simde__m256i mask_nonzero_mantissa =
+                            simde_mm256_xor_si256(select_mask, simde_mm256_set1_epi32(-1));
                         simde__m256i mask_denormal = simde_mm256_and_si256(mask_shift_gt_exp, mask_nonzero_mantissa);
 
                         exp_vector = simde_mm256_blendv_epi8(
@@ -218,3 +212,4 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     }
     return float_vec;
 }
+};  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt_stl/overloaded.hpp>
+#include <tt-metalium/bfloat4.hpp>
 #include "tt_stl/small_vector.hpp"
 #include "tt_stl/span.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -282,6 +283,8 @@ Tensor Tensor::from_vector(
 
 template <>
 std::vector<float> Tensor::to_vector<float>(std::optional<ttnn::QueueId> cq_id) const {
+    using tt::tt_metal::unpack_bfp4_tiles_into_float_vec;
+
     ZoneScoped;
     Tensor cpu_tensor = this->cpu(/*blocking=*/true, cq_id);
     switch (cpu_tensor.dtype()) {

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -174,6 +174,9 @@ Tensor pad_bfloat4_b(
     const ttnn::Shape& output_padded_shape,
     const ttnn::Shape& input_tensor_start,
     float pad_value) {
+    using tt::tt_metal::pack_as_bfp4_tiles;
+    using tt::tt_metal::unpack_bfp4_tiles_into_float_vec;
+
     auto tile = tensor.tensor_spec().tile();
     // TODO(arakhmati): do not convert to FLOAT32
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -174,9 +174,6 @@ Tensor pad_bfloat4_b(
     const ttnn::Shape& output_padded_shape,
     const ttnn::Shape& input_tensor_start,
     float pad_value) {
-    using tt::tt_metal::pack_as_bfp4_tiles;
-    using tt::tt_metal::unpack_bfp4_tiles_into_float_vec;
-
     auto tile = tensor.tensor_spec().tile();
     // TODO(arakhmati): do not convert to FLOAT32
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -29,6 +29,7 @@ using namespace tt;
 using sliding_window::ParallelConfig;
 using sliding_window::SlidingWindowConfig;
 using tt::tt_metal::pack_as_bfp4_tiles;
+using tt::tt_metal::pack_as_bfp8_tiles;
 
 namespace conv2d {
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -8,6 +8,7 @@
 #include <tt_stl/assert.hpp>
 #include <cstdint>
 #include <tt-logger/tt-logger.hpp>
+#include "tt-metalium/bfloat4.hpp"
 #include "tt-metalium/constants.hpp"
 #include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/shape.hpp"
@@ -27,6 +28,7 @@ namespace operations::conv {
 using namespace tt;
 using sliding_window::ParallelConfig;
 using sliding_window::SlidingWindowConfig;
+using tt::tt_metal::pack_as_bfp4_tiles;
 
 namespace conv2d {
 

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "ttnn/operations/core/to_dtype/to_dtype_op.hpp"
 
+#include <tt-metalium/bfloat4.hpp>
 #include "tt_stl/concepts.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
@@ -22,6 +23,9 @@ namespace detail {
 
 struct bfloat4_tag {};
 struct bfloat8_tag {};
+
+using tt::tt_metal::pack_as_bfp4_tiles;
+using tt::tt_metal::unpack_bfp4_tiles_into_float_vec;
 
 // Preprocess the storage to unpack the bfloat8/4 tiles into float32.
 tt::tt_metal::HostStorage preprocess_storage(

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.cpp
@@ -4,6 +4,7 @@
 #include "ttnn/operations/core/to_dtype/to_dtype_op.hpp"
 
 #include <tt-metalium/bfloat4.hpp>
+#include "tt-metalium/bfloat8.hpp"
 #include "tt_stl/concepts.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
@@ -26,6 +27,9 @@ struct bfloat8_tag {};
 
 using tt::tt_metal::pack_as_bfp4_tiles;
 using tt::tt_metal::unpack_bfp4_tiles_into_float_vec;
+
+using tt::tt_metal::pack_as_bfp8_tiles;
+using tt::tt_metal::unpack_bfp8_tiles_into_float_vec;
 
 // Preprocess the storage to unpack the bfloat8/4 tiles into float32.
 tt::tt_metal::HostStorage preprocess_storage(


### PR DESCRIPTION
### Ticket

### Problem description

1. bfloat4.hpp and bfloat8.hpp is under the tt-metalium api directory, however the functions exported by the two headers are in the root namespace, which is inconsistent with the general practice across the directory.
2. both files contains deprecated functions that are no longer used

### What's changed
1. Updated functions under the two files to `tt::tt_metal` namespace to conform to the norm.
2. Removed the definition and implementation of the deprecated functions

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes