### PR TITLE
Revert "minor fabric builder fix for eth handshake addressing (#29758)"

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -257,9 +257,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         next_l1_addr += 32;
     }
 
-    // The Ethernet handshake structure is 32 B.
     this->handshake_addr = next_l1_addr;
-    next_l1_addr += 2 * eth_channel_sync_size;
+    next_l1_addr += eth_channel_sync_size;
 
     // issue: https://github.com/tenstorrent/tt-metal/issues/29073. TODO: Re-enable after hang is resolved.
     // Ethernet txq IDs on WH are 0,1 and on BH are 0,1,2.
@@ -1142,7 +1141,8 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     direction(direction),
     local_fabric_node_id(local_fabric_node_id),
     peer_fabric_node_id(peer_fabric_node_id),
-    handshake_address(config.handshake_addr),
+    handshake_address(tt::round_up(
+        tt::tt_metal::hal::get_erisc_l1_unreserved_base(), FabricEriscDatamoverConfig::eth_channel_sync_size)),
     channel_buffer_size(config.channel_buffer_size_bytes),
     sender_channels_num_buffers(config.sender_channels_num_buffers),
     receiver_channels_num_buffers(config.receiver_channels_num_buffers),


### PR DESCRIPTION
This reverts commit c6f7f17b478cbe626f7e6482ff1ccf2dbeba294e.

This commit causes a hang in multiprocess fabric tests on T3K CI.
This seems very similar to the issue https://github.com/tenstorrent/tt-metal/issues/29249 where a change in address locations also caused a hang in the multiprocess tests. We should prioritize looking into what the issue is since we're bumping into this issue more often.