### PR TITLE
minor fabric builder fix for eth handshake addressing

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -257,8 +257,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         next_l1_addr += 32;
     }
 
+    // The Ethernet handshake structure is 32 B.
     this->handshake_addr = next_l1_addr;
-    next_l1_addr += eth_channel_sync_size;
+    next_l1_addr += 2 * eth_channel_sync_size;
 
     // issue: https://github.com/tenstorrent/tt-metal/issues/29073. TODO: Re-enable after hang is resolved.
     // Ethernet txq IDs on WH are 0,1 and on BH are 0,1,2.
@@ -1141,8 +1142,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     direction(direction),
     local_fabric_node_id(local_fabric_node_id),
     peer_fabric_node_id(peer_fabric_node_id),
-    handshake_address(tt::round_up(
-        tt::tt_metal::hal::get_erisc_l1_unreserved_base(), FabricEriscDatamoverConfig::eth_channel_sync_size)),
+    handshake_address(config.handshake_addr),
     channel_buffer_size(config.channel_buffer_size_bytes),
     sender_channels_num_buffers(config.sender_channels_num_buffers),
     receiver_channels_num_buffers(config.receiver_channels_num_buffers),


### PR DESCRIPTION
Updated handshake data-structure to be given 32 B  in the L1 address map instead of the current 16 because it is actually 32 B in size. Also propagated an argument that wasn't being propagated.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18149027646
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18149029449