### PR TITLE
Add remaining methods to CircularBuffer class

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -27,12 +27,6 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
-namespace tt {
-namespace tt_metal {
-class IDevice;
-}  // namespace tt_metal
-}  // namespace tt
-
 using namespace tt::tt_metal;
 
 constexpr CoreCoord worker_core = {0, 0};

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_subordinate_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_subordinate_test_kernel.cpp
@@ -31,6 +31,7 @@ void kernel_main() {
     auto get_idx = [n_pages](size_t i, size_t j) -> size_t { return i * n_pages + j; };
 
     for (int32_t i = 0; i < n_cbs; i++) {
+        experimental::CircularBuffer cb(i);
         auto* const output_buffer = reinterpret_cast<uint8_t*>(output_buffer_addrs[i]);
         for (int32_t j = 0; j < n_pages; j++) {
             // First level signal indicates the writer has pushed new pages to the CB
@@ -38,14 +39,14 @@ void kernel_main() {
             noc_semaphore_set(subordinate_sem_addr, 1);
 
             for (int32_t k = 0; k < n_pages; k++) {
-                auto result = cb_pages_available_at_front(i, k);
+                auto result = cb.pages_available_at_front(k);
                 output_buffer[get_idx(j, k)] = static_cast<uint8_t>(result);
             }
             noc_semaphore_wait(master_sem_addr, 2);
             noc_semaphore_set(master_sem_addr, 0);
             if (j > 0) {
-                cb_wait_front(i, j);
-                cb_pop_front(i, j);
+                cb.wait_front(j);
+                cb.pop_front(j);
             }
             // Second level signal indicates "alignment pages". We signal back that we are
             // done processing this step
@@ -53,8 +54,8 @@ void kernel_main() {
 
             if (j > 0) {
                 // snap back to alignment
-                cb_wait_front(i, n_pages - j);
-                cb_pop_front(i, n_pages - j);
+                cb.wait_front(n_pages - j);
+                cb.pop_front(n_pages - j);
             }
         }
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2413,6 +2413,8 @@ public:
     uint32_t get_cb_id() const { return cb_id_; }
 #ifdef DATA_FORMATS_DEFINED
     uint32_t get_tile_size() const { return ::get_tile_size(cb_id_); }
+    uint32_t get_tile_hw() const { return ::get_tile_hw(cb_id_); }
+    DataFormat get_dataformat() const { return ::get_dataformat(cb_id_); }
 #endif
 
     void reserve_back(int32_t num_pages) { cb_reserve_back(cb_id_, num_pages); }
@@ -2422,6 +2424,10 @@ public:
     void wait_front(int32_t num_pages) { cb_wait_front(cb_id_, num_pages); }
 
     void pop_front(int32_t num_pages) { cb_pop_front(cb_id_, num_pages); }
+
+    bool pages_reservable_at_back(int32_t num_pages) const { return cb_pages_reservable_at_back(cb_id_, num_pages); }
+
+    bool pages_available_at_front(int32_t num_pages) const { return cb_pages_available_at_front(cb_id_, num_pages); }
 
     uint32_t get_write_ptr() const {
         // return byte address (fifo_wr_ptr is 16B address)


### PR DESCRIPTION
### Ticket
Closes #29595

### What's changed
- Added the remaining methods required by #29595.
- Ported test_CircularBuffer_non_blocking.cpp to use the new CB API.

### Checklist
Ran TensixTestCircularBufferNonBlockingAPIs test and passed.
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18176567481) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18176569636) CI with