### PR TITLE
#22103: BH tiny tiles watcher fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -67,7 +67,7 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
     assert_with_pcc(torch_input_tensor, output_tensor, expected_pcc)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("n", [1])
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("m", [1024])
@@ -247,7 +247,7 @@ def test_matmul_reuse_config_sharded_fd_column(
     assert_with_pcc(pt_out, output_tensor, expected_pcc)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("b", [2])
 @pytest.mark.parametrize("h", [3])
 @pytest.mark.parametrize("m", [256])
@@ -355,7 +355,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
     return padded_number
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1280])
 @pytest.mark.parametrize("has_bias", [False, True])
@@ -790,7 +790,7 @@ def run_matmul_2d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
 @pytest.mark.parametrize("n", [768])
@@ -947,7 +947,7 @@ def run_matmul_1d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("m", [128])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1024])

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     constexpr auto in0_args = TensorAccessorArgs<1>();
 
     constexpr uint32_t cb_id_in0 = 0;
-
+    constexpr uint32_t one_tile = 1;
 #ifdef IN0_SHARDED
     const uint32_t in0_num_tiles = batch * num_blocks * in0_block_h * in0_block_w;
     cb_reserve_back(cb_id_in0, in0_num_tiles);
@@ -52,13 +52,28 @@ void kernel_main() {
         for (uint32_t block = 0; block < num_blocks; ++block) {
             cb_reserve_back(cb_id_in0, in0_block_num_tiles);
 
+#ifdef INTERMEDIATE_CB_READ
+            constexpr uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+            cb_reserve_back(in0_intermediate_cb_index, one_tile);
+            uint32_t l1_write_addr_helper = get_write_ptr(in0_intermediate_cb_index);
+#endif  // INTERMEDIATE_CB_READ
+
             l1_write_addr_in0 = get_write_ptr(cb_id_in0);
 
             uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
             for (uint32_t h = 0; h < in0_block_h; ++h) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; ++w) {
+#ifndef INTERMEDIATE_CB_READ
                     noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+#else
+                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_helper);
+                    noc_async_read_barrier();
+                    memcpy(
+                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in0),
+                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                        /*size=*/in0_single_tile_size_bytes);
+#endif  // INTERMEDIATE_CB_READ
 
                     // Zero out padded regions for the very last tile
                     if constexpr (last_ktile_w > 0) {
@@ -79,8 +94,15 @@ void kernel_main() {
             noc_async_read_barrier();
 
             cb_push_back(cb_id_in0, in0_block_num_tiles);
+
+#ifdef INTERMEDIATE_CB_READ
+            // Clean up helper CB
+            cb_push_back(in0_intermediate_cb_index, one_tile);
+            cb_wait_front(in0_intermediate_cb_index, one_tile);
+            cb_pop_front(in0_intermediate_cb_index, one_tile);
+#endif  // INTERMEDIATE_CB_READ
         }
         in0_tensor_start_tile_id += MtKt;
     }
-#endif
+#endif  // IN0_SHARDED
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -93,6 +93,7 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t one_tile = 1;
 
 #ifdef IN0_SHARDED
     // In case we need to send multiple blocks per shard, in0 sharded cb is cb2 and we extract the sub-blocks to cb0
@@ -110,7 +111,7 @@ void kernel_main() {
 
 #else
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, in0_single_tile_size_bytes);
-#endif
+#endif  // IN0_SHARDED
 
     // sparsity accessor
     constexpr uint32_t cb_id_sparsity = tt::CBIndex::c_6;
@@ -138,8 +139,8 @@ void kernel_main() {
 
 #ifdef IN0_SHARDED
     uint32_t in0_start_address = get_write_ptr(cb_id_in0);
-#endif
-#endif
+#endif  // IN0_SHARDED
+#endif  // SKIP_MCAST
 
     uint32_t l1_write_addr_sparsity = 0;
     if constexpr (batchB > 0) {
@@ -170,8 +171,8 @@ void kernel_main() {
                     noc_async_writes_flushed();
                     // Reset the semaphore value to VALID
                     noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
-#endif
-                    // We need to pass the value to compute UNPACK regardless of the value of is_batch_valid
+#endif  // SKIP_MCAST
+        // We need to pass the value to compute UNPACK regardless of the value of is_batch_valid
                     cb_reserve_back(nnz_cb_id, 1);
                     auto nnz_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(nnz_cb_id));
                     nnz_ptr[0] = is_batch_valid;
@@ -188,13 +189,13 @@ void kernel_main() {
 
 #ifdef IN0_SHARDED
             uint32_t in0_tensor_current_h_dim_block_start_addr = noc_shard_read_start_addr;
-#endif
+#endif  // IN0_SHARDED
             uint32_t in0_tensor_current_h_dim_block_tile_id = in0_tensor_start_tile_id;
             for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
                 for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
 #ifdef IN0_SHARDED
                     uint32_t in0_tensor_current_inner_dim_block_start_addr = in0_tensor_current_h_dim_block_start_addr;
-#endif
+#endif  // IN0_SHARDED
                     uint32_t in0_tensor_current_inner_dim_block_start_tile_id = in0_tensor_current_h_dim_block_tile_id;
                     for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                         if constexpr (fuse_op) {
@@ -206,12 +207,19 @@ void kernel_main() {
                         // Common for sharded and interleaved paths
                         cb_reserve_back(cb_id_in0, in0_block_num_tiles);
 #ifndef IN0_SHARDED
+
+#ifdef INTERMEDIATE_CB_READ
+                        constexpr uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+                        cb_reserve_back(in0_intermediate_cb_index, one_tile);
+                        uint32_t l1_write_addr_helper = get_write_ptr(in0_intermediate_cb_index);
+#endif  // INTERMEDIATE_CB_READ
+
                         uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
 
 #ifndef SKIP_MCAST
                         uint32_t in0_start_address =
                             l1_write_addr_in0;  // copy start address of block, to be used for mcasting
-#endif
+#endif                                          // SKIP_MCAST
 
                         // Copy in0 block into CB, as the default kernel
                         uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_inner_dim_block_start_tile_id;
@@ -219,7 +227,16 @@ void kernel_main() {
                             uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                             for (uint32_t w = 0; w < in0_block_w; ++w) {
                                 if (bh < num_blocks_h_dim - 1 || h < last_block_h) {
+#ifndef INTERMEDIATE_CB_READ
                                     noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+#else
+                                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_helper);
+                                    noc_async_read_barrier();
+                                    memcpy(
+                                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in0),
+                                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                                        /*size=*/in0_single_tile_size_bytes);
+#endif  // INTERMEDIATE_CB_READ
                                 }
 
                                 // Zero out padded regions for the very last tile
@@ -247,7 +264,7 @@ void kernel_main() {
 #ifndef SKIP_MCAST
                             in0_start_address =
                                 l1_write_addr_in0;  // copy start address of block, to be used for mcasting
-#endif
+#endif  // SKIP_MCAST
 
                             uint64_t noc_shard_read_addr = get_noc_addr(in0_tensor_current_inner_dim_block_start_addr);
 
@@ -261,7 +278,7 @@ void kernel_main() {
                             in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
                             noc_async_read_barrier();
                         }
-#endif
+#endif  // IN0_SHARDED
 
 #ifndef SKIP_MCAST
                         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
@@ -288,7 +305,7 @@ void kernel_main() {
                         // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
                         // latency which means data could be changed before write is issued.
                         noc_async_writes_flushed();
-#endif
+#endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
@@ -296,15 +313,21 @@ void kernel_main() {
                             in0_mcast_receiver_semaphore_addr,
                             in0_mcast_receiver_semaphore_noc_addr,
                             in0_mcast_num_cores);
-#endif
+#endif  // SKIP_MCAST
 
                         // Common for sharded and interleaved paths
                         cb_push_back(cb_id_in0, in0_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+                        // Clean up helper CB
+                        cb_push_back(in0_intermediate_cb_index, one_tile);
+                        cb_wait_front(in0_intermediate_cb_index, one_tile);
+                        cb_pop_front(in0_intermediate_cb_index, one_tile);
+#endif  // INTERMEDIATE_CB_READ
                     }
                 }
 #ifdef IN0_SHARDED
                 in0_tensor_current_h_dim_block_start_addr += in0_tensor_next_h_dim_block_stride_bytes;
-#endif
+#endif  // IN0_SHARDED
                 in0_tensor_current_h_dim_block_tile_id += in0_tensor_next_h_dim_block_stride;
             }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -302,9 +302,9 @@ void kernel_main() {
                         // Operand 1
                         cb_reserve_back(cb_id_in1, in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
-                        constexpr uint32_t helper_cb_index = tt::CBIndex::c_7;
-                        cb_reserve_back(helper_cb_index, one_tile);
-                        uint32_t l1_write_addr_helper = get_write_ptr(helper_cb_index);
+                        constexpr uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+                        cb_reserve_back(in1_intermediate_cb_index, one_tile);
+                        uint32_t l1_write_addr_helper = get_write_ptr(in1_intermediate_cb_index);
 #endif  // INTERMEDIATE_CB_READ
                         l1_write_addr_in1 = get_write_ptr(cb_id_in1);
                         uint64_t in1_start_address =
@@ -379,9 +379,9 @@ void kernel_main() {
                         cb_push_back(cb_id_in1, in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
                         // Clean up helper CB
-                        cb_push_back(helper_cb_index, one_tile);
-                        cb_wait_front(helper_cb_index, one_tile);
-                        cb_pop_front(helper_cb_index, one_tile);
+                        cb_push_back(in1_intermediate_cb_index, one_tile);
+                        cb_wait_front(in1_intermediate_cb_index, one_tile);
+                        cb_pop_front(in1_intermediate_cb_index, one_tile);
 #endif  // INTERMEDIATE_CB_READ
 #endif  // IN1_SHARDED
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -322,9 +322,9 @@ void kernel_main() {
                                     noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
                                     noc_async_read_barrier();
                                     memcpy(
-                                        reinterpret_cast<void*>(l1_write_addr_in1),
-                                        reinterpret_cast<const void*>(l1_write_addr_helper),
-                                        in1_single_tile_size_bytes);
+                                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in1),
+                                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                                        /*size=*/in1_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
                                 }
                                 l1_write_addr_in1 += in1_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -321,14 +321,10 @@ void kernel_main() {
 #else
                                     noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
                                     noc_async_read_barrier();
-
-                                    volatile tt_l1_ptr uint8_t* src =
-                                        reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr_helper);
-                                    volatile tt_l1_ptr uint8_t* dst =
-                                        reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr_in1);
-                                    for (uint32_t i = 0; i < in1_single_tile_size_bytes; ++i) {
-                                        dst[i] = src[i];
-                                    }
+                                    memcpy(
+                                        reinterpret_cast<void*>(l1_write_addr_in1),
+                                        reinterpret_cast<const void*>(l1_write_addr_helper),
+                                        in1_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
                                 }
                                 l1_write_addr_in1 += in1_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -88,6 +88,8 @@ void kernel_main() {
     // When sparsity is disabled, we just loop once
     constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
 
+    constexpr uint32_t one_tile = 1;
+
 #ifdef FUSE_BIAS
     // in3 mcast args
     const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
@@ -102,13 +104,13 @@ void kernel_main() {
 #ifndef BIAS_SHARDED
     uint32_t l1_write_addr_in3;
     // Bias accessor will be defined later after TensorAccessor args
-#endif
+#endif  // BIAS_SHARDED
 #else
     rt_args_idx += 2;  // Skip over placeholders
-#endif
+#endif  // FUSE_BIAS
 #ifndef OUT_SHARDED
     const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
-#endif
+#endif  // OUT_SHARDED
 
     constexpr bool fuse_op_all_gather = (bool)get_compile_time_arg_val(30);
     constexpr bool fuse_op_reduce_scatter = (bool)get_compile_time_arg_val(31);
@@ -134,7 +136,7 @@ void kernel_main() {
     constexpr auto after_bias_offset = bias_args.next_compile_time_args_offset();
 #else
     constexpr auto after_bias_offset = out_args.next_compile_time_args_offset();
-#endif
+#endif  // FUSE_BIAS
 
 // RT and COMPILE TIME ARGS for DRAM sharded weights
 #ifdef IN1_DRAM_SHARDED
@@ -146,13 +148,13 @@ void kernel_main() {
 
     constexpr uint32_t in1_dram_block_num_tiles = get_compile_time_arg_val(after_bias_offset);
     constexpr uint32_t in1_block_w_dram_bytes = get_compile_time_arg_val(after_bias_offset + 1);
-#endif
+#endif  // IN1_DRAM_SHARDED
 
 #ifdef FUSE_BIAS
 #ifndef BIAS_SHARDED
     const auto s3 = TensorAccessor(bias_args, in3_tensor_addr, bias_single_tile_size_bytes);
-#endif
-#endif
+#endif  // BIAS_SHARDED
+#endif  // FUSE_BIAS
 
     constexpr uint32_t cb_id_in1 = 1;
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
@@ -167,7 +169,7 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
-#endif
+#endif  // IN1_SHARDED
 
     //  WRITER
     constexpr uint32_t cb_id_out0 = tt::CBIndex::c_4;
@@ -200,8 +202,8 @@ void kernel_main() {
         in1_mcast_dest_noc_start_x, in1_mcast_dest_noc_start_y, in1_mcast_dest_noc_end_x, in1_mcast_dest_noc_end_y, 0);
 #ifdef IN1_SHARDED
     uint64_t in1_start_address = get_write_ptr(cb_id_in1);
-#endif
-#endif
+#endif  // IN1_SHARDED
+#endif  // SKIP_MCAST
 
     uint32_t l1_write_addr_sparsity = 0;
     if constexpr (batchB > 0) {
@@ -212,7 +214,7 @@ void kernel_main() {
 #ifdef IN1_DRAM_SHARDED
     constexpr uint32_t in1_dram_block_size_bytes = in1_dram_block_num_tiles * in1_single_tile_size_bytes;
     uint32_t in1_block_w_bytes = in1_block_w * in1_single_tile_size_bytes;
-#endif
+#endif  // IN1_DRAM_SHARDED
 
     for (uint32_t b = 0; b < batch; ++b) {
         uint32_t in1_batch_tile_id = in1_tensor_start_tile_id;
@@ -233,7 +235,7 @@ void kernel_main() {
 
 #ifdef IN1_DRAM_SHARDED
             uint32_t l1_read_addr_in1_offset = 0;
-#endif
+#endif  // IN1_DRAM_SHARDED
             uint32_t in1_tensor_current_h_dim_block_tile_id = in1_batch_tile_id;
             uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
             for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
@@ -241,7 +243,7 @@ void kernel_main() {
                 uint32_t out_tensor_current_w_dim_block_tile_id = out_tensor_current_h_dim_block_tile_id;
 #ifdef FUSE_BIAS
                 uint32_t in3_tensor_current_w_dim_block_tile_id = in3_tensor_start_tile_id;
-#endif
+#endif  // FUSE_BIAS
                 for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                     uint32_t in1_tensor_current_inner_dim_block_start_tile_id = in1_tensor_current_w_dim_block_tile_id;
 
@@ -299,6 +301,11 @@ void kernel_main() {
 #ifndef IN1_SHARDED
                         // Operand 1
                         cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+                        constexpr uint32_t helper_cb_index = tt::CBIndex::c_7;
+                        cb_reserve_back(helper_cb_index, one_tile);
+                        uint32_t l1_write_addr_helper = get_write_ptr(helper_cb_index);
+#endif  // INTERMEDIATE_CB_READ
                         l1_write_addr_in1 = get_write_ptr(cb_id_in1);
                         uint64_t in1_start_address =
                             l1_write_addr_in1;  // copy start address of block, to be used for mcasting
@@ -309,7 +316,20 @@ void kernel_main() {
                             uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                             for (uint32_t w = 0; w < in1_block_w; ++w) {
                                 if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+#ifndef INTERMEDIATE_CB_READ
                                     noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+#else
+                                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
+                                    noc_async_read_barrier();
+
+                                    volatile tt_l1_ptr uint8_t* src =
+                                        reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr_helper);
+                                    volatile tt_l1_ptr uint8_t* dst =
+                                        reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr_in1);
+                                    for (uint32_t i = 0; i < in1_single_tile_size_bytes; ++i) {
+                                        dst[i] = src[i];
+                                    }
+#endif  // INTERMEDIATE_CB_READ
                                 }
                                 l1_write_addr_in1 += in1_single_tile_size_bytes;
                                 in1_tensor_tile_id += in1_tensor_stride_w;
@@ -320,7 +340,7 @@ void kernel_main() {
 
                         // Barrier! make sure the reads are done
                         noc_async_read_barrier();
-#endif
+#endif  // IN1_SHARDED
 #endif  // IN1_DRAM_SHARDED
 
 #ifndef SKIP_MCAST
@@ -349,7 +369,7 @@ void kernel_main() {
                         // which means data could be changed before
                         //  write is issued.
                         noc_async_writes_flushed();
-#endif
+#endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
@@ -357,11 +377,17 @@ void kernel_main() {
                             in1_mcast_receiver_semaphore_addr,
                             in1_mcast_receiver_semaphore_noc_addr,
                             in1_mcast_num_cores);
-#endif
+#endif  // SKIP_MCAST
 
 #ifndef IN1_SHARDED
                         cb_push_back(cb_id_in1, in1_block_num_tiles);
-#endif
+#ifdef INTERMEDIATE_CB_READ
+                        // Clean up helper CB
+                        cb_push_back(helper_cb_index, one_tile);
+                        cb_wait_front(helper_cb_index, one_tile);
+                        cb_pop_front(helper_cb_index, one_tile);
+#endif  // INTERMEDIATE_CB_READ
+#endif  // IN1_SHARDED
                     }
 #ifdef FUSE_BIAS
                     // Only read bias on first batch, or we have multiple output blocks
@@ -421,7 +447,7 @@ void kernel_main() {
                         }
                         // Barrier! make sure the reads are done
                         noc_async_read_barrier();
-#endif
+#endif  // IN1_DRAM_SHARDED
 
 #ifndef SKIP_MCAST
 
@@ -448,7 +474,7 @@ void kernel_main() {
                         // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
                         // latency which means data could be changed before write is issued.
                         noc_async_writes_flushed();
-#endif
+#endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
 
     // COMPILE TIME ARGS
     constexpr uint32_t cb_id_in1 = 1;
-
+    constexpr uint32_t one_tile = 1;
     // WRITER
     constexpr uint32_t cb_id_out0 = tt::CBIndex::c_4;
 
@@ -63,12 +63,12 @@ void kernel_main() {
     const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
     uint32_t l1_write_addr_in1;
-#endif
+#endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
     const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
     const auto s = TensorAccessor(out_args, out_tensor_addr, output_single_tile_size_bytes);
-#endif
+#endif  // OUT_SHARDED
 
 #if not defined IN1_SHARDED or not defined OUT_SHARDED
     for (uint32_t b = 0; b < batch; ++b) {
@@ -77,14 +77,28 @@ void kernel_main() {
         for (uint32_t block = 0; block < num_blocks; ++block) {
             cb_reserve_back(cb_id_in1, in1_block_num_tiles);
 
+#ifdef INTERMEDIATE_CB_READ
+            constexpr uint32_t helper_cb_index = tt::CBIndex::c_7;
+            cb_reserve_back(helper_cb_index, one_tile);
+            uint32_t l1_write_addr_helper = get_write_ptr(helper_cb_index);
+#endif  // INTERMEDIATE_CB_READ
+
             l1_write_addr_in1 = get_write_ptr(cb_id_in1);
 
             uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_block_start_tile_id;
             for (uint32_t h = 0; h < in1_block_h; ++h) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; ++w) {
+#ifndef INTERMEDIATE_CB_READ
                     noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
-
+#else
+                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
+                    noc_async_read_barrier();
+                    memcpy(
+                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in1),
+                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                        /*size=*/in1_single_tile_size_bytes);
+#endif  // INTERMEDIATE_CB_READ
                     l1_write_addr_in1 += in1_single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                 }
@@ -99,7 +113,7 @@ void kernel_main() {
         if (bcast_B == 0) {
             in1_tensor_start_tile_id += KtNt;
         }
-#endif
+#endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
         // WRITER
@@ -131,11 +145,11 @@ void kernel_main() {
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
         }
         out_tensor_start_tile_id += MtNt;
-#endif
+#endif  // OUT_SHARDED
     }
-#endif
+#endif  // not defined IN1_SHARDED or not defined OUT_SHARDED
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_out0, batch * out_num_subblocks_h * out_num_subblocks_w * out_subblock_w * out_subblock_h);
-#endif
+#endif  // OUT_SHARDED
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -78,9 +78,9 @@ void kernel_main() {
             cb_reserve_back(cb_id_in1, in1_block_num_tiles);
 
 #ifdef INTERMEDIATE_CB_READ
-            constexpr uint32_t helper_cb_index = tt::CBIndex::c_7;
-            cb_reserve_back(helper_cb_index, one_tile);
-            uint32_t l1_write_addr_helper = get_write_ptr(helper_cb_index);
+            constexpr uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+            cb_reserve_back(in1_intermediate_cb_index, one_tile);
+            uint32_t l1_write_addr_helper = get_write_ptr(in1_intermediate_cb_index);
 #endif  // INTERMEDIATE_CB_READ
 
             l1_write_addr_in1 = get_write_ptr(cb_id_in1);
@@ -109,6 +109,12 @@ void kernel_main() {
             noc_async_read_barrier();
 
             cb_push_back(cb_id_in1, in1_block_num_tiles);
+#ifdef INTERMEDIATE_CB_READ
+            // Clean up helper CB
+            cb_push_back(in1_intermediate_cb_index, one_tile);
+            cb_wait_front(in1_intermediate_cb_index, one_tile);
+            cb_pop_front(in1_intermediate_cb_index, one_tile);
+#endif  // INTERMEDIATE_CB_READ
         }
         if (bcast_B == 0) {
             in1_tensor_start_tile_id += KtNt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -483,8 +483,7 @@ process_mcast_in0_program_and_create_override_variables(
 
     Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
     issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
-    addresses are not necessarily aligned due to non-64-byte-aligned page sizes across
-    multiple DRAM banks.
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
 
     Example scenario:
     - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -499,8 +499,13 @@ process_mcast_in0_program_and_create_override_variables(
 
     Note: This workaround should only be used for this specific alignment issue case.
     */
+    bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
     if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            mm_kernel_in0_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
         in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
         if (in1_needs_intermediate_cb_read) {
             mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
@@ -776,12 +781,20 @@ process_mcast_in0_program_and_create_override_variables(
 
     // Intermediate CB read
     if (in1_needs_intermediate_cb_read) {
-        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
-        tt_metal::CircularBufferConfig cb_intermediate_config =
-            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
-                .set_page_size(intermediate_cb_index, in1_single_tile_size)
-                .set_tile_dims(intermediate_cb_index, in1_tile);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
+        uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+        tt_metal::CircularBufferConfig cb_in1_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{in1_intermediate_cb_index, in1_data_format}})
+                .set_page_size(in1_intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(in1_intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in1_intermediate_config);
+    }
+    if (in0_needs_intermediate_cb_read) {
+        uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+        tt_metal::CircularBufferConfig cb_in0_intermediate_config =
+            tt_metal::CircularBufferConfig(in0_single_tile_size, {{in0_intermediate_cb_index, in0_data_format}})
+                .set_page_size(in0_intermediate_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_intermediate_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in0_intermediate_config);
     }
 
     // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height
@@ -1323,8 +1336,13 @@ process_mcast_in1_program_and_create_override_variables(
 
     Note: This workaround should only be used for this specific alignment issue case.
     */
+    bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
     if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            mm_kernel_in0_sender_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
         in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
         if (in1_needs_intermediate_cb_read) {
             mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
@@ -1543,12 +1561,20 @@ process_mcast_in1_program_and_create_override_variables(
 
     // Intermediate CB read
     if (in1_needs_intermediate_cb_read) {
-        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
-        tt_metal::CircularBufferConfig cb_intermediate_config =
-            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
-                .set_page_size(intermediate_cb_index, in1_single_tile_size)
-                .set_tile_dims(intermediate_cb_index, in1_tile);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
+        uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+        tt_metal::CircularBufferConfig cb_in1_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{in1_intermediate_cb_index, in1_data_format}})
+                .set_page_size(in1_intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(in1_intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in1_intermediate_config);
+    }
+    if (in0_needs_intermediate_cb_read) {
+        uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+        tt_metal::CircularBufferConfig cb_in0_intermediate_config =
+            tt_metal::CircularBufferConfig(in0_single_tile_size, {{in0_intermediate_cb_index, in0_data_format}})
+                .set_page_size(in0_intermediate_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_intermediate_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in0_intermediate_config);
     }
 
     // Parameters for last row, col, or block
@@ -3321,6 +3347,41 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
 
     mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
 
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in0_needs_intermediate_cb_read = false;
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            mm_kernel_in0_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+    }
+
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -3513,6 +3574,24 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         output_single_tile_size,
         out_CB_size / output_single_tile_size,
         out_CB_size);
+
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+        tt_metal::CircularBufferConfig cb_in1_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{in1_intermediate_cb_index, in1_data_format}})
+                .set_page_size(in1_intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(in1_intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in1_intermediate_config);
+    }
+    if (in0_needs_intermediate_cb_read) {
+        uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+        tt_metal::CircularBufferConfig cb_in0_intermediate_config =
+            tt_metal::CircularBufferConfig(in0_single_tile_size, {{in0_intermediate_cb_index, in0_data_format}})
+                .set_page_size(in0_intermediate_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_intermediate_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in0_intermediate_config);
+    }
 
     // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height
     uint32_t last_per_core_N = Nt % per_core_N == 0 ? per_core_N : Nt % per_core_N;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -477,6 +477,37 @@ process_mcast_in0_program_and_create_override_variables(
 
     mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
 
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes across
+    multiple DRAM banks.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+    }
+
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -742,6 +773,16 @@ process_mcast_in0_program_and_create_override_variables(
             bias_single_tile_size,
             in3_CB_size / bias_single_tile_size,
             in3_CB_size);
+    }
+
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
+        tt_metal::CircularBufferConfig cb_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
+                .set_page_size(intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
     }
 
     // Parameters for last row, col, or block, no need to re-calc h-dim since there's no split on height

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1301,6 +1301,36 @@ process_mcast_in1_program_and_create_override_variables(
         mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
     }
 
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+    }
+
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -1509,6 +1539,16 @@ process_mcast_in1_program_and_create_override_variables(
             bias_single_tile_size,
             in3_CB_size / bias_single_tile_size,
             in3_CB_size);
+    }
+
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
+        tt_metal::CircularBufferConfig cb_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
+                .set_page_size(intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
     }
 
     // Parameters for last row, col, or block

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -574,6 +574,44 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         mm_kernel_in1_receiver_writer_other_noc_setup_defines["OUT_SHARDED"] = "1";
     }
 
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes across
+    multiple DRAM banks.
+
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in0_needs_intermediate_cb_read = false;
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            // mm_kernel_in0_sender_interleaved_defines["INTERMEDIATE_CB_READ"] = "1"; // TODO: Check if needed
+        }
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+            // mm_kernel_in1_receiver_writer_defines["IN1_NEEDS_INTERMEDIATE_CB"] = "1";
+            // mm_kernel_in1_receiver_writer_other_noc_setup_defines["IN1_NEEDS_INTERMEDIATE_CB"] = "1";
+        }
+    }
+
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
@@ -873,6 +911,16 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             in3_CB_size / bias_single_tile_size,
             in3_CB_size);
     }
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
+        tt_metal::CircularBufferConfig cb_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
+                .set_page_size(intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
+    }
+    // TODO: Check for in0
 
     // Parameters for last row, col, or block
     uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -580,8 +580,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
     Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
     issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
-    addresses are not necessarily aligned due to non-64-byte-aligned page sizes across
-    multiple DRAM banks.
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
 
     Example scenario:
     - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -597,18 +597,11 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
     Note: This workaround should only be used for this specific alignment issue case.
     */
-    bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
     if (device->arch() == tt::ARCH::BLACKHOLE) {
-        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
         in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
-        if (in0_needs_intermediate_cb_read) {
-            // mm_kernel_in0_sender_interleaved_defines["INTERMEDIATE_CB_READ"] = "1"; // TODO: Check if needed
-        }
         if (in1_needs_intermediate_cb_read) {
             mm_kernel_in1_sender_writer_defines["INTERMEDIATE_CB_READ"] = "1";
-            // mm_kernel_in1_receiver_writer_defines["IN1_NEEDS_INTERMEDIATE_CB"] = "1";
-            // mm_kernel_in1_receiver_writer_other_noc_setup_defines["IN1_NEEDS_INTERMEDIATE_CB"] = "1";
         }
     }
 
@@ -920,7 +913,6 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 .set_tile_dims(intermediate_cb_index, in1_tile);
         tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
     }
-    // TODO: Check for in0
 
     // Parameters for last row, col, or block
     uint32_t last_per_core_M = M % per_core_M == 0 ? per_core_M : M % per_core_M;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -190,8 +190,13 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     alignment at the cost of additional memory bandwidth overhead.
     Note: This workaround should only be used for this specific alignment issue case.
     */
+    bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
     if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
+        if (in0_needs_intermediate_cb_read) {
+            mm_kernel_in0_reader_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
         in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
         if (in1_needs_intermediate_cb_read) {
             mm_kernel_in1_reader_writer_defines["INTERMEDIATE_CB_READ"] = "1";
@@ -366,12 +371,20 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
 
     // Intermediate CB read
     if (in1_needs_intermediate_cb_read) {
-        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
-        tt_metal::CircularBufferConfig cb_intermediate_config =
-            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
-                .set_page_size(intermediate_cb_index, in1_single_tile_size)
-                .set_tile_dims(intermediate_cb_index, in1_tile);
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
+        uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
+        tt_metal::CircularBufferConfig cb_in1_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{in1_intermediate_cb_index, in1_data_format}})
+                .set_page_size(in1_intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(in1_intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in1_intermediate_config);
+    }
+    if (in0_needs_intermediate_cb_read) {
+        uint32_t in0_intermediate_cb_index = tt::CBIndex::c_8;
+        tt_metal::CircularBufferConfig cb_in0_intermediate_config =
+            tt_metal::CircularBufferConfig(in0_single_tile_size, {{in0_intermediate_cb_index, in0_data_format}})
+                .set_page_size(in0_intermediate_cb_index, in0_single_tile_size)
+                .set_tile_dims(in0_intermediate_cb_index, in0_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_in0_intermediate_config);
     }
 
     // Write runtime args to device

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -173,6 +173,31 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
         mm_kernel_in1_reader_writer_defines["OUT_SHARDED"] = "1";
     }
 
+    // Intermediate CB read
+    /*
+    Blackhole architecture alignment issue workaround for tiny tiles:
+    Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment
+    issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 CB
+    addresses are not necessarily aligned due to non-64-byte-aligned page sizes.
+    Example scenario:
+    - Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
+    - CB configured with size=2 to hold both tiles
+    Result:
+    - Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
+    - Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned ✗)
+    Solution: Use an intermediate single-tile CB as a staging area. Read each tile into
+    the intermediate CB first, then copy to the destination CB. This ensures proper
+    alignment at the cost of additional memory bandwidth overhead.
+    Note: This workaround should only be used for this specific alignment issue case.
+    */
+    bool in1_needs_intermediate_cb_read = false;
+    if (device->arch() == tt::ARCH::BLACKHOLE) {
+        in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
+        if (in1_needs_intermediate_cb_read) {
+            mm_kernel_in1_reader_writer_defines["INTERMEDIATE_CB_READ"] = "1";
+        }
+    }
+
     tt::tt_metal::KernelHandle mm_kernel_in0_reader_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp",
@@ -338,6 +363,16 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
         output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), output_cb_config);
+
+    // Intermediate CB read
+    if (in1_needs_intermediate_cb_read) {
+        uint32_t intermediate_cb_index = tt::CBIndex::c_7;
+        tt_metal::CircularBufferConfig cb_intermediate_config =
+            tt_metal::CircularBufferConfig(in1_single_tile_size, {{intermediate_cb_index, in1_data_format}})
+                .set_page_size(intermediate_cb_index, in1_single_tile_size)
+                .set_tile_dims(intermediate_cb_index, in1_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_intermediate_config);
+    }
 
     // Write runtime args to device
     std::vector<uint32_t> mm_reader_args = {


### PR DESCRIPTION
### Ticket

#22103 

### Problem description

Blackhole architecture alignment issue workaround for tiny tiles:

Problem: When reading tiny tiles from DRAM to circular buffers (CB), address alignment issues occur. DRAM tile addresses are 64-byte aligned within each block, but L1 addresses are not necessarily aligned due to non-64-byte-aligned page sizes.

Example scenario:
- Two consecutive 544-byte tiles (16x32 tile of dtype bfloat8_b) stored on different DRAM banks
- CB configured with size=2 to hold both tiles

Result:
- Tile 0: DRAM Bank 0, Address 64    → CB L1 Address 0   (64-byte aligned ✓)
- Tile 1: DRAM Bank 1, Address 64    → CB L1 Address 544 (not 64-byte aligned 

Solution: Use an intermediate single-tile CB as a staging area. Read each tile  the intermediate CB first, then copy to the destination CB. This ensures alignment at the cost of additional memory bandwidth overhead - it is only used when necessary.

### What's changed

- Added intermediate CB of size one for resolving watcher issues.

### Important note

Fixing the error related to the watcher tool did not resolve the issue of incorrect results in tests using tiny tiles. An analysis was carried out with reference to the Wormhole architecture (where everything works correctly). The entire data path of both tensors was traced from loading into the CB through the LLK output up to saving data. At each stage, the data was compared against the Wormhole reference. The only point where discrepancies appeared was at the LLK output itself (and carried out to the output itself). This suggests that the incorrect results are caused by faulty tiny tile processing within the LLK operation, rather than at an earlier (or later) stage of data loading and writing (dataflow).
A new issue has been created and assigned to the LLK team for further investigation: https://github.com/tenstorrent/tt-metal/issues/29890 .
### Testing

Even though the skips in the test using the tiny tiles mechanism remain unchanged, everything was tested on both Wormhole and Blackhole with the watcher enabled at a 0.1 sampling rate, and no errors were observed.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18221616997
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18271226536
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes