### PR TITLE
[skip ci] Bumped efficientnet expected device perf

### DIFF
--- a/models/experimental/efficientnetb0/tests/perf/test_perf.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_perf.py
@@ -15,7 +15,7 @@ from models.common.utility_functions import (
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 145.4],
+        [1, 174.0],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
Device Perf CI failing because of efficientnetb0 being faster than expected
https://github.com/tenstorrent/tt-metal/actions/runs/18178159404/job/51749111896#step:34:215
https://github.com/tenstorrent/tt-metal/actions/runs/18181604221/job/51758794028#step:34:215
### What's changed
- bumped expected device perf