### PR TITLE
#29846: add fp32 reduce to groupnorm

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -359,7 +359,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_uniniti<FP32_DEST_ACC>();
+                reduce_uninit<FP32_DEST_ACC>();
                 cb_push_back(cb_ex_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_push_back(cb_ex, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -316,7 +316,7 @@ void MAIN {
 
                 // Partial/E[x]
                 index_h_offset = 0;
-                reduce_init(cb_x, cb_scaler, cb_ex_partial);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x, cb_scaler, cb_ex_partial);
                 cb_reserve_back(cb_ex_partial, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_scaler, 1);
@@ -325,7 +325,7 @@ void MAIN {
                 for (uint32_t h = 0; h < out_block_h_actual; ++h) {
                     for (uint32_t w = 0; w < block_w; ++w) {
                         uint32_t index = index_h_offset + w;
-                        reduce_tile(cb_x, cb_scaler, index, scaler0, dst0);
+                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x, cb_scaler, index, scaler0, dst0);
                     }
                     index_h_offset += block_w;
                 }
@@ -335,14 +335,14 @@ void MAIN {
                 tile_regs_release();
                 cb_pop_front(cb_x, out_block_hw_normal);
                 cb_push_back(cb_ex_partial, 1);
-                reduce_uninit();
+                reduce_uninit<FP32_DEST_ACC>();
 
                 cb_wait_front(cb_ex_partial, 1);
             }
             // End Local Redcue
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_reserve_back(cb_ex, 1);
@@ -351,14 +351,15 @@ void MAIN {
                 cb_wait_front(cb_scaler_global, 1);
                 cb_wait_front(cb_ex_external, cb_ex_external_tiles_required);
                 for (uint32_t external_i = 0; external_i < cb_ex_external_tiles_required; external_i++) {
-                    reduce_tile(cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
+                    reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                        cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
                 }
                 cb_pop_front(cb_ex_external, cb_ex_external_tiles_required);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_uninit();
+                reduce_uniniti<FP32_DEST_ACC>();
                 cb_push_back(cb_ex_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_push_back(cb_ex, 1);
@@ -466,7 +467,7 @@ void MAIN {
 
                 // Partial-Var(x)
                 index_h_offset = 0;
-                reduce_init(cb_xmm, cb_scaler, cb_ex2_partial);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_xmm, cb_scaler, cb_ex2_partial);
                 cb_reserve_back(cb_ex2_partial, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_xmm, out_block_hw_normal);
@@ -474,7 +475,7 @@ void MAIN {
                 for (uint32_t h = 0; h < out_block_h_actual; ++h) {
                     for (uint32_t w = 0; w < block_w; ++w) {
                         uint32_t index = index_h_offset + w;
-                        reduce_tile(cb_xmm, cb_scaler, index, scaler0, dst0);
+                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_xmm, cb_scaler, index, scaler0, dst0);
                     }
                     index_h_offset += block_w;
                 }
@@ -484,12 +485,12 @@ void MAIN {
                 tile_regs_release();
                 cb_push_back(cb_ex2_partial, 1);
                 cb_pop_front(cb_xmm, out_block_hw_normal);
-                reduce_uninit();
+                reduce_uninit<FP32_DEST_ACC>();
             }
             // End Local Reduce
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init(cb_ex_external, cb_scaler_global, cb_ex2_global);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex2_global);
                 cb_reserve_back(cb_ex2_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_reserve_back(cb_ex2, 1);
@@ -498,14 +499,15 @@ void MAIN {
                 cb_wait_front(cb_scaler_global, 1);
                 cb_wait_front(cb_ex_external, cb_ex_external_tiles_required);  // TODO DELETE THIS AND ADD POP
                 for (uint32_t external_i = 0; external_i < cb_ex_external_tiles_required; external_i++) {
-                    reduce_tile(cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
+                    reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                        cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
                 }
                 cb_pop_front(cb_ex_external, cb_ex_external_tiles_required);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex2_global);
                 tile_regs_release();
-                reduce_uninit();
+                reduce_uninit<FP32_DEST_ACC>();
                 cb_push_back(cb_ex2_global, 1);
                 if (num_cores_per_mcast_group > 1) {
                     cb_push_back(cb_ex2, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -237,34 +237,34 @@ void MAIN {
             tile_regs_release();
             cb_push_back(cb_ex2pe, 1);
             tile_regs_acquire();
-            reduce_init(cb_ex2pe, cb_scaler, cb_ex_partial);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, cb_ex_partial);
             cb_reserve_back(cb_ex_partial, 1);
             cb_wait_front(cb_scaler, 1);
             cb_wait_front(cb_ex2pe, 1);
             // reduce only one final tile
-            reduce_tile(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
             cb_pop_front(cb_ex2pe, 1);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex_partial);
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
-            reduce_uninit();
+            reduce_uninit<FP32_DEST_ACC>();
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_scaler_global, 1);
                 cb_wait_front(cb_ex_external, 1);
-                reduce_tile(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external, 1);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_uninit();
+                reduce_uninit<FP32_DEST_ACC>();
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }
@@ -353,34 +353,34 @@ void MAIN {
             cb_wait_front(cb_scaler, 1);
             cb_wait_front(cb_ex2pe, 1);
 
-            reduce_init(cb_ex2pe, cb_scaler, cb_ex_partial);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, cb_ex_partial);
 
             tile_regs_acquire();
-            reduce_tile(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex_partial);
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
 
-            reduce_uninit();
+            reduce_uninit<FP32_DEST_ACC>();
 
             cb_pop_front(cb_ex2pe, 1);
             cb_wait_front(cb_ex_partial, 1);
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init(cb_ex_external, cb_scaler_global, cb_ex_global);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
                 cb_wait_front(cb_scaler_global, 1);
                 cb_wait_front(cb_ex_external, 1);
-                reduce_tile(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external, 1);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_uninit();
+                reduce_uninit<FP32_DEST_ACC>();
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -752,6 +752,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     // compute kernel
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
     CreateKernel(
         program,
         (use_welford
@@ -2093,6 +2094,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core(
     // compute kernel
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
     CreateKernel(
         program,
         (use_welford ? "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp"


### PR DESCRIPTION
### Ticket
Link to Github Issue #29846

### Problem description
fp32 reduce would mostly improve accuracy in groupnorm with minimal perf overhead 

### What's changed
Use fp32 reduce when fp32 dest acc is enabled. 

Thresholds in tests are not updated because sometimes accuracy seems reduced.

E.g. improved
```
fp32
ULP (tensor(False), 'Max ULP Delta: 5505024.0')
ALLCLOSE (False, 'Max ATOL Delta: 0.3125, Max RTOL Delta: inf')
PCC True MSG 0.9998786666824843

old
ULP (tensor(False), 'Max ULP Delta: 6815744.0')
ALLCLOSE (False, 'Max ATOL Delta: 0.484375, Max RTOL Delta: inf')
PCC False MSG 0.9994839693808615
```
vs reduced
fp32
```
ULP (tensor(False), 'Max ULP Delta: 3145728.0')
ALLCLOSE (False, 'Max ATOL Delta: 0.0546875, Max RTOL Delta: inf')
PCC True MSG 0.9999357415241064
old
ULP (tensor(False), 'Max ULP Delta: 1720320.0')
ALLCLOSE (False, 'Max ATOL Delta: 0.0546875, Max RTOL Delta: inf')
PCC True MSG 0.9999499025346397
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18205140351
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18211691158
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) between https://github.com/tenstorrent/tt-metal/actions/runs/18205154684/job/51848005945 and https://github.com/tenstorrent/tt-metal/actions/runs/18211723613/job/51853903447 all tests passed (rebased to different commits on main)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18175316525
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/18211755965
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18175323006
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes

Also single card frequent models and ttnn tests passed https://github.com/tenstorrent/tt-metal/actions/runs/18205203426