### PR TITLE
Enable FP8 formats e5m2 and e4m3 on BH

### DIFF
--- a/tests/tt_metal/test_utils/df/df.hpp
+++ b/tests/tt_metal/test_utils/df/df.hpp
@@ -4,3 +4,5 @@
 
 #pragma once
 #include "tt_metal/test_utils/df/float32.hpp"
+#include "tt_metal/test_utils/df/fp8_e5m2.hpp"
+#include "tt_metal/test_utils/df/fp8_e4m3.hpp"

--- a/tests/tt_metal/test_utils/df/fp8_e4m3.hpp
+++ b/tests/tt_metal/test_utils/df/fp8_e4m3.hpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <iostream>
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::test_utils::df {
+
+//! Custom type is supported as long as the custom type supports the following custom functions
+//! static SIZEOF - indicates byte size of custom type
+//! to_float() - get float value from custom type
+//! to_packed() - get packed (into an integral type that is of the bitwidth specified by SIZEOF)
+//! Constructor(float in) - constructor with a float as the initializer
+
+class fp8_e4m3 {
+private:
+    uint8_t uint8_data = 0;
+
+public:
+    static constexpr size_t SIZEOF = 1;
+
+    fp8_e4m3() = default;
+
+    fp8_e4m3(float float_num) {
+        static_assert(sizeof float_num == sizeof(uint32_t), "Can only support 32bit fp");
+        uint32_t uint32_data = (*reinterpret_cast<uint32_t*>(&float_num));
+
+        uint8_t sign = uint32_data >> 31;
+
+        uint8_t exp = uint32_data >> 23;
+        int16_t exp_unbias = exp - 127;
+
+        uint32_t man = uint32_data & 0x7FFFFF;
+        bool man_zero = man == 0;
+
+        man >>= 20;
+
+        if (exp == 0 || exp_unbias <= -7) {  // Flush to zero
+            exp = 0;
+            man = 0;
+        } else if (exp == 0xFF || exp_unbias >= 8) {  // Flush to inf, but preserve NaNs
+            exp = 0xF;
+            man = (exp == 0xFF && !man_zero) ? 1 : 0;
+        } else {
+            exp = exp_unbias + 7;
+        }
+
+        uint8_data = sign << 7;
+        uint8_data |= exp << 3;
+        uint8_data |= man;
+    }
+
+    fp8_e4m3(uint32_t new_uint8_data) { uint8_data = new_uint8_data; }
+
+    operator float() const { return to_float(); }
+
+    float to_float() const {
+        uint8_t sign = uint8_data >> 7;
+
+        uint8_t exp = (uint8_data >> 3) & 0xF;
+        // If special exponent value, preserve, otherwise rebias
+        if (exp == 0) {
+            exp = 0;
+        } else if (exp == 0xF) {
+            exp = 0xFF;
+        } else {
+            exp = exp + (127 - 7);
+        }
+
+        uint32_t man = uint8_data & 0x7;
+        // Shift up mantissa to maintain the weight of high order bits
+        man <<= 20;
+
+        uint32_t uint32_data = sign << 31;
+        uint32_data |= exp << 23;
+        uint32_data |= man;
+
+        float v;
+        memcpy(&v, &uint32_data, sizeof(float));
+        return v;
+    }
+    uint8_t to_packed() const { return uint8_data; }
+    bool operator==(fp8_e4m3 rhs) { return uint8_data == rhs.uint8_data; }
+    bool operator!=(fp8_e4m3 rhs) { return uint8_data != rhs.uint8_data; }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const fp8_e4m3& val) {
+    os << val.to_packed();
+    return os;
+}
+}  // namespace tt::test_utils::df

--- a/tests/tt_metal/test_utils/df/fp8_e5m2.hpp
+++ b/tests/tt_metal/test_utils/df/fp8_e5m2.hpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <iostream>
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::test_utils::df {
+
+//! Custom type is supported as long as the custom type supports the following custom functions
+//! static SIZEOF - indicates byte size of custom type
+//! to_float() - get float value from custom type
+//! to_packed() - get packed (into an integral type that is of the bitwidth specified by SIZEOF)
+//! Constructor(float in) - constructor with a float as the initializer
+
+class fp8_e5m2 {
+private:
+    uint8_t uint8_data = 0;
+
+public:
+    static constexpr size_t SIZEOF = 1;
+
+    fp8_e5m2() = default;
+
+    fp8_e5m2(float float_num) {
+        static_assert(sizeof float_num == sizeof(uint32_t), "Can only support 32bit fp");
+        uint32_t uint32_data = (*reinterpret_cast<uint32_t*>(&float_num));
+
+        uint8_t sign = uint32_data >> 31;
+
+        uint8_t exp = uint32_data >> 23;
+        int16_t exp_unbias = exp - 127;
+
+        uint32_t man = uint32_data & 0x7FFFFF;
+        bool man_zero = man == 0;
+
+        man >>= 21;
+
+        if (exp == 0 || exp_unbias <= -15) {  // Flush to zero
+            exp = 0;
+            man = 0;
+        } else if (exp == 0xFF || exp_unbias >= 16) {  // Flush to inf, but preserve NaNs
+            exp = 0x1F;
+            man = (exp == 0xFF && !man_zero) ? 1 : 0;
+        } else {
+            exp = exp_unbias + 15;
+        }
+
+        uint8_data = sign << 7;
+        uint8_data |= exp << 2;
+        uint8_data |= man;
+    }
+
+    fp8_e5m2(uint32_t new_uint8_data) { uint8_data = new_uint8_data; }
+
+    operator float() const { return to_float(); }
+
+    float to_float() const {
+        uint8_t sign = uint8_data >> 7;
+
+        uint8_t exp = (uint8_data >> 2) & 0x1F;
+        // If special exponent value, preserve, otherwise rebias
+        if (exp == 0) {
+            exp = 0;
+        } else if (exp == 0x1F) {
+            exp = 0xFF;
+        } else {
+            exp = exp + (127 - 15);
+        }
+
+        uint32_t man = uint8_data & 0x3;
+        // Shift up mantissa to maintain the weight of high order bits
+        man <<= 21;
+
+        uint32_t uint32_data = sign << 31;
+        uint32_data |= exp << 23;
+        uint32_data |= man;
+
+        float v;
+        memcpy(&v, &uint32_data, sizeof(float));
+        return v;
+    }
+    uint8_t to_packed() const { return uint8_data; }
+    bool operator==(fp8_e5m2 rhs) { return uint8_data == rhs.uint8_data; }
+    bool operator!=(fp8_e5m2 rhs) { return uint8_data != rhs.uint8_data; }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const fp8_e5m2& val) {
+    os << val.to_packed();
+    return os;
+}
+}  // namespace tt::test_utils::df

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -34,6 +34,8 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
+#include "tt_metal/test_utils/df/fp8_e5m2.hpp"
+#include "tt_metal/test_utils/df/fp8_e4m3.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -67,6 +69,11 @@ const map<std::string, std::string> binary_op_name_to_op_kernel = {
     {"add", "add_tiles"},
     {"sub", "sub_tiles"},
     {"mul", "mul_tiles"},
+};
+const map<tt::DataFormat, float> data_format_to_rtol = {
+    {tt::DataFormat::Float16_b, 0.0155f},
+    {tt::DataFormat::Lf8, 0.25f},
+    {tt::DataFormat::Fp8_e4m3, 0.125f},
 };
 
 struct SingleCoreBinaryConfig {
@@ -111,6 +118,7 @@ void set_math_fid_masks(
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
+template <class DataFormat>
 bool single_core_binary(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SingleCoreBinaryConfig& test_config) {
     bool pass = true;
@@ -182,7 +190,7 @@ bool single_core_binary(
             defines["FULL_INIT"] = "1";
         }
         if (test_config.acc_to_dest) {
-            defines["DST_ACCUM_MODE"] = "1";
+            defines["ACCUM_IN_DEST"] = "1";
             defines["ELTWISE_OP_INIT"] = defines["ELTWISE_OP"] + "_init";
             if (test_config.binary_op == "mul") {
                 defines["MUL_TILES_WITH_DST_ACCUM"] = "1";
@@ -218,18 +226,18 @@ bool single_core_binary(
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
-    std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
-    std::vector<uint32_t> packed_input2 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
+    std::vector<uint32_t> packed_input0 = generate_packed_uniform_random_vector<uint32_t, DataFormat>(
+        -1.0f, 1.0f, byte_size / sizeof(DataFormat), std::chrono::system_clock::now().time_since_epoch().count());
+    std::vector<uint32_t> packed_input1 = generate_packed_uniform_random_vector<uint32_t, DataFormat>(
+        -1.0f, 1.0f, byte_size / sizeof(DataFormat), std::chrono::system_clock::now().time_since_epoch().count());
+    std::vector<uint32_t> packed_input2 = generate_packed_uniform_random_vector<uint32_t, DataFormat>(
+        -1.0f, 1.0f, byte_size / sizeof(DataFormat), std::chrono::system_clock::now().time_since_epoch().count());
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
     ////////////////////////////////////////////////////////////////////////////
-    auto input0 = unpack_vector<bfloat16, uint32_t>(packed_input0);
-    auto input1 = unpack_vector<bfloat16, uint32_t>(packed_input1);
-    auto input2 = unpack_vector<bfloat16, uint32_t>(packed_input2);
+    auto input0 = unpack_vector<DataFormat, uint32_t>(packed_input0);
+    auto input1 = unpack_vector<DataFormat, uint32_t>(packed_input1);
+    auto input2 = unpack_vector<DataFormat, uint32_t>(packed_input2);
 
     std::vector<float> temp_golden(input0.size());
     uint16_t srca_fid_mask = 0xFFFF;
@@ -240,44 +248,56 @@ bool single_core_binary(
         input0.end(),
         input1.begin(),
         temp_golden.begin(),
-        [&](const bfloat16& lhs, const bfloat16& rhs) {
+        [&](const DataFormat& lhs, const DataFormat& rhs) {
             if (test_config.binary_op == "add") {
-                return (static_cast<float>(lhs) + static_cast<float>(rhs));
+                return (lhs.to_float() + rhs.to_float());
             } else if (test_config.binary_op == "sub") {
-                return (static_cast<float>(lhs) - static_cast<float>(rhs));
+                return (lhs.to_float() - rhs.to_float());
             } else if (test_config.binary_op == "mul") {
-                return (
-                    static_cast<float>(
-                        std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(lhs) & srca_fid_mask))) *
-                    static_cast<float>(
-                        std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(rhs) & srcb_fid_mask))));
+                if constexpr (std::is_same_v<DataFormat, bfloat16>) {
+                    return (
+                        static_cast<float>(std::bit_cast<bfloat16>(
+                            static_cast<uint16_t>(std::bit_cast<uint16_t>(lhs) & srca_fid_mask))) *
+                        static_cast<float>(std::bit_cast<bfloat16>(
+                            static_cast<uint16_t>(std::bit_cast<uint16_t>(rhs) & srcb_fid_mask))));
+                } else {
+                    return (lhs.to_float() * rhs.to_float());
+                }
             } else if (test_config.binary_op.find("with_dest_reuse") != std::string::npos) {
-                return static_cast<float>(lhs);
+                return lhs.to_float();
             } else {
                 TT_THROW("Unsupported binary_op={}", test_config.binary_op);
                 return 0.0f;
             }
         });
 
-    std::vector<bfloat16> golden(input0.size());
+    std::vector<DataFormat> golden(input0.size());
     std::transform(
-        input2.begin(), input2.end(), temp_golden.begin(), golden.begin(), [&](const bfloat16& lhs, const float& rhs) {
+        input2.begin(),
+        input2.end(),
+        temp_golden.begin(),
+        golden.begin(),
+        [&](const DataFormat& lhs, const float& rhs) {
             // acc_to_dest accumulates dest value with binary output, for all binary operations
             if (test_config.acc_to_dest || test_config.binary_op == "add_with_dest_reuse") {
-                return (static_cast<float>(lhs) + rhs);
+                return (lhs.to_float() + rhs);
             } else if (test_config.binary_op == "sub_with_dest_reuse") {
-                return (static_cast<float>(lhs) - rhs);
+                return (lhs.to_float() - rhs);
             } else if (test_config.binary_op == "mul_with_dest_reuse") {
-                return (
-                    static_cast<float>(
-                        std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(lhs) & srca_fid_mask))) *
-                    static_cast<float>(std::bit_cast<bfloat16>(
-                        static_cast<uint16_t>(std::bit_cast<uint16_t>(bfloat16(rhs)) & srcb_fid_mask))));
+                if constexpr (std::is_same_v<DataFormat, bfloat16>) {
+                    return (
+                        static_cast<float>(std::bit_cast<bfloat16>(
+                            static_cast<uint16_t>(std::bit_cast<uint16_t>(lhs) & srca_fid_mask))) *
+                        static_cast<float>(std::bit_cast<bfloat16>(
+                            static_cast<uint16_t>(std::bit_cast<uint16_t>(bfloat16(rhs)) & srcb_fid_mask))));
+                } else {
+                    return (lhs.to_float() * rhs);
+                }
             } else {
                 return rhs;
             }
         });
-    auto packed_golden = pack_vector<uint32_t, bfloat16>(golden);
+    auto packed_golden = pack_vector<uint32_t, DataFormat>(golden);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
@@ -322,11 +342,71 @@ bool single_core_binary(
     distributed::ReadShard(cq, dest_buffer_data, output_dram_buffer, zero_coord, false);
     // tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
 
-    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
-        dest_buffer_data, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.0155f); });
+    pass &= is_close_packed_vectors<DataFormat, uint32_t>(
+        dest_buffer_data, packed_golden, [&](const DataFormat& a, const DataFormat& b) {
+            return is_close(a, b, data_format_to_rtol.at(test_config.l1_input_data_format));
+        });
     return pass;
 }
 }  // namespace unit_tests::compute::binary
+
+class BinaryParameterizedDeviceFixture
+    : public MeshDeviceFixture,
+      public testing::WithParamInterface<std::tuple<tt::DataFormat, MathFidelity, std::string, int, bool, bool>> {};
+
+TEST_P(BinaryParameterizedDeviceFixture, TensixBinaryComputeSingleCore) {
+    std::tuple<tt::DataFormat, MathFidelity, std::string, int, bool, bool> test_params = GetParam();
+    unit_tests::compute::binary::SingleCoreBinaryConfig test_config = {
+        .num_tiles = std::get<3>(test_params),
+        .tile_byte_size = tile_size(std::get<0>(test_params)),
+        .l1_input_data_format = std::get<0>(test_params),
+        .l1_output_data_format = std::get<0>(test_params),
+        .core = CoreCoord(0, 0),
+        .binary_op = std::get<2>(test_params),
+        .acc_to_dest = std::get<4>(test_params),
+        .full_init = std::get<5>(test_params),
+        .math_fidelity = std::get<1>(test_params)};
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        switch (std::get<0>(test_params)) {
+            case tt::DataFormat::Float16_b:
+                ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
+                break;
+            case tt::DataFormat::Lf8:
+                ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<tt::test_utils::df::fp8_e5m2>(
+                    devices_.at(id), test_config));
+                break;
+            case tt::DataFormat::Fp8_e4m3:
+                ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<tt::test_utils::df::fp8_e4m3>(
+                    devices_.at(id), test_config));
+                break;
+            default: TT_THROW("Unsupported DataFormat={}", std::get<0>(test_params)); break;
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensixBinaryComputeSingleCore,
+    BinaryParameterizedDeviceFixture,
+    ::testing::Combine(
+        ::testing::Values(tt::DataFormat::Float16_b, tt::DataFormat::Lf8, tt::DataFormat::Fp8_e4m3),
+        ::testing::Values(MathFidelity::LoFi, MathFidelity::HiFi2, MathFidelity::HiFi3, MathFidelity::HiFi4),
+        ::testing::Values("add", "sub", "mul"),
+        ::testing::Values(1, 4),         // num_tiles
+        ::testing::Values(true, false),  // acc_to_dest
+        ::testing::Values(true, false)   // full_init
+        ));
+
+INSTANTIATE_TEST_SUITE_P(
+    TensixBinaryComputeSingleCoreDestReuse,
+    BinaryParameterizedDeviceFixture,
+    ::testing::Combine(
+        ::testing::Values(tt::DataFormat::Float16_b, tt::DataFormat::Lf8, tt::DataFormat::Fp8_e4m3),
+        ::testing::Values(MathFidelity::LoFi, MathFidelity::HiFi2, MathFidelity::HiFi3, MathFidelity::HiFi4),
+        ::testing::Values("add_with_dest_reuse", "sub_with_dest_reuse", "mul_with_dest_reuse"),
+        ::testing::Values(1, 4),        // num_tiles
+        ::testing::Values(false),       // acc_to_dest
+        ::testing::Values(true, false)  // full_init
+        ));
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
@@ -343,7 +423,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -363,7 +443,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -383,7 +463,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -404,7 +484,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -425,7 +505,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -446,7 +526,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -466,7 +546,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -486,7 +566,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -506,7 +586,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -526,7 +606,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -546,7 +626,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -566,7 +646,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -592,7 +672,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -618,7 +698,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }
@@ -644,7 +724,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary<bfloat16>(devices_.at(id), test_config));
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
     // This input populates dest with values before binary operation
     // executes, this is used to test eltwise binary with dest re-use
     // and eltwise binary with dest accumulation
-    #if defined(DST_ACCUM_MODE) || defined(ELTWISE_DEST_REUSE_TYPE)
+#if defined(ACCUM_IN_DEST) || defined(ELTWISE_DEST_REUSE_TYPE)
     uint32_t src2_addr = get_arg_val<uint32_t>(5);
     uint32_t src2_bank_id = get_arg_val<uint32_t>(6);
 

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -38,6 +38,9 @@ public:
         return std::bit_cast<float>(uint32_data);
     }
 
+    // to_float method for consistency with fp8 types
+    constexpr float to_float() const { return static_cast<float>(*this); }
+
     // -- Comparison Operators ---
     constexpr bool operator==(bfloat16 rhs) const { return static_cast<float>(*this) == static_cast<float>(rhs); };
     constexpr std::partial_ordering operator<=>(bfloat16 rhs) noexcept {

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -70,6 +70,7 @@ inline std::ostream& operator<<(std::ostream& os, const DataFormat& format) {
         case DataFormat::Int8: os << "Int8"; break;
         case DataFormat::UInt8: os << "UInt8"; break;
         case DataFormat::Lf8: os << "Lf8"; break;
+        case DataFormat::Fp8_e4m3: os << "Fp8_e4m3"; break;
         case DataFormat::UInt16: os << "UInt16"; break;
         case DataFormat::UInt32: os << "UInt32"; break;
         case DataFormat::Int32: os << "Int32"; break;
@@ -97,6 +98,7 @@ constexpr static uint32_t datum_size(const DataFormat& format) {
         case DataFormat::Tf32: throw std::invalid_argument("TF32 unsupported atm");
         case DataFormat::Int8:
         case DataFormat::Lf8:
+        case DataFormat::Fp8_e4m3:
         case DataFormat::UInt8:
         case DataFormat::RawUInt8: return 1;
         case DataFormat::UInt16:
@@ -124,6 +126,7 @@ constexpr static uint32_t tile_size(const DataFormat& format) {
         case DataFormat::Tf32: throw std::invalid_argument("TF32 unsupported atm");
         case DataFormat::Int8:
         case DataFormat::Lf8:
+        case DataFormat::Fp8_e4m3:
         case DataFormat::UInt8:
         case DataFormat::RawUInt8: return 1024;
         case DataFormat::UInt16:

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -162,6 +162,7 @@ static constexpr uint32_t dprint_datum_size(const CommonDataFormat& format) {
         case CommonDataFormat::Bfp8_b:
         case CommonDataFormat::Int8:
         case CommonDataFormat::Lf8:
+        case CommonDataFormat::Fp8_e4m3:
         case CommonDataFormat::UInt8: return 1;  // Round up to 1 byte
         case CommonDataFormat::Invalid:
         default: return 0;  // Invalid/Unknown
@@ -181,6 +182,7 @@ static constexpr bool is_bfp(const CommonDataFormat& format) {
         case CommonDataFormat::Float32:
         case CommonDataFormat::Int8:
         case CommonDataFormat::Lf8:
+        case CommonDataFormat::Fp8_e4m3:
         case CommonDataFormat::UInt8:
         case CommonDataFormat::UInt16:
         case CommonDataFormat::UInt32:
@@ -207,6 +209,7 @@ static constexpr bool is_supported_format(const CommonDataFormat& format) {
         case CommonDataFormat::Bfp8:
         case CommonDataFormat::Float16:
         case CommonDataFormat::Lf8:
+        case CommonDataFormat::Fp8_e4m3:
         case CommonDataFormat::Invalid:
         default: return false;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -146,7 +146,8 @@ constexpr static std::int32_t MUL_HEADERLESS_TILE_SIZE_AND_INDEX(uint format, ui
         case ((uint8_t)DataFormat::Bfp2):
         case ((uint8_t)DataFormat::Bfp2_b): return ((index << 4) + (index << 2));
         case ((uint8_t)DataFormat::Int8):
-        case ((uint8_t)DataFormat::Lf8): return ((index << 6));
+        case ((uint8_t)DataFormat::Lf8):
+        case ((uint8_t)DataFormat::Fp8_e4m3): return ((index << 6));
         // Keep default as Bfp8?
         default: return ((index << 6) + (index << 2));
     };

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -63,6 +63,7 @@ uint32_t Tile::get_tile_size(const DataFormat& format) const {
         case DataFormat::Float32: return (tile_hw * 4);
         case DataFormat::Int8:
         case DataFormat::Lf8:
+        case DataFormat::Fp8_e4m3:
         case DataFormat::UInt8:
         case DataFormat::RawUInt8: return tile_hw;
         case DataFormat::UInt16:

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -319,6 +319,12 @@ void PrintTensixRegisterData(ostringstream* stream, int setwidth, uint32_t datum
         case static_cast<std::uint8_t>(tt::DataFormat::Tf32):
             *stream << setw(setwidth) << make_float(8, 10, datum) << " ";
             break;
+        case static_cast<std::uint8_t>(tt::DataFormat::Fp8_e4m3):
+            *stream << setw(setwidth) << make_float(4, 3, datum & 0xFF) << " ";
+            *stream << setw(setwidth) << make_float(4, 3, (datum >> 8) & 0xFF) << " ";
+            *stream << setw(setwidth) << make_float(4, 3, (datum >> 16) & 0xFF) << " ";
+            *stream << setw(setwidth) << make_float(4, 3, (datum >> 24) & 0xFF) << " ";
+            break;
         case static_cast<std::uint8_t>(tt::DataFormat::Float32): {
             float value;
             memcpy(&value, &datum, sizeof(float));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18157)

### Problem description
Missing support for FP8 formats

### What's changed
Add support for FP8 formats in LLK
Add C++ tests for unpack/pack
TODO: Add tests for tilize/untilize

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18143090740
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)