### PR TITLE
Bumped sd trace region size

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -7,4 +7,4 @@ from models.common.utility_functions import is_blackhole
 # L1 Small Size Constants
 SD_L1_SMALL_SIZE = 20928
 # Trace Region Size Constants
-SD_TRACE_REGION_SIZE = 814600080 if is_blackhole() else 789835776
+SD_TRACE_REGION_SIZE = 820000000 if is_blackhole() else 789835776


### PR DESCRIPTION
### Problem description
Models perf pipeline is red because SD fails due to size of trace buffer
https://github.com/tenstorrent/tt-metal/actions/runs/18154256254/job/51671104960#step:10:1484

### What's changed
- bumped trace region size