### PR TITLE
Allow tensor creation to send shapes that are not only 4 dimension

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -423,3 +423,28 @@ def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, devic
         assert "Unreachable" in str(e)
     else:
         pytest.fail("Expected an exception, but got none")
+
+
+@pytest.mark.parametrize(
+    "dtype,buffer,shape",
+    [
+        (ttnn.float32, [1, 2, 3], [1, 1, 3]),
+        (ttnn.float32, [1, 2, 3, 4, 5, 6], [1, 2, 3]),  # 3 x 2
+        (ttnn.float32, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], [2, 2, 3]),  # 2 x 3 x 2
+        (ttnn.float32, [1, 2, 3, 4], [1, 1, 1, 4]),  # 1 x 1 x 1 x4
+        (ttnn.float32, [1, 2, 3, 4], [1, 1, 4]),  # 1 x 1 x 4
+        (ttnn.float32, [1, 2, 3, 4], [1, 4]),  # 1 x 4
+        (ttnn.float32, [1, 2, 3, 4], [4]),  # 4
+        (ttnn.float32, [1, 2, 3, 4], [1, 1, 1, 1, 4]),  # 1 x 1 x 1 x 1 x 4 # 5d!
+        (ttnn.float32, [1, 2, 3, 4, 5, 6, 7, 8], [2, 1, 1, 1, 1, 4]),  # 2 x 1 x 1 x 1 x 4 # 6d!
+    ],
+)
+def test_tensor_creation_with_multiple_buffer_sizes(dtype, buffer, device, shape):
+    tt_tensor = ttnn.Tensor(
+        buffer,
+        shape,
+        dtype,
+        ttnn.Layout.TILE,
+        device,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None),
+    )

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -696,7 +696,7 @@ void pytensor_module(py::module& m_tensor) {
     pyTensor.def(py::init<ttnn::Tensor&>())
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           const std::optional<Tile>& tile,
@@ -746,7 +746,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,
@@ -808,7 +808,7 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             py::init<>([](std::vector<float>&& data,
-                          const std::array<uint32_t, 4>& shape,
+                          const std::vector<uint32_t>& shape,
                           DataType data_type,
                           Layout layout,
                           std::optional<MeshDevice*> device,
@@ -944,9 +944,7 @@ void pytensor_module(py::module& m_tensor) {
         .def_property_readonly("tile", [](const Tensor& self) { return self.tensor_spec().tile(); })
         .def(
             "deallocate",
-            [](Tensor& self, bool force) {
-                self.deallocate(force);
-            },
+            [](Tensor& self, bool force) { self.deallocate(force); },
             py::arg("force") = false,
             R"doc(
                 Dellocates all data of a tensor. This either deletes all host data or deallocates tensor data from device memory.
@@ -1099,8 +1097,8 @@ void pytensor_module(py::module& m_tensor) {
         .def(
             "pad",
             [](const Tensor& self,
-               const std::array<uint32_t, 4>& output_tensor_shape,
-               const std::array<uint32_t, 4>& input_tensor_start,
+               const std::vector<uint32_t>& output_tensor_shape,
+               const std::vector<uint32_t>& input_tensor_start,
                float pad_value) {
                 return self.pad(ttnn::Shape(output_tensor_shape), ttnn::Shape(input_tensor_start), pad_value);
             },


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/28739)

### Problem description
We were enforcing shapes of the tensor to be 4 dimensions, making the user have to fill with 1s when it was below 4, and not letting the user create them with shapes above 4 dimensions

### What's changed
Made the validations more flexible and added unit tests to guarantee that we allow higher dimensional shapes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes