### PR TITLE
#28628: use legacy layernorm for tt_transformers

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2274,6 +2274,8 @@ class ModelArgs:
             block_h=self.tile_padded_batch_rows // self.tile_size,
             block_w=block_w,
             inplace=False,
+            legacy_reduction=True,
+            legacy_rsqrt=True,
         )
 
     def detect_checkpoint_type(self) -> CheckpointType:

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -15,8 +15,8 @@ enum class LayerNormType { LAYERNORM, RMSNORM };
 enum class DistributedLayerNormStage { NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER };
 
 struct LayerNormDefaultProgramConfig {
-    bool legacy_reduction = false;
-    bool legacy_rsqrt = false;
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
     bool use_welford = false;
 };
 struct LayerNormShardedMultiCoreProgramConfig {
@@ -25,8 +25,8 @@ struct LayerNormShardedMultiCoreProgramConfig {
     std::size_t block_h{};
     std::size_t block_w{};
     bool inplace{};
-    bool legacy_reduction = false;
-    bool legacy_rsqrt = false;
+    bool legacy_reduction = true;
+    bool legacy_rsqrt = true;
 };
 
 using LayerNormProgramConfig = std::variant<LayerNormDefaultProgramConfig, LayerNormShardedMultiCoreProgramConfig>;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -17,8 +17,8 @@ void bind_normalization_layernorm_program_config(py::module& module) {
         .def(
             py::init<bool, bool, bool>(),
             py::kw_only(),
-            py::arg("legacy_reduction").noconvert() = false,
-            py::arg("legacy_rsqrt").noconvert() = false,
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true,
             py::arg("use_welford").noconvert() = false)
         .def("__repr__", [](const LayerNormDefaultProgramConfig& config) { return fmt::format("{}", config); });
 
@@ -31,8 +31,8 @@ void bind_normalization_layernorm_program_config(py::module& module) {
             py::arg("block_h").noconvert(),
             py::arg("block_w").noconvert(),
             py::arg("inplace").noconvert(),
-            py::arg("legacy_reduction").noconvert() = false,
-            py::arg("legacy_rsqrt").noconvert() = false)
+            py::arg("legacy_reduction").noconvert() = true,
+            py::arg("legacy_rsqrt").noconvert() = true)
         .def(
             "__repr__", [](const LayerNormShardedMultiCoreProgramConfig& config) { return fmt::format("{}", config); });
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes