### PR TITLE
[skip ci] Run ClangTidy on 24.04

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -12,7 +12,7 @@ on:
       version:
         required: false
         type: string
-        default: "22.04"
+        default: "24.04"
       architecture:
         required: false
         type: string
@@ -26,7 +26,7 @@ on:
       version:
         required: false
         type: string
-        default: "22.04"
+        default: "24.04"
       architecture:
         required: false
         type: string
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       distro: ${{ inputs.distro || 'ubuntu' }}
-      version: ${{ inputs.version || '22.04' }}
+      version: ${{ inputs.version || '24.04' }}
       architecture: ${{ inputs.architecture || 'amd64' }}
 
   clang-tidy:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/code-analysis.yaml
     secrets: inherit
     with:
-      version: 22.04
+      version: 24.04
 
   fail-fast:
     if: failure()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# REVERTME: force CI runs
-
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
No reason to stick on 22.04, and 24.04 comes default with a newer CMake that allows us to leverage `add_subdirectory( ... SYSTEM)` which is particularly beneficial for linters like ClangTidy.

### What's changed
22.04 -> 24.04 for the ClangTidy scan.