### PR TITLE
Validation tool for Ethernet Links in a Distributed Cluster

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -66,6 +66,9 @@ run_t3000_ttfabric_tests() {
   # TODO (issue: #24335) disabled slow dispatch tests for now, need to re-evaluate if need to add in a different pool
   #TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 
+  # Offline test for Cluster Validation Tool
+  ./build/tools/scaleout/run_cluster_validation --global-descriptor-path tools/tests/scaleout/global_system_descriptors/proto/4_lb_superpod_physical_desc.textproto --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto --deployment-descriptor-path tools/tests/scaleout/deployment_descriptors/16_lb_deployment.textproto --print-connectivity --log-ethernet-metrics --hard-fail
+
   # these tests cover mux fixture as well
   TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
   TT_METAL_FABRIC_TELEMETRY=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -26,11 +26,12 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
     using namespace tt::tt_metal::distributed::multihost;
     auto distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& hal_ptr = tt::tt_metal::MetalContext::instance().hal_ptr();
     constexpr bool using_mock_cluster_descriptor = false;
     constexpr bool run_discovery = true;
 
     auto physical_system_desc = tt::tt_metal::PhysicalSystemDescriptor(
-        cluster.get_driver(), distributed_context, using_mock_cluster_descriptor, run_discovery);
+        cluster.get_driver(), distributed_context, hal_ptr, using_mock_cluster_descriptor, run_discovery);
     // Run discovery again to ensure that state is cleared before re-discovery
     physical_system_desc.run_discovery();
     auto hostnames = physical_system_desc.get_all_hostnames();

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -26,12 +26,15 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
     using namespace tt::tt_metal::distributed::multihost;
     auto distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    const auto& hal_ptr = tt::tt_metal::MetalContext::instance().hal_ptr();
     constexpr bool using_mock_cluster_descriptor = false;
     constexpr bool run_discovery = true;
 
     auto physical_system_desc = tt::tt_metal::PhysicalSystemDescriptor(
-        cluster.get_driver(), distributed_context, hal_ptr, using_mock_cluster_descriptor, run_discovery);
+        cluster.get_driver(),
+        distributed_context,
+        &tt::tt_metal::MetalContext::instance().hal(),
+        using_mock_cluster_descriptor,
+        run_discovery);
     // Run discovery again to ensure that state is cleared before re-discovery
     physical_system_desc.run_discovery();
     auto hostnames = physical_system_desc.get_all_hostnames();

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(scaleout_tools)
 
+add_executable(run_cluster_validation validation/run_cluster_validation.cpp)
+
 # Library target
 add_library(scaleout_tools OBJECT)
 add_library(TT::ScaleoutTools ALIAS scaleout_tools)
@@ -44,6 +46,8 @@ target_sources(
 target_include_directories(scaleout_tools PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(scaleout_tools SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+target_include_directories(run_cluster_validation PRIVATE "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
+
 target_link_libraries(
     scaleout_tools
     PUBLIC
@@ -56,6 +60,14 @@ target_link_libraries(
         $<BUILD_INTERFACE:protobuf::libprotobuf>
 )
 
+target_link_libraries(
+    run_cluster_validation
+    PRIVATE
+        TT::ScaleoutTools
+        enchantum::enchantum
+        protobuf::libprotobuf
+        tt_metal
+)
 target_compile_features(scaleout_tools PUBLIC cxx_std_20)
 target_precompile_headers(scaleout_tools REUSE_FROM TT::CommonPCH)
 

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -25,7 +25,10 @@
 namespace tt::scaleout_tools {
 
 void validate_fsd_against_gsd(
-    const std::string& fsd_filename, const std::string& gsd_filename, bool strict_validation) {
+    const std::string& fsd_filename,
+    const std::string& gsd_filename,
+    bool strict_validation,
+    bool assert_on_connection_mismatch) {
     // Read the generated FSD using protobuf
     tt::scaleout_tools::fsd::proto::FactorySystemDescriptor generated_fsd;
     std::ifstream fsd_file(fsd_filename);
@@ -52,7 +55,7 @@ void validate_fsd_against_gsd(
     }
 
     // Handle the new GSD structure with compute_node_specs
-    if (!discovered_gsd["compute_node_specs"]) {
+    if (!discovered_gsd["compute_node_specs"] || discovered_gsd["compute_node_specs"].size() == 0) {
         throw std::runtime_error("GSD missing compute_node_specs");
     }
     YAML::Node asic_info_node = discovered_gsd["compute_node_specs"];
@@ -70,15 +73,9 @@ void validate_fsd_against_gsd(
         discovered_hostnames.insert(hostname_entry.first.as<std::string>());
     }
 
-    if (strict_validation) {
-        if (generated_hostnames != discovered_hostnames) {
-            throw std::runtime_error("Hostnames mismatch");
-        }
-    } else {
-        for (const auto& hostname : discovered_hostnames) {
-            if (generated_hostnames.find(hostname) == generated_hostnames.end()) {
-                throw std::runtime_error("Hostname not found in FSD: " + hostname);
-            }
+    for (const auto& hostname : discovered_hostnames) {
+        if (generated_hostnames.find(hostname) == generated_hostnames.end()) {
+            throw std::runtime_error("Hostname not found in FSD: " + hostname);
         }
     }
 
@@ -161,8 +158,13 @@ void validate_fsd_against_gsd(
         }
     }
     if (strict_validation) {
-        if (!fsd_board_types.empty()) {
-            throw std::runtime_error("Expected all board types to be found in FSD");
+        for (const auto& [fsd_key, fsd_board_type] : fsd_board_types) {
+            const auto& [hostname, tray_id] = fsd_key;
+            if (discovered_hostnames.find(hostname) != discovered_hostnames.end()) {
+                throw std::runtime_error(
+                    "Board type not found in GSD for discovered host " + hostname + ", tray " +
+                    std::to_string(tray_id));
+            }
         }
     }
 
@@ -172,13 +174,15 @@ void validate_fsd_against_gsd(
     }
 
     // Determine which connection types exist in the discovered GSD
-    bool has_local_eth_connections =
-        discovered_gsd["local_eth_connections"] && !discovered_gsd["local_eth_connections"].IsNull();
-    bool has_global_eth_connections =
-        discovered_gsd["global_eth_connections"] && !discovered_gsd["global_eth_connections"].IsNull();
+    bool has_local_eth_connections = discovered_gsd["local_eth_connections"] &&
+                                     !discovered_gsd["local_eth_connections"].IsNull() &&
+                                     discovered_gsd["local_eth_connections"].size() > 0;
+    bool has_global_eth_connections = discovered_gsd["global_eth_connections"] &&
+                                      !discovered_gsd["global_eth_connections"].IsNull() &&
+                                      discovered_gsd["global_eth_connections"].size() > 0;
 
     // At least one connection type should exist
-    if (!has_local_eth_connections && !has_global_eth_connections) {
+    if (!(has_local_eth_connections || has_global_eth_connections)) {
         throw std::runtime_error("No connection types found in discovered GSD");
     }
 
@@ -426,8 +430,10 @@ void validate_fsd_against_gsd(
     // Only in strict validation: also find connections in FSD but not in GSD
     if (strict_validation) {
         for (const auto& conn : generated_connections) {
-            if (discovered_connections.find(conn) == discovered_connections.end()) {
-                missing_in_gsd.insert(conn);
+            if (discovered_hostnames.count(conn.first.hostname) && discovered_hostnames.count(conn.second.hostname)) {
+                if (discovered_connections.find(conn) == discovered_connections.end()) {
+                    missing_in_gsd.insert(conn);
+                }
             }
         }
     }
@@ -474,7 +480,10 @@ void validate_fsd_against_gsd(
     // Handle validation results
     if (!missing_in_gsd.empty() || !extra_in_gsd.empty()) {
         std::string mode_text = strict_validation ? "" : " in non-strict validation";
-        throw std::runtime_error("Connection mismatch detected" + mode_text + ". Check console output for details.");
+        if (assert_on_connection_mismatch) {
+            throw std::runtime_error(
+                "Connection mismatch detected" + mode_text + ". Check console output for details.");
+        }
     } else {
         // Success message differs based on validation mode
         if (strict_validation) {

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -74,7 +74,7 @@ void validate_fsd_against_gsd(
     }
 
     for (const auto& hostname : discovered_hostnames) {
-        if (generated_hostnames.find(hostname) == generated_hostnames.end()) {
+        if (not generated_hostnames.contains(hostname)) {
             throw std::runtime_error("Hostname not found in FSD: " + hostname);
         }
     }
@@ -160,7 +160,7 @@ void validate_fsd_against_gsd(
     if (strict_validation) {
         for (const auto& [fsd_key, fsd_board_type] : fsd_board_types) {
             const auto& [hostname, tray_id] = fsd_key;
-            if (discovered_hostnames.find(hostname) != discovered_hostnames.end()) {
+            if (discovered_hostnames.contains(hostname)) {
                 throw std::runtime_error(
                     "Board type not found in GSD for discovered host " + hostname + ", tray " +
                     std::to_string(tray_id));
@@ -430,8 +430,9 @@ void validate_fsd_against_gsd(
     // Only in strict validation: also find connections in FSD but not in GSD
     if (strict_validation) {
         for (const auto& conn : generated_connections) {
-            if (discovered_hostnames.count(conn.first.hostname) && discovered_hostnames.count(conn.second.hostname)) {
-                if (discovered_connections.find(conn) == discovered_connections.end()) {
+            if (discovered_hostnames.contains(conn.first.hostname) &&
+                discovered_hostnames.contains(conn.second.hostname)) {
+                if (not discovered_connections.contains(conn)) {
                     missing_in_gsd.insert(conn);
                 }
             }

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -15,7 +15,12 @@ namespace tt::scaleout_tools {
 //   - gsd_filename: Path to the GSD YAML file
 //   - strict_validation: If true, checks that all connections match bidirectionally
 //                        If false, only checks that GSD connections exist in FSD
+//   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
+//                                    If false, missing connections are logged without an error being thrown
 void validate_fsd_against_gsd(
-    const std::string& fsd_filename, const std::string& gsd_filename, bool strict_validation = true);
+    const std::string& fsd_filename,
+    const std::string& gsd_filename,
+    bool strict_validation = true,
+    bool assert_on_connection_mismatch = true);
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <string>
+
+#include <factory_system_descriptor/utils.hpp>
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/distributed.hpp>
+#include "tt_metal/impl/context/metal_context.hpp"
+#include "tests/tt_metal/test_utils/test_common.hpp"
+#include <cabling_generator/cabling_generator.hpp>
+
+// Captures current list of supported inputargs
+struct InputArgs {
+    std::optional<std::string> cabling_descriptor_path = std::nullopt;
+    std::optional<std::string> deployment_descriptor_path = std::nullopt;
+    std::optional<std::string> fsd_path = std::nullopt;
+    std::optional<std::string> gsd_path = std::nullopt;
+    std::filesystem::path output_path = "";
+    bool fail_on_warning = false;
+    bool log_ethernet_metrics = false;
+    bool print_connectivity = false;
+    bool help = false;
+};
+
+// Struct to store connection information
+// Used to organize and print connection information
+struct ConnectionInfo {
+    tt::tt_metal::AsicID asic_id;
+    uint8_t channel;
+    std::string host;
+    tt::tt_metal::TrayID tray_id;
+    tt::tt_metal::ASICLocation asic_location;
+    tt::scaleout_tools::PortType port_type;
+    tt::tt_metal::AsicID connected_asic_id;
+    uint8_t connected_channel;
+    std::string connected_host;
+    tt::tt_metal::TrayID connected_tray_id;
+    tt::tt_metal::ASICLocation connected_asic_location;
+    tt::tt_metal::EthernetMetrics metrics;
+};
+
+void log_output_rank0(const std::string& message) {
+    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+        log_info(tt::LogDistributed, "{}", message);
+    }
+}
+
+std::filesystem::path generate_output_dir() {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%Y%m%d_%H%M%S");
+    std::string dir_name = ss.str();
+    const auto& rt_options = tt::tt_metal::MetalContext::instance().rtoptions();
+    std::filesystem::path output_dir_path = rt_options.get_root_dir() + "cluster_validation_logs/" + dir_name;
+    std::filesystem::create_directories(output_dir_path);
+    return output_dir_path;
+}
+
+InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
+    InputArgs input_args;
+
+    if (test_args::has_command_option(args_vec, "--cabling-descriptor-path")) {
+        TT_FATAL(
+            test_args::has_command_option(args_vec, "--deployment-descriptor-path"),
+            "Deployment Descriptor Path is required when Cabling Descriptor Path is provided.");
+        input_args.cabling_descriptor_path = test_args::get_command_option(args_vec, "--cabling-descriptor-path");
+    }
+    if (test_args::has_command_option(args_vec, "--deployment-descriptor-path")) {
+        TT_FATAL(
+            input_args.cabling_descriptor_path.has_value(),
+            "Cabling Descriptor Path is required when Deployment Descriptor Path is provided.");
+        input_args.deployment_descriptor_path = test_args::get_command_option(args_vec, "--deployment-descriptor-path");
+    }
+    if (test_args::has_command_option(args_vec, "--factory-descriptor-path")) {
+        TT_FATAL(
+            !(input_args.cabling_descriptor_path.has_value() || input_args.deployment_descriptor_path.has_value()),
+            "Pass in either Cabling Spec + Deployment Spec or just Factory System Descriptor.");
+        input_args.fsd_path = test_args::get_command_option(args_vec, "--factory-descriptor-path");
+    }
+    if (test_args::has_command_option(args_vec, "--global-descriptor-path")) {
+        input_args.gsd_path = test_args::get_command_option(args_vec, "--global-descriptor-path");
+    }
+    if (test_args::has_command_option(args_vec, "--output-path")) {
+        input_args.output_path = std::filesystem::path(test_args::get_command_option(args_vec, "--output-path"));
+    } else {
+        input_args.output_path = generate_output_dir();
+    }
+    log_output_rank0("Generating System Validation Logs in " + input_args.output_path.string());
+
+    input_args.fail_on_warning = test_args::has_command_option(args_vec, "--hard-fail");
+    input_args.log_ethernet_metrics = test_args::has_command_option(args_vec, "--log-ethernet-metrics");
+    input_args.print_connectivity = test_args::has_command_option(args_vec, "--print-connectivity");
+    input_args.help = test_args::has_command_option(args_vec, "--help");
+
+    TT_FATAL(
+        input_args.help || input_args.cabling_descriptor_path.has_value() || input_args.fsd_path.has_value(),
+        "Cluster Validation requires either Cabling Spec + Deployment Spec or a Factory System Descriptor.");
+
+    return input_args;
+}
+
+std::string get_factory_system_descriptor_path(const InputArgs& input_args) {
+    std::string fsd_path;
+    if (input_args.cabling_descriptor_path.has_value()) {
+        log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
+        tt::scaleout_tools::CablingGenerator cabling_generator(
+            input_args.cabling_descriptor_path.value(), input_args.deployment_descriptor_path.value());
+        fsd_path = input_args.output_path / "generated_factory_system_descriptor.textproto";
+        cabling_generator.emit_factory_system_descriptor(fsd_path);
+
+    } else {
+        fsd_path = input_args.fsd_path.value();
+    }
+    return fsd_path;
+}
+
+PhysicalSystemDescriptor generate_physical_system_descriptor(const InputArgs& input_args) {
+    auto log_hostnames = [&](const std::vector<std::string>& hostnames) {
+        std::stringstream ss;
+        for (const auto& hostname : hostnames) {
+            ss << hostname << ", ";
+        }
+        return ss.str();
+    };
+
+    if (input_args.gsd_path.has_value()) {
+        auto physical_system_descriptor = tt::tt_metal::PhysicalSystemDescriptor(input_args.gsd_path.value());
+        log_output_rank0("Detected Hosts: " + log_hostnames(physical_system_descriptor.get_all_hostnames()));
+        return physical_system_descriptor;
+    } else {
+        log_output_rank0("Running Physical Discovery");
+        constexpr bool run_discovery = true;
+        auto physical_system_descriptor = tt::tt_metal::PhysicalSystemDescriptor(
+            tt::tt_metal::MetalContext::instance().get_cluster().get_driver(),
+            tt::tt_metal::MetalContext::instance().get_distributed_context_ptr(),
+            tt::tt_metal::MetalContext::instance().hal_ptr(),
+            tt::tt_metal::MetalContext::instance().rtoptions().get_mock_enabled(),
+            run_discovery);
+        log_output_rank0("Physical Discovery Complete");
+        log_output_rank0("Detected Hosts: " + log_hostnames(physical_system_descriptor.get_all_hostnames()));
+        return physical_system_descriptor;
+    }
+}
+
+std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<tt::tt_fabric::chan_id_t, tt::scaleout_tools::PortType>>
+generate_port_types(const PhysicalSystemDescriptor& physical_system_descriptor) {
+    std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<tt::tt_fabric::chan_id_t, tt::scaleout_tools::PortType>>
+        port_types;
+    const auto& asic_connectivity_graph = physical_system_descriptor.get_system_graph().asic_connectivity_graph;
+
+    for (const auto& [asic_id, asic_descriptor] : physical_system_descriptor.get_asic_descriptors()) {
+        auto board_type = asic_descriptor.board_type;
+        auto board = tt::scaleout_tools::create_board(board_type);
+
+        const auto& asic_edges = asic_connectivity_graph.at(asic_descriptor.host_name).at(asic_id);
+        for (const auto& [dst_asic_id, eth_connections] : asic_edges) {
+            for (const auto& eth_connection : eth_connections) {
+                auto port = board.get_port_for_asic_channel(tt::scaleout_tools::AsicChannel{
+                    *(asic_descriptor.asic_location), tt::scaleout_tools::ChanId{eth_connection.src_chan}});
+                port_types[asic_id][eth_connection.src_chan] = port.port_type;
+            }
+        }
+    }
+    return port_types;
+}
+
+std::string get_port_type_str(const tt::scaleout_tools::PortType& port_type) {
+    switch (port_type) {
+        case tt::scaleout_tools::PortType::TRACE: return "TRACE";
+        case tt::scaleout_tools::PortType::QSFP_DD: return "QSFP_DD";
+        case tt::scaleout_tools::PortType::WARP100: return "WARP100";
+        case tt::scaleout_tools::PortType::WARP400: return "WARP400";
+        case tt::scaleout_tools::PortType::LINKING_BOARD_1: return "LINKING_BOARD_1";
+        case tt::scaleout_tools::PortType::LINKING_BOARD_2: return "LINKING_BOARD_2";
+        case tt::scaleout_tools::PortType::LINKING_BOARD_3: return "LINKING_BOARD_3";
+        default: return "UNKNOWN";
+    }
+}
+
+std::string log_ethernet_metrics_and_print_connectivity(
+    const InputArgs& input_args, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
+    std::stringstream unexpected_status_log;
+
+    if (input_args.log_ethernet_metrics || input_args.print_connectivity) {
+        log_output_rank0("Generating Ethernet Logs");
+    }
+
+    auto port_types = generate_port_types(physical_system_descriptor);
+
+    // Collect all connections and organize by: connection_type -> hostname -> port_type -> connections
+    // Using map with bool key: true = cross-host, false = local
+    std::map<bool, std::map<std::string, std::map<std::string, std::vector<ConnectionInfo>>>> organized_connections;
+
+    for (const auto& host : physical_system_descriptor.get_all_hostnames()) {
+        for (const auto& [asic_id, channel_metrics] : physical_system_descriptor.get_ethernet_metrics()) {
+            if (physical_system_descriptor.get_host_name_for_asic(asic_id) == host) {
+                auto tray_id = physical_system_descriptor.get_asic_descriptors().at(asic_id).tray_id;
+                auto asic_location = physical_system_descriptor.get_asic_descriptors().at(asic_id).asic_location;
+
+                for (const auto& [channel, metrics] : channel_metrics) {
+                    auto [connected_asic_id, connected_channel] =
+                        physical_system_descriptor.get_connected_asic_and_channel(asic_id, channel);
+                    auto connected_tray_id =
+                        physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).tray_id;
+                    auto connected_asic_location =
+                        physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).asic_location;
+                    const auto& connected_host = physical_system_descriptor.get_host_name_for_asic(connected_asic_id);
+                    auto port_type_str = get_port_type_str(port_types.at(asic_id).at(channel));
+
+                    ConnectionInfo conn_info{
+                        asic_id,
+                        channel,
+                        host,
+                        tray_id,
+                        asic_location,
+                        port_types.at(asic_id).at(channel),
+                        connected_asic_id,
+                        connected_channel,
+                        connected_host,
+                        connected_tray_id,
+                        connected_asic_location,
+                        metrics};
+
+                    // Organize: connection_type -> hostname -> port_type -> connections
+                    bool is_cross_host = (host != connected_host);
+                    organized_connections[is_cross_host][host][port_type_str].push_back(conn_info);
+
+                    if (metrics.retrain_count > 0) {
+                        unexpected_status_log << " Host: " << host << " Unique ID: " << std::hex << *asic_id
+                                              << " Tray: " << *tray_id << " ASIC: " << *asic_location
+                                              << " Channel: " << +channel << " Retrain Count: " << metrics.retrain_count
+                                              << std::endl;
+                    }
+                }
+            }
+        }
+    }
+
+    // Print organized connections: connection_type -> hostname -> port_type -> connections
+    if (input_args.print_connectivity || input_args.log_ethernet_metrics) {
+        // Iterate through connection types (true=cross-host, false=local)
+        for (const auto& [is_cross_host, hosts_map] : organized_connections) {
+            if (hosts_map.empty()) {
+                continue;
+            }
+
+            // Print connection type header
+            std::cout << std::endl;
+            if (is_cross_host) {
+                std::cout << " ============================== CROSS-HOST CONNECTIONS =============================== "
+                          << std::endl;
+            } else {
+                std::cout << " ============================== HOST-LOCAL CONNECTIONS =============================== "
+                          << std::endl;
+            }
+
+            // Iterate through hostnames
+            for (const auto& [hostname, port_types_map] : hosts_map) {
+                if (port_types_map.empty()) {
+                    continue;
+                }
+
+                // Print hostname header
+                std::cout << std::endl
+                          << "  =============================== Hostname: " << hostname
+                          << " =============================== " << std::endl;
+
+                // Iterate through port types
+                for (const auto& [port_type, connections] : port_types_map) {
+                    if (connections.empty()) {
+                        continue;
+                    }
+
+                    // Print port type header
+                    std::cout << std::endl
+                              << "             ---------------------- Port Type: " << port_type
+                              << " ---------------------- " << std::endl
+                              << std::endl;
+
+                    // Print all connections for this port type
+                    for (const auto& conn : connections) {
+                        std::cout << " [" << conn.host << "] Unique ID: " << std::hex << *conn.asic_id
+                                  << " Tray: " << std::dec << *conn.tray_id << ", ASIC Location: " << std::dec
+                                  << *conn.asic_location << ", Ethernet Channel: " << std::dec << +conn.channel
+                                  << std::endl;
+
+                        if (input_args.print_connectivity) {
+                            std::cout << "\tConnected to [" << conn.connected_host << "] Unique ID: " << std::hex
+                                      << *conn.connected_asic_id << " Tray: " << std::dec << *conn.connected_tray_id
+                                      << ", ASIC Location: " << std::dec << *conn.connected_asic_location
+                                      << ", Ethernet Channel: " << std::dec << +conn.connected_channel << std::endl;
+                        }
+                        if (input_args.log_ethernet_metrics) {
+                            std::cout << "\t Retrain Count: " << std::dec << conn.metrics.retrain_count << " ";
+                            std::cout << "CRC Errors: 0x" << std::hex << conn.metrics.crc_error_count << " ";
+                            std::cout << "Corrected Codewords: 0x" << std::hex << conn.metrics.corrected_codeword_count
+                                      << " ";
+                            std::cout << "Uncorrected Codewords: 0x" << std::hex
+                                      << conn.metrics.uncorrected_codeword_count << " ";
+                        }
+                        std::cout << std::endl;
+                    }
+                }
+            }
+        }
+    }
+
+    return unexpected_status_log.str();
+}
+
+void log_unexpected_statuses(const std::string& unexpected_status_log) {
+    if (!unexpected_status_log.empty()) {
+        std::cout << std::endl;
+        std::cout << " =============================== Logging Unexpected Ethernet Link Statuses "
+                     "=============================== "
+                  << std::endl;
+        std::cout << unexpected_status_log << std::endl;
+    }
+}
+
+void print_usage_info() {
+    std::cout << "Utility to validate Ethernet Links and Connections for a Multi-Node TT Cluster" << std::endl;
+    std::cout << "Compares live system state against the requested Cabling and Deployment Specifications" << std::endl
+              << std::endl;
+    std::cout << "Arguments:" << std::endl;
+    std::cout << "  --cabling-descriptor-path: Path to cabling descriptor" << std::endl;
+    std::cout << "  --deployment-descriptor-path: Path to deployment descriptor" << std::endl;
+    std::cout << "  --factory-descriptor-path: Path to factory descriptor" << std::endl;
+    std::cout << "  --global-descriptor-path: Path to global descriptor" << std::endl;
+    std::cout << "  --output-path: Path to output directory" << std::endl;
+    std::cout << "  --hard-fail: Fail on warning" << std::endl;
+    std::cout << "  --log-ethernet-metrics: Log ethernet live ethernet statistics" << std::endl;
+    std::cout << "  --print-connectivity: Print Ethernet Connectivity between ASICs" << std::endl;
+    std::cout << "  --help: Print usage information" << std::endl << std::endl;
+    std::cout << "To run on a multi-node cluster, use mpirun with a --hostfile option" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+    auto input_args = parse_input_args(std::vector<std::string>(argv, argv + argc));
+    if (input_args.help) {
+        print_usage_info();
+        return 0;
+    }
+
+    bool eth_connections_healthy = true;
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+
+    // Create physical system descriptor and discover the system
+    auto physical_system_descriptor = generate_physical_system_descriptor(input_args);
+    // Set output path for the YAML file
+    std::string gsd_yaml_path = input_args.output_path / "global_system_descriptor.yaml";
+    // Dump the discovered system to YAML
+    physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
+
+    if (*distributed_context.rank() == 0) {
+        log_output_rank0(
+            "Validating Factory System Descriptor (Golden Representation) against Global System Descriptor");
+        tt::scaleout_tools::validate_fsd_against_gsd(
+            get_factory_system_descriptor_path(input_args), gsd_yaml_path, true, input_args.fail_on_warning);
+        log_output_rank0("Factory System Descriptor (Golden Representation) Validation Complete");
+
+        std::string unexpected_status_log =
+            log_ethernet_metrics_and_print_connectivity(input_args, physical_system_descriptor);
+        log_unexpected_statuses(unexpected_status_log);
+    }
+    distributed_context.barrier();
+    if (input_args.fail_on_warning && !eth_connections_healthy) {
+        TT_THROW("Encountered unhealthy ethernet connections, listed above");
+        return -1;
+    }
+    return 0;
+}

--- a/tools/tests/scaleout/global_system_descriptors/proto/4_lb_superpod_physical_desc.textproto
+++ b/tools/tests/scaleout/global_system_descriptors/proto/4_lb_superpod_physical_desc.textproto
@@ -1,0 +1,3215 @@
+system_graph {
+  asic_connectivity_graph {
+    host_name: "metal-wh-12"
+    asic_topologies {
+      asic_id: 14521786539
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819243
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786438
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786451
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819155
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786429
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786438
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786539
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819142
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819142
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786438
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819243
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819155
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+          eth_connections {
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819281
+          eth_connections {
+            src_chan: 7
+            dst_chan: 1
+          }
+          eth_connections {
+            src_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819155
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786451
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819142
+          eth_connections {
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819133
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819216
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786429
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786451
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819133
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819243
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786539
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819142
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819133
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819236
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+          }
+          eth_connections {
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819133
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786429
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819155
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819243
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+  }
+  asic_connectivity_graph {
+    host_name: "metal-wh-11"
+    asic_topologies {
+      asic_id: 14521786547
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819251
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786512
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786525
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819229
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786425
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786512
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786547
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819216
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819251
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786547
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819216
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819129
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819275
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+          }
+          eth_connections {
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819216
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786512
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819251
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819229
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+          eth_connections {
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819155
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819229
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786525
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819216
+          eth_connections {
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819129
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819238
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786425
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786525
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819129
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819129
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786425
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819229
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819251
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+  }
+  asic_connectivity_graph {
+    host_name: "metal-wh-10"
+    asic_topologies {
+      asic_id: 14521786577
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819281
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786479
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819238
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786534
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819183
+          eth_connections {
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819080
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819229
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786534
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819238
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786376
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786479
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786577
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819183
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819183
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786479
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819281
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819238
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+          eth_connections {
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819075
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786376
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786534
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819080
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819281
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786577
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819183
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819080
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819142
+          eth_connections {
+            src_chan: 1
+            dst_chan: 7
+          }
+          eth_connections {
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819080
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786376
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819238
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819281
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+  }
+  asic_connectivity_graph {
+    host_name: "metal-wh-09"
+    asic_topologies {
+      asic_id: 10226819235
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786531
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819236
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819075
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+          eth_connections {
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786371
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786571
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819075
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819075
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786371
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819275
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819235
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+            is_local: true
+          }
+          eth_connections {
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819183
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786531
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786532
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819235
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819275
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786571
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819236
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819075
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819251
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+          }
+          eth_connections {
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 10226819236
+      topology {
+        asic_connections {
+          dst_asic_id: 14521786532
+          eth_connections {
+            src_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 9
+            dst_chan: 1
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819275
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819235
+          eth_connections {
+            src_chan: 15
+            dst_chan: 15
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 14
+            dst_chan: 14
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 10226819243
+          eth_connections {
+            src_chan: 1
+            dst_chan: 1
+          }
+          eth_connections {
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786532
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819236
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786531
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+    asic_topologies {
+      asic_id: 14521786571
+      topology {
+        asic_connections {
+          dst_asic_id: 10226819275
+          eth_connections {
+            dst_chan: 8
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 1
+            dst_chan: 9
+            is_local: true
+          }
+        }
+        asic_connections {
+          dst_asic_id: 14521786371
+          eth_connections {
+            src_chan: 7
+            dst_chan: 7
+            is_local: true
+          }
+          eth_connections {
+            src_chan: 6
+            dst_chan: 6
+            is_local: true
+          }
+        }
+      }
+    }
+  }
+  host_connectivity_graph {
+    src_host_name: "metal-wh-12"
+    host_connections {
+      dst_host_name: "metal-wh-11"
+      exit_node_connections {
+        src_exit_node: 10226819155
+        dst_exit_node: 10226819216
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819155
+        dst_exit_node: 10226819216
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-10"
+      exit_node_connections {
+        src_exit_node: 10226819142
+        dst_exit_node: 10226819281
+        eth_conn {
+          src_chan: 7
+          dst_chan: 1
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819142
+        dst_exit_node: 10226819281
+        eth_conn {
+          src_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-09"
+      exit_node_connections {
+        src_exit_node: 10226819243
+        dst_exit_node: 10226819236
+        eth_conn {
+          src_chan: 1
+          dst_chan: 1
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819243
+        dst_exit_node: 10226819236
+        eth_conn {
+        }
+      }
+    }
+  }
+  host_connectivity_graph {
+    src_host_name: "metal-wh-11"
+    host_connections {
+      dst_host_name: "metal-wh-12"
+      exit_node_connections {
+        src_exit_node: 10226819216
+        dst_exit_node: 10226819155
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819216
+        dst_exit_node: 10226819155
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-10"
+      exit_node_connections {
+        src_exit_node: 10226819229
+        dst_exit_node: 10226819238
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819229
+        dst_exit_node: 10226819238
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-09"
+      exit_node_connections {
+        src_exit_node: 10226819251
+        dst_exit_node: 10226819275
+        eth_conn {
+          src_chan: 1
+          dst_chan: 1
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819251
+        dst_exit_node: 10226819275
+        eth_conn {
+        }
+      }
+    }
+  }
+  host_connectivity_graph {
+    src_host_name: "metal-wh-10"
+    host_connections {
+      dst_host_name: "metal-wh-12"
+      exit_node_connections {
+        src_exit_node: 10226819281
+        dst_exit_node: 10226819142
+        eth_conn {
+          src_chan: 1
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819281
+        dst_exit_node: 10226819142
+        eth_conn {
+          dst_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-11"
+      exit_node_connections {
+        src_exit_node: 10226819238
+        dst_exit_node: 10226819229
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819238
+        dst_exit_node: 10226819229
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-09"
+      exit_node_connections {
+        src_exit_node: 10226819183
+        dst_exit_node: 10226819075
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819183
+        dst_exit_node: 10226819075
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+  }
+  host_connectivity_graph {
+    src_host_name: "metal-wh-09"
+    host_connections {
+      dst_host_name: "metal-wh-12"
+      exit_node_connections {
+        src_exit_node: 10226819236
+        dst_exit_node: 10226819243
+        eth_conn {
+          src_chan: 1
+          dst_chan: 1
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819236
+        dst_exit_node: 10226819243
+        eth_conn {
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-11"
+      exit_node_connections {
+        src_exit_node: 10226819275
+        dst_exit_node: 10226819251
+        eth_conn {
+          src_chan: 1
+          dst_chan: 1
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819275
+        dst_exit_node: 10226819251
+        eth_conn {
+        }
+      }
+    }
+    host_connections {
+      dst_host_name: "metal-wh-10"
+      exit_node_connections {
+        src_exit_node: 10226819075
+        dst_exit_node: 10226819183
+        eth_conn {
+          src_chan: 7
+          dst_chan: 7
+        }
+      }
+      exit_node_connections {
+        src_exit_node: 10226819075
+        dst_exit_node: 10226819183
+        eth_conn {
+          src_chan: 6
+          dst_chan: 6
+        }
+      }
+    }
+  }
+}
+asic_descriptors {
+  asic_id: 10226819142
+  asic_descriptor {
+    tray_id: 2
+    board_type: 4
+    unique_id: 10226819142
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786451
+  asic_descriptor {
+    tray_id: 3
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786451
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819129
+  asic_descriptor {
+    tray_id: 1
+    board_type: 4
+    unique_id: 10226819129
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819133
+  asic_descriptor {
+    tray_id: 4
+    board_type: 4
+    unique_id: 10226819133
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819251
+  asic_descriptor {
+    tray_id: 4
+    board_type: 4
+    unique_id: 10226819251
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786525
+  asic_descriptor {
+    tray_id: 2
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786525
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786425
+  asic_descriptor {
+    tray_id: 1
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786425
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819229
+  asic_descriptor {
+    tray_id: 2
+    board_type: 4
+    unique_id: 10226819229
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819243
+  asic_descriptor {
+    tray_id: 1
+    board_type: 4
+    unique_id: 10226819243
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786429
+  asic_descriptor {
+    tray_id: 4
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786429
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786547
+  asic_descriptor {
+    tray_id: 4
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786547
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819080
+  asic_descriptor {
+    tray_id: 1
+    board_type: 4
+    unique_id: 10226819080
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819281
+  asic_descriptor {
+    tray_id: 4
+    board_type: 4
+    unique_id: 10226819281
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786376
+  asic_descriptor {
+    tray_id: 1
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786376
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819238
+  asic_descriptor {
+    tray_id: 2
+    board_type: 4
+    unique_id: 10226819238
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819155
+  asic_descriptor {
+    tray_id: 3
+    board_type: 4
+    unique_id: 10226819155
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786577
+  asic_descriptor {
+    tray_id: 4
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786577
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819183
+  asic_descriptor {
+    tray_id: 3
+    board_type: 4
+    unique_id: 10226819183
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786479
+  asic_descriptor {
+    tray_id: 3
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786479
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786534
+  asic_descriptor {
+    tray_id: 2
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786534
+    host_name: "metal-wh-10"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786438
+  asic_descriptor {
+    tray_id: 2
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786438
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819075
+  asic_descriptor {
+    tray_id: 3
+    board_type: 4
+    unique_id: 10226819075
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786539
+  asic_descriptor {
+    tray_id: 1
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786539
+    host_name: "metal-wh-12"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819235
+  asic_descriptor {
+    tray_id: 2
+    board_type: 4
+    unique_id: 10226819235
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786371
+  asic_descriptor {
+    tray_id: 3
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786371
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819216
+  asic_descriptor {
+    tray_id: 3
+    board_type: 4
+    unique_id: 10226819216
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819275
+  asic_descriptor {
+    tray_id: 4
+    board_type: 4
+    unique_id: 10226819275
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786531
+  asic_descriptor {
+    tray_id: 2
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786531
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 10226819236
+  asic_descriptor {
+    tray_id: 1
+    board_type: 4
+    unique_id: 10226819236
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786532
+  asic_descriptor {
+    tray_id: 1
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786532
+    host_name: "metal-wh-09"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786512
+  asic_descriptor {
+    tray_id: 3
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786512
+    host_name: "metal-wh-11"
+  }
+}
+asic_descriptors {
+  asic_id: 14521786571
+  asic_descriptor {
+    tray_id: 4
+    asic_location: 1
+    board_type: 4
+    unique_id: 14521786571
+    host_name: "metal-wh-09"
+  }
+}
+host_to_mobo_name {
+  host_name: "metal-wh-12"
+  mobo_name: "X12DPG-QT6"
+}
+host_to_mobo_name {
+  host_name: "metal-wh-11"
+  mobo_name: "X12DPG-QT6"
+}
+host_to_mobo_name {
+  host_name: "metal-wh-10"
+  mobo_name: "X12DPG-QT6"
+}
+host_to_mobo_name {
+  host_name: "metal-wh-09"
+  mobo_name: "X12DPG-QT6"
+}
+host_to_rank {
+  host_name: "metal-wh-12"
+  rank: 3
+}
+host_to_rank {
+  host_name: "metal-wh-11"
+  rank: 2
+}
+host_to_rank {
+  host_name: "metal-wh-10"
+  rank: 1
+}
+host_to_rank {
+  host_name: "metal-wh-09"
+}
+exit_node_connection_table {
+  host_name: "metal-wh-12"
+  exit_connections {
+    src_exit_node: 10226819243
+    dst_exit_node: 10226819236
+    eth_conn {
+      src_chan: 1
+      dst_chan: 1
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819243
+    dst_exit_node: 10226819236
+    eth_conn {
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819155
+    dst_exit_node: 10226819216
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819155
+    dst_exit_node: 10226819216
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819142
+    dst_exit_node: 10226819281
+    eth_conn {
+      src_chan: 7
+      dst_chan: 1
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819142
+    dst_exit_node: 10226819281
+    eth_conn {
+      src_chan: 6
+    }
+  }
+}
+exit_node_connection_table {
+  host_name: "metal-wh-11"
+  exit_connections {
+    src_exit_node: 10226819251
+    dst_exit_node: 10226819275
+    eth_conn {
+      src_chan: 1
+      dst_chan: 1
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819251
+    dst_exit_node: 10226819275
+    eth_conn {
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819229
+    dst_exit_node: 10226819238
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819229
+    dst_exit_node: 10226819238
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819216
+    dst_exit_node: 10226819155
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819216
+    dst_exit_node: 10226819155
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+}
+exit_node_connection_table {
+  host_name: "metal-wh-10"
+  exit_connections {
+    src_exit_node: 10226819281
+    dst_exit_node: 10226819142
+    eth_conn {
+      src_chan: 1
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819281
+    dst_exit_node: 10226819142
+    eth_conn {
+      dst_chan: 6
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819238
+    dst_exit_node: 10226819229
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819238
+    dst_exit_node: 10226819229
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819183
+    dst_exit_node: 10226819075
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819183
+    dst_exit_node: 10226819075
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+}
+exit_node_connection_table {
+  host_name: "metal-wh-09"
+  exit_connections {
+    src_exit_node: 10226819275
+    dst_exit_node: 10226819251
+    eth_conn {
+      src_chan: 1
+      dst_chan: 1
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819275
+    dst_exit_node: 10226819251
+    eth_conn {
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819236
+    dst_exit_node: 10226819243
+    eth_conn {
+      src_chan: 1
+      dst_chan: 1
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819236
+    dst_exit_node: 10226819243
+    eth_conn {
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819075
+    dst_exit_node: 10226819183
+    eth_conn {
+      src_chan: 7
+      dst_chan: 7
+    }
+  }
+  exit_connections {
+    src_exit_node: 10226819075
+    dst_exit_node: 10226819183
+    eth_conn {
+      src_chan: 6
+      dst_chan: 6
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786451
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 29839
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 64674
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 107
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 53
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819281
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 15687
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 34252
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 2992
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 1112
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 247
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 191862
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 111090
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 2844
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786532
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 12713
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1839560
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 12001
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 1389
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786376
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 482
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 2639
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 477
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819183
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 39532
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 51153
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 2312
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 2677
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 802
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 357
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 34953
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 896
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819080
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 24345
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 61347
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 1538
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 723
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 4926045
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 245354
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786534
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 13959
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1100
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 10
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 20357
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819236
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 45663
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 897157
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 23402
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3086
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 8129654
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 8656683
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 471895
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 53243
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786371
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 77054
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 457
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 681
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 2212
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786479
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 990
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 34
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 23484
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1624191
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786531
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 308756
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 42277
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2087373
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 14056
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786438
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 52
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 97847
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 6372
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 31675
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819075
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 27270
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 280621
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 3
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 222
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 29
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 23881
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 4708
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819251
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 20720
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 192700
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 171
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 110
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 23660
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1165512
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 37202
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 6538
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819133
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 260
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 12394
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 40
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 155863
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2061
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786539
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 16215
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 5276
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 11671
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 797
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819235
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 37
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 48
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 2
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 568
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 46425
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 63489
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819238
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 1027
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 57853
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 9193
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 15680
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 361
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 4292
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 465764
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 169452
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819129
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 444
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 184974
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3726
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 31000
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 322498
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 5514
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819275
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 91880
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 164880
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 152
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 4801
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 1132770
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 644043
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 173548
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 28566
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819216
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 86441
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 294973
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 301
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 35774
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 2023
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 16791
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 63186
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2486039
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786525
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 507
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 13493
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 187
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 16589
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786425
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 6987
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 3088
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 28176
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 690549
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786571
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 55965
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 104
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 68146
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 28368
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786512
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 5517
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 6947
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 162721
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 90465
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819229
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 22843
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 56133
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 35
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 6006
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 73
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3127
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1181951
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 1449625
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819142
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 444
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 50048
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 769
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 201
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1479
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 913
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1112
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 12579959
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786429
+  channel_metrics {
+    channel: 7
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 9195
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 13646
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 30870
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786547
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 5276
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 61557
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 4440
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 36208
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819243
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 2638
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 88996
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 145
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 61248
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 45405
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 241938
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 173505
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 556
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786577
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 542169
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 649791
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 205
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 3658
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819155
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 8309
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 357854
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 129
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 6551
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 21
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 129
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 344292
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 56630
+    }
+  }
+}

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -477,10 +477,10 @@ void ControlPlane::init_control_plane(
     const auto& driver = tt::tt_metal::MetalContext::instance().get_cluster().get_driver();
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-
+    const auto& hal_ptr = tt::tt_metal::MetalContext::instance().hal_ptr();
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
     this->physical_system_descriptor_ =
-        std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(driver, distributed_context, rtoptions);
+        std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(driver, distributed_context, hal_ptr, rtoptions);
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
 
     this->initialize_distributed_contexts();

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -477,10 +477,9 @@ void ControlPlane::init_control_plane(
     const auto& driver = tt::tt_metal::MetalContext::instance().get_cluster().get_driver();
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    const auto& hal_ptr = tt::tt_metal::MetalContext::instance().hal_ptr();
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
-    this->physical_system_descriptor_ =
-        std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(driver, distributed_context, hal_ptr, rtoptions);
+    this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
+        driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
 
     this->initialize_distributed_contexts();

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -4,16 +4,23 @@
 
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
+#include <set>
 
+#include <umd/device/cluster.hpp>
+#include <umd/device/soc_descriptor.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/distributed_context.hpp>
-#include "tt_metal/llrt/tt_cluster.hpp"
+
 #include "tt_metal/llrt/tunnels_from_mmio_device.hpp"
+#include "tt_metal/llrt/hal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
-#include "tt_metal/impl/context/metal_context.hpp"
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 
 namespace tt::tt_metal {
+
+const std::unique_ptr<tt::umd::Cluster> PhysicalSystemDescriptor::null_cluster = nullptr;
+const std::unique_ptr<Hal> PhysicalSystemDescriptor::null_hal = nullptr;
 
 /**************************************************************************************************
  Discovery helper functions
@@ -136,22 +143,33 @@ struct EthEndpoint {
 PhysicalSystemDescriptor::PhysicalSystemDescriptor(
     const std::unique_ptr<tt::umd::Cluster>& cluster,
     const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
+    const std::unique_ptr<tt::tt_metal::Hal>& hal,
     const llrt::RunTimeOptions& rtoptions,
     bool run_discovery) :
-    PhysicalSystemDescriptor(cluster, distributed_context, rtoptions.get_mock_enabled(), run_discovery) {}
+    PhysicalSystemDescriptor(cluster, distributed_context, hal, rtoptions.get_mock_enabled(), run_discovery) {}
 
 PhysicalSystemDescriptor::PhysicalSystemDescriptor(
     const std::unique_ptr<tt::umd::Cluster>& cluster,
     const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
+    const std::unique_ptr<tt::tt_metal::Hal>& hal,
     bool using_mock_cluster_descriptor,
     bool run_discovery) :
     cluster_(cluster),
     distributed_context_(distributed_context),
+    hal_(hal),
     using_mock_cluster_desc_(using_mock_cluster_descriptor) {
     if (run_discovery) {
         this->run_discovery();
     }
 }
+
+PhysicalSystemDescriptor::PhysicalSystemDescriptor(const std::string& proto_desc_path) :
+    cluster_(null_cluster), distributed_context_(nullptr), hal_(null_hal), using_mock_cluster_desc_(false) {
+    auto proto_desc = deserialize_physical_system_descriptor_from_text_proto_file(proto_desc_path);
+    this->merge(std::move(proto_desc));
+}
+
+PhysicalSystemDescriptor::~PhysicalSystemDescriptor() = default;
 
 void PhysicalSystemDescriptor::resolve_hostname_uniqueness() {
     using namespace tt::tt_metal::distributed::multihost;
@@ -299,6 +317,7 @@ void PhysicalSystemDescriptor::run_local_discovery() {
                 .eth_conn = EthConnection(eth_chan, dst_chan, false)});
         }
     }
+    this->generate_ethernet_metrics();
     system_graph_.host_connectivity_graph[hostname] = {};
 }
 
@@ -335,6 +354,10 @@ void PhysicalSystemDescriptor::merge(PhysicalSystemDescriptor&& other) {
         exit_node_connection_table_[host_name] = std::move(exit_connections);
     }
 
+    for (auto& [asic, metrics] : other.ethernet_metrics_) {
+        ethernet_metrics_[asic] = std::move(metrics);
+    }
+
     // Merging PhysicalSystemDescriptors using mock and real clusters is undefined and unsupported
     TT_FATAL(
         is_using_mock_cluster() == other.is_using_mock_cluster(),
@@ -344,8 +367,22 @@ void PhysicalSystemDescriptor::merge(PhysicalSystemDescriptor&& other) {
 void PhysicalSystemDescriptor::remove_unresolved_nodes() {
     for (auto& [host, asic_group] : system_graph_.asic_connectivity_graph) {
         for (auto& [src_asic, edges] : asic_group) {
-            std::erase_if(
+            auto edges_copy = edges;
+            auto num_erased_edges = std::erase_if(
                 edges, [&](const auto& pair) { return asic_descriptors_.find(pair.first) == asic_descriptors_.end(); });
+            // Erase the metrics for the deleted edges
+            if (num_erased_edges > 0) {
+                // Build set of remaining edges for O(log n) lookup instead of O(n) std::find
+                std::set<typename std::decay_t<decltype(edges)>::value_type> remaining_edges(
+                    edges.begin(), edges.end());
+                for (const auto& edge : edges_copy) {
+                    if (remaining_edges.find(edge) == remaining_edges.end()) {
+                        for (const auto& eth_conn : edge.second) {
+                            ethernet_metrics_[src_asic].erase(eth_conn.src_chan);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -412,8 +449,7 @@ void PhysicalSystemDescriptor::exchange_metadata(bool issue_gather) {
                     tt::stl::Span<uint8_t>(serialized_peer_desc.data(), serialized_peer_desc.size())),
                 Rank{rank},
                 Tag{0});
-            auto peer_desc =
-                deserialize_physical_system_descriptor_from_bytes(cluster_, distributed_context_, serialized_peer_desc);
+            auto peer_desc = deserialize_physical_system_descriptor_from_bytes(serialized_peer_desc);
             this->merge(std::move(peer_desc));
         }
     }
@@ -727,6 +763,90 @@ std::vector<ExitNodeConnection> PhysicalSystemDescriptor::get_connecting_exit_no
         }
     }
     return {};
+}
+
+uint32_t PhysicalSystemDescriptor::get_chip_id_for_asic(AsicID asic_id) const {
+    auto cluster_desc = cluster_->get_cluster_description();
+    const auto& chip_unique_ids = cluster_desc->get_chip_unique_ids();
+    for (const auto& [chip_id, unique_id] : chip_unique_ids) {
+        if (unique_id == *asic_id) {
+            return chip_id;
+        }
+    }
+    TT_FATAL(false, "Chip ID not found for asic ID {}", asic_id);
+    return 0;
+}
+
+std::pair<AsicID, uint8_t> PhysicalSystemDescriptor::get_connected_asic_and_channel(
+    AsicID asic_id, uint8_t chan_id) const {
+    auto host = asic_descriptors_.at(asic_id).host_name;
+    auto asic_graph = system_graph_.asic_connectivity_graph.at(host);
+    for (const auto& [src_asic, edges] : asic_graph) {
+        if (src_asic != asic_id) {
+            continue;
+        }
+        for (const auto& edge : edges) {
+            auto dst_asic = edge.first;
+
+            for (const auto& eth_conn : edge.second) {
+                if (eth_conn.src_chan == chan_id) {
+                    return {dst_asic, eth_conn.dst_chan};
+                }
+            }
+        }
+    }
+    TT_FATAL(false, "No connected ASIC and channel found for asic ID {} and channel ID {}", asic_id, chan_id);
+    return {AsicID{0}, 0};
+}
+
+void PhysicalSystemDescriptor::generate_ethernet_metrics() {
+    const auto& local_asics = get_asics_connected_to_host(my_host_name());
+    const auto& local_asic_graph = get_asic_topology(my_host_name());
+
+    auto retrain_count_addr = hal_->get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::RETRAIN_COUNT);
+    auto crc_addr =
+        hal_->get_dev_addr(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::CRC_ERR);
+    auto corr_addr =
+        hal_->get_dev_addr(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::CORR_CW);
+    auto uncorr_addr = hal_->get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNCORR_CW);
+
+    for (const auto& asic : local_asics) {
+        const auto& asic_connections = local_asic_graph.at(asic);
+        for (const auto& [dst_asic, eth_connections] : asic_connections) {
+            for (const auto& eth_connection : eth_connections) {
+                uint32_t retrain_count_val = 0, crc_error_val = 0, corr_val_lo = 0, corr_val_hi = 0, uncorr_val_lo = 0,
+                         uncorr_val_hi = 0;
+
+                auto src_eth_chan = eth_connection.src_chan;
+                auto src_chip_id = get_chip_id_for_asic(asic);
+                const auto& soc_desc = cluster_->get_soc_descriptor(src_chip_id);
+                const auto& translated_eth_core =
+                    soc_desc.get_eth_core_for_channel(src_eth_chan, CoordSystem::TRANSLATED);
+
+                cluster_->read_from_device(
+                    &retrain_count_val, src_chip_id, translated_eth_core, retrain_count_addr, sizeof(uint32_t));
+                cluster_->read_from_device(
+                    &crc_error_val, src_chip_id, translated_eth_core, crc_addr, sizeof(uint32_t));
+                cluster_->read_from_device(&corr_val_hi, src_chip_id, translated_eth_core, corr_addr, sizeof(uint32_t));
+                cluster_->read_from_device(
+                    &corr_val_lo, src_chip_id, translated_eth_core, corr_addr + 4, sizeof(uint32_t));
+                cluster_->read_from_device(
+                    &uncorr_val_hi, src_chip_id, translated_eth_core, uncorr_addr, sizeof(uint32_t));
+                cluster_->read_from_device(
+                    &uncorr_val_lo, src_chip_id, translated_eth_core, uncorr_addr + 4, sizeof(uint32_t));
+
+                ethernet_metrics_[asic][src_eth_chan] = {
+                    .retrain_count = retrain_count_val,
+                    .crc_error_count = crc_error_val,
+                    .corrected_codeword_count =
+                        (static_cast<uint64_t>(corr_val_hi) << 32) | static_cast<uint64_t>(corr_val_lo),
+                    .uncorrected_codeword_count =
+                        (static_cast<uint64_t>(uncorr_val_hi) << 32) | static_cast<uint64_t>(uncorr_val_lo)};
+            }
+        }
+    }
 }
 
 const HostTopology& PhysicalSystemDescriptor::get_host_topology() const {

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -29,6 +29,8 @@ class DistributedContext;
 
 namespace tt::tt_metal {
 
+class Hal;
+
 using AsicID = tt::stl::StrongType<uint64_t, struct AsicIDTag>;
 using TrayID = tt::stl::StrongType<uint32_t, struct TrayIDTag>;
 using ASICLocation = tt::stl::StrongType<uint32_t, struct ASICLocationTag>;
@@ -44,6 +46,14 @@ struct ASICDescriptor {
     BoardType board_type = BoardType::UNKNOWN;
     AsicID unique_id;
     std::string host_name;
+};
+
+// Live Ethernet Link Metrics
+struct EthernetMetrics {
+    uint32_t retrain_count = 0;
+    uint32_t crc_error_count = 0;
+    uint64_t corrected_codeword_count = 0;
+    uint64_t uncorrected_codeword_count = 0;
 };
 
 // Specify an ethernet connection between two ASICs
@@ -134,13 +144,21 @@ public:
     PhysicalSystemDescriptor(
         const std::unique_ptr<tt::umd::Cluster>& cluster,
         const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
+        const std::unique_ptr<tt::tt_metal::Hal>& hal,
         const tt::llrt::RunTimeOptions& rtoptions,
         bool run_discovery = true);
     PhysicalSystemDescriptor(
         const std::unique_ptr<tt::umd::Cluster>& cluster,
         const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
+        const std::unique_ptr<tt::tt_metal::Hal>& hal,
         bool using_mock_cluster_descriptor,
         bool run_discovery);
+    // Constructor generating a PhysicalSystemDescriptor based on a protobuf
+    // descriptor (can be used entirely offline).
+    PhysicalSystemDescriptor(const std::string& proto_desc_path);
+
+    ~PhysicalSystemDescriptor();
+
     void run_discovery(bool run_global_discovery = true);
     // ASIC Topology Query APIs
     std::vector<AsicID> get_asic_neighbors(AsicID asic_id) const;
@@ -149,6 +167,7 @@ public:
     TrayID get_tray_id(AsicID asic_id) const;
     ASICLocation get_asic_location(AsicID asic_id) const;
     std::vector<AsicID> get_asics_connected_to_host(const std::string& hostname) const;
+    std::pair<AsicID, uint8_t> get_connected_asic_and_channel(AsicID asic_id, uint8_t chan_id) const;
 
     // Host Topology Query APIs
     std::vector<std::string> get_host_neighbors(const std::string& hostname) const;
@@ -172,12 +191,21 @@ public:
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
     bool is_using_mock_cluster() const { return using_mock_cluster_desc_; }
+    const std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>>& get_ethernet_metrics() const {
+        return ethernet_metrics_;
+    }
 
     PhysicalConnectivityGraph& get_system_graph() { return system_graph_; }
     std::unordered_map<AsicID, ASICDescriptor>& get_asic_descriptors() { return asic_descriptors_; }
     std::unordered_map<std::string, std::string>& get_host_mobo_name_map() { return host_to_mobo_name_; }
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
+    std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>>& get_ethernet_metrics() {
+        return ethernet_metrics_;
+    }
+
+    static const std::unique_ptr<tt::umd::Cluster> null_cluster;
+    static const std::unique_ptr<Hal> null_hal;
 
     // Utility APIs to Print Physical System Descriptor
     void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt);
@@ -190,17 +218,22 @@ private:
     void merge(PhysicalSystemDescriptor&& other);
     void exchange_metadata(bool issue_gather);
     void generate_cross_host_connections();
+    void generate_ethernet_metrics();
+    uint32_t get_chip_id_for_asic(AsicID asic_id) const;
     void remove_unresolved_nodes();
     void resolve_hostname_uniqueness();
     void validate_graphs();
+
     const std::unique_ptr<tt::umd::Cluster>& cluster_;
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
+    const std::unique_ptr<Hal>& hal_;
     const bool using_mock_cluster_desc_;
     PhysicalConnectivityGraph system_graph_;
     std::unordered_map<AsicID, ASICDescriptor> asic_descriptors_;
     std::unordered_map<std::string, std::string> host_to_mobo_name_;
     std::unordered_map<std::string, uint32_t> host_to_rank_;
     ExitNodeConnectionTable exit_node_connection_table_;
+    std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>> ethernet_metrics_;
     bool all_hostnames_unique_ = true;
 };
 

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -144,18 +144,18 @@ public:
     PhysicalSystemDescriptor(
         const std::unique_ptr<tt::umd::Cluster>& cluster,
         const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
-        const std::unique_ptr<tt::tt_metal::Hal>& hal,
+        const Hal* hal,
         const tt::llrt::RunTimeOptions& rtoptions,
         bool run_discovery = true);
     PhysicalSystemDescriptor(
         const std::unique_ptr<tt::umd::Cluster>& cluster,
         const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
-        const std::unique_ptr<tt::tt_metal::Hal>& hal,
+        const Hal* hal,
         bool using_mock_cluster_descriptor,
         bool run_discovery);
     // Constructor generating a PhysicalSystemDescriptor based on a protobuf
     // descriptor (can be used entirely offline).
-    PhysicalSystemDescriptor(const std::string& proto_desc_path);
+    PhysicalSystemDescriptor(const std::string& mock_proto_desc_path);
 
     ~PhysicalSystemDescriptor();
 
@@ -205,7 +205,6 @@ public:
     }
 
     static const std::unique_ptr<tt::umd::Cluster> null_cluster;
-    static const std::unique_ptr<Hal> null_hal;
 
     // Utility APIs to Print Physical System Descriptor
     void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt);
@@ -226,7 +225,7 @@ private:
 
     const std::unique_ptr<tt::umd::Cluster>& cluster_;
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
-    const std::unique_ptr<Hal>& hal_;
+    const Hal* hal_;
     const bool using_mock_cluster_desc_;
     PhysicalConnectivityGraph system_graph_;
     std::unordered_map<AsicID, ASICDescriptor> asic_descriptors_;

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -2,6 +2,14 @@ syntax = "proto3";
 
 package tt.fabric.proto;
 
+// Live Ethernet Link Metrics
+message EthernetMetrics {
+    uint32 retrain_count = 1;
+    uint32 crc_error_count = 2;
+    uint64 corrected_codeword_count = 3;
+    uint64 uncorrected_codeword_count = 4;
+}
+
 // Ethernet connection between two ASICs
 message EthConnection {
     uint32 src_chan = 1;
@@ -90,6 +98,18 @@ message ExitNodeConnectionTable {
     repeated ExitNodeConnection exit_connections = 2;
 }
 
+// Map entry for ethernet metrics per channel
+message ChannelEthernetMetrics {
+    uint32 channel = 1;
+    EthernetMetrics metrics = 2;
+}
+
+// Map entry for ASIC ID to ethernet metrics
+message AsicEthernetMetrics {
+    uint64 asic_id = 1;
+    repeated ChannelEthernetMetrics channel_metrics = 2;
+}
+
 // Top-level Physical System Descriptor message
 message PhysicalSystemDescriptor {
     PhysicalConnectivityGraph system_graph = 1;
@@ -98,4 +118,5 @@ message PhysicalSystemDescriptor {
     repeated HostToRankMap host_to_rank = 4;
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
     bool mock_cluster = 6;
+    repeated AsicEthernetMetrics ethernet_metrics = 7;
 }

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -56,6 +56,24 @@ ExitNodeConnection proto_to_exit_node_connection(const tt::fabric::proto::ExitNo
     return exit_conn;
 }
 
+// Convert EthernetMetrics to protobuf
+void ethernet_metrics_to_proto(const EthernetMetrics& metrics, tt::fabric::proto::EthernetMetrics* proto_metrics) {
+    proto_metrics->set_retrain_count(metrics.retrain_count);
+    proto_metrics->set_crc_error_count(metrics.crc_error_count);
+    proto_metrics->set_corrected_codeword_count(metrics.corrected_codeword_count);
+    proto_metrics->set_uncorrected_codeword_count(metrics.uncorrected_codeword_count);
+}
+
+// Convert protobuf to EthernetMetrics
+EthernetMetrics proto_to_ethernet_metrics(const tt::fabric::proto::EthernetMetrics& proto_metrics) {
+    EthernetMetrics metrics;
+    metrics.retrain_count = proto_metrics.retrain_count();
+    metrics.crc_error_count = proto_metrics.crc_error_count();
+    metrics.corrected_codeword_count = proto_metrics.corrected_codeword_count();
+    metrics.uncorrected_codeword_count = proto_metrics.uncorrected_codeword_count();
+    return metrics;
+}
+
 // Convert AsicTopology to protobuf
 void asic_topology_to_proto(const AsicTopology& topology, tt::fabric::proto::HostAsicConnectivity* host_asic_conn) {
     for (const auto& [asic_id, connections] : topology) {
@@ -192,15 +210,29 @@ void physical_system_descriptor_to_proto(
 
     // Set mock cluster flag
     proto_desc->set_mock_cluster(descriptor.is_using_mock_cluster());
+
+    // Convert ethernet metrics
+    for (const auto& [asic_id, channel_metrics] : descriptor.get_ethernet_metrics()) {
+        auto* proto_asic_metrics = proto_desc->add_ethernet_metrics();
+        proto_asic_metrics->set_asic_id(*asic_id);
+
+        for (const auto& [channel, metrics] : channel_metrics) {
+            auto* proto_channel_metrics = proto_asic_metrics->add_channel_metrics();
+            proto_channel_metrics->set_channel(channel);
+            ethernet_metrics_to_proto(metrics, proto_channel_metrics->mutable_metrics());
+        }
+    }
 }
 
 // Convert protobuf to PhysicalSystemDescriptor
 std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
-    const std::unique_ptr<tt::umd::Cluster>& cluster,
-    const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
     const tt::fabric::proto::PhysicalSystemDescriptor& proto_desc) {
     auto descriptor = std::make_unique<PhysicalSystemDescriptor>(
-        cluster, distributed_context, proto_desc.mock_cluster(), false);  // Don't run discovery
+        PhysicalSystemDescriptor::null_cluster,
+        nullptr,
+        PhysicalSystemDescriptor::null_hal,
+        proto_desc.mock_cluster(),
+        false);  // Don't run discovery
 
     // Convert system graph
     auto& system_graph = descriptor->get_system_graph();
@@ -254,6 +286,20 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
         exit_node_connection_table[proto_table.host_name()] = std::move(exit_connections);
     }
 
+    // Convert ethernet metrics
+    auto& ethernet_metrics = descriptor->get_ethernet_metrics();
+    for (const auto& proto_asic_metrics : proto_desc.ethernet_metrics()) {
+        AsicID asic_id{proto_asic_metrics.asic_id()};
+        std::unordered_map<uint8_t, EthernetMetrics> channel_metrics;
+
+        for (const auto& proto_channel_metrics : proto_asic_metrics.channel_metrics()) {
+            uint8_t channel = static_cast<uint8_t>(proto_channel_metrics.channel());
+            channel_metrics[channel] = proto_to_ethernet_metrics(proto_channel_metrics.metrics());
+        }
+
+        ethernet_metrics[asic_id] = std::move(channel_metrics);
+    }
+
     return descriptor;
 }
 
@@ -295,16 +341,29 @@ std::vector<uint8_t> serialize_physical_system_descriptor_to_bytes(const Physica
     return result;
 }
 
-PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(
-    const std::unique_ptr<tt::umd::Cluster>& cluster,
-    const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
-    const std::vector<uint8_t>& data) {
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(const std::vector<uint8_t>& data) {
     tt::fabric::proto::PhysicalSystemDescriptor proto_desc;
     if (!proto_desc.ParseFromArray(data.data(), data.size())) {
         throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from protobuf binary format");
     }
 
-    return std::move(*proto_to_physical_system_descriptor(cluster, distributed_context, proto_desc));
+    return *proto_to_physical_system_descriptor(proto_desc);
 }
 
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_file(
+    const std::string& text_proto_file) {
+    std::ifstream gsd_file(text_proto_file);
+    if (!gsd_file.is_open()) {
+        throw std::runtime_error("Failed to open file for reading: " + text_proto_file);
+    }
+
+    std::string text_proto((std::istreambuf_iterator<char>(gsd_file)), std::istreambuf_iterator<char>());
+    gsd_file.close();
+    tt::fabric::proto::PhysicalSystemDescriptor physical_system_descriptor;
+    if (!google::protobuf::TextFormat::ParseFromString(text_proto, &physical_system_descriptor)) {
+        throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from text proto file: " + text_proto_file);
+    }
+
+    return *proto_to_physical_system_descriptor(physical_system_descriptor);
+}
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
     auto descriptor = std::make_unique<PhysicalSystemDescriptor>(
         PhysicalSystemDescriptor::null_cluster,
         nullptr,
-        PhysicalSystemDescriptor::null_hal,
+        nullptr,
         proto_desc.mock_cluster(),
         false);  // Don't run discovery
 

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp
@@ -23,13 +23,14 @@ class PhysicalSystemDescriptor;
 // Emit PhysicalSystemDescriptor to a text proto file
 void emit_physical_system_descriptor_to_text_proto(
     const PhysicalSystemDescriptor& descriptor, const std::optional<std::string>& file_path);
+
 // Serialize PhysicalSystemDescriptor to protobuf binary format (byte vector)
 std::vector<uint8_t> serialize_physical_system_descriptor_to_bytes(const PhysicalSystemDescriptor& descriptor);
 
 // Deserialize from protobuf binary format to PhysicalSystemDescriptor (byte vector)
-PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(
-    const std::unique_ptr<tt::umd::Cluster>& cluster,
-    const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
-    const std::vector<uint8_t>& data);
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(const std::vector<uint8_t>& data);
+
+PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_file(
+    const std::string& text_proto_file);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -312,11 +312,6 @@ const Hal& MetalContext::hal() const {
     return *hal_;
 }
 
-const std::unique_ptr<Hal>& MetalContext::hal_ptr() const {
-    TT_FATAL(hal_, "Trying to get hal before initializing it.");
-    return hal_;
-}
-
 dispatch_core_manager& MetalContext::get_dispatch_core_manager() {
     TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before initializing it.");
     return *dispatch_core_manager_;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -296,29 +296,34 @@ MetalContext::~MetalContext() {
 llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }
 
 Cluster& MetalContext::get_cluster() {
-    TT_FATAL(cluster_, "Trying to get cluster before intializing it.");
+    TT_FATAL(cluster_, "Trying to get cluster before initializing it.");
     return *cluster_;
 }
 
 const llrt::RunTimeOptions& MetalContext::rtoptions() const { return rtoptions_; }
 
 const Cluster& MetalContext::get_cluster() const {
-    TT_FATAL(cluster_, "Trying to get cluster before intializing it.");
+    TT_FATAL(cluster_, "Trying to get cluster before initializing it.");
     return *cluster_;
 }
 
 const Hal& MetalContext::hal() const {
-    TT_FATAL(hal_, "Trying to get hal before intializing it.");
+    TT_FATAL(hal_, "Trying to get hal before initializing it.");
     return *hal_;
 }
 
+const std::unique_ptr<Hal>& MetalContext::hal_ptr() const {
+    TT_FATAL(hal_, "Trying to get hal before initializing it.");
+    return hal_;
+}
+
 dispatch_core_manager& MetalContext::get_dispatch_core_manager() {
-    TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before intializing it.");
+    TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before initializing it.");
     return *dispatch_core_manager_;
 }
 
 DispatchQueryManager& MetalContext::get_dispatch_query_manager() {
-    TT_FATAL(dispatch_query_manager_, "Trying to get dispatch_query_manager before intializing it.");
+    TT_FATAL(dispatch_query_manager_, "Trying to get dispatch_query_manager before initializing it.");
     return *dispatch_query_manager_;
 }
 
@@ -328,7 +333,7 @@ const DispatchMemMap& MetalContext::dispatch_mem_map() const {
 
 const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) const {
     auto& mem_map = dispatch_mem_map_[enchantum::to_underlying(core_type)];
-    TT_FATAL(mem_map, "Tried to get dispatch_mem_map for {} before intializing it.", core_type);
+    TT_FATAL(mem_map, "Tried to get dispatch_mem_map for {} before initializing it.", core_type);
     return *mem_map;
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -53,6 +53,7 @@ public:
     const Cluster& get_cluster() const;
     const llrt::RunTimeOptions& rtoptions() const;
     const Hal& hal() const;
+    const std::unique_ptr<Hal>& hal_ptr() const;
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
     const DispatchMemMap& dispatch_mem_map() const;  // DispatchMemMap for the core type we're dispatching on.

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -53,7 +53,6 @@ public:
     const Cluster& get_cluster() const;
     const llrt::RunTimeOptions& rtoptions() const;
     const Hal& hal() const;
-    const std::unique_ptr<Hal>& hal_ptr() const;
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
     const DispatchMemMap& dispatch_mem_map() const;  // DispatchMemMap for the core type we're dispatching on.


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- We need a Multi-Node Cluster Validation tool for internal and external use
- `test_system_health` works well for single host systems, but has no context of remote hosts or cross-host ethernet links
- `run_cluster_validation` is a step towards solving this problem

### What's changed
- Add `run_cluster_validation` tool, which relies on the `PhysicalSystemDescriptor` and `FactorySystemDescriptor` for validating ethernet connectivity across a multi-node cluster
- CLI Interface:

```
Utility to validate Ethernet Links and Connections for a Multi-Node TT Cluster
Compares live system state against the requested Cabling and Deployment Specifications

 Arguments:
  --cabling-descriptor-path: Path to cabling descriptor
  --deployment-descriptor-path: Path to deployment descriptor
  --factory-descriptor-path: Path to factory descriptor
  --global-descriptor-path: Path to global descriptor
  --output-path: Path to output directory
  --hard-fail: Fail on warning
  --log-ethernet-metrics: Log ethernet live ethernet statistics
  --print-connectivity: Print Ethernet Connectivity between ASICs
  --help: Print usage information
  ```

- Multi-Host Usage Example:
```
mpirun --hostfile host_file ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path <CABLING_DESC> --deployment-descriptor-path <DEPLOYMENT_DESC> --print-connectivity --log-ethernet-metrics --hard-fail
```

- Example Output (this is for a T3K Super-Pod):
```
============================== HOST-LOCAL CONNECTIONS =============================== 

  =============================== Hostname: metal-wh-09 =============================== 

             ---------------------- Port Type: QSFP_DD ---------------------- 

 [metal-wh-09] Unique ID: 26190e0a4 Tray: 1, ASIC Location: 0, Ethernet Channel: 7
        Connected to [metal-wh-09] Unique ID: 26190e0cb Tray: 4, ASIC Location: 0, Ethernet Channel: 7
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0x84172b Uncorrected Codewords: 0x0 
....
             ---------------------- Port Type: TRACE ---------------------- 

 [metal-wh-09] Unique ID: 36190e0cb Tray: 4, ASIC Location: 1, Ethernet Channel: 0
        Connected to [metal-wh-09] Unique ID: 26190e0cb Tray: 4, ASIC Location: 0, Ethernet Channel: 8
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0x6ed0 Uncorrected Codewords: 0x0 
....
             ---------------------- Port Type: WARP100 ---------------------- 

 [metal-wh-09] Unique ID: 36190e0cb Tray: 4, ASIC Location: 1, Ethernet Channel: 7
        Connected to [metal-wh-09] Unique ID: 36190e003 Tray: 3, ASIC Location: 1, Ethernet Channel: 7
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0x68 Uncorrected Codewords: 0x0 
 ....

============================== CROSS-HOST CONNECTIONS =============================== 

  =============================== Hostname: metal-wh-09 =============================== 

             ---------------------- Port Type: QSFP_DD ---------------------- 

 [metal-wh-09] Unique ID: 26190e0a4 Tray: 1, ASIC Location: 0, Ethernet Channel: 1
        Connected to [metal-wh-12] Unique ID: 26190e0ab Tray: 1, ASIC Location: 0, Ethernet Channel: 1
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0xdb085 Uncorrected Codewords: 0x0 
...

  =============================== Hostname: metal-wh-10 =============================== 

             ---------------------- Port Type: QSFP_DD ---------------------- 

 [metal-wh-10] Unique ID: 26190e0d1 Tray: 4, ASIC Location: 0, Ethernet Channel: 0
        Connected to [metal-wh-12] Unique ID: 26190e046 Tray: 2, ASIC Location: 0, Ethernet Channel: 6
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0xb1c Uncorrected Codewords: 0x0 
...

  =============================== Hostname: metal-wh-11 =============================== 

             ---------------------- Port Type: QSFP_DD ---------------------- 

 [metal-wh-11] Unique ID: 26190e0b3 Tray: 4, ASIC Location: 0, Ethernet Channel: 0
        Connected to [metal-wh-09] Unique ID: 26190e0cb Tray: 4, ASIC Location: 0, Ethernet Channel: 0
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0x198a Uncorrected Codewords: 0x0 
...

  =============================== Hostname: metal-wh-12 =============================== 

             ---------------------- Port Type: QSFP_DD ---------------------- 

 [metal-wh-12] Unique ID: 26190e053 Tray: 3, ASIC Location: 0, Ethernet Channel: 6
        Connected to [metal-wh-11] Unique ID: 26190e090 Tray: 3, ASIC Location: 0, Ethernet Channel: 6
         Retrain Count: 0 CRC Errors: 0x0 Corrected Codewords: 0xdd36 Uncorrected Codewords: 0x0 
...

```
- Also supports an offline mode to validate a pre-generated Global System Descriptor
- This utility can be seen as a more generic `test_system_health` and can be used as a replacement

- Follow on work:
   -  Expand this utility to send traffic over all ethernet links in the GSD for additional validation
   - Use this for directed link resets
   - Export outputs to CSV, YAML, etc. (based on user requests)
   - Packaging to as a standalone (Debian?) utility
  
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes