### PR TITLE
#0: [skip ci] BH multi-card demos: Add an input to regenerate ttnn model weight cache

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         type: number
         default: 4
+      regenerate-ttnn-cache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   multi-card-demo-tests:
@@ -61,7 +65,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data:ro
+        - "${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data${{ inputs.regenerate-ttnn-cache == true && ':rw' || ':ro' }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -139,7 +143,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data:ro
+        - "${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data${{ inputs.regenerate-ttnn-cache == true && ':rw' || ':ro' }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -2,7 +2,18 @@ name: "(Blackhole) Multi-card Demo tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      regenerate-ttnn-cache:
+        description: "Regenerate model ttnn cache (removes :ro from volume mount)"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      regenerate-ttnn-cache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-artifact:
@@ -40,3 +51,4 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       extra-tag: ${{ matrix.test-group.extra-tag }}
       num_devices: ${{ matrix.test-group.num_devices }}
+      regenerate-ttnn-cache: ${{ inputs.regenerate-ttnn-cache || false  }}

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       regenerate-ttnn-cache:
-        description: "Regenerate model ttnn cache (removes :ro from volume mount)"
+        description: "Mount model cache volume read-write to regenerate TTNN cache (otherwise read-only)."
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
### Ticket
None

### Problem description
Annoying to have to edit the volume mount in the container manually

### What's changed
Add an input for it (When true set ttnn cache container mount to read-write `:rw` otherwise set read-only `:ro`)

### Checklist
- [x] BH multicard demos  https://github.com/tenstorrent/tt-metal/actions/runs/18198206040