### PR TITLE
Docs Update for Fused/Matmul/Reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -549,7 +549,7 @@ void py_module(py::module& module) {
         Memory Support:
             - Interleaved: DRAM and L1
             - Input A also supports sharding (width, height, block), with row major orientation, depending on the program config
-            - Input B must be interleaved for multi-cast matmuls, but can be width sharded for certain reuse/multi-core configs
+            - Input B also supports sharding (width, height, block), with row major orientation depending on the program config, although in a more limited manner than Input A
             - Sharded outputs (when used): must match Input A buffer type and memory layout; some configs disallow width sharded outputs
 
         Example:

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -492,6 +492,9 @@ void py_module(py::module& module) {
         - In order to leverage sharded matmul implementations we can shard both `input_tensor_a` and `input_tensor_b`. The sharding strategy used will be according
           to the sharding strategy on the respective tensor. A sharded 1D matmul can be either HEIGHT or WIDTH sharded, 2D matmuls can be BLOCK sharded.
 
+          - For 1D sharded matmul variants (width- or height-sharded inputs), if a sharded :attr:`memory_config` is
+            provided for the output, its memory layout and buffer type must match those of :attr:`input_tensor_a`.
+
           Note: the broadcasting logic only looks at the batch dimensions when determining if the inputs
           are broadcastable, and not the matrix dimensions. For example, if :attr:`input_tensor_a` is a
           (`j` x `1` x `n_size` x `m_size`) tensor and :attr:`input_tensor_b` is a (`k_size` x `m_size` x `p`)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -508,6 +508,25 @@ void py_module(py::module& module) {
           - if they are default then they should be set based on optional output tensor
           - if the are not default then they should be compared and if there is a difference an error is reported
 
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
+
+        Keyword Args:
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
+            dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
+            program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str, optional): the activation function to be applied. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
         Note:
             The input tensors support the following data types and layouts:
 
@@ -527,25 +546,11 @@ void py_module(py::module& module) {
                 * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
                   - TILE
 
-        Args:
-            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
-            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
-
-        Keyword Args:
-            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
-            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
-            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
-            dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
-            program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str, optional): the activation function to be applied. Defaults to `None`.
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
-            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
-            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
-            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
-
-
-        Returns:
-            ttnn.Tensor: the output tensor.
+        Memory Support:
+            - Interleaved: DRAM and L1
+            - Input A also supports sharding (width, height, block), with row major orientation, depending on the program config
+            - Input B must be interleaved for multi-cast matmuls, but can be width sharded for certain reuse/multi-core configs
+            - Sharded outputs (when used): must match Input A buffer type and memory layout; some configs disallow width sharded outputs
 
         Example:
             >>> # matrix x matrix - no batch dimensions

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -995,7 +995,7 @@ void py_module(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                * - BFLOAT16
                   - TILE
 
             .. list-table:: input_tensor_b
@@ -1003,8 +1003,10 @@ void py_module(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
                   - TILE
+
+            FLOAT32 is only supported if :attr:`nnz` is provided.
 
             .. list-table:: sparsity
                 :header-rows: 1
@@ -1013,6 +1015,7 @@ void py_module(py::module& module) {
                   - layout
                 * - BFLOAT16
                   - ROW_MAJOR
+
         Example:
             >>> # Sparse matmul for 64 batch, 128 sequence, 512 hidden dimensions, 8 experts
             >>> expert_weights = ttnn.ones([1, 8, 512, 512])

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -439,6 +439,8 @@ void py_module(py::module& module) {
         module,
         ::ttnn::matmul,
         R"doc(
+        ``ttnn.matmul(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, transpose_a: bool = False, transpose_b: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, program_config: Optional[ttnn.MatmulProgramConfig] = None, activation: Optional[str] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, core_grid: Optional[ttnn.CoreGrid] = None, output_tile: Optional[list[int]] = None, optional_output_tensor: Optional[ttnn.Tensor] = None, global_cb: Optional[ttnn.GlobalCircularBuffer] = None, sub_device_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor``
+
         Returns the matrix product of two tensors.
 
         The input tensors need to be tiled and at least 1-dimensional.
@@ -502,6 +504,25 @@ void py_module(py::module& module) {
         - Note: If optional output tensor is specified, then dtype and memory config need to be checked as follows:
           - if they are default then they should be set based on optional output tensor
           - if the are not default then they should be compared and if there is a difference an error is reported
+
+        Note:
+            The input tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
@@ -614,9 +635,38 @@ void py_module(py::module& module) {
         module,
         ::ttnn::linear,
         R"doc(
+        ``ttnn.linear(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, bias: Optional[ttnn.Tensor] = None, transpose_a: bool = False, transpose_b: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, program_config: Optional[ttnn.MatmulProgramConfig] = None, activation: Optional[str] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, core_grid: Optional[ttnn.CoreGrid] = None, output_tile: Optional[list[int]] = None, optional_output_tensor: Optional[ttnn.Tensor] = None, global_cb: Optional[ttnn.GlobalCircularBuffer] = None, sub_device_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor``
+
         Returns the linear transformation of the inputs.
 
         The limitations and behaviours are the same as for matmul.
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: bias
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
@@ -703,11 +753,32 @@ void py_module(py::module& module) {
         module,
         ::ttnn::matmul_batched_weights,
         R"doc(
+        ``ttnn.matmul_batched_weights(input_tensor_a: ttnn.Tensor, input_tensors_b: list[ttnn.Tensor], transpose_a: bool = False, transpose_b: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, program_config: Optional[ttnn.MatmulProgramConfig] = None, activation: Optional[str] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, core_grid: Optional[ttnn.CoreGrid] = None, output_tile: Optional[list[int]] = None, optional_output_tensor: Optional[ttnn.Tensor] = None, global_cb: Optional[ttnn.GlobalCircularBuffer] = None, sub_device_id: Optional[ttnn.SubDeviceId] = None) -> list[ttnn.Tensor]``
+
         performs matrix multiplication for a single input tensor a with multiple tensors b, return a vector of output tensors.
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
             input_tensors_b (ttnn.Tensor): the second tensor vector to be multiplied. Needs to be on the device.
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensors_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
 
         Keyword Args:
             bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
@@ -778,6 +849,8 @@ void py_module(py::module& module) {
         module,
         ::ttnn::addmm,
         R"doc(
+        ``ttnn.addmm(input_tensor: ttnn.Tensor, mat1_tensor: ttnn.Tensor, mat2_tensor: ttnn.Tensor, alpha: float = 1.0, beta: float = 1.0, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, program_config: Optional[ttnn.MatmulProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, core_grid: Optional[ttnn.CoreGrid] = None, output_tile: Optional[list[int]] = None, optional_output_tensor: Optional[ttnn.Tensor] = None) -> ttnn.Tensor``
+
         Returns a matrix products of tensors mat1_tensor and mat2_tensor. Tensor input_tensor is added to the final result.
 
         - If mat1_tensor has shape (n, m) and mat2_tensor has shape (m, p), input_tensor needs to be of shape (n, p) and
@@ -793,6 +866,33 @@ void py_module(py::module& module) {
         - If beta is 0, then content of input_tensor is ignored.
 
         - Arguments beta and alpha should be real numbers;
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: mat1_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: mat2_tensor
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
 
         Args:
             input_tensor (ttnn.Tensor): tensor to be added to result of matrix multiplication of mat1_tensor and mat2_tensor
@@ -862,6 +962,8 @@ void py_module(py::module& module) {
         module,
         ::ttnn::sparse_matmul,
         R"doc(
+        ``ttnn.sparse_matmul(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, sparsity: ttnn.Tensor, nnz: Optional[int] = None, is_input_a_sparse: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, program_config: Optional[ttnn.MatmulProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, core_grid: Optional[ttnn.CoreGrid] = None, output_tile: Optional[list[int]] = None, optional_output_tensor: Optional[ttnn.Tensor] = None, global_cb: Optional[ttnn.GlobalCircularBuffer] = None, sub_device_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor``
+
         Performs sparse matrix multiplication on input tensors based on sparsity tensor that has scale factor for each token.
 
         Args:
@@ -882,6 +984,32 @@ void py_module(py::module& module) {
         Returns:
             ttnn.Tensor: the output tensor with sparse results.
 
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensor_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: sparsity
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT16
+                  - ROW_MAJOR
         Example:
             >>> # Sparse matmul for 64 batch, 128 sequence, 512 hidden dimensions, 8 experts
             >>> expert_weights = ttnn.ones([1, 8, 512, 512])
@@ -899,6 +1027,8 @@ void py_module(py::module& module) {
             >>> output = ttnn.sparse_matmul(expert_weights, tokens, sparsity=sparsity_bitmask, nnz=4)
             >>> print(output.shape)
             [64, 128, 8, 512]
+
+
         )doc",
         ttnn::pybind_overload_t{
             [](decltype(::ttnn::sparse_matmul)& self,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -19,6 +19,8 @@ void bind_batch_norm_operation(py::module& module) {
         module,
         ttnn::batch_norm,
         R"doc(
+        ``ttnn.batch_norm(input: ttnn.Tensor, running_mean: Optional[ttnn.Tensor] = None, running_var: Optional[ttnn.Tensor] = None, training: bool = False, eps: float = 1e-05, momentum: float = 0.1, weight: Optional[ttnn.Tensor] = None, bias: Optional[ttnn.Tensor] = None, output: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor``
+
         Applies batch norm over each channel on :attr:`input_tensor`.
         See `Spatial Batch Normalization <https://arxiv.org/abs/1502.03167>`_ for more details.
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -66,6 +66,9 @@ void bind_batch_norm_operation(py::module& module) {
 
             These apply for all the tensor inputs to this operation, including the optional :attr:`output` tensor.
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+
         Limitations:
             - All input tensors must be tilized, interleaved, rank 4, and on-device.
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -18,6 +18,8 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
         module,
         ttnn::group_norm,
         R"doc(
+                ``ttnn.group_norm(input_tensor: ttnn.Tensor, num_groups: int, epsilon: float = 1e-12, input_mask: Optional[ttnn.Tensor] = None, weight: Optional[ttnn.Tensor] = None, bias: Optional[ttnn.Tensor] = None, reciprocals: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, core_grid: Optional[ttnn.CoreGrid] = None, inplace: bool = True, output_layout: Optional[ttnn.Layout] = None, num_out_blocks: Optional[int] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, negative_mask: Optional[ttnn.Tensor] = None, use_welford: bool = False) -> ttnn.Tensor``
+
                 Computes group_norm over :attr:`input_tensor`.
                 See `Group Normalization <https://arxiv.org/abs/1803.08494>`_ for more details.
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -100,6 +100,10 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                     * - BFLOAT16
                       - TILE, ROW_MAJOR
 
+            Memory Support:
+              - Interleaved: DRAM and L1
+              - Sharded (L1): Height and Block sharded
+
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
               - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
@@ -108,7 +112,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.
               - When generating inputs (e.g. weight, bias) for block sharded tensors, the number of cores in a column should draw upon core.x rather than core.y.
               - When generating inputs (e.g. weight, bias) for height sharded tensors, the number of cores in a column should be 1 rather than core.y.
-              - Width-sharding is not supported (use height or block sharding)
+              - Width-sharding is not supported
 
             Example (Sharded Input):
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -113,7 +113,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
             Example (Sharded Input):
                 .. code-block:: python
 
-                     N, C, H, W = 1, 64, 32, 1
+                    N, C, H, W = 1, 64, 32, 1
                     num_groups = 2
 
                     # Prepare random inputs

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -42,18 +42,21 @@ void bind_normalization_layernorm_operation(py::module& module) {
         module,
         ttnn::layer_norm,
         R"doc(
-            Compute layer norm over :attr:`input_tensor`.
-            See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
-            .. math::
+        ``ttnn.layer_norm(input_tensor: ttnn.Tensor, epsilon: float = 1e-12, weight: Optional[ttnn.Tensor] = None, bias: Optional[ttnn.Tensor] = None, residual_input_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, program_config: Optional[ttnn.ProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor``
 
-                \text{layer_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
+          Compute layer norm over :attr:`input_tensor`.
+          See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
-            Where:
-                - :math:`\mu` is the mean of the input tensor. This is computed over the last dimension of the input tensor (W).
-                - :math:`\sigma^2` is the variance of the input tensor. This is computed over the last dimension of the input tensor (W) and is biased.
-                - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
-                - :math:`\epsilon` is a small constant
+          .. math::
+
+              \text{layer_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
+
+          Where:
+              - :math:`\mu` is the mean of the input tensor. This is computed over the last dimension of the input tensor (W).
+              - :math:`\sigma^2` is the variance of the input tensor. This is computed over the last dimension of the input tensor (W) and is biased.
+              - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
+              - :math:`\epsilon` is a small constant
 
 
         Args:
@@ -112,8 +115,10 @@ void bind_normalization_layernorm_operation(py::module& module) {
 
                * - dtype
                  - layout
-               * - BFLOAT16, FLOAT32, BFLOAT8_B (typically matches input; PRE_ALL_GATHER produces BF16)
+               * - BFLOAT16, FLOAT32, BFLOAT8_B
                  - TILE
+
+            Output dtype typically matches input; PRE_ALL_GATHER produces BF16
 
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -120,13 +120,18 @@ void bind_normalization_layernorm_operation(py::module& module) {
 
             Output dtype typically matches input; PRE_ALL_GATHER produces BF16
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+            - Sharded (L1): Block sharded
+
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.
             - Unsharded tensors must be interleaved, sharded tensors cannot be height sharded.
+            - If the input is sharded, the :attr:`output` and :attr:`residual_input_tensor` must have identical shard spec and memory config.
             - If `residual_input_tensor` is provided, it must match the input's padded shape.
             - If TILE: `weight` and `bias` padded dim must match input's last padded dim; padded height must equal TILE_HEIGHT (i.e. 32).
             - If ROW_MAJOR: `weight` and `bias` last padded dim must be TILE_WIDTH and the stick count must align with the input width.
-            - If the input is sharded, the :attr:`output` and :attr:`residual_input_tensor` must have identical shard spec and memory config.
+
 
         Example:
             .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -87,6 +87,8 @@ void bind_normalization_rms_norm(py::module& module) {
             - If `residual_input_tensor` is provided, it must match the :attr:`input_tensor`'s padded shape.
             - If the `weight`/`bias` tensors are TILE layout: last padded dim must match :attr:`input_tensor`'s last padded dim.
             - If the `weight`/`bias` tensors are ROW_MAJOR layout: last padded dim must be TILE_WIDTH.
+            - If the :attr:`input_tensor` is sharded, the :attr:`output` must also be sharded. In that case, the
+              :attr:`output` memory layout and buffer type must match the :attr:`input_tensor`'s memory configuration.
 
         Example:
             .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -19,6 +19,8 @@ void bind_normalization_rms_norm(py::module& module) {
         module,
         ttnn::rms_norm,
         R"doc(
+            ``ttnn.rms_norm(input_tensor: ttnn.Tensor, epsilon: float = 1e-12, weight: Optional[ttnn.Tensor] = None, bias: Optional[ttnn.Tensor] = None, residual_input_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, program_config: Optional[ttnn.ProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor``
+
             Computes RMS norm over :attr:`input_tensor`.
             See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
@@ -81,6 +81,9 @@ void bind_normalization_rms_norm(py::module& module) {
                * - BFLOAT16, FLOAT32, BFLOAT8_B (matching input)
                  - TILE
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.
             - Unsharded tensors must be interleaved, sharded inputs cannot be height-sharded.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -129,6 +129,10 @@ void bind_normalization_softmax_operation(py::module& module) {
                * - BFLOAT16, FLOAT32, BFLOAT8_B
                  - TILE
 
+            Note:
+                * All tensors must be on-device and interleaved (TILE layout).
+                * Using the attention-optimized kernels requires a 4D input tensor and reducing on the last dimension.
+
             Example:
                 .. code-block:: python
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -98,6 +98,8 @@ void bind_normalization_softmax_program_config_operation(py::module& module) {
 void bind_normalization_softmax_operation(py::module& module) {
     const auto doc =
         R"doc(
+            ``ttnn.softmax(input_tensor: ttnn.Tensor, dim: int = -1, memory_config: Optional[ttnn.MemoryConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, numeric_stable: bool = True) -> ttnn.Tensor``
+
             Computes the softmax function over the specified dimension of the input tensor.
 
             The softmax function is defined as:
@@ -106,7 +108,7 @@ void bind_normalization_softmax_operation(py::module& module) {
                 \text{softmax}(x_i) = \frac{e^{x_i}}{\sum_{j=1}^{K} e^{x_j}}
 
             Args:
-                input_tensor (ttnn.Tensor): The input tensor to apply softmax to.
+                input_tensor (ttnn.Tensor): The input tensor to apply softmax to. Must be on the device.
                 dim (int, optional): The dimension along which to compute softmax. Defaults to -1 (last dimension).
 
             Keyword Args:
@@ -161,6 +163,8 @@ void bind_normalization_softmax_operation(py::module& module) {
 void bind_normalization_softmax_scale_mask_operation(py::module& module) {
     const auto doc =
         R"doc(
+            ``ttnn.scale_mask_softmax(input_tensor: ttnn.Tensor, scale: Optional[float] = None, mask: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, is_causal_mask: bool = False, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, numeric_stable: bool = True) -> ttnn.Tensor``
+
             Computes a fused scale-mask-softmax operation along the last dimension of the input tensor.
 
             This operation performs the following sequence:
@@ -259,6 +263,8 @@ void bind_normalization_softmax_scale_mask_operation(py::module& module) {
 void bind_normalization_softmax_inplace_operation(py::module& module) {
     const auto doc =
         R"doc(
+            ``ttnn.softmax_in_place(input_tensor: ttnn.Tensor, dim: int = -1, program_config: Optional[ttnn.SoftmaxProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, numeric_stable: bool = True) -> ttnn.Tensor``
+
             Computes the softmax function along the last dimension of the input tensor in-place.
 
             This operation modifies the input tensor directly, making it memory-efficient by avoiding
@@ -289,7 +295,7 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
                  - TILE
 
             Note:
-                * The input tensor is modified in-place to save memory.
+                * The input tensor is modified in-place to save memory. Must already be on the device.
                 * For very wide tensors, the operation may fall back to standard softmax if circular buffers would consume more than 90% of L1 memory.
                 * Supports both default and sharded multi-core program configurations.
 
@@ -341,6 +347,8 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
 void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module) {
     const auto doc =
         R"doc(
+            ``ttnn.scale_mask_softmax_in_place(input_tensor: ttnn.Tensor, scale: Optional[float] = None, mask: Optional[ttnn.Tensor] = None, program_config: Optional[ttnn.SoftmaxProgramConfig] = None, is_causal_mask: bool = False, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, numeric_stable: bool = False) -> ttnn.Tensor``
+
             Computes a fused scale-mask-softmax operation along the last dimension in-place.
 
             This operation modifies the input tensor directly and performs the following sequence:
@@ -478,6 +486,8 @@ void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module)
 void bind_normalization_softmax_scale_casual_mask_HW_inplace_operation(py::module& module) {
     const auto doc =
         R"doc(
+            ``ttnn.scale_causal_mask_hw_dims_softmax_in_place(input_tensor: ttnn.Tensor, scale: Optional[float] = None, mask: Optional[ttnn.Tensor] = None, program_config: Optional[ttnn.SoftmaxProgramConfig] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None, numeric_stable: bool = False) -> ttnn.Tensor``
+
             Specialized in-place operation for causal masked softmax with height-width dimension constraints.
 
             This is an optimized version of scale_mask_softmax_in_place specifically designed for transformer
@@ -528,6 +538,7 @@ void bind_normalization_softmax_scale_casual_mask_HW_inplace_operation(py::modul
 
             Note:
                 * This is an experimental/specialized feature optimized for specific transformer attention patterns.
+                * Inputs must be on the device.
                 * Input tensor must be sharded for optimal performance.
                 * Mask shape is constrained to [1, 1, H, W] format.
                 * Provides better performance than general scale_mask_softmax_in_place for these specific constraints.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -119,15 +119,16 @@ void bind_normalization_softmax_operation(py::module& module) {
             Returns:
                 ttnn.Tensor: Output tensor with softmax applied along the specified dimension.
 
-            Supported dtypes and layouts
+            Note:
+                The tensors support the following data types and layouts:
 
-            .. list-table::
-               :header-rows: 1
+                .. list-table::
+                    :header-rows: 1
 
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, FLOAT32, BFLOAT8_B
-                 - TILE
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, FLOAT32, BFLOAT8_B
+                        - TILE
 
             Note:
                 * All tensors must be on-device and interleaved (TILE layout).
@@ -193,25 +194,26 @@ void bind_normalization_softmax_scale_mask_operation(py::module& module) {
             Returns:
                 ttnn.Tensor: Output tensor with the fused scale-mask-softmax operation applied.
 
-            Supported dtypes and layouts:
-
-            .. list-table:: Input Tensor
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, FLOAT32, BFLOAT8_B
-                 - TILE
-
-            .. list-table:: Mask Tensor (optional)
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, BFLOAT8_B
-                 - TILE, ROW_MAJOR
-
             Note:
+                The tensors support the following data types and layouts:
+
+                .. list-table:: Input Tensor
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, FLOAT32, BFLOAT8_B
+                        - TILE
+
+                .. list-table:: Mask Tensor (optional)
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, BFLOAT8_B
+                        - TILE, ROW_MAJOR
+
+            Limitations:
                 * All tensors must be on-device.
                 * For ROW_MAJOR masks: intermediate dimensions (except last two) must be 1; last dimension must equal TILE_WIDTH; width must align to input tensor's tile width.
 
@@ -288,17 +290,18 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
             Returns:
                 ttnn.Tensor: The same tensor as input with softmax applied in-place.
 
-            Supported dtypes and layouts:
-
-            .. list-table::
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, FLOAT32, BFLOAT8_B
-                 - TILE
-
             Note:
+                The tensors support the following data types and layouts:
+
+                .. list-table::
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, FLOAT32, BFLOAT8_B
+                        - TILE
+
+            Limitations:
                 * The input tensor is modified in-place to save memory. Must already be on the device.
                 * For very wide tensors, the operation may fall back to standard softmax if circular buffers would consume more than 90% of L1 memory.
                 * Supports both default and sharded multi-core program configurations.
@@ -377,27 +380,28 @@ void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module)
             Returns:
                 ttnn.Tensor: The same tensor as input with the fused scale-mask-softmax operation applied in-place.
 
-            Supported dtypes and layouts:
-
-            .. list-table:: Input Tensor
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, FLOAT32, BFLOAT8_B
-                 - TILE
-
-            .. list-table:: Mask Tensor (optional)
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-                 - Ranks
-               * - BFLOAT16, BFLOAT8_B
-                 - TILE, ROW_MAJOR
-                 - 2, 3, 4
-
             Note:
+                The tensors support the following data types and layouts:
+
+                .. list-table:: Input Tensor
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, FLOAT32, BFLOAT8_B
+                        - TILE
+
+                .. list-table:: Mask Tensor (optional)
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                        - Ranks
+                    * - BFLOAT16, BFLOAT8_B
+                        - TILE, ROW_MAJOR
+                        - 2, 3, 4
+
+            Limitations:
                 * All tensors must be on-device.
                 * For unsharded ROW_MAJOR masks: intermediate dimensions (except last two) must be 1; last dimension must equal TILE_WIDTH; width must align to input tensor.
                 * For sharded inputs: mask must be TILE layout with identical padded shape to input.
@@ -495,14 +499,8 @@ void bind_normalization_softmax_scale_casual_mask_HW_inplace_operation(py::modul
             Specialized in-place operation for causal masked softmax with height-width dimension constraints.
 
             This is an optimized version of scale_mask_softmax_in_place specifically designed for transformer
-            attention patterns where the causal mask only affects the height and width dimensions. This operation
-            provides better performance for specific use cases with the following constraints:
-
-            **Requirements:**
-            * Input tensor should be sharded for optimal performance
-            * Attention mask must be interleaved and have shape [1, 1, H, W] (hw_dims_only)
-            * The mask is treated as a causal mask by design
-            * Scale parameter is typically provided for attention scaling
+            attention patterns where the causal mask only affects the height and width dimensions.
+            This operation provides better performance than general :func:`ttnn.scale_mask_softmax_in_place` for these specific constraints.
 
             The operation performs:
             1. Scales the input: ``input_tensor *= scale`` (if scale is provided)
@@ -522,30 +520,32 @@ void bind_normalization_softmax_scale_casual_mask_HW_inplace_operation(py::modul
             Returns:
                 ttnn.Tensor: The same tensor as input with the specialized causal scale-mask-softmax operation applied in-place.
 
-            Supported dtypes and layouts:
-
-            .. list-table:: Input Tensor (Sharded)
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, FLOAT32, BFLOAT8_B
-                 - TILE
-
-            .. list-table:: Mask Tensor [1, 1, H, W]
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-               * - BFLOAT16, BFLOAT8_B
-                 - TILE (interleaved)
-
             Note:
+                The tensors support the following data types and layouts:
+
+                .. list-table:: Input Tensor (Sharded)
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, FLOAT32, BFLOAT8_B
+                        - TILE
+
+                .. list-table:: Mask Tensor [1, 1, H, W]
+                    :header-rows: 1
+
+                    * - Dtypes
+                        - Layouts
+                    * - BFLOAT16, BFLOAT8_B
+                        - TILE (interleaved)
+
+            Limitations:
                 * This is an experimental/specialized feature optimized for specific transformer attention patterns.
                 * Inputs must be on the device.
                 * Input tensor must be sharded for optimal performance.
-                * Mask shape is constrained to [1, 1, H, W] format.
-                * Provides better performance than general scale_mask_softmax_in_place for these specific constraints.
+                * Attention mask must be interleaved and have shape [1, 1, H, W] (i.e. hw_dims_only)
+                * The mask is treated as a causal mask by design
+                * Scale parameter is typically provided for attention scaling
 
             Example:
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -130,8 +130,12 @@ void bind_normalization_softmax_operation(py::module& module) {
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
                         - TILE
 
-            Note:
-                * All tensors must be on-device and interleaved (TILE layout).
+            Memory Support:
+                - Interleaved: DRAM and L1
+                - Sharded (L1): Height sharded
+
+            Limitations:
+                * All tensors must be on-device, interleaved, and tile layout.
                 * Using the attention-optimized kernels requires a 4D input tensor and reducing on the last dimension.
 
             Example:

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -39,12 +39,6 @@ void bind_reduction_cumprod_operation(py::module& module) {
         Returns:
             ttnn.Tensor: the output tensor.
 
-        Example:
-            .. code-block:: python
-
-                input_tensor = ttnn.rand((N, N), device=device)
-                output_tensor = ttnn.cumprod(input_tensor, dim=0)
-
         Note:
             If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.
 
@@ -67,10 +61,7 @@ void bind_reduction_cumprod_operation(py::module& module) {
                  - dim in {0, 1, ..., rank - 3} or dim in {-rank, -rank + 1, ..., -3}
 
         Example:
-
             .. code-block:: python
-
-                import ttnn
 
                 # Create tensor
                 tensor_input = ttnn.rand((2,3,4), device=device)
@@ -79,9 +70,10 @@ void bind_reduction_cumprod_operation(py::module& module) {
                 tensor_output = ttnn.cumprod(tensor_input, dim=0)
 
                 # With preallocated output and dtype
-                preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
+                preallocated_output = ttnn.rand([2, 3, 4], dtype=ttnn.bfloat16, device=device)
 
-                tensor_output = ttnn.cumprod(tensor_input, dim=0, dtype=torch.bfloat16, output=preallocated_output)
+                tensor_output = ttnn.cumprod(tensor_input, dim=0, dtype=ttnn.bfloat16, out=preallocated_output)
+
         )doc";
 
     using OperationType = decltype(ttnn::cumprod);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -60,6 +60,13 @@ void bind_reduction_cumprod_operation(py::module& module) {
                  - 3, 4, 5
                  - dim in {0, 1, ..., rank - 3} or dim in {-rank, -rank + 1, ..., -3}
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+
+        Limitations:
+            - Preallocated output must have the same shape as the input
+            - Preallocated output for integer types is not supported
+
         Example:
             .. code-block:: python
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -40,8 +40,10 @@ void bind_reduction_cumprod_operation(py::module& module) {
             ttnn.Tensor: the output tensor.
 
         Example:
-            input_tensor = ttnn.rand((N, N), device=device)
-            output_tensor = ttnn.cumprod(input_tensor, dim=0)
+            .. code-block:: python
+
+                input_tensor = ttnn.rand((N, N), device=device)
+                output_tensor = ttnn.cumprod(input_tensor, dim=0)
 
         Note:
             If both `dtype` and `output` are specified then `output.dtype` must match `dtype`.

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.cpp
@@ -18,6 +18,8 @@ namespace ttnn::operations::reduction::accumulation::detail {
 void bind_reduction_cumprod_operation(py::module& module) {
     auto docstring =
         R"doc(
+        ``ttnn.cumprod(input: ttnn.Tensor, dim: int, dtype: Optional[ttnn.DataType] = None, reverse_order: bool = False, out: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
+
         Returns cumulative product of `input` along dimension `dim`
         For a given `input` of size N, the `output` will also contain N elements and be such that:
 
@@ -26,7 +28,7 @@ void bind_reduction_cumprod_operation(py::module& module) {
 
 
         Args:
-            input (ttnn.Tensor): input tensor
+            input (ttnn.Tensor): input tensor. Must be on the device.
             dim (int): dimension along which to compute cumulative product
 
         Keyword Args:
@@ -64,20 +66,20 @@ void bind_reduction_cumprod_operation(py::module& module) {
 
         Example:
 
-        .. code-block:: python
+            .. code-block:: python
 
-            import ttnn
+                import ttnn
 
-            # Create tensor
-            tensor_input = ttnn.rand((2,3,4), device=device)
+                # Create tensor
+                tensor_input = ttnn.rand((2,3,4), device=device)
 
-            # Apply ttnn.cumprod() on dim=0
-            tensor_output = ttnn.cumprod(tensor_input, dim=0)
+                # Apply ttnn.cumprod() on dim=0
+                tensor_output = ttnn.cumprod(tensor_input, dim=0)
 
-            # With preallocated output and dtype
-            preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
+                # With preallocated output and dtype
+                preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
 
-            tensor_output = ttnn.cumprod(tensor_input, dim=0, dtype=torch.bfloat16, output=preallocated_output)
+                tensor_output = ttnn.cumprod(tensor_input, dim=0, dtype=torch.bfloat16, output=preallocated_output)
         )doc";
 
     using OperationType = decltype(ttnn::cumprod);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -20,6 +20,8 @@ namespace py = pybind11;
 void bind_reduction_cumsum_operation(py::module& module) {
     auto docstring =
         R"doc(
+        ``ttnn.cumsum(input: ttnn.Tensor, dim: int, dtype: Optional[ttnn.DataType] = None, reverse_order: bool = False, out: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
+
         Returns cumulative sum of :attr:`input` along dimension :attr:`dim`
         For a given :attr:`input` of size N, the :attr:`output` will also contain N elements and be such that:
 
@@ -27,7 +29,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
             \mathrm{{output}}_i = \mathrm{{input}}_1 + \mathrm{{input}}_2 + \cdots + \mathrm{{input}}_i
 
         Args:
-            input (ttnn.Tensor): input tensor
+            input (ttnn.Tensor): input tensor. Must be on the device.
             dim (int): dimension along which to compute cumulative sum
 
         Keyword Args:

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -71,7 +71,7 @@ void bind_reduction_cumsum_operation(py::module& module) {
                 tensor_output = ttnn.cumsum(tensor_input, dim=0)
 
                 # With preallocated output and dtype
-                preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
+                preallocated_output = ttnn.rand([2, 3, 4], dtype=ttnn.bfloat16, device=device)
 
                 tensor_output = ttnn.cumsum(tensor_input, dim=0, dtype=ttnn.bfloat16, out=preallocated_output)
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -40,7 +40,6 @@ void bind_reduction_cumsum_operation(py::module& module) {
         Returns:
             ttnn.Tensor: the output tensor.
 
-
         Note:
             If both :attr:`dtype` and :attr:`output` are specified then :attr:`output.dtype` must match :attr:`dtype`.
 
@@ -63,21 +62,19 @@ void bind_reduction_cumsum_operation(py::module& module) {
                  - dim in {0, 1, ..., rank - 3} or dim in {-rank, -rank + 1, ..., -3}
 
         Example:
+            .. code-block:: python
 
-        .. code-block:: python
+                # Create tensor
+                tensor_input = ttnn.rand((2, 3, 4), device=device)
 
-            import ttnn
+                # Apply ttnn.cumsum() on dim=0
+                tensor_output = ttnn.cumsum(tensor_input, dim=0)
 
-            # Create tensor
-            tensor_input = ttnn.rand((2, 3, 4), device=device)
+                # With preallocated output and dtype
+                preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
 
-            # Apply ttnn.cumsum() on dim=0
-            tensor_output = ttnn.cumsum(tensor_input, dim=0)
+                tensor_output = ttnn.cumsum(tensor_input, dim=0, dtype=ttnn.bfloat16, out=preallocated_output)
 
-            # With preallocated output and dtype
-            preallocated_output = ttnn.from_torch(torch.rand([2, 3, 4]), dtype=ttnn.bfloat16, device=device)
-
-            tensor_output = ttnn.cumsum(tensor_input, dim=0, dtype=torch.bfloat16, out=preallocated_output)
         )doc";
 
     using OperationType = decltype(ttnn::cumsum);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -61,6 +61,13 @@ void bind_reduction_cumsum_operation(py::module& module) {
                  - 3, 4, 5
                  - dim in {0, 1, ..., rank - 3} or dim in {-rank, -rank + 1, ..., -3}
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+
+        Limitations:
+            - Preallocated output must have the same shape as the input
+            - Preallocated output for integer types is not supported
+
         Example:
             .. code-block:: python
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -66,13 +66,14 @@ void bind_reduction_argmax_operation(py::module& module) {
                 - Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
 
             Example:
-                input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+              .. code-block:: python
+                  input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-                # Last dim reduction yields shape of [1, 1, 32, 1]
-                output_onedim = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
+                  # Last dim reduction yields shape of [1, 1, 32, 1]
+                  output_onedim = ttnn.argmax(input_tensor, dim=-1, keepdim=True)
 
-                # All dim reduction yields shape of []
-                output_alldim = ttnn.argmax(input_tensor)
+                  # All dim reduction yields shape of []
+                  output_alldim = ttnn.argmax(input_tensor)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -67,6 +67,7 @@ void bind_reduction_argmax_operation(py::module& module) {
 
             Example:
               .. code-block:: python
+
                   input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
 
                   # Last dim reduction yields shape of [1, 1, 32, 1]

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -15,6 +15,8 @@ namespace ttnn::operations::reduction::detail {
 void bind_reduction_argmax_operation(py::module& module) {
     auto doc =
         R"doc(
+            ``ttnn.argmax(input_tensor: ttnn.Tensor, dim: Optional[int] = None, keepdim: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, output_tensor: Optional[ttnn.Tensor] = None) -> ttnn.Tensor``
+
             Returns the indices of the maximum value of elements in the :attr:`input_tensor`.
             If no :attr:`dim` is provided, it will return the indices of maximum value of all elements in given :attr:`input_tensor`.
 
@@ -37,17 +39,17 @@ void bind_reduction_argmax_operation(py::module& module) {
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - FLOAT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
                     * - BFLOAT16
-                        - ROW_MAJOR
+                      - ROW_MAJOR
                     * - UINT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
                     * - INT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
                     * - UINT16
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 The output tensor will be of the following data type and layout:
 
@@ -55,12 +57,13 @@ void bind_reduction_argmax_operation(py::module& module) {
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - UINT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
             Limitations:
-                Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
+                - All input tensors must be on-device.
+                - Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
 
             Example:
                 input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.ROW_MAJOR_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -61,9 +61,13 @@ void bind_reduction_argmax_operation(py::module& module) {
                     * - UINT32
                       - ROW_MAJOR
 
+            Memory Support:
+                - Interleaved: DRAM and L1
+
             Limitations:
                 - All input tensors must be on-device.
                 - Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
+                - Sharding is not supported for this operation
 
             Example:
               .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -16,47 +16,48 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
     namespace py = pybind11;
     auto doc = fmt::format(
         R"doc(
-        {0}
+        ``{1}(input_tensor: ttnn.Tensor, dim: Optional[int] = None, keepdim: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None, compute_kernel_config: Optional[ttnn.ComputeKernelConfig] = None, scalar: float = 1.0, correction: bool = True) -> ttnn.Tensor``
 
         Computes the {0} of the input tensor :attr:`input_a` along the specified dimension :attr:`dim`.
         If no dimension is provided, {0} is computed over all dimensions yielding a single value.
 
-            Args:
-                input_a (ttnn.Tensor): the input tensor.
-                dim (number): dimension value to reduce over.
-                keepdim (bool, optional): keep original dimension size. Defaults to `False`.
+        Args:
+            input_a (ttnn.Tensor): the input tensor. Must be on the device.
+            dim (number): dimension value to reduce over.
+            keepdim (bool, optional): keep original dimension size. Defaults to `False`.
 
-            Keyword Args:
-                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                compute_kernel_config (ttnn.ComputeKernelConfig, optional): Compute kernel configuration for the operation. Defaults to `None`.
-                scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
-                correction (bool, optional): Applies only to std - whether to apply Bessel's correction (i.e. N-1). Defaults to `True`.
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            compute_kernel_config (ttnn.ComputeKernelConfig, optional): Compute kernel configuration for the operation. Defaults to `None`.
+            scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
+            correction (bool, optional): Applies only to :func:`ttnn.std` - whether to apply Bessel's correction (i.e. N-1). Defaults to `True`.
 
-            Returns:
-                ttnn.Tensor: the output tensor.
+        Returns:
+            ttnn.Tensor: the output tensor.
 
-            Note:
-                The input tensor supports the following data types and layouts:
+        Note:
+            The input tensor supports the following data types and layouts:
 
-                .. list-table:: Input Tensor
-                    :header-rows: 1
+            .. list-table:: Input Tensor
+                :header-rows: 1
 
-                    * - dtype
-                        - layout
-                    * - FLOAT32
-                        - ROW_MAJOR, TILE
-                    * - BFLOAT16
-                        - ROW_MAJOR, TILE
-                    * - BFLOAT8_B
-                        - ROW_MAJOR, TILE
-                    * - INT32
-                        - ROW_MAJOR, TILE
-                    * - UINT32
-                        - ROW_MAJOR, TILE
+                * - dtype
+                  - layout
+                * - FLOAT32
+                  - ROW_MAJOR, TILE
+                * - BFLOAT16
+                  - ROW_MAJOR, TILE
+                * - BFLOAT8_B
+                  - ROW_MAJOR, TILE
+                * - INT32
+                  - ROW_MAJOR, TILE
+                * - UINT32
+                  - ROW_MAJOR, TILE
 
-                The output tensor will match the data type and layout of the input tensor.
+            The output tensor will match the data type and layout of the input tensor.
 
-            Example:
+        Example:
+            .. code-block:: python
 
                 input_a = ttnn.rand(1, 2), dtype=torch.bfloat16, device=device)
                 output = {1}(input_a, dim, memory_config)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -56,6 +56,11 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
 
             The output tensor will match the data type and layout of the input tensor.
 
+        Memory Support:
+            - Interleaved: DRAM and L1
+            - Sharded (L1): Width, Height, and ND sharding
+            - Output sharding/layout will mirror the input
+
         Example:
             .. code-block:: python
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -55,6 +55,9 @@ void bind_reduction_moe_operation(py::module& module) {
 
                 The output tensor will match the data type and layout of the input tensor.
 
+            Memory Support:
+                - Interleaved: DRAM and L1
+
             Limitations:
                 - Tensors must be 4D with shape [N, C, H, W], and must be located on the device.
                 - For the :attr:`input_tensor`, N*C*H must be a multiple of 32. The last dimension must be a power of two and ≥64.
@@ -62,7 +65,7 @@ void bind_reduction_moe_operation(py::module& module) {
                 - For the :attr:`topk_mask_tensor`, H must be 32 and W must match :attr:`k` (i.e. 32).
                 - For the :attr:`expert_mask_tensor`, H must be 32 and W must match W of the :attr:`input_tensor`.
                 - All of the shape validations are performed on padded shapes.
-                - Sharded outputs are not supported for this operation.
+                - Sharding is not supported for this operation.
 
             Example:
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -65,14 +65,16 @@ void bind_reduction_moe_operation(py::module& module) {
                 - Sharded outputs are not supported for this operation.
 
             Example:
-                N, C, H, W = 1, 1, 32, 64
-                k = 32
+                .. code-block:: python
 
-                input_tensor = ttnn.rand([N, C, H, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-                expert_mask = ttnn.zeros([N, C, 1, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-                topE_mask = ttnn.zeros([N, C, 1, k], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+                    N, C, H, W = 1, 1, 32, 64
+                    k = 32
 
-                ttnn_output = ttnn.moe(input_tensor, expert_mask, topE_mask, k)
+                    input_tensor = ttnn.rand([N, C, H, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+                    expert_mask = ttnn.zeros([N, C, 1, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+                    topE_mask = ttnn.zeros([N, C, 1, k], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+                    ttnn_output = ttnn.moe(input_tensor, expert_mask, topE_mask, k)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -62,6 +62,7 @@ void bind_reduction_moe_operation(py::module& module) {
                 - For the :attr:`topk_mask_tensor`, H must be 32 and W must match :attr:`k` (i.e. 32).
                 - For the :attr:`expert_mask_tensor`, H must be 32 and W must match W of the :attr:`input_tensor`.
                 - All of the shape validations are performed on padded shapes.
+                - Sharded outputs are not supported for this operation.
 
             Example:
                 N, C, H, W = 1, 1, 32, 64

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -18,7 +18,8 @@ namespace ttnn::operations::reduction::detail {
 
 void bind_reduction_moe_operation(py::module& module) {
     auto doc =
-        R"doc(moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt) -> ttnn.Tensor
+        R"doc(
+            ``ttnn.moe(input_tensor: ttnn.Tensor, expert_mask_tensor: ttnn.Tensor, topk_mask_tensor: ttnn.Tensor, k: int = 32, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
 
             Returns the weight of the zero-th MoE expert.
 
@@ -48,14 +49,14 @@ void bind_reduction_moe_operation(py::module& module) {
                         :header-rows: 1
 
                         * - dtype
-                            - layout
+                          - layout
                         * - BFLOAT16
-                            - TILE
+                          - TILE
 
                 The output tensor will match the data type and layout of the input tensor.
 
             Limitations:
-                - Tensors must be 4D.
+                - Tensors must be 4D with shape [N, C, H, W], and must be located on the device.
                 - For the :attr:`input_tensor`, N*C*H must be a multiple of 32. The last dimension must be a power of two and ≥64.
                 - :attr:`k` must be exactly 32.
                 - For the :attr:`topk_mask_tensor`, H must be 32 and W must match :attr:`k` (i.e. 32).

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -18,6 +18,8 @@ template <typename unary_operation_t>
 void bind_reduction_prod_operation(py::module& module, const unary_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
+            ``{1}(input_tensor: ttnn.Tensor, dim: Optional[int] = None, keepdim: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
+
             Computes the product of all elements on specified :attr:`dim` of the :attr:`input_tensor` tensor.
 
             If no :attr:`dim` is provided (or :attr:`dim` is set to `None`), it will compute the full product of every element in the :attr:`input_tensor` tensor.
@@ -25,11 +27,20 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
             If :attr:`keepdim` is `True`, the resulting tensor will have the same rank as the :attr:`input_tensor` tensor, but with the specified :attr:`dim` reduced to 1.
             Otherwise, the target :attr:`dim` will be squeezed, resulting in an output tensor with one less dimension than the :attr:`input_tensor` tensor.
 
+
+            {0} is also overloaded with a niche NC version of this function, with the following definition:
+
+            ``{1}(input_tensor: ttnn.Tensor, output_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
+
+            This version allows for a list of :attr:`dims` to be specified instead of a :attr:`dim`, requires an :attr:`output_tensor` tensor, and does not support :attr:`keepdim`.
+            It is only intended for use with the NC dimensions (0, 1).
+
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
 
             Keyword Args:
                 dim (int, optional): Dimension to perform prod. Defaults to `None`.
+                dims (List[int], optional): Dimensions to perform prod. Defaults to `None`. Mutually exclusive with `dim`.
                 keepdim (bool, optional): keep original dimension size. Defaults to `False`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
@@ -43,9 +54,9 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - TILE, ROW_MAJOR
+                      - TILE, ROW_MAJOR
 
                 The :attr:`output_tensor` will be in the following data type and layout:
 
@@ -53,17 +64,32 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - TILE
+                      - TILE
 
             Limitations:
+                - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), the :attr:`input_tensor` must be bfloat16, and keepdim=True is not supported  (as this operation results in a scalar).
 
-            Example::
-                tensor = ttnn.rand((1,2), device=device)
-                output = {1}(tensor, dim=0)
-                output_all_dims = {1}(tensor)
+            Example:
+                .. code-block:: python
+
+                    tensor = ttnn.rand((1,2), device=device)
+                    output = {1}(tensor, dim=0)
+                    output_all_dims = {1}(tensor)
+
+            Example (NC Product):
+                .. code-block:: python
+
+                    dims = [0,1]
+                    input_shape = [2, 3, 4, 5]
+                    output_shape = [1, 1, 4, 5] # shape on any dimension being reduced will be 1
+
+                    input_tensor = ttnn.rand(input_shape, device)
+                    output_tensor = ttnn.rand(output_shape, device)
+
+                    output = {1}(input_tensor=input_tensor, output_tensor=output_tensor, dims=dims)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -68,9 +68,13 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                     * - BFLOAT16
                       - TILE
 
+            Memory Support:
+                - Interleaved: DRAM and L1
+
             Limitations:
                 - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), the :attr:`input_tensor` must be bfloat16, and keepdim=True is not supported  (as this operation results in a scalar).
+                - Sharding is not supported for this operation
 
             Example:
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -116,6 +116,9 @@ void bind_reduction_sampling_operation(py::module& module) {
             Returns:
                 ttnn.Tensor: The output tensor containing sampled indices.
 
+            Memory Support:
+              - Interleaved: DRAM and L1
+
             Limitations:
               - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
               - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
@@ -124,7 +127,6 @@ void bind_reduction_sampling_operation(py::module& module) {
               - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
               - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
               - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
-              - All tensors use an INTERLEAVED memory layout.
 
             Example:
                 .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -15,6 +15,8 @@ namespace py = pybind11;
 void bind_reduction_sampling_operation(py::module& module) {
     auto doc =
         R"doc(
+            ``ttnn.sampling(input_values_tensor: ttnn.Tensor, input_indices_tensor: ttnn.Tensor, k: ttnn.Tensor, p: ttnn.Tensor, temp: ttnn.Tensor, seed: Optional[int] = None, sub_core_grids: Optional[ttnn.CoreRangeSet] = None, output_tensor: Optional[ttnn.Tensor] = None) -> ttnn.Tensor``
+
             Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
 
             This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
@@ -53,53 +55,54 @@ void bind_reduction_sampling_operation(py::module& module) {
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - TILE
+                      - TILE
 
 
                 .. list-table:: input_indices_tensor
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - UINT32, INT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 .. list-table:: k
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - UINT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 .. list-table:: p, temp
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT16
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 If no :attr:`output_tensor` is provided, the return tensor will be as follows:
                 .. list-table:: output_tensor (default)
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - UINT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
 
                 If :attr:`output_tensor` is provided, the supported data types and layout are:
                 .. list-table:: output_tensor (if provided)
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - INT32, UINT32
-                        - ROW_MAJOR
+                      - ROW_MAJOR
                 Limitations:
+                - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
                 - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
                 - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
                 - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -125,13 +125,15 @@ void bind_reduction_sampling_operation(py::module& module) {
                 ttnn.Tensor: The output tensor containing sampled indices.
 
             Example:
-                input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
-                input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                .. code-block:: python
 
-                output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+                    input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
+                    input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                    k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                    p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                    temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+                    output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_pybind.cpp
@@ -15,40 +15,50 @@ namespace py = pybind11;
 void bind_reduction_sampling_operation(py::module& module) {
     auto doc =
         R"doc(
-            ``ttnn.sampling(input_values_tensor: ttnn.Tensor, input_indices_tensor: ttnn.Tensor, k: ttnn.Tensor, p: ttnn.Tensor, temp: ttnn.Tensor, seed: Optional[int] = None, sub_core_grids: Optional[ttnn.CoreRangeSet] = None, output_tensor: Optional[ttnn.Tensor] = None) -> ttnn.Tensor``
+          ``ttnn.sampling(input_values_tensor: ttnn.Tensor, input_indices_tensor: ttnn.Tensor, k: ttnn.Tensor, p: ttnn.Tensor, temp: ttnn.Tensor, seed: Optional[int] = None, sub_core_grids: Optional[ttnn.CoreRangeSet] = None, output_tensor: Optional[ttnn.Tensor] = None) -> ttnn.Tensor``
 
-            Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
+          Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
 
-            This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
-            and :attr:`p` (top-p nucleus sampling). The operation uses the :attr:`input_indices_tensor` for indexing and applies sampling
-            under the given seed for reproducibility.
+          This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
+          and :attr:`p` (top-p nucleus sampling). The operation uses the :attr:`input_indices_tensor` for indexing and applies sampling
+          under the given seed for reproducibility.
 
-            The op first converts the :attr:`input_values_tensor` into probabilities by doing a softmax.
+          The op first converts the :attr:`input_values_tensor` into probabilities by doing a softmax.
 
-            In top-k sampling, the op considers only the k highest-probability values from the input distribution. The remaining values are ignored, regardless of their probabilities.
-            In top-p sampling, the op selects values from the input distribution such that the cumulative probability mass is less than or equal to a threshold p.
-            When combining top-k and top-p sampling, the op first applies the top-k filter and then the top-p filter.
+          In top-k sampling, the op considers only the k highest-probability values from the input distribution. The remaining values are ignored, regardless of their probabilities.
+          In top-p sampling, the op selects values from the input distribution such that the cumulative probability mass is less than or equal to a threshold p.
+          When combining top-k and top-p sampling, the op first applies the top-k filter and then the top-p filter.
 
-            Within this selected corpus, multinomial sampling is applied. Multinomial sampling selects values from a given distribution by comparing each probability with a randomly generated number between 0 and 1. Specifically, the operation identifies the largest cumulative probability that exceeds the random threshold.
+          Within this selected corpus, multinomial sampling is applied. Multinomial sampling selects values from a given distribution by comparing each probability with a randomly generated number between 0 and 1. Specifically, the operation identifies the largest cumulative probability that exceeds the random threshold.
 
-            The op finally returns input_indices_tensor[final_index]  where final_index is the index of the largest cumulative probability > random number found in the multinomial sampling.
+          The op finally returns input_indices_tensor[final_index]  where final_index is the index of the largest cumulative probability > random number found in the multinomial sampling.
 
-            Currently, this operation supports inputs and outputs with specific memory layout and data type constraints.
+          Currently, this operation supports inputs and outputs with specific memory layout and data type constraints.
 
-            Equivalent PyTorch code:
-                .. code-block:: python
+          Equivalent PyTorch code:
+              .. code-block:: python
 
-                    return torch.sampling(
-                        input_values_tensor,
-                        input_indices_tensor,
-                        k=k,
-                        p=p,
-                        temp=temp,
-                        seed=seed,
-                        optional_output_tensor=optional_output_tensor,
-                    )
+                  return torch.sampling(
+                      input_values_tensor,
+                      input_indices_tensor,
+                      k=k,
+                      p=p,
+                      temp=temp,
+                      seed=seed,
+                      optional_output_tensor=optional_output_tensor,
+                  )
 
-            Note:
+            Args:
+                input_values_tensor (ttnn.Tensor): The input tensor containing values to sample from.
+                input_indices_tensor (ttnn.Tensor): The input tensor containing indices to assist with sampling.
+                k (ttnn.Tensor): Top-k values for sampling.
+                p (ttnn.Tensor): Top-p (nucleus) probabilities for sampling.
+                temp (ttnn.Tensor): Temperature tensor for scaling (1/T).
+                seed (int, optional): Seed for sampling randomness. Defaults to `0`.
+                sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
+                optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+
+              Note:
                 This operations only supports inputs and outputs according to the following data types and layout:
 
                 .. list-table:: input_values_tensor
@@ -94,6 +104,7 @@ void bind_reduction_sampling_operation(py::module& module) {
                       - ROW_MAJOR
 
                 If :attr:`output_tensor` is provided, the supported data types and layout are:
+
                 .. list-table:: output_tensor (if provided)
                     :header-rows: 1
 
@@ -101,39 +112,30 @@ void bind_reduction_sampling_operation(py::module& module) {
                       - layout
                     * - INT32, UINT32
                       - ROW_MAJOR
-                Limitations:
-                - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
-                - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
-                - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
-                - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
-                - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
-                - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
-                - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
-                - All tensors use an INTERLEAVED memory layout.
-
-            Args:
-                input_values_tensor (ttnn.Tensor): The input tensor containing values to sample from.
-                input_indices_tensor (ttnn.Tensor): The input tensor containing indices to assist with sampling.
-                k (ttnn.Tensor): Top-k values for sampling.
-                p (ttnn.Tensor): Top-p (nucleus) probabilities for sampling.
-                temp (ttnn.Tensor): Temperature tensor for scaling (1/T).
-                seed (int, optional): Seed for sampling randomness. Defaults to `0`.
-                sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
-                optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
             Returns:
                 ttnn.Tensor: The output tensor containing sampled indices.
 
+            Limitations:
+              - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
+              - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
+              - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
+              - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
+              - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
+              - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
+              - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
+              - All tensors use an INTERLEAVED memory layout.
+
             Example:
                 .. code-block:: python
 
-                    input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
-                    input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                    k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                    p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                    temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                  input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
+                  input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                  k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                  p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                  temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-                    output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+                  output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -78,8 +78,10 @@ void bind_reduction_topk_operation(py::module& module) {
                 - Sharded outputs are not supported for this operation.
 
             Example:
-                input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)
-                topk_values, topk_indices = ttnn.topk(input_tensor, k=32, dim=-1, largest=True, sorted=True)
+                .. code-block:: python
+
+                    input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)
+                    topk_values, topk_indices = ttnn.topk(input_tensor, k=32, dim=-1, largest=True, sorted=True)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -12,7 +12,8 @@ namespace py = pybind11;
 
 void bind_reduction_topk_operation(py::module& module) {
     auto doc =
-        R"doc(topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, ) -> Tuple[ttnn.Tensor, ttnn.Tensor]
+        R"doc(
+            ``ttnn.topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out: Optional[Tuple[ttnn.Tensor, ttnn.Tensor]] = None, memory_config: Optional[ttnn.MemoryConfig] = None, sub_core_grids: Optional[ttnn.CoreRangeSet] = None, indices_tensor: Optional[ttnn.Tensor] = None) -> Tuple[ttnn.Tensor, ttnn.Tensor]``
 
             Returns the :attr:`k` largest or :attr:`k` smallest elements of the :attr:`input_tensor` along a given dimension :attr:`dim`.
 
@@ -51,21 +52,22 @@ void bind_reduction_topk_operation(py::module& module) {
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - BFLOAT8, BFLOAT16
-                        - TILE
+                      - TILE
 
                 .. list-table:: index_tensor
                     :header-rows: 1
 
                     * - dtype
-                        - layout
+                      - layout
                     * - UINT16, UINT32
-                        - TILE
+                      - TILE
 
                 The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
 
             Limitations:
+                - Inputs must be located on-device.
                 - The op fundamentally operates on 4D tensors with shape [N, C, H, W], and with :attr:`dim` of -1. The tensor will be manipulated as needed when this is not the case, and restored afterwards.
                 - For :attr:`input_tensor`, N*C*H must be a multiple of 32
                 - W is ideally ≥64. If this is not the case the op will pad the tensor to satisfy this constraint.

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -75,6 +75,7 @@ void bind_reduction_topk_operation(py::module& module) {
                 - The padding is currently only supported for bfloat16, float32, int32, and uint32.
                 - To enable multicore execution, the width of :attr:`input_tensor` along :attr:`dim` must be ≥8192 and <65536, and :attr:`k` must be ≤64.
                 - All shape validations are performed on padded shapes.
+                - Sharded outputs are not supported for this operation.
 
             Example:
                 input_tensor = ttnn.rand([1, 1, 32, 64], device=device, layout=ttnn.TILE_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -66,6 +66,9 @@ void bind_reduction_topk_operation(py::module& module) {
 
                 The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
 
+            Memory Support:
+                - Interleaved: DRAM and L1
+
             Limitations:
                 - Inputs must be located on-device.
                 - The op fundamentally operates on 4D tensors with shape [N, C, H, W], and with :attr:`dim` of -1. The tensor will be manipulated as needed when this is not the case, and restored afterwards.
@@ -75,7 +78,7 @@ void bind_reduction_topk_operation(py::module& module) {
                 - The padding is currently only supported for bfloat16, float32, int32, and uint32.
                 - To enable multicore execution, the width of :attr:`input_tensor` along :attr:`dim` must be ≥8192 and <65536, and :attr:`k` must be ≤64.
                 - All shape validations are performed on padded shapes.
-                - Sharded outputs are not supported for this operation.
+                - Sharded output memory configs are not supported for this operation.
 
             Example:
                 .. code-block:: python


### PR DESCRIPTION
### Ticket
#28959 
#29861

### Problem description
Fused/Matmul/Reduce needed further attention. 

### What's changed
- Function headers were added for all ops
- Matmul support matrices were added
- Memory support section added for all ops
- Ensure ops mention that tensors need to be on-device
- Assorted spacing issues were fixed 
- The prod op now documents the NC multidim variant
- Some notes on the output tensors were added
- Fixed some examples that could not be run

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18173341478)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes