### PR TITLE
[skip ci] Stable diffusion bumped l1 small size on BH

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -5,6 +5,6 @@
 from models.common.utility_functions import is_blackhole
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 20928
+SD_L1_SMALL_SIZE = 21056 if is_blackhole() else 20928
 # Trace Region Size Constants
 SD_TRACE_REGION_SIZE = 820000000 if is_blackhole() else 789835776


### PR DESCRIPTION
### Problem description
Models perf test fails on p150 due to lack of l1 small
https://github.com/tenstorrent/tt-metal/actions/runs/18181544177/job/51758904270#step:10:1090

### What's changed
- bumped l1 small size only for blackhole