### PR TITLE
#27841 Fix repeat batches

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -807,6 +807,7 @@ def test_demo_text(
                     k_cache, v_cache = layer.attention.layer_past
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
+            generator.prev_page_table = None
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
 


### PR DESCRIPTION

### Ticket
#27841 (this should also effect every single model using repeat batches)
### Problem description
- The cause of hang is caused by failing to reset the inputs in between repeat batches. This is due to the logic introduced in the generator around `prev_page_table` that controls when we copy the tensors from host memory to device memory. Namely, the page table, the tokens, the current position and the rope index.

### What's changed
- A straightforward fix is to explicitly reset the `prev_page_table` after each repeat batch in our `simple_text_demo.py`.

### Checklist