### PR TITLE
Revert "Option to recreate reshape mapping tensor"

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.cpp
@@ -83,7 +83,6 @@ void py_module(py::module& module) {
     py_bind_interleaved_to_sharded(module);
     py_bind_interleaved_to_sharded_partial(module);
     py_bind_repeat(module);
-    py_bind_reshape_enum(module);
     py_bind_reshape(module);
     py_bind_reshape_view(module);
     py_bind_view(module);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -20,7 +20,6 @@
 #include "ttnn/types.hpp"
 #include "ttnn/decorators.hpp"
 
-#include "ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
 #include "reshape_program_factory.hpp"
 
@@ -419,44 +418,19 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
         [reader_kernel_id,
          writer_kernel_id,
          utilized_cores,
-         // capture this to cache the computed mapping tensor. Cheap copy since data is on device.
-         mapping_tensor](
+         // cache this tensor
+         mapping_tensor_device_buffer = mapping_tensor.device_storage()](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<Tensor>& output_tensors) mutable {
-            const auto& input_tensor = input_tensors.at(0);
-            const auto& output_tensor = output_tensors.at(0);
-
-            const auto& op = *reinterpret_cast<const ttnn::ReshapeDeviceOperation*>(operation);
-            if (op.recreate_mapping_tensor) {
-                const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-                const auto& face_shape = input_tensor.tensor_spec().tile().get_face_shape();
-                const uint32_t num_input_pages =
-                    tt::div_up(input_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
-                const uint32_t num_output_pages =
-                    tt::div_up(output_tensor.physical_volume(), tile_shape[0] * tile_shape[1]);
-
-                mapping_tensor = detail::compute_reshape_mapping_host_tensor(
-                                     num_input_pages,
-                                     num_output_pages,
-                                     input_tensor.logical_shape(),
-                                     output_tensor.logical_shape(),
-                                     tile_shape,
-                                     face_shape)
-                                     .to_device(input_tensor.device());
-            }
-
-            const auto input_buffer_addr = input_tensor.buffer()->address();
-            const auto output_buffer_addr = output_tensor.buffer()->address();
+            const std::vector<Tensor>& output_tensors) {
+            const auto input_buffer_addr = input_tensors.at(0).buffer()->address();
+            const auto output_buffer_addr = output_tensors.at(0).buffer()->address();
 
             for (const auto& core : utilized_cores) {
                 auto& reader_runtime_args_core = GetRuntimeArgs(program, reader_kernel_id, core);
                 reader_runtime_args_core.at(0) = input_buffer_addr;
-                if (op.recreate_mapping_tensor) {
-                    reader_runtime_args_core.at(1) = mapping_tensor.buffer()->address();
-                }
 
                 auto& writer_runtime_args_core = GetRuntimeArgs(program, writer_kernel_id, core);
                 writer_runtime_args_core.at(0) = output_buffer_addr;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -66,17 +66,4 @@ operation::ProgramWithCallbacks ReshapeDeviceOperation::create_program(
             input_tensors.at(0), output_tensors.at(0));
     }
 }
-
-tt::tt_metal::operation::Hash ReshapeDeviceOperation::compute_program_hash(
-    const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto& input_shape = input_tensor.logical_shape();
-    const auto layout = input_tensor.layout();
-    const auto& input_mem_config = input_tensor.memory_config();
-
-    // don't hash on ReshapeDeviceOperation::recreate_mapping_tensor
-
-    return tt::tt_metal::operation::hash_operation<ReshapeDeviceOperation>(
-        input_shape, layout, input_mem_config, this->logical_output_shape, this->output_mem_config);
-}
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -13,7 +13,6 @@ struct ReshapeDeviceOperation {
     const ttnn::Shape logical_output_shape;
     const ttnn::Shape padded_output_shape;
     tt::tt_metal::MemoryConfig output_mem_config;
-    const bool recreate_mapping_tensor;
 
     // Required functions to all tensor op functions
     void update_structure(const Tensor& input_tensor);
@@ -25,8 +24,6 @@ struct ReshapeDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
-    // custom hash function, don't hash on `recreate_mapping_tensor`
-    tt::tt_metal::operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
 };
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -9,13 +9,6 @@
 
 
 namespace ttnn {
-
-enum class TileReshapeMapMode {
-    CACHE,
-    RECREATE,
-
-};
-
 namespace operations::data_movement {
 
 std::pair<ttnn::Shape, ttnn::Shape> shape_corrector(
@@ -34,21 +27,18 @@ struct ReshapeViewOperation {
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE);
+        const std::optional<PadValue>& pad_value = std::nullopt);
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const ttnn::Shape& padded_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE);
+        const std::optional<PadValue>& pad_value = std::nullopt);
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE);
+        const std::optional<PadValue>& pad_value = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
@@ -16,8 +16,6 @@ namespace ttnn::operations::data_movement {
 
 namespace detail {
 
-using ttnn::TileReshapeMapMode;
-
 template <typename data_movement_operation_t>
 void bind_reshape_view(pybind11::module& module, const data_movement_operation_t& operation, const char* doc) {
     bind_registered_operation(
@@ -29,56 +27,41 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
                const ttnn::Tensor& input_tensor,
                const ttnn::Shape& shape,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
-                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode);
-            },
+               const std::optional<PadValue>& pad_value) -> ttnn::Tensor { return self(input_tensor, shape); },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("pad_value") = std::nullopt,
-            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE},
+            py::arg("pad_value") = std::nullopt},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::Shape& logical_shape,
                const ttnn::Shape& padded_shape,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
-                return self(input_tensor, logical_shape, padded_shape, memory_config, pad_value, reshape_tile_mode);
+               const std::optional<PadValue>& pad_value) -> ttnn::Tensor {
+                return self(input_tensor, logical_shape, padded_shape);
             },
             py::arg("input_tensor"),
             py::arg("logical_shape"),
             py::arg("padded_shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("pad_value") = std::nullopt,
-            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE},
+            py::arg("pad_value") = std::nullopt},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int32_t>& shape,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
-                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode);
-            },
+               const std::optional<PadValue>& pad_value) -> ttnn::Tensor { return self(input_tensor, shape); },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("pad_value") = std::nullopt,
-            py::arg("recreate_mapping_tensor") = ttnn::TileReshapeMapMode::CACHE});
+            py::arg("pad_value") = std::nullopt});
 }
-}  // namespace detail
 
-void py_bind_reshape_enum(pybind11::module& module) {
-    py::enum_<ttnn::TileReshapeMapMode>(module, "TileReshapeMapMode")
-        .value("CACHE", ttnn::TileReshapeMapMode::CACHE)
-        .value("RECREATE", ttnn::TileReshapeMapMode::RECREATE);
-}
+}  // namespace detail
 
 void py_bind_reshape_view(pybind11::module& module) {
     detail::bind_reshape_view(
@@ -97,7 +80,6 @@ void py_bind_reshape_view(pybind11::module& module) {
         Keyword Args:
             * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config
             * :attr:`pad_value` (number): Value to pad the output tensor. Default is 0
-            * :attr:`recreate_mapping_tensor` (bool): Advanced option. Set to true to recompute and realloc mapping tensor. This may alleviate DRAM fragmentation but is slow.
 
         Returns:
             ttnn.Tensor: the output tensor with the new shape.

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.hpp
@@ -10,6 +10,4 @@ namespace ttnn::operations::data_movement {
 
 void py_bind_reshape_view(pybind11::module& module);
 
-void py_bind_reshape_enum(pybind11::module& module);
-
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -411,6 +411,3 @@ from ttnn._ttnn.device import get_arch_name as _get_arch_name
 
 def get_arch_name():
     return _get_arch_name()
-
-
-from ttnn._ttnn.operations.data_movement import TileReshapeMapMode


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#28399

@amorrisonTT 

This PR caused deterministic failure in ttnn unit tests.
https://github.com/tenstorrent/tt-metal/actions/runs/18176257401/job/51748525949

No passing run of all post commit was ever acheived.

Why was this merged?