### PR TITLE
Infer output memory config in `ttnn.convert_to_hwc`

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -56,15 +56,11 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim):
     input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
-    output_shard_shape = (padded_sharded_dim, C)
-    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
-
     input_tensor = ttnn.Tensor(
         input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
     )
 
-    actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    actual = ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
     actual = ttnn.to_torch(actual)
 
     passed, message = assert_equal(expected, actual)
@@ -158,3 +154,52 @@ def test_convert_to_hwc_dram(
 
     passed, message = assert_equal(expected, actual)
     assert passed, message
+
+
+def test_convert_to_hwc_l1_input_with_memory_config_should_fail(device):
+    C = 8
+    HW = 32
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    padded_sharded_dim = 32
+
+    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
+
+    input_shard_shape = (C, padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    output_shard_shape = (padded_sharded_dim, C)
+    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    with pytest.raises(
+        RuntimeError,
+        match="When input tensor is in L1, output memory_config is inferred using the input tensor and should not be specified",
+    ):
+        ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+
+
+def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
+    C = 8
+    HW = 32
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    padded_sharded_dim = 32
+
+    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
+
+    input_shard_shape = (C, padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    with pytest.raises(
+        RuntimeError, match="When input tensor is in DRAM, output memory_config must be explicitly specified"
+    ):
+        ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)

--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -10,6 +10,7 @@ from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("C", [8, 16])
+@pytest.mark.parametrize("provide_memory_config", [True, False])
 @pytest.mark.parametrize(
     "HW, core_grid, padded_sharded_dim",
     (
@@ -43,7 +44,7 @@ from tests.ttnn.utils_for_testing import assert_equal
         ),  # UNet Shallow
     ),
 )
-def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim):
+def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_memory_config):
     device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
     requested_num_cores = core_grid.num_cores()
     if device_num_cores < requested_num_cores:
@@ -60,7 +61,16 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim):
         input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
     )
 
-    actual = ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
+    if provide_memory_config:
+        output_shard_shape = (padded_sharded_dim, C)
+        output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec
+        )
+        actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    else:
+        actual = ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
+
     actual = ttnn.to_torch(actual)
 
     passed, message = assert_equal(expected, actual)
@@ -154,33 +164,6 @@ def test_convert_to_hwc_dram(
 
     passed, message = assert_equal(expected, actual)
     assert passed, message
-
-
-def test_convert_to_hwc_l1_input_with_memory_config_should_fail(device):
-    C = 8
-    HW = 32
-    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    padded_sharded_dim = 32
-
-    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
-
-    input_shard_shape = (C, padded_sharded_dim)
-    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
-
-    input_tensor = ttnn.Tensor(
-        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
-    )
-
-    output_shard_shape = (padded_sharded_dim, C)
-    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
-
-    with pytest.raises(
-        RuntimeError,
-        match="When input tensor is in L1, output memory_config is inferred using the input tensor and should not be specified",
-    ):
-        ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
 
 
 def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -8,9 +8,56 @@
 
 namespace ttnn::operations::experimental::cnn {
 
+static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Tensor& input_tensor) {
+    using namespace tt::constants;
+
+    TT_FATAL(input_tensor.is_sharded(), "Input tensor must be sharded to infer output memory config");
+
+    const auto& input_memory_config = input_tensor.memory_config();
+    TT_FATAL(
+        input_memory_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
+        "Input tensor must be width sharded");
+
+    const auto& input_shape = input_tensor.logical_shape();
+    const auto C = input_shape[-2];
+
+    const auto& input_shard_spec = input_memory_config.shard_spec().value();
+    const auto input_shard_width = input_shard_spec.shape[1];
+    const auto output_shard_height = input_shard_width;  // HW dimension per core stays the same
+
+    const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, C};
+    auto output_shard_spec =
+        tt::tt_metal::ShardSpec(input_shard_spec.grid, output_shard_shape, input_shard_spec.orientation);
+
+    return tt::tt_metal::MemoryConfig(
+        tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        input_tensor.memory_config().buffer_type(),
+        output_shard_spec);
+}
+
 ttnn::Tensor ExecuteConvertToHWC::invoke(
     const Tensor& a, const std::optional<MemoryConfig>& memory_config, const std::optional<DataType>& dtype) {
-    auto program = ConvertToHWC{memory_config.value_or(a.memory_config()), dtype.value_or(a.dtype())};
+    const auto& input_memory_config = a.memory_config();
+    const bool is_dram_input = input_memory_config.buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    tt::tt_metal::MemoryConfig output_memory_config;
+
+    if (is_dram_input) {
+        // DRAM input: explicit memory_config is required
+        TT_FATAL(
+            memory_config.has_value(),
+            "When input tensor is in DRAM, output memory_config must be explicitly specified");
+        output_memory_config = memory_config.value();
+    } else {
+        // L1 input: memory_config should not be provided (use automatic inference)
+        TT_FATAL(
+            !memory_config.has_value(),
+            "When input tensor is in L1, output memory_config is inferred using the input tensor and should not be "
+            "specified");
+        output_memory_config = infer_hwc_output_memory_config(a);
+    }
+
+    auto program = ConvertToHWC{output_memory_config, dtype.value_or(a.dtype())};
     return tt::tt_metal::operation::run(program, {a}, {}, {}).at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -43,18 +43,16 @@ ttnn::Tensor ExecuteConvertToHWC::invoke(
     tt::tt_metal::MemoryConfig output_memory_config;
 
     if (is_dram_input) {
-        // DRAM input: explicit memory_config is required
         TT_FATAL(
             memory_config.has_value(),
             "When input tensor is in DRAM, output memory_config must be explicitly specified");
         output_memory_config = memory_config.value();
     } else {
-        // L1 input: memory_config should not be provided (use automatic inference)
-        TT_FATAL(
-            !memory_config.has_value(),
-            "When input tensor is in L1, output memory_config is inferred using the input tensor and should not be "
-            "specified");
-        output_memory_config = infer_hwc_output_memory_config(a);
+        if (memory_config.has_value()) {
+            output_memory_config = memory_config.value();
+        } else {
+            output_memory_config = infer_hwc_output_memory_config(a);
+        }
     }
 
     auto program = ConvertToHWC{output_memory_config, dtype.value_or(a.dtype())};

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -9,8 +9,6 @@
 namespace ttnn::operations::experimental::cnn {
 
 static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Tensor& input_tensor) {
-    using namespace tt::constants;
-
     TT_FATAL(input_tensor.is_sharded(), "Input tensor must be sharded to infer output memory config");
 
     const auto& input_memory_config = input_tensor.memory_config();

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -26,7 +26,7 @@ void bind_convert_to_hwc(py::module& module) {
     Args:
         input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
-                                                     Required only for DRAM inputs
+                                                     Required only for DRAM inputs.
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -23,37 +23,15 @@ void bind_convert_to_hwc(py::module& module) {
     The input tensor is expected to be in row-major layout and width-sharded in L1 or DRAM.
     The output is a row-major height-sharded tensor.
 
-    **Requirements:**
-    - Input channel dimension (C) must be a multiple of 8
-    - Input must be width-sharded
-
-    **Memory Configuration Behavior:**
-
-    - **L1 input**: Memory configuration is automatically inferred to create an optimal height-sharded output.
-      Providing an explicit `memory_config` will raise an error.
-
-    - **DRAM input**: Memory configuration must be explicitly provided via the `memory_config` parameter.
-      Omitting `memory_config` will raise an error.
-
-    This design ensures optimal performance for common L1 use cases while requiring explicit
-    configuration for complex DRAM scenarios that may need custom sharding strategies.
-
     Args:
         input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
-                            The channel dimension (C) must be a multiple of 8.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
-                                                     Required for DRAM inputs, forbidden for L1 inputs.
+                                                     Required only for DRAM inputs
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:
         ttnn.Tensor: Output tensor in HWC format, height-sharded
 
-    Example:
-        >>> # L1 input - automatic inference
-        >>> output = ttnn.experimental.convert_to_hwc(l1_tensor, dtype=ttnn.bfloat16)
-
-        >>> # DRAM input - explicit config required
-        >>> output = ttnn.experimental.convert_to_hwc(dram_tensor, memory_config=output_config, dtype=ttnn.bfloat16)
     )doc";
 
     ttnn::bind_registered_operation(

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -26,7 +26,7 @@ void bind_convert_to_hwc(py::module& module) {
     Args:
         input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
-                                                     Required only for DRAM inputs.
+                                                     Required only for DRAM inputs. If omitted for L1 inputs, the output memory_config is automatically inferred.
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:


### PR DESCRIPTION
### Summary

Automatically infers the output memory configuration in `ttnn.convert_to_hwc` function, eliminating the need for manual memory config specification and improving usability.

Previously, this was required even though only one specific value would ever be admitted, so it makes sense to just infer it automatically. The `memory_config` is still always required if DRAM inputs are used.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18221165630
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18221167877
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18221177333