### PR TITLE
SFPI 7.3.0: Drop 32 from toolchain name

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -184,7 +184,6 @@ jobs:
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_reduce_scatter_apc.py \
-            tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/perf_tests.py \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_gather_nightly.py \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all.py \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_combine_bh.py \

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -133,9 +133,9 @@ foreach(ARCH IN LISTS ARCHS)
 endforeach()
 
 if(TT_USE_SYSTEM_SFPI)
-    set(GPP_CMD "/opt/tenstorrent/sfpi/compiler/bin/riscv32-tt-elf-g++")
+    set(GPP_CMD "/opt/tenstorrent/sfpi/compiler/bin/riscv-tt-elf-g++")
 else()
-    set(GPP_CMD "${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-tt-elf-g++")
+    set(GPP_CMD "${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv-tt-elf-g++")
 endif()
 
 if(NOT EXISTS "${GPP_CMD}")

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -139,7 +139,7 @@ void JitBuildEnv::init(
 
     bool sfpi_found = false;
     for (unsigned i = 0; i < 2; ++i) {
-        auto gxx = sfpi_roots[i] + "/compiler/bin/riscv32-tt-elf-g++";
+        auto gxx = sfpi_roots[i] + "/compiler/bin/riscv-tt-elf-g++";
         if (std::filesystem::exists(gxx)) {
             this->gpp_ += gxx + " ";
             this->gpp_include_dir_ = sfpi_roots[i] + "/include";

--- a/tt_metal/lite_fabric/build.cpp
+++ b/tt_metal/lite_fabric/build.cpp
@@ -121,7 +121,7 @@ int CompileFabricLite(
     defines.insert(defines.end(), extra_defines.begin(), extra_defines.end());
 
     std::ostringstream oss;
-    oss << GetToolchainPath(root_dir.string()) << "riscv32-tt-elf-g++ ";
+    oss << GetToolchainPath(root_dir.string()) << "riscv-tt-elf-g++ ";
     oss << GetCommonOptions() << " ";
 
     for (const auto& include : includes) {
@@ -157,7 +157,7 @@ int LinkFabricLite(
     const std::filesystem::path output_ld = out_dir / "lite_fabric_preprocessed.ld";
 
     std::ostringstream preprocess_oss;
-    preprocess_oss << GetToolchainPath(root_dir.string()) << "riscv32-tt-elf-g++ ";
+    preprocess_oss << GetToolchainPath(root_dir.string()) << "riscv-tt-elf-g++ ";
     preprocess_oss << fmt::format("-I{} ", tunneling_dir.string());  // Include path for the memory defs header
     preprocess_oss << "-E -P -x c ";                                 // Preprocess only, no line markers, treat as C
     preprocess_oss << fmt::format("-o {} ", output_ld.string());
@@ -174,7 +174,7 @@ int LinkFabricLite(
 
     // Now link using the preprocessed linker script
     std::ostringstream link_oss;
-    link_oss << GetToolchainPath(root_dir.string()) << "riscv32-tt-elf-g++ ";
+    link_oss << GetToolchainPath(root_dir.string()) << "riscv-tt-elf-g++ ";
     link_oss << GetCommonOptions() << " ";
     link_oss << "-Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles ";
     link_oss << fmt::format("-T{} ", output_ld.string());  // Use preprocessed linker script
@@ -197,7 +197,7 @@ int LinkFabricLite(
     bin_path.replace_extension(".bin");
 
     std::ostringstream objcopy_oss;
-    objcopy_oss << GetToolchainPath(root_dir.string()) << "riscv32-tt-elf-objcopy -O binary ";
+    objcopy_oss << GetToolchainPath(root_dir.string()) << "riscv-tt-elf-objcopy -O binary ";
     objcopy_oss << elf_out << " " << bin_path;
 
     std::string objcopy_cmd = objcopy_oss.str();

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -4,10 +4,10 @@ sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi_\([-.0-9a-zA-Z]*\)_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_version=\2'"\n"'sfpi_\3_\4_md5=\1/' *-build/sfpi_*.md5 | sort -u
-sfpi_aarch64_deb_md5=a67c257092b55af74b16d1ca03305f05
-sfpi_aarch64_rpm_md5=3ec63a0a7b83485867f103c7fd3f5079
-sfpi_aarch64_txz_md5=6f0380cb9d50055e0c31f5b7e96fb638
-sfpi_version=7.2.0
-sfpi_x86_64_deb_md5=df7a206658fc40cf31fe7282343a2752
-sfpi_x86_64_rpm_md5=9634997e6101227dae10bd9701f046e8
-sfpi_x86_64_txz_md5=e408d57cc776d4d51055323c5e29cf02
+sfpi_aarch64_deb_md5=bbe267282dc8c36554bc91354e47fc7d
+sfpi_aarch64_rpm_md5=f146cc686ffd08f5d5bf55055f2010f2
+sfpi_aarch64_txz_md5=d03da69379ea08386ce88dfb2bcdb88c
+sfpi_version=7.3.0
+sfpi_x86_64_deb_md5=100e9834fe6877a186440b241f69da65
+sfpi_x86_64_rpm_md5=38def21cfa7cfebef8e9def61019f7cc
+sfpi_x86_64_txz_md5=17970c8034b039f269d9a9db8e841e45


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29186

### Problem description
Quasar is 64-bit, naming the toolchain as riscv32 is wrong

### What's changed
Rename toolchain to be register-size agnostic

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes