### PR TITLE
fix async_noc_read alignment issue for sampling.

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -236,12 +236,11 @@ void kernel_main() {
     constexpr uint32_t cb_id_temp = get_compile_time_arg_val(16);
     constexpr uint32_t core_id = get_compile_time_arg_val(17);
     constexpr uint32_t ids_per_batch = get_compile_time_arg_val(18);
-    // Calculate chunk sizes based on total cores (32 cores per tensor)
-    constexpr uint32_t num_cores = 32;
-    constexpr uint32_t k_chunk_size = num_cores * 4;     // 4 bytes per uint32_t
-    constexpr uint32_t p_chunk_size = num_cores * 2;     // 2 bytes per uint16_t
-    constexpr uint32_t temp_chunk_size = num_cores * 2;  // 2 bytes per uint16_t
-    constexpr uint32_t out_chunk_size = num_cores * 4;   // 4 bytes per uint32_t
+    constexpr uint32_t num_cores = get_compile_time_arg_val(19);
+    constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
+    constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
+    constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
+    constexpr uint32_t out_chunk_size = num_cores * sizeof(uint32_t);   // 4 bytes per uint32_t
     // Reduce ops need to multiply by a scalar. We always want to multiply by 1.0f
     generate_reduce_scaler(scale_cb_index, packed_identity_scalar);
     // read k, p, temp

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -236,6 +236,12 @@ void kernel_main() {
     constexpr uint32_t cb_id_temp = get_compile_time_arg_val(16);
     constexpr uint32_t core_id = get_compile_time_arg_val(17);
     constexpr uint32_t ids_per_batch = get_compile_time_arg_val(18);
+    // Calculate chunk sizes based on total cores (32 cores per tensor)
+    constexpr uint32_t num_cores = 32;
+    constexpr uint32_t k_chunk_size = num_cores * 4;     // 4 bytes per uint32_t
+    constexpr uint32_t p_chunk_size = num_cores * 2;     // 2 bytes per uint16_t
+    constexpr uint32_t temp_chunk_size = num_cores * 2;  // 2 bytes per uint16_t
+    constexpr uint32_t out_chunk_size = num_cores * 4;   // 4 bytes per uint32_t
     // Reduce ops need to multiply by a scalar. We always want to multiply by 1.0f
     generate_reduce_scaler(scale_cb_index, packed_identity_scalar);
     // read k, p, temp
@@ -244,32 +250,38 @@ void kernel_main() {
     cb_reserve_back(cb_id_k, 1);
     uint32_t cb_id_k_ptr = get_write_ptr(cb_id_k);
     uint64_t k_noc_addr = get_noc_addr(0, addrg_k);
-    noc_async_read(k_noc_addr + core_id * 4, cb_id_k_ptr, 4);
+    // Read the entire aligned chunk to avoid NOC alignment issues
+    noc_async_read(k_noc_addr, cb_id_k_ptr, k_chunk_size);
     noc_async_read_barrier();
     cb_push_back(cb_id_k, 1);
     volatile tt_l1_ptr uint32_t* k_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_id_k_ptr);
-    uint32_t k = k_ptr[0];
+    // Index into the chunk to get this core's value
+    uint32_t k = k_ptr[core_id];
 
     const auto addrg_p = TensorAccessor(p_args, p_addr, 64);
     cb_reserve_back(cb_id_p, 1);
     uint32_t cb_id_p_ptr = get_write_ptr(cb_id_p);
     uint64_t p_noc_addr = get_noc_addr(0, addrg_p);
-    noc_async_read(p_noc_addr + core_id * 2, cb_id_p_ptr, 2);
+    // Read the entire aligned chunk to avoid NOC alignment issues
+    noc_async_read(p_noc_addr, cb_id_p_ptr, p_chunk_size);
     noc_async_read_barrier();
     cb_push_back(cb_id_p, 1);
     volatile tt_l1_ptr uint16_t* p_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_id_p_ptr);
-    uint32_t p = p_ptr[0];
+    // Index into the chunk to get this core's value
+    uint32_t p = p_ptr[core_id];
 
     const auto addrg_temp = TensorAccessor(temp_args, temp_addr, 64);
     // cb_reserve_back(cb_id_temp, 1);
     uint32_t cb_id_temp_ptr = get_write_ptr(cb_id_temp);
     uint64_t temp_noc_addr = get_noc_addr(0, addrg_temp);
-    noc_async_read(temp_noc_addr + core_id * 2, cb_id_temp_ptr, 2);
+    // Read the entire aligned chunk to avoid NOC alignment issues
+    noc_async_read(temp_noc_addr, cb_id_temp_ptr, temp_chunk_size);
     noc_async_read_barrier();
     // cb_push_back(cb_id_temp, 1);
 
     volatile tt_l1_ptr uint16_t* temp_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_id_temp_ptr);
-    uint16_t temp = temp_ptr[0];
+    // Index into the chunk to get this core's value
+    uint16_t temp = temp_ptr[core_id];
     uint32_t temp_packed = (static_cast<uint32_t>(temp) << 16) + static_cast<uint32_t>(temp);
     generate_bcast_unary_scalar(cb_id_temp, temp_packed);
     // generate the top-k mask
@@ -372,6 +384,7 @@ void kernel_main() {
 
     const auto s_out = TensorAccessor(dst_args, dst_addr, out_stick_size);
     uint64_t dst_noc_addr = get_noc_addr(0, s_out);
+    // Write individual core result - output buffer should handle alignment
     noc_async_write(out_addr + core_id * 4, dst_noc_addr + core_id * 4, 4);
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -38,7 +38,6 @@ tt::tt_metal::operation::ProgramWithCallbacks sampling_multicore_interleaved(
 
     uint32_t input_values_tile_size = tile_size(input_values_cb_data_format);
     uint32_t index_tile_size = tile_size(index_cb_data_format);
-    uint32_t temp_tile_size = tile_size(temp_cb_data_format);
 
     auto input_values_buffer = input_values_tensor.buffer();
     auto input_indices_buffer = input_indices_tensor.buffer();
@@ -190,22 +189,28 @@ tt::tt_metal::operation::ProgramWithCallbacks sampling_multicore_interleaved(
     const uint32_t uint32_bytes = 4;
     const uint32_t bf16_bytes = 2;
     uint32_t k_cb_index = tt::CBIndex::c_14;
+    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
+    uint32_t k_chunk_size = num_cores * uint32_bytes;
     tt::tt_metal::CircularBufferConfig k_cb_config =
-        tt::tt_metal::CircularBufferConfig(TILE_WIDTH * uint32_bytes, {{k_cb_index, k_cb_data_format}})
-            .set_page_size(k_cb_index, TILE_WIDTH * uint32_bytes);
+        tt::tt_metal::CircularBufferConfig(k_chunk_size, {{k_cb_index, k_cb_data_format}})
+            .set_page_size(k_cb_index, k_chunk_size);
     tt::tt_metal::CreateCircularBuffer(program, core_grid, k_cb_config);
 
     uint32_t p_cb_index = tt::CBIndex::c_15;
+    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
+    uint32_t p_chunk_size = num_cores * bf16_bytes;
     tt::tt_metal::CircularBufferConfig p_cb_config =
-        tt::tt_metal::CircularBufferConfig(TILE_WIDTH * bf16_bytes, {{p_cb_index, p_cb_data_format}})
-            .set_page_size(p_cb_index, TILE_WIDTH * bf16_bytes);
+        tt::tt_metal::CircularBufferConfig(p_chunk_size, {{p_cb_index, p_cb_data_format}})
+            .set_page_size(p_cb_index, p_chunk_size);
     tt::tt_metal::CreateCircularBuffer(program, core_grid, p_cb_config);
 
     // Add temp circular buffer
     uint32_t temp_cb_index = tt::CBIndex::c_16;
+    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
+    uint32_t temp_chunk_size = num_cores * bf16_bytes;
     tt::tt_metal::CircularBufferConfig temp_cb_config =
-        tt::tt_metal::CircularBufferConfig(temp_tile_size, {{temp_cb_index, temp_cb_data_format}})
-            .set_page_size(temp_cb_index, temp_tile_size);
+        tt::tt_metal::CircularBufferConfig(temp_chunk_size, {{temp_cb_index, temp_cb_data_format}})
+            .set_page_size(temp_cb_index, temp_chunk_size);
     tt::tt_metal::CreateCircularBuffer(program, core_grid, temp_cb_config);
 
     std::vector<uint32_t> reader_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -267,6 +267,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sampling_multicore_interleaved(
                 temp_cb_index,
                 i,
                 TILE_WIDTH,
+                num_cores,
             });
         tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
             program,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27392)

### Problem description
Some ops have noc alignment issue that's been captured by tt sim

### What's changed
Adjust the memory access pattern for sampling op such that the DRAM and L1 are always aligned during data movement.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18169319693) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes