### PR TITLE
#0: [skip ci] Update blackhole multi-card demos in release-build-test-publish.yaml

### DIFF
--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -125,12 +125,12 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
+            extra-tag: pipeline-perf
             num_devices: 2
-          # - name: RackBox Demo tests
-          #   runner-label: BH-RackBox
-          #   extra-tag: pipeline-functional
-          #   num_devices: 8
+          - name: LoudBox Demo tests
+            runner-label: BH-LoudBox
+            extra-tag: pipeline-perf
+            num_devices: 8
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Package and release flow missing LoudBox demos

### What's changed
Update the workflow to match call in BH nightly and https://github.com/tenstorrent/tt-metal/blob/main/.github/workflows/blackhole-multi-card-demo-tests.yaml 

### Checklist
None