### PR TITLE
Prefill trace for Llama-3.1-8B

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -35,9 +35,84 @@ jobs:
       matrix:
         default-demo-tests:
           [[
+            { name: "falcon7b", runner-label: "N150", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
             { name: "llama3", runner-label: "N150", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
+            { name: "vgg", runner-label: "N150", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
+            { name: "bert_tiny", runner-label: "N150", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
+            { name: "bert", runner-label: "N150", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
+            { name: "resnet", runner-label: "N150", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
+            { name: "distilbert", runner-label: "N150", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
+            { name: "mnist", runner-label: "N150", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
+            { name: "squeezebert", runner-label: "N150", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, # Joseph Chu
+            { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
+            { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
+            { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov11", runner-label: "N150", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov11m", runner-label: "N150", performance: false, cmd: run_yolov11m_func, owner_id: U04B9QAMM4N, civ2-compatible: true}, # Dimitri Gnidash
+            { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov8s_world", runner-label: "N150", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "swin_s", runner-label: "N150", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
+            { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+            { name: "yolov8x", runner-label: "N150", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov8s", runner-label: "N150", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+            { name: "yolov4", runner-label: "N150", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
+            { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
+            { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func, owner_id: U0837MYG788}, # Marko Radosavljevic
+            { name: "yolov10x", runner-label: "N150", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov12x", runner-label: "N150", performance: false, cmd: run_yolov12x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov7", runner-label: "N150", performance: false, cmd: run_yolov7_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov6l", runner-label: "N150", performance: false, cmd: run_yolov6l_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "efficientnet_b0", runner-label: "N150", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "vovnet", runner-label: "N150", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "swin_v2", runner-label: "N150", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov5x", runner-label: "N150", performance: false, cmd: "pytest models/demos/yolov5x/demo/demo.py", owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "swin_s", runner-label: "N300", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
+            { name: "falcon7b", runner-label: "N300", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
             { name: "llama3", runner-label: "N300", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
+            { name: "vgg", runner-label: "N300", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
+            { name: "bert_tiny", runner-label: "N300", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
+            { name: "bert", runner-label: "N300", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
+            { name: "resnet", runner-label: "N300", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
+            { name: "distilbert", runner-label: "N300", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
+            { name: "mnist", runner-label: "N300", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
+            { name: "squeezebert", runner-label: "N300", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, #Joseph Chu
+            { name: "yolov8x", runner-label: "N300", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov8s", runner-label: "N300", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov9c", runner-label: "N300", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+            { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
             { name: "llama3", runner-label: "N300", performance: true, cmd: run_llama3_perf, owner_id: U03PUAKE719}, # Miguel Tairum
+            { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
+            { name: "efficientnet_b0", runner-label: "N300", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "whisper", runner-label: "N300", performance: true, cmd: run_whisper_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
+  #          { name: "mamba", runner-label: "N300", performance: true, cmd: run_mamba_perf, owner_id: U06ECNVR0EN}, # Evan Smal
+            { name: "segformer", runner-label: "N300", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
+            { name: "sentence_bert", runner-label: "N300", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov11", runner-label: "N300", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov11m", runner-label: "N300", performance: false, cmd: run_yolov11m_func, owner_id: U04B9QAMM4N, civ2-compatible: true}, # Dimitri Gnidash
+            { name: "yolov8s_world", runner-label: "N300", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+            { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
+            { name: "yolov4", runner-label: "N300", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
+            { name: "yolov10x", runner-label: "N300", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov7", runner-label: "N300", performance: false, cmd: run_yolov7_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov6l", runner-label: "N300", performance: false, cmd: run_yolov6l_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "yolov12x", runner-label: "N300", performance: false, cmd: run_yolov12x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "vovnet", runner-label: "N300", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "swin_v2", runner-label: "N300", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            { name: "yolov5x", runner-label: "N300", performance: false, cmd: "pytest models/demos/yolov5x/demo/demo.py", owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            # Moved to t3k tests until OOM on single card runners resolved
+            # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
+            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_perfunc, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+            { name: "ds_r1_qwen", runner-label: "N300", performance: false, cmd: run_ds_r1_qwen_func, owner_id: U07RY6B5FLJ, civ2-compatible: true},  #Gongyu Wang
+            # { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews TODO: Gemma3 N150 tests pulled due to OOM; will be addressed in future PR
+            { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews
+            { name: "phi4", runner-label: "N300", performance: false, cmd: run_phi4_func, owner_id: U094PKWHNJ0, civ2-compatible: true},  # Petar Milojevic
           ]]
     steps:
       - name: Compute tests

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -35,84 +35,9 @@ jobs:
       matrix:
         default-demo-tests:
           [[
-            { name: "falcon7b", runner-label: "N150", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
             { name: "llama3", runner-label: "N150", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "vgg", runner-label: "N150", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
-            { name: "bert_tiny", runner-label: "N150", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "bert", runner-label: "N150", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "resnet", runner-label: "N150", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "distilbert", runner-label: "N150", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
-            { name: "mnist", runner-label: "N150", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "squeezebert", runner-label: "N150", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, # Joseph Chu
-            { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
-            { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
-            { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov11", runner-label: "N150", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov11m", runner-label: "N150", performance: false, cmd: run_yolov11m_func, owner_id: U04B9QAMM4N, civ2-compatible: true}, # Dimitri Gnidash
-            { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov8s_world", runner-label: "N150", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_s", runner-label: "N150", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
-            { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "yolov8x", runner-label: "N150", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov8s", runner-label: "N150", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "yolov4", runner-label: "N150", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
-            { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "yolov10x", runner-label: "N150", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov12x", runner-label: "N150", performance: false, cmd: run_yolov12x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov7", runner-label: "N150", performance: false, cmd: run_yolov7_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov6l", runner-label: "N150", performance: false, cmd: run_yolov6l_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "efficientnet_b0", runner-label: "N150", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "vovnet", runner-label: "N150", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_v2", runner-label: "N150", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov5x", runner-label: "N150", performance: false, cmd: "pytest models/demos/yolov5x/demo/demo.py", owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_s", runner-label: "N300", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
-            { name: "falcon7b", runner-label: "N300", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
             { name: "llama3", runner-label: "N300", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "vgg", runner-label: "N300", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
-            { name: "bert_tiny", runner-label: "N300", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "bert", runner-label: "N300", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "resnet", runner-label: "N300", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "distilbert", runner-label: "N300", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
-            { name: "mnist", runner-label: "N300", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "squeezebert", runner-label: "N300", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, #Joseph Chu
-            { name: "yolov8x", runner-label: "N300", performance: false, cmd: run_yolov8x_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov8s", runner-label: "N300", performance: false, cmd: run_yolov8s_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov9c", runner-label: "N300", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-            { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
             { name: "llama3", runner-label: "N300", performance: true, cmd: run_llama3_perf, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
-            { name: "efficientnet_b0", runner-label: "N300", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "whisper", runner-label: "N300", performance: true, cmd: run_whisper_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
-  #          { name: "mamba", runner-label: "N300", performance: true, cmd: run_mamba_perf, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "segformer", runner-label: "N300", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
-            { name: "sentence_bert", runner-label: "N300", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov11", runner-label: "N300", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov11m", runner-label: "N300", performance: false, cmd: run_yolov11m_func, owner_id: U04B9QAMM4N, civ2-compatible: true}, # Dimitri Gnidash
-            { name: "yolov8s_world", runner-label: "N300", performance: false, cmd: run_yolov8s_world_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "yolov4", runner-label: "N300", performance: false, cmd: run_yolov4_perf, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (Sudhanshu Singhal)
-            { name: "yolov10x", runner-label: "N300", performance: false, cmd: run_yolov10x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov7", runner-label: "N300", performance: false, cmd: run_yolov7_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov6l", runner-label: "N300", performance: false, cmd: run_yolov6l_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "yolov12x", runner-label: "N300", performance: false, cmd: run_yolov12x_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "vovnet", runner-label: "N300", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_v2", runner-label: "N300", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov5x", runner-label: "N300", performance: false, cmd: "pytest models/demos/yolov5x/demo/demo.py", owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            # Moved to t3k tests until OOM on single card runners resolved
-            # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
-            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_perfunc, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-            { name: "ds_r1_qwen", runner-label: "N300", performance: false, cmd: run_ds_r1_qwen_func, owner_id: U07RY6B5FLJ, civ2-compatible: true},  #Gongyu Wang
-            # { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews TODO: Gemma3 N150 tests pulled due to OOM; will be addressed in future PR
-            { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews
-            { name: "phi4", runner-label: "N300", performance: false, cmd: run_phi4_func, owner_id: U094PKWHNJ0, civ2-compatible: true},  # Petar Milojevic
           ]]
     steps:
       - name: Compute tests

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1255,6 +1255,28 @@ class ModelArgs:
             )
             logger.info(f"LM head grid: {self.lm_head_core_grid}")
 
+    def can_enable_trace(self, prefill_seq_len):
+        """
+        This function is used to determine if trace should be enabled for the prefill.
+        Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
+        If we have chunked prefill, we disable tracing because there is no support to pass parameters such as chunk_start and chunk_end to trace.
+        There is no support to pass them as a tensor, and then inside the trace read it as a number.
+        # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
+        """
+        # Trace in prefill is currently supported only for Llama-3.1-8B
+        # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
+        if self.base_model_name != "Llama-3.1-8B":
+            return False
+        if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
+            return False
+
+        if self.device_name == "N150":
+            allowed_seq_lens = [128, 256, 512, 1024]
+        else:
+            allowed_seq_lens = [128, 256, 512, 1024, 2048, 4096, 8192]
+
+        return prefill_seq_len in allowed_seq_lens and prefill_seq_len <= self.max_prefill_chunk_size
+
     def get_xqkv_prefill_mem_cfg(self, seq_len):
         return ttnn.create_sharded_memory_config(
             (((self.n_kv_heads // self.cluster_shape[1]) * seq_len // (8 * 8)), self.head_dim),

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -549,7 +549,7 @@ def prepare_generator_args(
             1,  # repeat_batches
             1024,  # max_seq_len
             1,  # batch_size
-            500,  # max_generated_tokens
+            2,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -549,7 +549,7 @@ def prepare_generator_args(
             1,  # repeat_batches
             1024,  # max_seq_len
             1,  # batch_size
-            2,  # max_generated_tokens
+            500,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -626,7 +626,7 @@ def prepare_generator_args(
     ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 184915840, "num_command_queues": 1}], indirect=True
+    "device_params", [{"fabric_config": True, "trace_region_size": 70000000, "num_command_queues": 1}], indirect=True
 )
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -626,7 +626,7 @@ def prepare_generator_args(
     ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 60000000, "num_command_queues": 1}], indirect=True
+    "device_params", [{"fabric_config": True, "trace_region_size": 184915840, "num_command_queues": 1}], indirect=True
 )
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -626,7 +626,7 @@ def prepare_generator_args(
     ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 30000000, "num_command_queues": 1}], indirect=True
+    "device_params", [{"fabric_config": True, "trace_region_size": 60000000, "num_command_queues": 1}], indirect=True
 )
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1285,8 +1285,8 @@ def test_demo_text(
                 # T3K targets
                 "T3K_Llama-3.1-70B": 228,
                 "T3K_Qwen2.5-72B": (290, 1.35),  # (value, high_tolerance_ratio)
-                "T3K_Qwen2.5-Coder-32B": (215, 1.27),  # (value, high_tolerance_ratio)
-                "T3K_Qwen3-32B": 230,  # Issue: Perf regression being tracked on issue #29834
+                "T3K_Qwen2.5-Coder-32B": (275, 1.55),  # (value, high_tolerance_ratio)
+                "T3K_Qwen3-32B": 100,  # Issue: Perf regression being tracked on issue #29834
             }
             ci_target_decode_tok_s_u = {
                 # N150 targets - higher is better

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1285,8 +1285,8 @@ def test_demo_text(
                 # T3K targets
                 "T3K_Llama-3.1-70B": 228,
                 "T3K_Qwen2.5-72B": (290, 1.35),  # (value, high_tolerance_ratio)
-                "T3K_Qwen2.5-Coder-32B": (275, 1.55),  # (value, high_tolerance_ratio)
-                "T3K_Qwen3-32B": 100,  # Issue: Perf regression being tracked on issue #29834
+                "T3K_Qwen2.5-Coder-32B": (215, 1.27),  # (value, high_tolerance_ratio)
+                "T3K_Qwen3-32B": 230,  # Issue: Perf regression being tracked on issue #29834
             }
             ci_target_decode_tok_s_u = {
                 # N150 targets - higher is better

--- a/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
@@ -80,9 +80,7 @@ def convert2ref(state_dict):
     (1, None),
     ids=["1layer", "all_layers"],
 )
-@pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 30000000, "num_command_queues": 1}], indirect=True
-)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_model_inference(
     paged_attention,
     page_params,

--- a/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
@@ -97,8 +97,6 @@ def test_model_inference(
     request,
     device_params,
 ):
-    # This must be disabled if tracing is being used!
-    mesh_device.clear_program_cache()
     test_id = request.node.callspec.id
     num_layers = num_layers
     if is_ci_env:
@@ -222,7 +220,6 @@ def test_model_inference(
     start_pos = 0
     # Run TT model
     logger.info(f"Running TT model...")
-    mesh_device.clear_program_cache()
     tt_output_torch = generator.prefill_forward_text(
         tt_prefill_input,
         page_table=page_table,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -220,6 +220,9 @@ class Generator:
             use_chunked_prefill = prefill_ids.shape[-1] > self.model_args[model_id].max_prefill_chunk_size
             if use_chunked_prefill:
                 enable_trace = False
+            logger.info(
+                f"Prefill seq len: {prefill_seq_len}, max_prefill_chunk_size: {self.model_args[model_id].max_prefill_chunk_size}, enable trace: {enable_trace}"
+            )
 
             page_table_user = (
                 self._get_prefill_user_page_table(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -189,6 +189,9 @@ class Generator:
     ):
         if page_table is not None:
             assert isinstance(page_table, torch.Tensor), "page_table mush be torch.Tensor"
+        else:
+            # Only paged attention is supported for prefill
+            enable_trace = False
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -71,7 +71,7 @@ class Generator:
         model_id=-1,
     ):
         host_inputs = self.model[model_id].prepare_prefill_inputs_host(prefill_ids, page_table=page_table)
-        # We don't need to copy these matrices since they are already on device (we took care of that in prepare_prefill_inputs_host)
+        # These matrices will actually be pointing to the whole cos_matrix and sin_matrix that was allocated on device in the RotarySetup class
         tt_rot_mats_prefill_global = host_inputs[1]
         tt_rot_mats_prefill_local = host_inputs[2]
         host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4])

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -70,7 +70,7 @@ class Generator:
         kv_cache=None,
         model_id=-1,
     ):
-        host_inputs = self.model[model_id].prepare_prefill_inputs_host(prefill_ids, page_table=page_table)
+        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, page_table=page_table)
         # These matrices will actually be pointing to the whole cos_matrix and sin_matrix that was allocated on device in the RotarySetup class
         tt_rot_mats_prefill_global = host_inputs[1]
         tt_rot_mats_prefill_local = host_inputs[2]
@@ -149,7 +149,7 @@ class Generator:
         page_table=None,
         model_id=-1,
     ):
-        host_inputs = self.model[model_id].prepare_prefill_inputs_host(prefill_ids, page_table=page_table)
+        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, page_table=page_table)
         host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4])
 
         device_inputs = copy_host_to_device(
@@ -168,7 +168,7 @@ class Generator:
         There is no support to pass them as a tensor, and then inside the trace read it as a number.
         # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
         """
-        if prefill_seq_len not in [128, 256, 512, 1024, 2048, 4096, 8192]:
+        if prefill_seq_len not in [128, 256, 512, 1024, 2048, 4096]:
             return False
         if prefill_seq_len > self.model_args[0].max_prefill_chunk_size:
             return False

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -177,8 +177,6 @@ class Generator:
             # Only paged attention is supported for prefill
             enable_trace = False
 
-        enable_trace = enable_trace and self.model_args[0].model_supports_trace()
-
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size
 
@@ -206,9 +204,7 @@ class Generator:
                 [tokens[idx : idx + 1, :seq_len], torch.zeros(1, prefill_seq_len - seq_len).long()], dim=-1
             )
 
-            enable_trace_current_prompt = enable_trace and self.model_args[model_id].trace_supported_seq_len(
-                prefill_seq_len
-            )
+            enable_trace_current_prompt = enable_trace and self.model_args[model_id].can_enable_trace(prefill_seq_len)
 
             logger.info(
                 f"Prefill seq len: {prefill_seq_len}, max_prefill_chunk_size: {self.model_args[0].max_prefill_chunk_size}, trace: {enable_trace_current_prompt}"

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -176,6 +176,14 @@ class Generator:
             return False
         return True
 
+    def model_supports_trace(self):
+        """
+        This function is used to determine if trace should be enabled for the model.
+        """
+        if "mixtral" in self.model_args[0].model_name.lower():
+            return False
+        return True
+
     # Note: This function is called by vLLM
     def prefill_forward_text(
         self,
@@ -192,6 +200,8 @@ class Generator:
         else:
             # Only paged attention is supported for prefill
             enable_trace = False
+
+        enable_trace = enable_trace and self.model_supports_trace()
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -168,7 +168,7 @@ class Generator:
         There is no support to pass them as a tensor, and then inside the trace read it as a number.
         # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
         """
-        if prefill_seq_len not in [128, 256, 512, 1024, 2048, 4096]:
+        if prefill_seq_len not in [128, 256, 512, 1024, 2048, 4096, 8192]:
             return False
         if prefill_seq_len > self.model_args[0].max_prefill_chunk_size:
             return False

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -172,7 +172,7 @@ class Generator:
             return False
         if prefill_seq_len > self.model_args[0].max_prefill_chunk_size:
             return False
-        if hasattr(self.model_args[0], "sliding_window"):
+        if self.model_args[0].sliding_window != None:
             return False
         return True
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -172,7 +172,7 @@ class Generator:
             return False
         if prefill_seq_len > self.model_args[0].max_prefill_chunk_size:
             return False
-        if self.model_args[0].sliding_window != None:
+        if hasattr(self.model_args[0], "sliding_window") and getattr(self.model_args[0], "sliding_window") != None:
             return False
         return True
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -306,11 +306,6 @@ class Generator:
                 )
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
-        # We need to synchronize to make sure the prefill is finished
-        # We want to make sure that if some processing is done on the host on the tensors used in prefill, that those tensors will have correct data (in other words, that prefill is fully finished)
-        # Synchronization is not needed always (depends on the workflow), but we want to be safe for future workflow changes
-        for model_id in range(self.data_parallel):
-            ttnn.synchronize_device(self.model_args[model_id].mesh_device)
         return output_logits
 
     def prefill_forward_single_user_text(

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -167,7 +167,7 @@ class Transformer(LightweightModule):
         logits = ttnn.to_layout(logits, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return logits
 
-    def prepare_prefill_inputs_host(self, tokens, page_table=None, chunk_page_table=None):
+    def prepare_prefill_inputs_trace(self, tokens, page_table=None, chunk_page_table=None):
         """
         Inputs are torch tensors or python types. This function returns ttnn
         tensors on host.
@@ -185,7 +185,7 @@ class Transformer(LightweightModule):
     def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None, trace_enabled=False):
         """
         Inputs are torch tensors or python types. This function returns ttnn
-        tensors on device.
+        tensors on device if trace is disabled or on host if trace is enabled.
         TODO: Debate whether this function is responsible for padding
         """
 

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -203,7 +203,7 @@ class Transformer(LightweightModule):
             self.rope_setup.cos_matrix.shape[2] >= start_pos + S
         ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {self.rope_setup.cos_matrix.shape[2]}"
 
-        # We need to use the whole cos_matrix and sin_matrix for tracing because we can't pass the start_pos and end_pos to the trace, so we use the whole matrix for all seq_lens when using trace
+        # We set the end_pos to max_seq_len so that we don't create a new tensor for the whole cos_matrix and sin_matrix ; in case of trace, we will use the whole matrix for all seq_lens supported by trace
         start_pos = 0 if trace_enabled else start_pos
         end_pos = self.args.max_seq_len if trace_enabled else start_pos + S
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1835,7 +1835,7 @@ class ModelArgs:
         # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
         """
         # Trace in prefill is currently supported only for Llama-3.1-8B
-        # TODO: Support all other models that use tt_transformers
+        # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
         if self.base_model_name != "Llama-3.1-8B":
             return False
         if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1826,6 +1826,35 @@ class ModelArgs:
     def is_llama_vision(self):
         return ("llama" in self.CKPT_DIR.lower()) and ("vision" in self.CKPT_DIR.lower())
 
+    def trace_supported_seq_len(self, prefill_seq_len):
+        """
+        This function is used to determine if trace should be enabled for the prefill.
+        Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
+        If we have chunked prefill, we disable tracing because there is no support to pass parameters such as chunk_start and chunk_end to trace.
+        There is no support to pass them as a tensor, and then inside the trace read it as a number.
+        # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
+        """
+        # Define allowed sequence lengths based on device
+        if self.device_name == "N150":
+            allowed_seq_lens = [128, 256, 512, 1024]
+        else:
+            allowed_seq_lens = [128, 256, 512, 1024, 2048, 4096, 8192]
+
+        return prefill_seq_len in allowed_seq_lens and prefill_seq_len <= self.max_prefill_chunk_size
+
+    def model_supports_trace(self):
+        """
+        This function is used to determine if trace should be enabled for the model.
+        """
+        model_name_lower = self.model_name.lower()
+        if "mixtral" in model_name_lower:
+            return False
+        if "llama" in model_name_lower and "70b" in model_name_lower:
+            return False
+        if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
+            return False
+        return True
+
     def get_state_dict_prefix(self, module_name, layer_num, is_vision=False):
         text_prefix = self.state_dict_text_prefix
         vision_prefix = self.state_dict_vision_prefix

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1834,7 +1834,8 @@ class ModelArgs:
         There is no support to pass them as a tensor, and then inside the trace read it as a number.
         # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
         """
-        # Define allowed sequence lengths based on device
+        # Trace in prefill is currently supported only for Llama-3.1-8B
+        # TODO: Support all other models that use tt_transformers
         if self.base_model_name != "Llama-3.1-8B":
             return False
         if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25722

### Problem description

- Enable tracing in prefill for Llama-3.1-8B
- Support for N150, N300, T3K and Galaxy
- Support for sequence lengths up to 8K tokens
- Currently there is good perf optimization for sequence lengths < 1K tokens, but there are also minor perf optimizations for sequence length that go up to 8K tokens, so that's why we keep them there

### What's changed

- Added support for tracing - keep consistent tensor shapes for all sequence lengths that get padded to the same length
- Transfer all input parameters (tensors) of each individual prompt from host to device, so that the recorded ops on the device (trace) can execute them on correct tensors for each prompt

### Checklist
- [x] [All post commit] - https://github.com/tenstorrent/tt-metal/actions/runs/18921937228
- [x] (For models and ops writers) [Single-card demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/18921950353
- [ ] [Galaxy demo tests, for Llama] https://github.com/tenstorrent/tt-metal/actions/runs/18922004809
- [x] (For runtime and ops writers) [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/18921962108
- [x] (For models and ops writers) [T3000 demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/18921973529