### PR TITLE
#28204: Create P300 upstream container

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -250,6 +250,11 @@ jobs:
       - ${{ matrix.bh-config.runner-label }}
       - in-service
     steps:
+      - name: Download Llama model weights from LFC
+        timeout-minutes: 15
+        run: |
+          mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
+          wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run image
         timeout-minutes: 30
         env:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -322,6 +322,7 @@ jobs:
           - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -20,6 +20,7 @@ env:
   BLACKHOLE_LLMBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-llmbox
   BLACKHOLE_DESKBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-deskbox
   BLACKHOLE_LOUDBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-loudbox
+  BLACKHOLE_P300_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300
 
 jobs:
   build-artifact:
@@ -51,6 +52,7 @@ jobs:
       bh-llmbox-image-tag: ${{ steps.set-image-tags.outputs.bh-llmbox-image-tag }}
       bh-deskbox-image-tag: ${{ steps.set-image-tags.outputs.bh-deskbox-image-tag }}
       bh-loudbox-image-tag: ${{ steps.set-image-tags.outputs.bh-loudbox-image-tag }}
+      bh-p300-image-tag: ${{ steps.set-image-tags.outputs.bh-p300-image-tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,6 +71,7 @@ jobs:
           echo "bh-llmbox-image-tag=${{ env.BLACKHOLE_LLMBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
           echo "bh-deskbox-image-tag=${{ env.BLACKHOLE_DESKBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
           echo "bh-loudbox-image-tag=${{ env.BLACKHOLE_LOUDBOX_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
+          echo "bh-p300-image-tag=${{ env.BLACKHOLE_P300_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
   build-images:
     needs:
       - build-artifact
@@ -124,6 +127,13 @@ jobs:
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_loudbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+            techdebt-install-ttt-reqs: true
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
+            dockerfile: dockerfile/upstream_test_images/Dockerfile
+            test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+            hw-topology: blackhole_p300
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
@@ -226,6 +236,25 @@ jobs:
         env:
           LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+  test-bh-p300-image:
+    needs:
+      - get-image-tags
+      - build-images
+    strategy:
+      fail-fast: false
+      matrix:
+        bh-config:
+          - runner-label: P300
+            image-name: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
+    runs-on:
+      - ${{ matrix.bh-config.runner-label }}
+      - in-service
+    steps:
+      - name: Run image
+        timeout-minutes: 30
+        env:
+          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
+        run: docker run --network none --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -307,6 +307,7 @@ jobs:
       - get-image-tags
       - test-wh-6u-image
       - test-bh-image
+      - test-bh-p300-image
       - test-bh-multicard-image
     permissions:
       packages: write

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -256,7 +256,7 @@ jobs:
           mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run image
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
         run: docker run --network none --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -120,7 +120,7 @@ test_suite_bh_multi_pcie_llama_demo_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama demo model tests"
     verify_llama_dir_
 
-    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
+    if [[ "$hw_topology" == "blackhole_deskbox" ]] || [[ "$hw_topology" == "blackhole_p300" ]]; then
         local data_parallel_devices="2"
     elif [[ "$hw_topology" == "blackhole_llmbox" ]]; then
         local data_parallel_devices="4"
@@ -140,7 +140,7 @@ test_suite_bh_multi_pcie_llama_stress_tests() {
     echo "[upstream-tests] Running BH LLMBox upstream Llama stress model tests"
     verify_llama_dir_
 
-    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
+    if [[ "$hw_topology" == "blackhole_deskbox" ]] || [[ "$hw_topology" == "blackhole_p300" ]]; then
         local data_parallel_devices="2"
     elif [[ "$hw_topology" == "blackhole_llmbox" ]]; then
         local data_parallel_devices="4"
@@ -231,6 +231,14 @@ test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_loudbox"]="
+test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_multi_pcie_llama_demo_tests"
+
+hw_topology_test_suites["blackhole_p300"]="
+test_suite_bh_umd_unit_tests
+test_suite_bh_pcie_didt_tests
+test_suite_bh_single_pcie_python_unit_tests
+test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -238,7 +238,6 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_p300"]="
 test_suite_bh_umd_unit_tests
-test_suite_bh_pcie_didt_tests
 test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_metal_unit_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -113,6 +113,8 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
         pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb.py
     elif [[ "$hw_topology" == "blackhole_loudbox" ]]; then
         pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lb.py
+    elif [[ "$hw_topology" == "blackhole_p300" ]]; then
+        pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
     fi
 }
 

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -27,7 +27,7 @@ test_suite_bh_umd_unit_tests() {
     # ./build/test/umd/api/api_tests
     ./build/test/umd/blackhole/unit_tests
     # Filter out the test that is failing due to local YAML files, see: https://github.com/tenstorrent/tt-metal/issues/24359
-    ./build/test/umd/api/api_tests --gtest_filter=-ApiClusterTest.DifferentConstructors
+    # ./build/test/umd/api/api_tests --gtest_filter=-ApiClusterTest.DifferentConstructors
 }
 
 # Function to run BH single PCIe small ML model tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -27,7 +27,16 @@ test_suite_bh_umd_unit_tests() {
     # ./build/test/umd/api/api_tests
     ./build/test/umd/blackhole/unit_tests
     # Filter out the test that is failing due to local YAML files, see: https://github.com/tenstorrent/tt-metal/issues/24359
-    # ./build/test/umd/api/api_tests --gtest_filter=-ApiClusterTest.DifferentConstructors
+    gtest_filter="-ApiClusterTest.DifferentConstructors"
+
+    # Add more tests to exclude if hw_topology is blackhole_p300
+    # Issue: https://github.com/tenstorrent/tt-umd/issues/1412
+    if [[ "$hw_topology" == "blackhole_p300" ]]; then
+        gtest_filter+=":-ApiClusterDescriptorTest.VerifyStandardTopology"
+        gtest_filter+=":-ApiClusterTest.OpenChipsByPciId"
+        gtest_filter+=":-ApiClusterTest.OpenClusterByLogicalID"
+    fi
+    ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }
 
 # Function to run BH single PCIe small ML model tests
@@ -238,7 +247,6 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_p300"]="
 test_suite_bh_umd_unit_tests
-test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_llama_demo_tests"


### PR DESCRIPTION
### Ticket
#28204 

### Problem description
P300 container required for syseng functional testing

### What's changed
Create P300 container with some CI runner specific changes:
- P300 runners do not have hugepages (using viommu)
- Model weights and ttnn caches need to be downloaded from LFC, they are not stored locally on the machine

### Checklist
- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/18213948202/job/51928673258
https://github.com/tenstorrent/tt-metal/actions/runs/18284821766
