### PR TITLE
[skip ci] Alway run TTSIM Integration tests, no matter what changes

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -177,7 +177,7 @@ jobs:
       product: tt-metalium
 
   ttsim-integration-tests:
-    needs: [ build, find-changed-files ]
+    needs: [ build ]
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -178,14 +178,6 @@ jobs:
 
   ttsim-integration-tests:
     needs: [ build, find-changed-files ]
-    if: ${{
-        (github.ref_name == 'main' ||
-        needs.find-changed-files.outputs.cmake-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-nn-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true') &&
-        github.event.pull_request.head.repo.fork == false
-      }}
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml


### PR DESCRIPTION
### Ticket
NA

### Problem description
There was a regression caused to TTSIM CI, because someone changed python code, renamed files and such, and this did not trigger ttsim tests to run, because of the find changed files detection.

### What's changed
Always run TTSIM tests. Assuming we will not be bottlenecked by CPU jobs.