### PR TITLE
Re-enable Sampling Tests for BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/test_sampling.py
@@ -14,7 +14,6 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     get_lib_dtype,
 )
-from models.common.utility_functions import skip_for_blackhole
 
 
 def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device):
@@ -181,7 +180,6 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
     )
 
 
-@skip_for_blackhole("Failing on Blackhole, see Issue#26176")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -206,7 +204,6 @@ def test_sampling_callback(shape, k, p, seed, device):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@skip_for_blackhole("Failing on Blackhole, see Issue#26176")
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26176

### Problem description
Sampling was performing unaligned NOC transactions. This was caught with tt-sim and fixed in https://github.com/tenstorrent/tt-metal/pull/29752. 

With the aligned reads, sampling passes on BH with watcher enabled. 

### What's changed
Reverts commit 3f728d717430d3ea773cc4054e4a7222ba8682f0 to remove the skips

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18198937800)