### PR TITLE
Bring up tt-fabric on BH Galaxy

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -77,22 +77,36 @@ public:
         // Fabric Reliability Mode
         // Default to STRICT_SYSTEM_HEALTH_SETUP_MODE
         // If RELIABILITY_MODE is set, use the value from the environment variable
+        static const std::map<std::string, tt::tt_fabric::FabricReliabilityMode> reliability_mode_map = {
+            {"strict", tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE},
+            {"relaxed", tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE}
+        };
+        auto reliability_mode_to_string = [](tt::tt_fabric::FabricReliabilityMode mode) -> std::string {
+            switch (mode) {
+                case tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE:
+                    return "STRICT_SYSTEM_HEALTH_SETUP_MODE";
+                case tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE:
+                    return "RELAXED_SYSTEM_HEALTH_SETUP_MODE";
+                default:
+                    return "UNKNOWN";
+            }
+        };
         tt::tt_fabric::FabricReliabilityMode reliability_mode =
             tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         const char* reliability_mode_env = getenv("RELIABILITY_MODE");
         if (reliability_mode_env != nullptr) {
             std::string mode_str(reliability_mode_env);
-            if (mode_str == "strict") {
-                reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-                log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");
-            } else if (mode_str == "relaxed") {
-                reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
-                log_info(tt::LogTest, "Fabric Reliability Mode: RELAXED_SYSTEM_HEALTH_SETUP_MODE");
+            auto it = reliability_mode_map.find(mode_str);
+            if (it != reliability_mode_map.end()) {
+                reliability_mode = it->second;
+                log_info(tt::LogTest, "Fabric Reliability Mode: {}", reliability_mode_to_string(reliability_mode));
             } else {
                 log_warning(
                     tt::LogTest,
                     "Invalid RELIABILITY_MODE '{}'. Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE",
                     mode_str);
+                // reliability_mode remains default
+                log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");
             }
         } else {
             log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -101,12 +101,11 @@ public:
                 reliability_mode = it->second;
                 log_info(tt::LogTest, "Fabric Reliability Mode: {}", reliability_mode_to_string(reliability_mode));
             } else {
+                // reliability_mode remains default
                 log_warning(
                     tt::LogTest,
-                    "Invalid RELIABILITY_MODE '{}'. Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE",
+                    "Invalid RELIABILITY_MODE '{}'. Fabric Reliability Mode set to: STRICT_SYSTEM_HEALTH_SETUP_MODE",
                     mode_str);
-                // reliability_mode remains default
-                log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");
             }
         } else {
             log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -76,40 +76,15 @@ public:
 
         // Fabric Reliability Mode
         // Default to STRICT_SYSTEM_HEALTH_SETUP_MODE
-        // If RELIABILITY_MODE is set, use the value from the environment variable
-        static const std::map<std::string, tt::tt_fabric::FabricReliabilityMode> reliability_mode_map = {
-            {"strict", tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE},
-            {"relaxed", tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE}
-        };
-        auto reliability_mode_to_string = [](tt::tt_fabric::FabricReliabilityMode mode) -> std::string {
-            switch (mode) {
-                case tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE:
-                    return "STRICT_SYSTEM_HEALTH_SETUP_MODE";
-                case tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE:
-                    return "RELAXED_SYSTEM_HEALTH_SETUP_MODE";
-                default:
-                    return "UNKNOWN";
-            }
-        };
+        // If runtime option RELIABILITY_MODE is set, use the value from the runtime option
         tt::tt_fabric::FabricReliabilityMode reliability_mode =
             tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-        const char* reliability_mode_env = getenv("RELIABILITY_MODE");
-        if (reliability_mode_env != nullptr) {
-            std::string mode_str(reliability_mode_env);
-            auto it = reliability_mode_map.find(mode_str);
-            if (it != reliability_mode_map.end()) {
-                reliability_mode = it->second;
-                log_info(tt::LogTest, "Fabric Reliability Mode: {}", reliability_mode_to_string(reliability_mode));
-            } else {
-                // reliability_mode remains default
-                log_warning(
-                    tt::LogTest,
-                    "Invalid RELIABILITY_MODE '{}'. Fabric Reliability Mode set to: STRICT_SYSTEM_HEALTH_SETUP_MODE",
-                    mode_str);
-            }
-        } else {
-            log_info(tt::LogTest, "Fabric Reliability Mode: STRICT_SYSTEM_HEALTH_SETUP_MODE");
+        // Query runtime options for an env-parsed override
+        auto reliability_mode_override = tt::tt_metal::MetalContext::instance().rtoptions().get_reliability_mode();
+        if (reliability_mode_override.has_value()) {
+            reliability_mode = reliability_mode_override.value();
         }
+        log_info(tt::LogTest, "Fabric Reliability Mode: {}", enchantum::to_string(reliability_mode));
 
         // Set up all available devices
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/edm_fabric_connection_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/edm_fabric_connection_test_kernel.cpp
@@ -94,6 +94,9 @@ void kernel_main() {
         pkt_hdr_fwd->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr_fwd}, packet_size);
 
         while (*connection_token_ptr != 1) {
+            // On Blackhole, we need to invalidate the cache to make sure the token is read
+            // from SRAM and we are not spinning on a stale value.
+            invalidate_l1_cache();
             noc_async_write(source_l1_buffer_address, noc0_dest_addr_fwd, packet_size);
         }
         *connection_token_ptr = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -387,6 +387,7 @@ Tests:
         iterations: 10
 
   - name: "FabricMuxSimpleUnicastWriteLinear"
+    skip: [GALAXY, BLACKHOLE_GALAXY]
     fabric_setup:
       topology: Linear
       fabric_tensix_config: Mux
@@ -402,6 +403,7 @@ Tests:
               device: [0, 1]
 
   - name: "FabricMuxAllToAllUnicastMesh"
+    skip: [GALAXY, BLACKHOLE_GALAXY]
     fabric_setup:
       topology: Mesh
       fabric_tensix_config: Mux
@@ -416,6 +418,7 @@ Tests:
       - type: all_to_all
 
   - name: "FabricMuxAllToAllUnicastMeshDynamic"
+    skip: [GALAXY, BLACKHOLE_GALAXY]
     fabric_setup:
       topology: Mesh
       routing_type: Dynamic

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -109,18 +109,13 @@ public:
         const auto& fabric_tensix_config = fabric_setup.fabric_tensix_config.value();
 
         // Fabric Reliability Mode
-        // Default to STRICT_SYSTEM_HEALTH_SETUP_MODE
-        // If RELIABILITY_MODE is set, it takes precedence over fabric_setup.fabric_reliability_mode
+        // Default to STRICT; if runtime option (from rtoptions) is set, it takes precedence over
+        // fabric_setup.fabric_reliability_mode
         tt::tt_fabric::FabricReliabilityMode reliability_mode =
             tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-        const char* reliability_mode_env = std::getenv("RELIABILITY_MODE");
-        if (reliability_mode_env != nullptr) {
-            std::string mode_str(reliability_mode_env);
-            if (mode_str == "relaxed") {
-                reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
-            } else if (mode_str == "strict") {
-                reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-            }
+        auto reliability_mode_override = tt::tt_metal::MetalContext::instance().rtoptions().get_reliability_mode();
+        if (reliability_mode_override.has_value()) {
+            reliability_mode = reliability_mode_override.value();
         } else if (fabric_setup.fabric_reliability_mode.has_value()) {
             reliability_mode = fabric_setup.fabric_reliability_mode.value();
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -122,6 +122,7 @@ struct ParsedTestConfig {
     std::string name;               // Original base name for golden lookup
     std::string parametrized_name;  // Enhanced name for debugging and logging
     TestFabricSetup fabric_setup;
+    std::optional<std::vector<std::string>> skip;  // Platforms on which this test should be skipped
     std::optional<std::string> on_missing_param_policy;
     std::optional<ParsedTrafficPatternConfig> defaults;
     std::optional<ParametrizationOptionsMap> parametrization_params;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -195,6 +195,16 @@ ParsedTestConfig YamlConfigParser::parse_test_config(const YAML::Node& test_yaml
         test_config.patterns = high_level_patterns;
     }
 
+    if (test_yaml["skip"]) {
+        const auto& skip_yaml = test_yaml["skip"];
+        TT_FATAL(skip_yaml.IsSequence(), "Expected 'skip' to be a sequence of platform strings.");
+        std::vector<std::string> skips;
+        for (const auto& s : skip_yaml) {
+            skips.push_back(parse_scalar<std::string>(s));
+        }
+        test_config.skip = std::move(skips);
+    }
+
     if (test_yaml["senders"]) {
         const auto& senders_yaml = test_yaml["senders"];
         TT_FATAL(senders_yaml.IsSequence(), "Expected senders to be a sequence");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -29,6 +29,7 @@
 
 #include "tt_fabric_test_interfaces.hpp"
 #include "tt_fabric_test_common_types.hpp"
+#include <tt-metalium/hal.hpp>
 
 namespace tt::tt_fabric {
 namespace fabric_tests {
@@ -411,8 +412,23 @@ public:
 private:
     static constexpr uint32_t MIN_RING_TOPOLOGY_DEVICES = 4;
 
-    // Helper function to check if a test should be skipped based on topology and device count
+    // Helper function to check if a test should be skipped based on:
+    // 1. topology and device count
+    // 2. architecture or cluster type
     bool should_skip_test(const ParsedTestConfig& test_config) const {
+        // Skip if the test declares platforms to skip and this platform matches
+        if (test_config.skip.has_value()) {
+            // Determine current platform identifiers
+            auto arch_name = tt::tt_metal::hal::get_arch_name();
+            auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+            std::string cluster_name = enchantum::to_string(cluster_type).data();
+            for (const auto& token : test_config.skip.value()) {
+                if (token == arch_name || token == cluster_name) {
+                    log_info(LogTest, "Skipping test '{}' on architecture or platform '{}'", test_config.name, token);
+                    return true;
+                }
+            }
+        }
         if (test_config.fabric_setup.topology == Topology::Ring) {
             uint32_t num_devices = device_info_provider_.get_local_node_ids().size();
             if (num_devices < MIN_RING_TOPOLOGY_DEVICES) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -421,7 +421,7 @@ private:
             // Determine current platform identifiers
             auto arch_name = tt::tt_metal::hal::get_arch_name();
             auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
-            std::string cluster_name = enchantum::to_string(cluster_type).data();
+            std::string cluster_name = std::string(enchantum::to_string(cluster_type));
             for (const auto& token : test_config.skip.value()) {
                 if (token == arch_name || token == cluster_name) {
                     log_info(LogTest, "Skipping test '{}' on architecture or platform '{}'", test_config.name, token);

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -103,7 +103,7 @@ private:
     void init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const;
     void initialize_active_devices() const;
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
-    void wait_for_fabric_router_sync(const uint32_t timeout_ms = 5000) const;
+    void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;
     tt_metal::IDevice* get_device(chip_id_t id) const;
     void teardown_fd(const std::unordered_set<chip_id_t>& devices_to_close);
 

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -103,7 +103,7 @@ private:
     void init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const;
     void initialize_active_devices() const;
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
-    void wait_for_fabric_router_sync() const;
+    void wait_for_fabric_router_sync(const uint32_t timeout_ms = 5000) const;
     tt_metal::IDevice* get_device(chip_id_t id) const;
     void teardown_fd(const std::unordered_set<chip_id_t>& devices_to_close);
 

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -18,6 +18,7 @@
 #include "hostdevcommon/fabric_common.h"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/relay_mux.hpp"
+#include <fmt/ranges.h>
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000
@@ -246,11 +247,13 @@ void build_tt_fabric_program(
         active_fabric_eth_channels.insert({direction, active_eth_chans});
         log_debug(
             tt::LogMetal,
-            "Building fabric router -> device (phys): {}, (logical): {}, direction: {}, active_eth_chans: {}",
+            "Building fabric router -> device (phys): {}, (logical): {}, direction: {}, active_eth_chans.size(): {}, "
+            "active_eth_chans: [{}]",
             device->id(),
             control_plane.get_fabric_node_id_from_physical_chip_id(device->id()).chip_id,
             direction,
-            active_eth_chans.size());
+            active_eth_chans.size(),
+            fmt::join(active_eth_chans, ", "));
     }
 
     if (active_fabric_eth_channels.empty()) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -595,21 +595,29 @@ void MetalContext::initialize_control_plane() {
     // If the cluster is a GALAXY and the fabric type is TORUS_XY, override the mesh graph descriptor path
     if (cluster_->is_ubb_galaxy()) {
         std::string mesh_graph_descriptor;
-        switch (tt::tt_fabric::get_fabric_type(this->fabric_config_)) {
-            case tt::tt_fabric::FabricType::TORUS_XY:
-                mesh_graph_descriptor = "single_galaxy_torus_xy_graph_descriptor" + suffix;
-                break;
-            case tt::tt_fabric::FabricType::TORUS_X:
-                mesh_graph_descriptor = "single_galaxy_torus_x_graph_descriptor" + suffix;
-                break;
-            case tt::tt_fabric::FabricType::TORUS_Y:
-                mesh_graph_descriptor = "single_galaxy_torus_y_graph_descriptor" + suffix;
-                break;
-            default: mesh_graph_descriptor = "single_galaxy_mesh_graph_descriptor" + suffix; break;
+        if (cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
+            // For Blackhole Galaxy, only use the default descriptor
+            mesh_graph_descriptor = "single_bh_galaxy_mesh_graph_descriptor" + suffix;
+        } else {
+            // For regular Galaxy, handle different fabric types
+            switch (tt::tt_fabric::get_fabric_type(this->fabric_config_)) {
+                case tt::tt_fabric::FabricType::TORUS_XY:
+                    mesh_graph_descriptor = "single_galaxy_torus_xy_graph_descriptor" + suffix;
+                    break;
+                case tt::tt_fabric::FabricType::TORUS_X:
+                    mesh_graph_descriptor = "single_galaxy_torus_x_graph_descriptor" + suffix;
+                    break;
+                case tt::tt_fabric::FabricType::TORUS_Y:
+                    mesh_graph_descriptor = "single_galaxy_torus_y_graph_descriptor" + suffix;
+                    break;
+                default: mesh_graph_descriptor = "single_galaxy_mesh_graph_descriptor" + suffix; break;
+            }
         }
         mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
                                "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
     }
+
+    log_debug(tt::LogMetal, "Using mesh graph descriptor: {}", mesh_graph_desc_path);
 
     TT_FATAL(!mesh_graph_desc_path.empty(), "No mesh graph descriptor found for cluster type");
     TT_FATAL(

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -615,17 +615,6 @@ void DevicePool::wait_for_fabric_router_sync(const uint32_t timeout_ms) const {
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane.get_fabric_context();
 
-    auto edm_status_to_string = [](uint32_t status) -> std::string {
-        switch (status) {
-            case tt::tt_fabric::EDMStatus::STARTED: return "STARTED";
-            case tt::tt_fabric::EDMStatus::REMOTE_HANDSHAKE_COMPLETE: return "REMOTE_HANDSHAKE_COMPLETE";
-            case tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE: return "LOCAL_HANDSHAKE_COMPLETE";
-            case tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC: return "READY_FOR_TRAFFIC";
-            case tt::tt_fabric::EDMStatus::TERMINATED: return "TERMINATED";
-            default: return fmt::format("UNKNOWN(0x{:08x})", status);
-        }
-    };
-
     auto wait_for_handshake = [&](IDevice* dev) {
         if (!dev) {
             TT_THROW("Fabric router sync on null device. All devices must be opened for Fabric.");
@@ -657,13 +646,10 @@ void DevicePool::wait_for_fabric_router_sync(const uint32_t timeout_ms) const {
                     master_router_logical_core.str(),
                     router_sync_address);
                 TT_THROW(
-                    "Fabric Router Sync: Timeout after {} ms. Device {}: Expected status {} (0x{:08x}), got {} "
-                    "(0x{:08x})",
+                    "Fabric Router Sync: Timeout after {} ms. Device {}: Expected status 0x{:08x}, got 0x{:08x}",
                     timeout_ms,
                     dev->id(),
-                    edm_status_to_string(expected_status),
                     expected_status,
-                    edm_status_to_string(master_router_status[0]),
                     master_router_status[0]);
             }
         }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -11,6 +11,7 @@
 #include <umd/device/types/arch.hpp>
 #include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <future>
 #include <set>
@@ -605,7 +606,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
 }
 
-void DevicePool::wait_for_fabric_router_sync() const {
+void DevicePool::wait_for_fabric_router_sync(const uint32_t timeout_ms) const {
     tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (!tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         return;
@@ -613,6 +614,17 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane.get_fabric_context();
+
+    auto edm_status_to_string = [](uint32_t status) -> std::string {
+        switch (status) {
+            case tt::tt_fabric::EDMStatus::STARTED: return "STARTED";
+            case tt::tt_fabric::EDMStatus::REMOTE_HANDSHAKE_COMPLETE: return "REMOTE_HANDSHAKE_COMPLETE";
+            case tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE: return "LOCAL_HANDSHAKE_COMPLETE";
+            case tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC: return "READY_FOR_TRAFFIC";
+            case tt::tt_fabric::EDMStatus::TERMINATED: return "TERMINATED";
+            default: return fmt::format("UNKNOWN(0x{:08x})", status);
+        }
+    };
 
     auto wait_for_handshake = [&](IDevice* dev) {
         if (!dev) {
@@ -629,9 +641,31 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
         const auto [router_sync_address, expected_status] = fabric_context.get_fabric_router_sync_address_and_status();
         std::vector<std::uint32_t> master_router_status{0};
+        auto start_time = std::chrono::steady_clock::now();
         while (master_router_status[0] != expected_status) {
             tt_metal::detail::ReadFromDeviceL1(
                 dev, master_router_logical_core, router_sync_address, 4, master_router_status, CoreType::ETH);
+
+            // Check for timeout
+            auto current_time = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time).count();
+            if (elapsed_ms > timeout_ms) {
+                log_info(
+                    tt::LogMetal,
+                    "Fabric Router Sync: master chan={}, logical core={}, sync address=0x{:08x}",
+                    master_router_chan,
+                    master_router_logical_core.str(),
+                    router_sync_address);
+                TT_THROW(
+                    "Fabric Router Sync: Timeout after {} ms. Device {}: Expected status {} (0x{:08x}), got {} "
+                    "(0x{:08x})",
+                    timeout_ms,
+                    dev->id(),
+                    edm_status_to_string(expected_status),
+                    expected_status,
+                    edm_status_to_string(master_router_status[0]),
+                    master_router_status[0]);
+            }
         }
 
         auto ready_address_and_signal = fabric_context.get_fabric_router_ready_address_and_signal();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -606,7 +606,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
 }
 
-void DevicePool::wait_for_fabric_router_sync(const uint32_t timeout_ms) const {
+void DevicePool::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
     tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (!tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         return;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -198,6 +198,16 @@ RunTimeOptions::RunTimeOptions() {
         this->enable_hw_cache_invalidation = true;
     }
 
+    // Parse RELIABILITY_MODE: "strict" or "relaxed"
+    if (const char* reliability_mode_str = getenv("RELIABILITY_MODE"); reliability_mode_str != nullptr) {
+        std::string mode(reliability_mode_str);
+        if (mode == "relaxed") {
+            reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+        } else if (mode == "strict") {
+            reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+        }
+    }
+
     if (std::getenv("TT_METAL_SIMULATOR")) {
         this->simulator_path = std::getenv("TT_METAL_SIMULATOR");
         this->runtime_target_device_ = tt::TargetDevice::Simulator;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -25,6 +25,7 @@
 #include "tt_target_device.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <tt-metalium/fabric_types.hpp>
 
 namespace tt {
 
@@ -206,6 +207,9 @@ class RunTimeOptions {
 
     // Using MGD 2.0 syntax for mesh graph descriptor in Fabric Control Plane
     bool use_mesh_graph_descriptor_2_0 = false;
+
+    // Reliability mode override parsed from environment (RELIABILITY_MODE)
+    std::optional<tt::tt_fabric::FabricReliabilityMode> reliability_mode = std::nullopt;
 
 public:
     RunTimeOptions();
@@ -482,6 +486,9 @@ public:
     // NOTE: Enabling this option will lead to a 0-2% performance degradation for fabric traffic.
     bool get_enable_fabric_telemetry() const { return enable_fabric_telemetry; }
     void set_enable_fabric_telemetry(bool enable) { enable_fabric_telemetry = enable; }
+
+    // Reliability mode override accessor
+    std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }
 
     // Mock cluster accessors
     bool get_mock_enabled() const { return runtime_target_device_ == TargetDevice::Mock; }


### PR DESCRIPTION
Fixing some issues on first attempt to run tt-fabric unit and reliability tests on BH Galaxy.

1. We were missing the appropriate mesh graph descriptor file selection for BH Galaxy.
2. Added timeout in case fabric routers are not able to initialize
3. Change NOC0 coordinates to TRANSLATED. Bug introduced by https://github.com/tenstorrent/tt-metal/pull/29298
4. Add env variable so that we can specify STRICT/RELAXED reliability modes easily for Fabric gtest fixtures. Currently its hardcoded to STRICT. The change is to allow user to override that by manually specifying the mode when running the test. Its useful when new platforms have some ethernet link issues and not all links come up.
5. Add env variable override for yaml tests to override test specified reliability mode. 
6. Add "skip" field to yaml tests. test can be skipped for chip arch or platform. Useful to run test_fabric_sanity_common.yaml on Galaxy. The yaml has some mux tests that do not fit on galaxy. With the skip field set in the tests, we can run sanity_common.yaml on Galaxy. Tests not meant for galaxy will be skipped.

Ran the following tests:
`RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"`
`RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*"`
`RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml`
`RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml `



### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes