### PR TITLE
update a2a dispatch/combine unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_6U.py
@@ -45,8 +45,8 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_to_all_combine_t3000 import (
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("axis", [0, 1])
-@pytest.mark.parametrize("batches_per_device", [8])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7000])
 @pytest.mark.parametrize("seq", [1, 2])
@@ -63,7 +63,7 @@ def test_all_to_all_combine_no_trace(
     mesh_shape,
     axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq,
@@ -78,9 +78,7 @@ def test_all_to_all_combine_no_trace(
     if seq == 2 and ttnn.L1_MEMORY_CONFIG in (input_memory_config, output_memory_config):
         pytest.skip("Prefill needs to run in DRAM")
 
-    devices = mesh_shape[0] * mesh_shape[1]
-    batch = batches_per_device * devices
-    experts = experts_per_device * devices
+    batch = batches_per_device * mesh_shape[axis]
 
     run_all_to_all_combine_test(
         mesh_device,
@@ -116,8 +114,8 @@ def test_all_to_all_combine_no_trace(
     "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize("cluster_axis", [1])
-@pytest.mark.parametrize("batches_per_device", [8])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize(
@@ -136,7 +134,7 @@ def test_perf(
     mesh_shape,
     cluster_axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq_len,
@@ -155,7 +153,6 @@ def test_perf(
         dispatch_devices = mesh_shape[cluster_axis]
 
     batch = batches_per_device * dispatch_devices
-    experts = experts_per_device * dispatch_devices
 
     trace_all_to_all_combine(
         mesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py
@@ -51,8 +51,8 @@ from tracy import signpost
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("cluster_axis", [0, 1])
-@pytest.mark.parametrize("batches_per_device", [16])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize(
@@ -73,7 +73,7 @@ def test_all_to_all_dispatch_no_trace(
     mesh_shape,
     cluster_axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq_len,
@@ -91,7 +91,6 @@ def test_all_to_all_dispatch_no_trace(
         dispatch_devices = mesh_shape[cluster_axis]
 
     batch = batches_per_device * dispatch_devices
-    experts = experts_per_device * dispatch_devices
 
     run_all_to_all_dispatch_test(
         mesh_device,
@@ -141,8 +140,8 @@ def test_all_to_all_dispatch_no_trace(
     "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize("cluster_axis", [0, 1])
-@pytest.mark.parametrize("batches_per_device", [8])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize(
@@ -164,7 +163,7 @@ def test_all_to_all_dispatch_trace(
     mesh_shape,
     cluster_axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq_len,
@@ -182,7 +181,6 @@ def test_all_to_all_dispatch_trace(
         dispatch_devices = mesh_shape[cluster_axis]
 
     batch = batches_per_device * dispatch_devices
-    experts = experts_per_device * dispatch_devices
 
     run_all_to_all_dispatch_test(
         mesh_device,
@@ -222,8 +220,8 @@ def test_all_to_all_dispatch_trace(
     "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize("cluster_axis", [1])
-@pytest.mark.parametrize("batches_per_device", [8])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("batches_per_device", [32])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize(
@@ -244,7 +242,7 @@ def test_decode_perf(
     mesh_shape,
     cluster_axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq_len,
@@ -262,7 +260,6 @@ def test_decode_perf(
         dispatch_devices = mesh_shape[cluster_axis]
 
     batch = batches_per_device * dispatch_devices
-    experts = experts_per_device * dispatch_devices
 
     run_all_to_all_dispatch_test(
         mesh_device,
@@ -304,7 +301,7 @@ def test_decode_perf(
 )
 @pytest.mark.parametrize("cluster_axis", [1])
 @pytest.mark.parametrize("batches_per_device", [8])
-@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("experts", [256])
 @pytest.mark.parametrize("select_experts_k", [8])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.parametrize(
@@ -325,7 +322,7 @@ def test_prefill_perf(
     mesh_shape,
     cluster_axis,
     batches_per_device,
-    experts_per_device,
+    experts,
     select_experts_k,
     hidden_size,
     seq_len,
@@ -343,7 +340,6 @@ def test_prefill_perf(
         dispatch_devices = mesh_shape[cluster_axis]
 
     batch = batches_per_device * dispatch_devices
-    experts = experts_per_device * dispatch_devices
 
     run_all_to_all_dispatch_test(
         mesh_device,


### PR DESCRIPTION

This pull request updates the unit tests for the all-to-all dispatch and combine 6U tests
 ### What's changed
 1. Standarized `batch_per_device`=32 in decode case
 2. Removed `experts_per_device` parameter instead parameterized `experts` assuming `Expert Parallel=num_devices`. 

## Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes