### PR TITLE
Add as applicable payload (dispatch command) header as CQDispatchCmd/…

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -249,7 +249,6 @@ void gen_linear_or_packed_write_test(
 
     bool done = false;
     while (!done && total_size_bytes < buffer_size) {
-        total_size_bytes += sizeof(CQDispatchCmd);
         if (debug_g) {
             total_size_bytes += sizeof(CQDispatchCmd);
         }
@@ -273,6 +272,7 @@ void gen_linear_or_packed_write_test(
                     xfer_size_bytes = min_xfer_size_bytes_g;
                 }
 
+                total_size_bytes += sizeof(CQDispatchCmdLarge);
                 if (is_linear_multicast) {
                     gen_dispatcher_multicast_write_cmd(
                         device, dispatch_cmds, worker_cores, device_data, xfer_size_bytes);
@@ -282,8 +282,12 @@ void gen_linear_or_packed_write_test(
                 }
                 break;
             }
-            case 4: gen_rnd_dispatcher_packed_write_cmd(device, dispatch_cmds, device_data); break;
+            case 4:
+                total_size_bytes += sizeof(CQDispatchCmd);
+                gen_rnd_dispatcher_packed_write_cmd(device, dispatch_cmds, device_data);
+                break;
             case 5:
+                total_size_bytes += sizeof(CQDispatchCmd);
                 done = gen_rnd_dispatcher_packed_write_large_cmd(
                     device, worker_cores, dispatch_cmds, device_data, buffer_size - total_size_bytes);
                 break;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -505,6 +505,8 @@ void process_write_linear(
     uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
     uint64_t length = cmd->write_linear.length;
     uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
+    // DPRINT << "process_write_linear noc_xy:0x" << HEX() << dst_noc << ", write_offset:" << write_offset_index << ",
+    // dst_addr:0x" << dst_addr << ", length:0x" << length << ", data_ptr:0x" << data_ptr << DEC() << ENDL();
     if (multicast) {
         cq_noc_async_wwrite_init_state<CQ_NOC_sNDl, true>(0, dst_noc, dst_addr);
     } else {


### PR DESCRIPTION
…CQDispatchCmdLarge in test_prefetcher/test_dispatcher

### Ticket
No ticket

### Problem description
PR 28953 introduced a regression in test_prefetcher (and possibly test_dispatcher too), which resulted in P100 tests failing. This PR provides a fix.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes