### PR TITLE
[Fabric] Fixes for big-mesh

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -939,7 +939,7 @@ private:
 
     void expand_all_devices_uniform_pattern(ParsedTestConfig& test, const ParsedTrafficPatternConfig& base_pattern) {
         log_debug(LogTest, "Expanding all_devices_uniform_pattern for test: {}", test.name);
-        std::vector<FabricNodeId> devices = device_info_provider_.get_local_node_ids();
+        std::vector<FabricNodeId> devices = device_info_provider_.get_global_node_ids();
         TT_FATAL(!devices.empty(), "Cannot expand all_devices_uniform_pattern because no devices were found.");
 
         for (const auto& src_node : devices) {
@@ -952,7 +952,7 @@ private:
         ParsedTestConfig& test, const ParsedTrafficPatternConfig& base_pattern, HighLevelTrafficPattern pattern_type) {
         const char* pattern_name = (pattern_type == HighLevelTrafficPattern::OneToAll) ? "one_to_all" : "all_to_all";
         log_debug(LogTest, "Expanding {}_multicast pattern for test: {}", pattern_name, test.name);
-        std::vector<FabricNodeId> devices = device_info_provider_.get_local_node_ids();
+        std::vector<FabricNodeId> devices = device_info_provider_.get_global_node_ids();
         TT_FATAL(!devices.empty(), "Cannot expand {}_multicast because no devices were found.", pattern_name);
 
         // Determine which devices should be senders
@@ -1084,7 +1084,7 @@ private:
             test.name,
             static_cast<int>(test.fabric_setup.topology));
 
-        std::vector<FabricNodeId> all_devices = device_info_provider_.get_local_node_ids();
+        std::vector<FabricNodeId> all_devices = device_info_provider_.get_global_node_ids();
         TT_FATAL(!all_devices.empty(), "Cannot expand line sync patterns because no devices were found.");
 
         // Create sync patterns based on topology - returns multiple patterns per device for mcast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -350,6 +350,9 @@ public:
 
         log_debug(tt::LogTest, "Initializing sync memory for line sync");
 
+        // multi-host barrier to avoid race condition
+        fixture_->barrier();
+
         // Initialize sync memory location with 16 bytes of zeros on all devices
         uint32_t global_sync_address = this->sender_memory_map_.get_global_sync_address();
         uint32_t global_sync_memory_size = this->sender_memory_map_.get_global_sync_region_size();

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -47,7 +47,8 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
         return {fabric_edm_type, fabric_edm_axis};
     }
 
-    auto physical_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id0);
+    // Need global mesh shape to determine dateline placement for multi-host setups
+    auto physical_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id0, tt::tt_fabric::MeshScope::GLOBAL);
     TT_FATAL(physical_mesh_shape.dims() == 2, "Dateline routing only supported for 2D mesh");
 
     auto mesh_num_rows = physical_mesh_shape[0];


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/30417

### Problem description
Torus/ring tests were hanging for the 4X4 BH QB cluster (big-mesh setup)

### What's changed
1. Added a host barrier before sync memory init
2. Fixed test expansion for certain patterns

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18474688537)
- [ ] [BH multi-card] (https://github.com/tenstorrent/tt-metal/actions/runs/18477996922)
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18474704566)
- [x] New/Existing tests provide coverage for changes
- [ ]  [Multi host] (https://github.com/tenstorrent/tt-metal/actions/runs/18478668959)
- [ ]  [T3K Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/18477999904/job/52647624900)