### PR TITLE
Experimental: allow loading kernels from binary file

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -222,6 +222,10 @@ public:
     // Allowing to get corresponding MeshDevice for a given device to properly schedule programs / create buffers for
     // it. This is currently used exclusively by profiler.
     virtual std::shared_ptr<distributed::MeshDevice> get_mesh_device() = 0;
+
+    // Kernel binary path prefix for pre-compiled kernels (experimental)
+    virtual void set_kernel_binary_path_prefix(const std::string& prefix) = 0;
+    virtual const std::string& get_kernel_binary_path_prefix() const = 0;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/api/tt-metalium/experimental/precompiled_kernel.hpp
+++ b/tt_metal/api/tt-metalium/experimental/precompiled_kernel.hpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+
+namespace tt {
+
+namespace tt_metal {
+
+class IDevice;
+
+namespace experimental {
+
+// clang-format off
+/**
+ * Create a kernel from pre-compiled binaries for environments without source files.
+ *
+ * WORKFLOW:
+ * 1. Run your program with normal JIT compilation (calling CreateKernel()) to populate cache (~/.cache/tt-metal-cache/)
+ * 2. Copy kernel binaries from cache to your deployment location, preserving directory structure
+ * 3. Call SetKernelBinaryPathPrefix() to set the deployment location
+ * 4. Use CreateKernelFromBinary() instead of CreateKernel()
+ *
+ * CACHE STRUCTURE:
+ * The JIT cache generates paths like:
+ * ~/.cache/tt-metal-cache/<git_hash>/<build_key>/kernels/<kernel_name>/<kernel_hash>/<processor>/<processor>.elf
+ *
+ * Where:
+ * - git_hash: Current git commit (10 chars, e.g., "3493929f10")
+ * - build_key: Build configuration hash (architecture, flags, defines)
+ * - kernel_name: Name from source file without .cpp (e.g., "simple_add")
+ * - kernel_hash: Compilation configuration hash (includes compile-time args, defines, etc.)
+ * - processor: Processor type (brisc, ncrisc, trisc0, trisc1, trisc2, erisc)
+ *
+ * IMPORTANT: The same kernel can have multiple kernel_hash values if used with different compile-time
+ * arguments. You must copy ALL hash directories for a kernel.
+ *
+ * EXAMPLE:
+ * ```cpp
+ * // Set the binary path (call once per device)
+ * SetKernelBinaryPathPrefix(device, "/path/to/binaries");
+ *
+ * // Compute hash of original path (can be done once and hardcoded)
+ * auto hash = ComputeKernelOriginalPathHash("path/to/kernel.cpp");
+ *
+ * // Create kernel from binary (replaces CreateKernel)
+ * auto kernel = CreateKernelFromBinary(
+ *     program, "kernel_name", core_spec, config, hash
+ * );
+ * ```
+ *
+ * | Argument               | Description                                                                                                    | Type                                                                     | Valid Range | Required |
+ * |------------------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|-------------|----------|
+ * | program                | The program to which this kernel will be added to                                                              | Program &                                                                |             | Yes      |
+ * | kernel_name            | Name of the pre-compiled kernel binary (name of source file without .cpp)                                      | const std::string &                                                      |             | Yes      |
+ * | core_spec              | Either a single logical core, a range of logical cores or a set of logical core ranges for kernel placement    | const std::variant<CoreCoord, CoreRange, CoreRangeSet> &                 |             | Yes      |
+ * | config                 | Config for data movement, compute, or ethernet kernel (must match the config used during JIT compilation)      | const std::variant<DataMovementConfig,ComputeConfig,EthernetConfig> &    |             | Yes      |
+ * | original_path_or_hash  | Original kernel source path (string) or pre-computed hash (from ComputeKernelOriginalPathHash())               | const std::variant<std::string, size_t> &                                |             | Yes      |
+ */
+// clang-format on
+KernelHandle CreateKernelFromBinary(
+    Program& program,
+    const std::string& kernel_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config,
+    const std::variant<std::string, size_t>& original_path_or_hash);
+
+// clang-format off
+/**
+ * Set the root directory containing pre-compiled kernel binaries.
+ *
+ * The directory structure must be:
+ * <binary_path_prefix>/kernels/<kernel_name>/<kernel_hash>/<processor>/<processor>.elf
+ *
+ * This directory structure matches the cache structure (excluding git_hash and build_key components).
+ * You can copy it from: ~/.cache/tt-metal-cache/<git_hash>/<build_key>/
+ *
+ * Must be called before CreateKernelFromBinary().
+ *
+ * EXAMPLE:
+ * ```cpp
+ * // For architecture-specific binaries:
+ * std::string binary_path;
+ * if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+ *     binary_path = "deployment/wormhole/kernels";
+ * } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+ *     binary_path = "deployment/blackhole/kernels";
+ * }
+ * experimental::SetKernelBinaryPathPrefix(device, binary_path);
+ * ```
+ *
+ * Return value: void
+ *
+ * | Argument           | Description                                   | Type                | Valid Range | Required |
+ * |--------------------|-----------------------------------------------|---------------------|-------------|----------|
+ * | device             | The device to set the binary path prefix for | IDevice*             |             | Yes      |
+ * | binary_path_prefix | Root path to directory containing kernels/   | const std::string & |             | Yes      |
+ */
+// clang-format on
+void SetKernelBinaryPathPrefix(IDevice* device, const std::string& binary_path_prefix);
+
+// clang-format off
+/**
+ * Compute a hash of the original kernel source path for use with CreateKernelFromBinary.
+ *
+ * The kernel compilation hash includes a hash of the original source file path. This function
+ * allows you to compute that hash once (during development) and use it in production code
+ * instead of passing the path as a string.
+ *
+ * RECOMMENDED WORKFLOW:
+ * 1. During development, call this function to get the hash for each kernel
+ * 2. Store these hashes as constants in your production code
+ * 3. In production, pass the hash to CreateKernelFromBinary instead of the path string
+ *
+ * EXAMPLE:
+ * ```cpp
+ * // Development: compute hash
+ * auto hash = ComputeKernelOriginalPathHash("tt_metal/kernels/compute/simple_add.cpp");
+ * // Output: 7112760208363739310
+ *
+ * // Production: use hardcoded hash
+ * constexpr size_t SIMPLE_ADD_HASH = 7112760208363739310ULL;
+ * CreateKernelFromBinary(program, "simple_add", core_spec, config, SIMPLE_ADD_HASH);
+ * ```
+ *
+ * Return value: size_t - Hash of the path that can be passed to CreateKernelFromBinary
+ *
+ * | Argument      | Description                                            | Type                | Valid Range | Required |
+ * |---------------|--------------------------------------------------------|---------------------|-------------|----------|
+ * | original_path | The original path of the kernel source (the .cpp file) | const std::string & |             | Yes      |
+ */
+// clang-format on
+size_t ComputeKernelOriginalPathHash(const std::string& original_path);
+
+}  // namespace experimental
+
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -125,6 +125,8 @@ private:
     // Num Virtual Eth Cores == Max Number of Eth Cores across all opened devices (Issue #19729)
     std::size_t num_virtual_eth_cores_ = 0;
     std::unique_ptr<program_cache::detail::ProgramCache> program_cache_;
+    // Kernel binary path prefix for pre-compiled kernels (experimental)
+    std::string kernel_binary_path_prefix_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
     // Recursively quiesce all submeshes.
@@ -257,6 +259,10 @@ public:
     uint32_t num_sub_devices() const override;
     bool is_mmio_capable() const override;
     std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
+
+    // Kernel binary path prefix for pre-compiled kernels (experimental)
+    void set_kernel_binary_path_prefix(const std::string& prefix) override { kernel_binary_path_prefix_ = prefix; }
+    const std::string& get_kernel_binary_path_prefix() const override { return kernel_binary_path_prefix_; }
 
     // A MeshDevice is a collection of devices arranged in a 2D grid.
     // The type parameter allows the caller to specify how to linearize the devices in the mesh.

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -106,10 +106,11 @@ struct KernelDescriptor {
         DataMovementConfigDescriptor,
         ComputeConfigDescriptor,
         EthernetConfigDescriptor>;
-    enum class SourceType { FILE_PATH, SOURCE_CODE };
+    enum class SourceType { FILE_PATH, SOURCE_CODE, EXPERIMENTAL_BINARY_PATH [[deprecated]] };
 
     std::string kernel_source;
     SourceType source_type = SourceType::FILE_PATH;
+    std::variant<std::string, size_t> binary_hash;
 
     CoreRangeSet core_ranges;
     CompileTimeArgs compile_time_args;

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -178,6 +178,10 @@ public:
         this->mesh_device = mesh_device;
     };
 
+    // Kernel binary path prefix for pre-compiled kernels (experimental)
+    void set_kernel_binary_path_prefix(const std::string& prefix) override { kernel_binary_path_prefix_ = prefix; }
+    const std::string& get_kernel_binary_path_prefix() const override { return kernel_binary_path_prefix_; }
+
 private:
     static constexpr uint32_t DEFAULT_NUM_SUB_DEVICES = 1;
 
@@ -220,6 +224,9 @@ private:
 
     uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
+
+    // Kernel binary path prefix for pre-compiled kernels (experimental)
+    std::string kernel_binary_path_prefix_;
     uint8_t num_hw_cqs_ = 1;
 
     // SystemMemoryManager is the interface to the hardware command queue

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -7,6 +7,8 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <kernel_types.hpp>
+#include <host_api.hpp>
+#include <tt-metalium/experimental/precompiled_kernel.hpp>
 #include <enchantum/enchantum.hpp>
 #include <tt_stl/tt_stl/reflection.hpp>
 #include <algorithm>
@@ -93,12 +95,74 @@ fs::path resolve_path(const fs::path& given_file_name) {
 }
 }  // namespace
 
-KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
-    source_(source), source_type_(source_type) {
+// Unified constructor with explicit SourceType
+KernelSource::KernelSource(SourceType source_type, const std::string& source) :
+    source_(source), source_type_(source_type), original_path_or_hash_(std::string("")) {
     if (source_type == FILE_PATH) {
         path_ = resolve_path(source);
+    } else if (source_type == SOURCE_CODE) {
+        // No path validation needed for source code
+    } else {
+        TT_THROW(
+            "Invalid SourceType {} for 2-parameter constructor. Use 3-parameter constructor for BINARY_PATH.",
+            source_type);
     }
-};
+}
+
+// Constructor for BINARY_PATH kernels (needs additional parameter)
+KernelSource::KernelSource(
+    SourceType source_type,
+    const std::string& kernel_name,
+    const std::variant<std::string, size_t>& original_path_or_hash) :
+    source_(kernel_name), source_type_(source_type), original_path_or_hash_(original_path_or_hash) {
+    if (source_type != BINARY_PATH) {
+        TT_THROW("Invalid SourceType {} for 3-parameter constructor. Only BINARY_PATH is supported.", source_type);
+    }
+    path_ = kernel_name;
+}
+
+size_t KernelSource::get_original_path_hash() const {
+    return std::visit(
+        [](const auto& value) -> size_t {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<T, std::string>) {
+                // Use the same hash computation as the public API
+                return tt::tt_metal::experimental::ComputeKernelOriginalPathHash(value);
+            } else {
+                return value;  // already a hash
+            }
+        },
+        original_path_or_hash_);
+}
+
+std::string KernelSource::generate_elf_path(
+    const IDevice* device, const Kernel* kernel, int processor_index, const std::string& jit_target_path) const {
+    if (this->source_type_ == KernelSource::BINARY_PATH) {
+        // For BINARY_PATH kernels, construct path to match JIT cache structure
+        const std::string& device_prefix = device->get_kernel_binary_path_prefix();
+
+        // Extract the kernel full name which contains: kernel_name/hash/
+        // The kernel_full_name_ is set during JIT compilation as: kernel_name/hash/
+        const std::string& kernel_full_name = kernel->get_full_kernel_name();
+
+        // Use HAL jit build query to get the correct processor directory name
+        const auto& hal = MetalContext::instance().hal();
+        const auto& jit_build_query = hal.get_jit_build_query();
+        HalJitBuildQueryInterface::Params params{
+            false,  // is_fw
+            kernel->get_kernel_programmable_core_type(),
+            kernel->get_kernel_processor_class(),
+            processor_index};
+        std::string processor_dir = jit_build_query.target_name(params);
+
+        // Construct full path matching JIT structure: prefix/kernel_full_name/processor_dir/processor_dir.elf
+        // kernel_full_name already contains trailing slash
+        return fmt::format("{}/{}{}/{}.elf", device_prefix, kernel_full_name, processor_dir, processor_dir);
+    } else {
+        // For JIT-compiled kernels, return the provided target path
+        return jit_target_path;
+    }
+}
 
 Kernel::Kernel(
     HalProgrammableCoreType programmable_core_type,
@@ -147,6 +211,8 @@ void Kernel::register_kernel_with_watcher() {
     if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
         this->watcher_kernel_id_ =
             MetalContext::instance().watcher_server()->register_kernel(this->kernel_src_.source_);
+    } else if (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH) {
+        this->watcher_kernel_id_ = MetalContext::instance().watcher_server()->register_kernel(this->name());
     } else {
         TT_FATAL(this->kernel_src_.source_type_ == KernelSource::SOURCE_CODE, "Unsupported kernel source type!");
         this->watcher_kernel_id_ = MetalContext::instance().watcher_server()->register_kernel(this->name());
@@ -247,6 +313,23 @@ void Kernel::process_named_compile_time_args(
 }
 
 bool Kernel::binaries_exist_on_disk(const IDevice* device) const {
+    // If kernel source is a binary path, check if the binary actually exists
+    if (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH) {
+        // Check all expected binaries for this kernel type
+        for (int i = 0; i < this->expected_num_binaries(); ++i) {
+            int processor_index = this->get_kernel_processor_type(i);
+            if (!std::filesystem::exists(
+                    this->kernel_src_.generate_elf_path(device, this, processor_index, this->kernel_src_.path_))) {
+                log_info(
+                    LogLoader,
+                    "Binary does not exist on disk: {}",
+                    this->kernel_src_.generate_elf_path(device, this, processor_index, this->kernel_src_.path_));
+                return false;
+            }
+        }
+        return true;
+    }
+
     const uint32_t core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
@@ -271,10 +354,16 @@ std::vector<std::string> Kernel::file_paths(IDevice& device) const {
     auto& hal = MetalContext::instance().hal();
     uint32_t core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
+
     for (int i = 0; i < this->expected_num_binaries(); i++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
             device.build_id(), core_type, processor_class, this->get_kernel_processor_type(i));
-        file_paths.push_back(build_state.get_target_out_path(this->kernel_full_name_));
+        std::string jit_target_path = build_state.get_target_out_path(this->kernel_full_name_);
+
+        std::string elf_path =
+            this->kernel_src_.generate_elf_path(&device, this, this->get_kernel_processor_type(i), jit_target_path);
+
+        file_paths.push_back(elf_path);
     }
     return file_paths;
 }
@@ -290,7 +379,15 @@ uint8_t ComputeKernel::expected_num_binaries() const {
 
 const std::vector<const ll_api::memory*>& Kernel::binaries(uint64_t build_key) const {
     auto iter = binaries_.find(build_key);
-    TT_FATAL(iter != binaries_.end(), "binary not found");
+    if (iter == binaries_.end()) {
+        TT_FATAL(
+            false,
+            "Binary not found for kernel '{}' (source: '{}', type: {})",
+            this->name(),
+            this->kernel_src_.source_,
+            KernelSource::source_type_to_string(this->kernel_src_.source_type_));
+    }
+
     if (iter->second.size() != expected_num_binaries()) {
         TT_THROW(
             "Expected {} binaries but have {} for kernel {}",
@@ -354,6 +451,9 @@ std::string ComputeKernel::config_hash() const {
 
 std::string Kernel::compute_hash() const {
     size_t define_hash_value = 0;
+    size_t kernel_src_hash = (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH)
+                                 ? this->kernel_src_.get_original_path_hash()
+                                 : std::hash<std::string>{}(this->kernel_src_.source_);
     for (const auto& [define, value] : this->defines_) {
         ttsl::hash::hash_combine(define_hash_value, std::hash<std::string>{}(define + value));
     }
@@ -362,7 +462,7 @@ std::string Kernel::compute_hash() const {
 
     return fmt::format(
         "{}_{}_{}_{}_{}",
-        std::hash<std::string>{}(this->kernel_src_.source_),
+        kernel_src_hash,
         fmt::join(this->compile_time_args_, "_"),
         define_hash_value,
         named_args_hash_value,
@@ -548,6 +648,11 @@ void ComputeKernel::set_build_options(JitBuildOptions& build_options) const {
 }
 
 void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
+    // Skip generation if using pre-compiled binaries
+    if (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH) {
+        return;
+    }
+
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type =
@@ -561,6 +666,11 @@ void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*b
 }
 
 void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
+    // Skip generation if using pre-compiled binaries
+    if (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH) {
+        return;
+    }
+
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t erisc_core_type =
@@ -574,6 +684,11 @@ void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build
 }
 
 void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
+    // Skip generation if using pre-compiled binaries
+    if (this->kernel_src_.source_type_ == KernelSource::BINARY_PATH) {
+        return;
+    }
+
     jit_build_genfiles_triscs_src(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type =
@@ -596,7 +711,7 @@ void Kernel::set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>
 }
 
 void DataMovementKernel::read_binaries(IDevice* device) {
-    TT_ASSERT(this->binaries_exist_on_disk(device));
+    TT_FATAL(this->binaries_exist_on_disk(device), "cannot read binaries for kernel {}", this->name());
     std::vector<const ll_api::memory*> binaries;
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
@@ -605,12 +720,16 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
+
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
         device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+    std::string jit_target_path = build_state.get_target_out_path(this->kernel_full_name_);
+
+    std::string binary_path = this->kernel_src_.generate_elf_path(device, this, riscv_id, jit_target_path);
+
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id).memory_load;
-    const ll_api::memory& binary_mem =
-        llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+    const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
     binaries.push_back(&binary_mem);
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
@@ -620,19 +739,23 @@ void DataMovementKernel::read_binaries(IDevice* device) {
 
 void EthernetKernel::read_binaries(IDevice* device) {
     // untested
-    TT_ASSERT(this->binaries_exist_on_disk(device));
+    TT_FATAL(this->binaries_exist_on_disk(device), "cannot read binaries for kernel {}", this->name());
     std::vector<const ll_api::memory*> binaries;
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     constexpr auto k_EthDmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
+
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
         device->build_id(), erisc_core_type, k_EthDmClassIndex, erisc_id);
+    std::string jit_target_path = build_state.get_target_out_path(this->kernel_full_name_);
+
+    std::string binary_path = this->kernel_src_.generate_elf_path(device, this, erisc_id, jit_target_path);
     // TODO: fix when active eth supports relo
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(erisc_core_type, k_EthDmClassIndex, erisc_id).memory_load;
-    const ll_api::memory& binary_mem = llrt::get_risc_binary(
-        build_state.get_target_out_path(this->kernel_full_name_), load_type, [this](ll_api::memory& binary_mem) {
+    const ll_api::memory& binary_mem =
+        llrt::get_risc_binary(binary_path, load_type, [this](ll_api::memory& binary_mem) {
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
                 this->config_.eth_mode != Eth::IDLE) {
                 // text_addr and some of span's addr point to IRAM base address.
@@ -655,7 +778,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
 }
 
 void ComputeKernel::read_binaries(IDevice* device) {
-    TT_ASSERT(this->binaries_exist_on_disk(device));
+    TT_FATAL(this->binaries_exist_on_disk(device), "cannot read binaries for kernel {}", this->name());
     std::vector<const ll_api::memory*> binaries;
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -663,12 +786,15 @@ void ComputeKernel::read_binaries(IDevice* device) {
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
             device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
+        std::string jit_target_path = build_state.get_target_out_path(this->kernel_full_name_);
+
+        std::string binary_path = this->kernel_src_.generate_elf_path(device, this, trisc_id, jit_target_path);
+
         auto load_type = MetalContext::instance()
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
                              .memory_load;
-        const ll_api::memory& binary_mem =
-            llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
+        const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -6,6 +6,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 #include <string>
+#include <fmt/format.h>
 
 #include "api/tt-metalium/data_types.hpp"
 #include "api/tt-metalium/kernel_types.hpp"
@@ -21,19 +22,32 @@
 
 namespace tt::tt_metal {
 
+class KernelImpl;  // Forward declaration
+
 struct KernelSource {
-    enum SourceType { FILE_PATH, SOURCE_CODE };
+    enum SourceType { FILE_PATH, SOURCE_CODE, BINARY_PATH };
 
     std::string source_;
     SourceType source_type_;
+    std::variant<std::string, size_t>
+        original_path_or_hash_;  // If user wants to hide the original path, they can provide a hash instead
     // if source_type_ is FILE_PATH, file pointed by path_ exists at time of construction
-    std::filesystem::path path_;
+    // if source_type_ is BINARY_PATH, path_ points to the precompiled binary file/directory
+    std::filesystem::path
+        path_;  // .cpp if source_type_=FILE_PATH OR or directory with binaries if source_type_=BINARY_PATH
 
-    KernelSource(const std::string& source, const SourceType& source_type);
+    // Unified constructor with explicit SourceType
+    explicit KernelSource(SourceType source_type, const std::string& source);
+
+    // Constructor for BINARY_PATH kernels (needs additional parameter)
+    explicit KernelSource(
+        SourceType source_type,
+        const std::string& kernel_name,
+        const std::variant<std::string, size_t>& original_path_or_hash);
 
     std::string name() const {
         std::string name;
-        if (this->source_type_ == SourceType::FILE_PATH) {
+        if (this->source_type_ == SourceType::FILE_PATH || this->source_type_ == SourceType::BINARY_PATH) {
             const std::size_t start_pos_of_name = this->source_.rfind("/") + 1;
             const std::size_t pos_of_dot = this->source_.rfind(".");
             name = this->source_.substr(start_pos_of_name, (pos_of_dot - start_pos_of_name));
@@ -41,6 +55,28 @@ struct KernelSource {
             name = "Kernel_Source_Code";
         }
         return name;
+    }
+
+    // Get the original path hash for BINARY_PATH kernels
+    // Uses the same hash computation as the public API
+    size_t get_original_path_hash() const;
+
+    // Generate ELF path for a specific processor configuration
+    // For BINARY_PATH: constructs path as device_prefix/kernel_name/kernel_hash/processor_dir/processor_dir.elf
+    // For other types: uses JIT build system to get target path
+    std::string generate_elf_path(
+        const IDevice* device,
+        const Kernel* kernel,
+        int processor_index,
+        const std::string& jit_target_path = "") const;
+
+    static std::string_view source_type_to_string(KernelSource::SourceType source_type) {
+        switch (source_type) {
+            case FILE_PATH: return "FILE_PATH";
+            case SOURCE_CODE: return "SOURCE_CODE";
+            case BINARY_PATH: return "BINARY_PATH";
+            default: return "UNKNOWN";
+        }
     }
 };
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -9,6 +9,7 @@
 #include <graph_tracking.hpp>
 #include <enchantum/enchantum.hpp>
 #include <memory_reporter.hpp>
+#include <tt-metalium/experimental/precompiled_kernel.hpp>
 #include "impl/buffers/semaphore.hpp"
 #include <tt_align.hpp>
 #include <algorithm>
@@ -168,12 +169,14 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
     // configuration (necessary for dispatch kernels).
     // Also account for watcher/dprint enabled in hash because they enable additional code to
     // be compiled into the kernel.
+    // Account for architecture in hash because binaries are different for different architectures, but
+    // the same for different devices of the same architecture.
     std::string compile_hash_str = fmt::format(
         "{}_{}_{}_{}",
-        build_key,
         std::to_string(std::hash<tt_hlk_desc>{}(build_options.hlk_desc)),
         kernel->compute_hash(),
-        tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
+        tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string(),
+        build_key);
     size_t compile_hash = std::hash<std::string>{}(compile_hash_str);
 
 #ifdef GENERATE_HASH_LOG
@@ -181,8 +184,9 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
     static std::mutex mutex_;
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        f << kernel->name() << " :: " << build_key << "::" << std::hash<tt_hlk_desc>{}(build_options.hlk_desc)
-          << " :: " << kernel->compute_hash() << " :: " << compile_hash_str << " " << compile_hash << std::endl
+        f << kernel->name() << "::" << std::hash<tt_hlk_desc>{}(build_options.hlk_desc)
+          << " :: " << kernel->compute_hash() << "::" << arch << " :: " << compile_hash_str << " " << compile_hash
+          << std::endl
           << std::flush;
     }
 #endif
@@ -241,7 +245,8 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
     }
 
     for (auto& kernel_descriptor : descriptor.kernels) {
-        bool is_file = kernel_descriptor.source_type == KernelDescriptor::SourceType::FILE_PATH;
+        bool is_src_file = kernel_descriptor.source_type == KernelDescriptor::SourceType::FILE_PATH;
+        bool is_binary = kernel_descriptor.source_type == KernelDescriptor::SourceType::EXPERIMENTAL_BINARY_PATH;
         std::vector<uint32_t> compile_args(
             kernel_descriptor.compile_time_args.begin(), kernel_descriptor.compile_time_args.end());
         std::map<std::string, std::string> defines(kernel_descriptor.defines.begin(), kernel_descriptor.defines.end());
@@ -305,9 +310,16 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
             kernel_descriptor.config);
 
         auto kernel_handle =
-            is_file
+            is_src_file
                 ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
-                : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
+                : (is_binary ? tt_metal::experimental::CreateKernelFromBinary(
+                                   *this,
+                                   kernel_descriptor.kernel_source,
+                                   kernel_descriptor.core_ranges,
+                                   config,
+                                   kernel_descriptor.binary_hash)
+                             : CreateKernelFromString(
+                                   *this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config));
 
         for (size_t i = 0; i < kernel_descriptor.runtime_args.size(); i++) {
             for (size_t j = 0; j < kernel_descriptor.runtime_args[i].size(); j++) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -60,6 +60,10 @@ string get_kernel_source_to_include(const KernelSource& kernel_src) {
             return "#include \"" + kernel_src.path_.string() + "\"\n";
         }
         case KernelSource::SOURCE_CODE: return kernel_src.source_;
+        case KernelSource::BINARY_PATH: {
+            // For binary kernels, no source code needs to be included since they're already compiled
+            return "";
+        }
     }
     ttsl::unreachable();
 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1013,7 +1013,7 @@ KernelHandle CreateDataMovementKernel(
     const bool are_both_noc_in_use = data_movement_config_status.noc0_in_use && data_movement_config_status.noc1_in_use;
 
     std::string kernel_name;
-    if (kernel_src.source_type_ == KernelSource::FILE_PATH) {
+    if (kernel_src.source_type_ == KernelSource::FILE_PATH || kernel_src.source_type_ == KernelSource::BINARY_PATH) {
         kernel_name = kernel_src.source_;
     } else {
         TT_FATAL(kernel_src.source_type_ == KernelSource::SOURCE_CODE, "Unsupported kernel source type!");
@@ -1118,7 +1118,7 @@ KernelHandle CreateKernel(
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     CoreRangeSet core_ranges = GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+    KernelSource kernel_src(KernelSource::FILE_PATH, file_name);
     KernelHandle kernel = std::visit(
         ttsl::overloaded{
             [&](const DataMovementConfig& cfg) {
@@ -1139,7 +1139,7 @@ KernelHandle CreateKernelFromString(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config) {
     CoreRangeSet core_ranges = GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(kernel_src_code, KernelSource::SOURCE_CODE);
+    KernelSource kernel_src(KernelSource::SOURCE_CODE, kernel_src_code);
     return std::visit(
         ttsl::overloaded{
             [&](const DataMovementConfig& cfg) {
@@ -1419,6 +1419,35 @@ void UpdateDynamicCircularBufferAddress(
     auto circular_buffer = program.impl().get_circular_buffer(cb_handle);
     TT_FATAL(circular_buffer->is_global_circular_buffer(), "CircularBuffer must be linked to a GlobalCircularBuffer!");
     circular_buffer->set_global_circular_buffer(global_circular_buffer);
+}
+
+void SetKernelBinaryPathPrefix(IDevice* device, const std::string& binary_path_prefix) {
+    // Store the binary path prefix on the device
+    // This will be used when constructing paths for BINARY_PATH kernels
+    device->set_kernel_binary_path_prefix(binary_path_prefix);
+}
+
+size_t ComputeKernelOriginalPathHash(const std::string& original_path) {
+    return std::hash<std::string>{}(original_path);
+}
+
+KernelHandle CreateKernelFromBinary(
+    Program& program,
+    const std::string& kernel_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config,
+    const std::variant<std::string, size_t>& original_path_or_hash) {
+    KernelSource kernel_src(KernelSource::BINARY_PATH, kernel_name, original_path_or_hash);
+    CoreRangeSet core_ranges = GetCoreRangeSet(core_spec);
+    return std::visit(
+        ttsl::overloaded{
+            [&](const DataMovementConfig& cfg) {
+                return CreateDataMovementKernel(program, kernel_src, core_ranges, cfg);
+            },
+            [&](const ComputeConfig& cfg) { return CreateComputeKernel(program, kernel_src, core_ranges, cfg); },
+            [&](const EthernetConfig& cfg) { return CreateEthernetKernel(program, kernel_src, core_ranges, cfg); },
+        },
+        config);
 }
 
 }  // namespace experimental

--- a/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
@@ -171,7 +171,11 @@ void py_module_types(py::module& module) {
         Defines whether the kernel source is provided as a file path or inline source code.
     )pbdoc")
         .value("FILE_PATH", tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH, "Kernel source is a file path")
-        .value("SOURCE_CODE", tt::tt_metal::KernelDescriptor::SourceType::SOURCE_CODE, "Kernel source is inline code");
+        .value("SOURCE_CODE", tt::tt_metal::KernelDescriptor::SourceType::SOURCE_CODE, "Kernel source is inline code")
+        .value(
+            "BINARY_PATH",
+            tt::tt_metal::KernelDescriptor::SourceType::EXPERIMENTAL_BINARY_PATH,
+            "Kernel source is a binary path");
 
     kernel_descriptor_class
         .def(py::init<>(), R"pbdoc(
@@ -181,6 +185,7 @@ void py_module_types(py::module& module) {
             py::init<
                 const std::string&,
                 tt::tt_metal::KernelDescriptor::SourceType,
+                std::variant<std::string, size_t>,
                 CoreRangeSet,
                 tt::tt_metal::KernelDescriptor::CompileTimeArgs,
                 tt::tt_metal::KernelDescriptor::Defines,
@@ -190,6 +195,7 @@ void py_module_types(py::module& module) {
                 tt::tt_metal::KernelDescriptor::ConfigDescriptor>(),
             py::arg("kernel_source"),
             py::arg("source_type") = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH,
+            py::arg("binary_hash") = "",
             py::arg("core_ranges"),
             py::arg("compile_time_args"),
             py::arg("defines") = tt::tt_metal::KernelDescriptor::Defines(),
@@ -202,7 +208,8 @@ void py_module_types(py::module& module) {
 
                 Args:
                     kernel_source: Path to kernel source file or inline kernel source code
-                    source_type: Type of source (FILE_PATH or INLINE)
+                    source_type: Type of source (FILE_PATH, INLINE, BINARY_PATH)
+                    binary_hash: Original path or hash of the kernel source when providing a binary path
                     core_ranges: Set of core ranges where the kernel will execute
                     compile_time_args: Arguments provided at compile time
                     defines: Preprocessor definitions for kernel compilation


### PR DESCRIPTION
### Ticket
This is a PoC solution to:
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11006)

### Problem description
Described in the issue linked above.

### What's changed
This PR adds an experimental API call CreateKernelFromBinary, which allows to by-pass compilation from source and use pre-compiled elf binaries. 

[Example usage](https://github.com/tenstorrent/tt-metal/blob/prybicki/aot-compilation-poc-test/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes