### PR TITLE
Bumped unet perf on BH

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -129,7 +129,7 @@ def run_multi_iteration_perf_test(test_func, num_runs, *args, **kwargs) -> Perfo
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1633.0) if is_wormhole_b0() else (1, 4, 2869.0),),
+    ((1, 4, 1633.0) if is_wormhole_b0() else (1, 4, 2898.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"


### PR DESCRIPTION
### Problem description
Device perf CI is red because of functional unet being faster than expected.
(https://github.com/tenstorrent/tt-metal/actions/runs/18149518501/job/51657918744#step:18:139)
Perf needs to be bumped.

### What's changed
- Bumped BH unet expected perf