### PR TITLE
Workaround for multi-host t3k chip pinning

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -257,8 +257,9 @@ TEST(MultiHost, TestSplit2x2Fabric1DSanity) {
 }
 
 TEST(MultiHost, TestBigMesh2x4ControlPlaneInit) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::tt_metal::ClusterType::T3K) {
-        log_info(tt::LogTest, "This test is only for T3K");
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() !=
+        tt::tt_metal::ClusterType::N300_2x2) {
+        log_info(tt::LogTest, "This test is only for N300 2x2");
         GTEST_SKIP();
     }
 
@@ -278,11 +279,6 @@ TEST(MultiHost, TestBigMesh2x4Fabric2DSanity) {
         log_info(tt::LogTest, "This test is only for N300 2x2");
         GTEST_SKIP();
     }
-
-    log_warning(
-        tt::LogTest,
-        "This test is currently broken due to a bug in logical to physical mapping nw chip pinning, Issue #29719");
-    GTEST_SKIP();
 
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -312,12 +308,6 @@ TEST(MultiHost, TestBigMesh2x4Fabric1DSanity) {
         log_info(tt::LogTest, "This test is only for N300 2x2");
         GTEST_SKIP();
     }
-
-    // This test is currently broken due to a bug in logical to physical mapping nw chip pinning
-    log_warning(
-        tt::LogTest,
-        "This test is currently broken due to a bug in logical to physical mapping nw chip pinning, Issue #29719");
-    GTEST_SKIP();
 
     tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -53,24 +53,6 @@
 namespace tt::tt_fabric {
 
 namespace {
-// TODO: Support custom operator< for eth_coord_t to allow usage in std::set
-struct EthCoordComparator {
-    bool operator()(const eth_coord_t& eth_coord_a, const eth_coord_t& eth_coord_b) const {
-        if (eth_coord_a.cluster_id != eth_coord_b.cluster_id) {
-            return eth_coord_a.cluster_id < eth_coord_b.cluster_id;
-        }
-        if (eth_coord_a.x != eth_coord_b.x) {
-            return eth_coord_a.x < eth_coord_b.x;
-        }
-        if (eth_coord_a.y != eth_coord_b.y) {
-            return eth_coord_a.y < eth_coord_b.y;
-        }
-        if (eth_coord_a.rack != eth_coord_b.rack) {
-            return eth_coord_a.rack < eth_coord_b.rack;
-        }
-        return eth_coord_a.shelf < eth_coord_b.shelf;
-    }
-};
 
 // Get the physical chip ids for a mesh
 std::unordered_map<chip_id_t, std::vector<CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(chip_id_t chip_id) {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -681,22 +681,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_logical_chip_to_physical_chi
                 // TODO: Support custom operator< for eth_coord_t to allow usage in std::set
                 const auto min_coord =
                     *std::min_element(chip_eth_coords.begin(), chip_eth_coords.end(), [](const auto& a, const auto& b) {
-                        const auto& [chip_a, eth_coord_a] = a;
-                        const auto& [chip_b, eth_coord_b] = b;
-
-                        if (eth_coord_a.cluster_id != eth_coord_b.cluster_id) {
-                            return eth_coord_a.cluster_id < eth_coord_b.cluster_id;
-                        }
-                        if (eth_coord_a.x != eth_coord_b.x) {
-                            return eth_coord_a.x < eth_coord_b.x;
-                        }
-                        if (eth_coord_a.y != eth_coord_b.y) {
-                            return eth_coord_a.y < eth_coord_b.y;
-                        }
-                        if (eth_coord_a.rack != eth_coord_b.rack) {
-                            return eth_coord_a.rack < eth_coord_b.rack;
-                        }
-                        return eth_coord_a.shelf < eth_coord_b.shelf;
+                        return a.second < b.second;
                     });
 
                 nw_chip_physical_id =


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29719

### Problem description
This is because the nw chip gets pinned once for every local host, and doesn't know about the host-to-host connections, so it sometimes pins it like this:

Image
T3K Big mesh multi-chip NW chip pinning is currently not correct.

### What's changed
- [x] Using ethernet coordinates to make NW chip pinning correc
- [x] Enabled T3k big mesh 2x4 tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18198234895)
- [x] [Multi-host tests](https://github.com/tenstorrent/tt-metal/actions/runs/18175510931)