### PR TITLE
[skip ci] misc-uniqueptr-reset-release

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -123,7 +123,6 @@ Checks: >
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unconventional-assign-operator,
-  -misc-uniqueptr-reset-release,
   -misc-unused-parameters,
   -misc-unused-using-decls,
   -misc-use-anonymous-namespace,


### PR DESCRIPTION
### Ticket
#22758 

### Problem description
We have this check disabled - seemingly for no reason.
https://clang.llvm.org/extra/clang-tidy/checks/misc/uniqueptr-reset-release.html

### What's changed
- Enable check