### PR TITLE
add APIs and corresponding tests to use some overlay scratch registers in fabric

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
         test_simple_dram_buffer.cpp
         test_simple_l1_buffer.cpp
         test_soc_descriptor.cpp
+        test_stream_scratch_register.cpp
         test_tilize_untilize.cpp
         test_worker_config_buffer.cpp
         test_blockfloat_common.cpp

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -19,7 +19,7 @@ TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterTensixCores) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Use core (0,0) for testing
@@ -52,7 +52,7 @@ TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterEriscCores) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
     // Get first available ethernet core

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "gtest/gtest.h"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+namespace tt::tt_metal {
+
+// Test stream scratch register APIs on Tensix cores (both RISC0 and RISC1)
+TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterTensixCores) {
+    // Get device from fixture
+    auto mesh_device = this->devices_[0];
+
+    // Create workload for mesh device
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = CreateProgram();
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    auto& program_ = workload.get_programs().at(device_range);
+
+    // Use core (0,0) for testing
+    CoreCoord test_core = {0, 0};
+
+    // Create kernel for RISC0 (DataMovementProcessor::RISCV_0)
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp",
+        test_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // Execute the program
+    this->RunProgram(mesh_device, workload);
+}
+
+// Test stream scratch register APIs on Erisc cores
+TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterEriscCores) {
+    // Get device from fixture
+    auto mesh_device = this->devices_[0];
+    auto device = mesh_device->get_devices()[0];
+
+    // Check if device has active ethernet cores
+    if (device->get_active_ethernet_cores(true).empty()) {
+        GTEST_SKIP() << "No active ethernet cores available on this device";
+    }
+
+    // Create workload for mesh device
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = CreateProgram();
+    distributed::AddProgramToMeshWorkload(workload, std::move(program), device_range);
+    auto& program_ = workload.get_programs().at(device_range);
+
+    // Get first available ethernet core
+    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+
+    // Create CoreRangeSet for this single ethernet core
+    std::set<CoreRange> eth_core_ranges;
+    eth_core_ranges.insert(CoreRange(eth_core, eth_core));
+
+    // Create kernel for ethernet core with EthernetConfig
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp",
+        eth_core_ranges,
+        EthernetConfig{.noc = NOC::NOC_0});
+
+    // Execute the program
+    this->RunProgram(mesh_device, workload);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
+
+void kernel_main() {
+    // Define test values: 0, 1000, and (2^24 - 1)
+    constexpr uint32_t test_values[] = {1, 1000, 16777215};
+    constexpr uint32_t num_test_values = 3;
+
+    // Validate that we can write up to 24 bits; use the get address API
+    auto scratch_register_address = reinterpret_cast<volatile uint32_t*>(get_stream_scratch_register_address(0));
+    for (uint32_t i = 0; i < (1 << 24); i++) {
+        *scratch_register_address = i;
+        uint32_t readback = *scratch_register_address;
+        if (readback != i) {
+            ASSERT(false);
+            while (1);
+        }
+    }
+    {
+        *scratch_register_address = 0xc0ffee;
+        uint32_t readback = read_stream_scratch_register(0);
+        if (readback != 0xc0ffee) {
+            ASSERT(false);
+            while (1);
+        }
+
+        write_stream_scratch_register(0, 1);
+        readback = *scratch_register_address;
+        if (readback != 1) {
+            ASSERT(false);
+            while (1);
+        }
+    }
+
+    // Check for all stream IDs
+    for (uint8_t stream_id = 0; stream_id <= 31; stream_id++) {
+        // PART 1: Direct memory access test
+        // Test write_stream_scratch_register() and read_stream_scratch_register()
+        for (uint32_t i = 0; i < num_test_values; i++) {
+            uint32_t val = test_values[i];
+            write_stream_scratch_register(stream_id, val);
+            uint32_t readback = read_stream_scratch_register(stream_id);
+            ASSERT(readback == val);
+            if (readback != val) {
+                while (1);
+            }
+        }
+
+        // PART 2: NOC inline write test
+        // Test noc_inline_dw_write() followed by read_stream_scratch_register()
+
+        // Get the register address for this stream
+        uint32_t reg_addr = get_stream_scratch_register_address(stream_id);
+
+        // Convert to NOC address for current core
+        uint64_t noc_addr = get_noc_addr(my_x[0], my_y[0], reg_addr, noc_index);
+
+        for (uint32_t i = 0; i < num_test_values; i++) {
+            uint32_t val = test_values[i];
+
+            // Write using NOC inline write to register space
+            noc_inline_dw_write<InlineWriteDst::REG>(noc_addr, val);
+
+            // Wait for NOC write to complete
+            noc_async_write_barrier(noc_index);
+
+            // Read back and verify
+            uint32_t readback = read_stream_scratch_register(stream_id);
+            ASSERT(readback == val);
+            if (readback != val) {
+                while (1);
+            }
+
+            // Clear the register to make sure we aren't crossing wires with other stream registers
+            noc_inline_dw_write<InlineWriteDst::REG>(noc_addr, 0);
+
+            // Wait for NOC write to complete
+            noc_async_write_barrier(noc_index);
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     // Validate that we can write up to 24 bits; use the get address API
     auto scratch_register_address = reinterpret_cast<volatile uint32_t*>(get_stream_scratch_register_address(0));
     for (uint32_t i = 1; i < 24; i++) {
-        auto test_value = 1 << (i - 1);
+        uint32_t test_value = 1 << (i - 1);
         *scratch_register_address = test_value;
         uint32_t readback = *scratch_register_address;
         if (readback != test_value) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
@@ -12,18 +12,20 @@ void kernel_main() {
 
     // Validate that we can write up to 24 bits; use the get address API
     auto scratch_register_address = reinterpret_cast<volatile uint32_t*>(get_stream_scratch_register_address(0));
-    for (uint32_t i = 0; i < (1 << 24); i++) {
-        *scratch_register_address = i;
+    for (uint32_t i = 1; i < 24; i++) {
+        auto test_value = 1 << (i - 1);
+        *scratch_register_address = test_value;
         uint32_t readback = *scratch_register_address;
-        if (readback != i) {
+        if (readback != test_value) {
             ASSERT(false);
             while (1);
         }
     }
     {
-        *scratch_register_address = 0xc0ffee;
+        constexpr uint32_t test_value = 0xc0ffee;
+        *scratch_register_address = test_value;
         uint32_t readback = read_stream_scratch_register(0);
-        if (readback != 0xc0ffee) {
+        if (readback != test_value) {
             ASSERT(false);
             while (1);
         }
@@ -44,8 +46,8 @@ void kernel_main() {
             uint32_t val = test_values[i];
             write_stream_scratch_register(stream_id, val);
             uint32_t readback = read_stream_scratch_register(stream_id);
-            ASSERT(readback == val);
             if (readback != val) {
+                ASSERT(false);
                 while (1);
             }
         }
@@ -70,8 +72,8 @@ void kernel_main() {
 
             // Read back and verify
             uint32_t readback = read_stream_scratch_register(stream_id);
-            ASSERT(readback == val);
             if (readback != val) {
+                ASSERT(false);
                 while (1);
             }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp
@@ -12,8 +12,8 @@ void kernel_main() {
 
     // Validate that we can write up to 24 bits; use the get address API
     auto scratch_register_address = reinterpret_cast<volatile uint32_t*>(get_stream_scratch_register_address(0));
-    for (uint32_t i = 1; i < 24; i++) {
-        uint32_t test_value = 1 << (i - 1);
+    for (uint32_t i = 0; i < 24; i++) {
+        uint32_t test_value = 1 << i;
         *scratch_register_address = test_value;
         uint32_t readback = *scratch_register_address;
         if (readback != test_value) {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp
@@ -11,6 +11,31 @@
 
 using StreamId = tt::tt_fabric::NamedType<uint32_t, struct StreamIdType>;
 
+//------------------------- Stream Scratch Register --------------------------
+//--------------------------------  24 bits ----------------------------------
+template <uint32_t stream_id>
+FORCE_INLINE uint32_t get_stream_scratch_register_address() {
+    return STREAM_REG_ADDR(stream_id, STREAM_REMOTE_SRC_REG_INDEX);
+}
+FORCE_INLINE uint32_t get_stream_scratch_register_address(uint8_t stream_id) {
+    return STREAM_REG_ADDR(stream_id, STREAM_REMOTE_SRC_REG_INDEX);
+}
+template <uint32_t stream_id>
+FORCE_INLINE uint32_t read_stream_scratch_register() {
+    return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_SRC_REG_INDEX);
+}
+FORCE_INLINE uint32_t read_stream_scratch_register(uint8_t stream_id) {
+    return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_SRC_REG_INDEX);
+}
+template <uint32_t stream_id>
+FORCE_INLINE uint32_t write_stream_scratch_register(uint32_t val) {
+    return NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_SRC_REG_INDEX, val);
+}
+FORCE_INLINE uint32_t write_stream_scratch_register(uint8_t stream_id, uint32_t val) {
+    return NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_SRC_REG_INDEX, val);
+}
+
+//------------------------- AutoInc on  Write Register --------------------------
 // This will be an atomic register read to the register
 template <uint32_t stream_id>
 FORCE_INLINE int32_t get_ptr_val() {


### PR DESCRIPTION
Incremental change towards enabling elastic channels in fabric. These new scratch registers are not auto-increment on write. This will be needed to provide an efficient elastic channel implementation. Note that these registers have a maximum capacity of 24 bits, so the elastic channels implementation (out of the box) will only be able to support ~16MB of addressability per bank (unless the we pack the addressing to a coarser granularity).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/18143650376
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18143651848
- [x] New/Existing tests provide coverage for changes
