### PR TITLE
Bring tt-smi from pypi

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -5,7 +5,7 @@
 # Make it match pyproject.toml
 loguru==0.6.0
 
-git+https://github.com/tenstorrent/tt-smi.git@v3.0.27
+tt-smi==3.0.27
 
 # For github workflow unit test failure annotations
 pytest-github-actions-annotate-failures==0.3.0

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -5,7 +5,7 @@
 # Make it match pyproject.toml
 loguru==0.6.0
 
-tt-smi==3.0.27
+tt-smi==3.0.30
 
 # For github workflow unit test failure annotations
 pytest-github-actions-annotate-failures==0.3.0


### PR DESCRIPTION
### Ticket
NA

### Problem description
We currently use a legacy mechanism to bring tt-smi into the docker container.
This mechanism requires having the build environment dependencies for tt-smi like rustc.

### What's changed
Change to use newly available pypi package with precompiled sources.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes