### PR TITLE
Fix libdir logic in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 
 import os
 import glob
+import platform
 import shutil
 import subprocess
 import sys
@@ -25,14 +26,25 @@ readme_path = Path(__file__).absolute().parent / "README.md"
 readme = readme_path.read_text(encoding="utf-8")
 
 
-# Get the platform-specific lib directory name
-def get_lib_dir():
-    if sys.platform == "win32":
-        return "bin"  # Windows DLLs go in bin directory
-    elif sys.platform.startswith("linux"):
-        return "lib64" if os.path.exists("/usr/lib64") else "lib"
-    else:  # macOS and others
-        return "lib"
+def get_lib_dir() -> str:
+    """
+    Inspired by GNUInstallDirs logic:
+    default = 'lib'
+    upgrade to 'lib64' only on 64-bit Linux that is not Debian/Arch/Alpine.
+    """
+    libdir = "lib"
+
+    if platform.system() == "Linux":
+        # skip lib64 on Debian/Arch/Alpine
+        if not (
+            Path("/etc/debian_version").exists()
+            or Path("/etc/arch-release").exists()
+            or Path("/etc/alpine-release").exists()
+        ):
+            if platform.architecture()[0] == "64bit":
+                libdir = "lib64"
+
+    return libdir
 
 
 BUNDLE_SFPI = False


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/23847

### Problem description
The logic for determining the OS specific prefix for library directory was wrong.

### What's changed
Replace the existing function with new logic inspired by CMake's GNUInstallDirs
https://github.com/Kitware/CMake/blob/ceecafd7d51166825c30278e2e9ee3832ce37936/Modules/GNUInstallDirs.cmake#L115

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18183763700) CI passes
- [x] New/Existing tests provide coverage for changes