### PR TITLE
MPWI Eliminate Idx Tensor Typecast and Bug Fix For Partial Sticks

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -13,7 +13,7 @@ def test_max_pool2d_with_indices(device):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 1
+    in_c = 24
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -13,7 +13,7 @@ def test_max_pool2d_with_indices(device):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 24
+    in_c = 1
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -20,6 +20,7 @@ dtypes = [
     (torch.bfloat16, ttnn.bfloat8_b),
     (torch.int32, ttnn.int32),
     (torch.int32, ttnn.uint32),
+    (torch.int16, ttnn.uint16),
 ]
 shapes = [(1,), (2,), (2, 3), (4, 16, 3, 1), (4, 3, 1, 2, 2)]
 repeat_shapes = [
@@ -61,6 +62,9 @@ def test_repeat(device, layout, dtype, shape, repeat_shape):
     if layout == ttnn.ROW_MAJOR_LAYOUT and ttnn_dtype == ttnn.bfloat8_b:
         pytest.skip("Illegal config")
 
+    if layout == ttnn.TILE_LAYOUT and ttnn_dtype == ttnn.uint16:
+        pytest.skip("UINT16 tensors cannot be tilized - only bfloat16/float32/int32/uint32 supported")
+
     mul = lambda x, y: x * y
     torch_input_tensor = torch.arange(0, reduce(mul, shape, 1), dtype=torch_dtype).reshape(shape)
 
@@ -73,7 +77,14 @@ def test_repeat(device, layout, dtype, shape, repeat_shape):
         output.shape == torch_result.shape
     ), f"Output shape {output.shape} does not match torch shape {torch_result.shape}"
 
-    assert_with_pcc(torch_result, output, 0.9999)
+    # Convert unsigned PyTorch dtypes to int32 for PCC check since comp_pcc doesn't support uint dtypes
+    pcc_torch_result = torch_result
+    pcc_output = output
+    if torch_dtype == torch.uint16:
+        pcc_torch_result = torch_result.to(torch.int32)
+        pcc_output = output.to(torch.int32)
+
+    assert_with_pcc(pcc_torch_result, pcc_output, 0.9999)
 
 
 @pytest.mark.parametrize("layout", layouts)

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -22,8 +22,9 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32,
-        "Can only work with bfloat16/float32 or int32/uint32 tensors");
+            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32 or
+            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16,
+        "Can only work with bfloat16/float32 or int32/uint32/uint16 tensors");
     // is this relevant?
     TT_FATAL(
         this->m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -19,12 +19,12 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "This function is for RM->RM");
     TT_FATAL(
-        input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
+        input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16 or
+            input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32 or
             input_tensor_a.dtype() == tt::tt_metal::DataType::INT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16,
-        "Can only work with bfloat16/float32 or int32/uint32/uint16 tensors");
+            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
+        "Can only work with UINT16, BFLOAT16, UINT32, INT32, FLOAT32 data types");
     // is this relevant?
     TT_FATAL(
         this->m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -421,6 +421,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     const bool is_output_tiled = output_layout == Layout::TILE;
     const bool is_output_block_format = is_block_float(outputs[0].dtype());
+    const bool zero_pages = is_output_tiled && is_output_block_format;
 
     // Conditionally allocate temporary CB - only needed for TILED output
     uint32_t pre_tilize_cb_id = 32;  // default invalid CB ID
@@ -573,7 +574,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         stride_w,                       // 33
         dilation_h,                     // 34
         dilation_w,                     // 35
-        (uint32_t)return_indices};      // 36
+        (uint32_t)return_indices,       // 36
+        (uint32_t)zero_pages};          // 37
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -64,6 +64,8 @@ void validate_pool2d(
         auto kernel_h = sliding_window_config.window_hw.first;
         auto kernel_w = sliding_window_config.window_hw.second;
         TT_FATAL(kernel_h * kernel_w == 9, "only kernel sizes equal to 9 are supported, got {}x{}", kernel_h, kernel_w);
+
+        TT_FATAL(output_layout == Layout::ROW_MAJOR, "Only ROW_MAJOR supported when return_indices is true");
     }
 
     TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
@@ -79,18 +81,6 @@ void validate_pool2d(
             "For width and block sharding, input channels ({}) should be divisible by num_shards ({})",
             input_shape[3],
             num_shards_c);
-    }
-
-    // check that the input shape isn't too large for indices in uint16
-    if (return_indices) {
-        auto in_h = sliding_window_config.input_hw.first;
-        auto in_w = sliding_window_config.input_hw.second;
-        TT_FATAL(
-            in_h * in_w <= std::numeric_limits<uint16_t>::max(),
-            "input HW shape ({} * {}) is too large for indices stored in uint16 with a limit of {}",
-            in_h,
-            in_w,
-            std::numeric_limits<uint16_t>::max());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -253,10 +253,10 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         Shape spatial_shape({1, input_h, input_w, 1});
 
         // Create indices tensor with UINT32 since repeat operation requires it
-        Tensor indices_hw = ttnn::index_all<uint32_t>(
+        Tensor indices_hw = ttnn::index_all<uint16_t>(
             spatial_shape,
             spatial_shape,  // No padding needed for spatial-only shape
-            DataType::UINT32);
+            DataType::UINT16);
         Shape repeat_shape({batch_size, 1, 1, channels});
         Tensor index_full = ttnn::repeat(indices_hw.to_device(input_tensor.device()), repeat_shape);
 
@@ -265,21 +265,10 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
         Shape flattened_shape({1, 1, nhw, channels});
         Tensor index_full_reshaped = ttnn::reshape(index_full, flattened_shape);
 
-        // Convert to TILE layout for typecast operation
-        Tensor index_full_tiled = ttnn::to_layout(index_full_reshaped, ttnn::TILE_LAYOUT);
-
-        // Convert to UINT16
-        Tensor index_full_uint16 = ttnn::typecast(index_full_tiled, DataType::UINT16);
-
-        // Convert back to ROW_MAJOR layout
-        if (!is_in_tiled) {
-            index_full_uint16 = ttnn::to_layout(index_full_uint16, ttnn::ROW_MAJOR_LAYOUT);
-        }
-
         TT_FATAL(
             input_tensor_sharded.memory_config().is_sharded(), "Input tensor must be sharded to shard indices tensor.");
         index_tensor_sharded =
-            ttnn::to_memory_config(index_full_uint16, input_tensor_sharded.memory_config(), std::nullopt);
+            ttnn::to_memory_config(index_full_reshaped, input_tensor_sharded.memory_config(), std::nullopt);
     }
 
     std::vector<Tensor> haloed_tensors;

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -252,7 +252,7 @@ static std::variant<Tensor, MaxPoolWithIndicesResult> pool2d_invoke(
     if (return_indices) {
         Shape spatial_shape({1, input_h, input_w, 1});
 
-        // Create indices tensor with UINT32 since repeat operation requires it
+        // Create the index tensor
         Tensor indices_hw = ttnn::index_all<uint16_t>(
             spatial_shape,
             spatial_shape,  // No padding needed for spatial-only shape


### PR DESCRIPTION
### Ticket
Related To https://github.com/tenstorrent/tt-metal/issues/27845

### Problem description
Previously the index tensor was first constructed in UInt32 since `ttnn::repeat` did not support UInt16, this resulted in having to tilize the tensor, typecast it, and then untilize it.

There was also a bug where the in CB was zeroed out unnecessarily in some cases for partial sticks.

### What's changed
20% overall device kernel time reduction per MPWI call.

`ttnn::repeat` already supported UInt16 format so the TT_FATAL check has been updated accordingly. Thus the index tensor can now be created in UInt16 eliminating the tilize, typecast and untilize operations.

The pool reader kernel has also been updated to eliminate the zeroing calls, excepting cases where we have tiled output with a block data format in which case the zeroing is necessary to prevent scaling issues with padding/junk values.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208733311
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208734716
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208744291
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208742749
Failing on main, this PR hits same unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208738174
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208740719
Failing on main, this PR hits same unrelated error
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18208745693
- [x] New/Existing tests provide coverage for changes