### PR TITLE
Fixed Bandwidth Summary upload bug

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -1198,12 +1198,12 @@ private:
         // Output directory already set in initialize_bandwidth_results_csv_file()
         std::filesystem::path output_path =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
-        std::filesystem::path summary_csv_file_path = output_path / summary_oss.str();
+        csv_summary_file_path_ = output_path / summary_oss.str();
 
         // Create detailed CSV file with header
-        std::ofstream summary_csv_stream(summary_csv_file_path, std::ios::out | std::ios::trunc);  // Truncate file
+        std::ofstream summary_csv_stream(csv_summary_file_path_, std::ios::out | std::ios::trunc);  // Truncate file
         if (!summary_csv_stream.is_open()) {
-            log_error(tt::LogTest, "Failed to create summary CSV file: {}", summary_csv_file_path.string());
+            log_error(tt::LogTest, "Failed to create summary CSV file: {}", csv_summary_file_path_.string());
             return;
         }
 
@@ -1215,7 +1215,7 @@ private:
         }
         summary_csv_stream << ",tolerance_percent";
         summary_csv_stream << "\n";
-        log_info(tt::LogTest, "Initialized summary CSV file: {}", summary_csv_file_path.string());
+        log_info(tt::LogTest, "Initialized summary CSV file: {}", csv_summary_file_path_.string());
 
         // Write data rows
         for (const auto& result : bandwidth_results_summary_) {
@@ -1246,7 +1246,7 @@ private:
             summary_csv_stream << "\n";
         }
         summary_csv_stream.close();
-        log_info(tt::LogTest, "Bandwidth summary results appended to CSV file: {}", summary_csv_file_path.string());
+        log_info(tt::LogTest, "Bandwidth summary results appended to CSV file: {}", csv_summary_file_path_.string());
     }
 
     std::string get_golden_csv_filename() {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29907

### Problem description
A previous PR enabled Bandwidth CSV files to be uploaded as artifacts after CI runs. To do this, `test_tt_fabric` copies the CSV files into the `generated/test_reports` directory for artifact upload. The framework finds the files using file paths such as `csv_summary_file_path_`, which are initialized during file creation, and stored throughout program execution. However, a subsequent PR skipped initialization `csv_summary_file_path_` (using a local variable instead), and thus the file was not copied into the artifacts directory. 

### What's changed
- Modified `tt_fabric_test_context.hpp` so that the Bandwidth Summary CSV file path is initialized correctly. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18222298394
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18222322732
- [x] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18222307754