### PR TITLE
[TT-Train] Added loading of the safetensors for LLama3.2 1b and tinyllama

### DIFF
--- a/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
@@ -11,9 +11,9 @@ training_config:
   weight_decay: 0.01
   use_moreh_adamw: true
   use_kahan_summation: false
-  use_clip_grad_norm: true
+  use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  tokenizer_path: "data/tinyllama-tokenizer.json" # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
+  tokenizer_path:  '/home/ubuntu/git/llama3_tokenizer.json' # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
   tokenizer_type: "bpe"
   transformer_config:
     num_heads: 32
@@ -22,6 +22,7 @@ training_config:
     intermediate_dim: 8192
     dropout_prob: 0.0
     num_blocks: 16
+    weight_tying: "enabled"
     vocab_size: 32000 # not using Meta vocab size (128256), see comment about tokenizer choice above.
     max_sequence_length: 2048
     runner_type: memory_efficient
@@ -32,6 +33,10 @@ training_config:
         high_freq_factor: 4.0
         low_freq_factor: 1.0
         original_context_length: 8192
+# if you want to run as eval with weighgts from hugging face:
+# 1. Download weights from hugging face
+# 2. nano_gpt --safetensors /path/to/meta-llama/Llama3.2-1B/  -c configs/training_shakespeare_llama3.2_1B.yaml --eval 1
+
 eval_config:
   repetition_penalty: 1.0
   temperature: 0.7

--- a/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
@@ -13,8 +13,7 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  #tokenizer_path:  '/home/ubuntu/git/llama3_tokenizer.json' # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
-  tokenizer_path: "data/tinyllama-tokenizer.json"
+  tokenizer_path: "data/tinyllama-tokenizer.json" # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
   tokenizer_type: "bpe"
   transformer_config:
     num_heads: 32

--- a/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_2_1B.yaml
@@ -13,7 +13,8 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  tokenizer_path:  '/home/ubuntu/git/llama3_tokenizer.json' # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
+  #tokenizer_path:  '/home/ubuntu/git/llama3_tokenizer.json' # using tinyllama tokenizer because the real Meta tokenizer is gated on HF.
+  tokenizer_path: "data/tinyllama-tokenizer.json"
   tokenizer_type: "bpe"
   transformer_config:
     num_heads: 32

--- a/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
+++ b/tt-train/configs/training_shakespeare_llama3_tensor_parallel.yaml
@@ -21,6 +21,13 @@ training_config:
     vocab_size: 96
     max_sequence_length: 256
     runner_type: default
+    theta: 500000
+    weight_tying: "enabled"
+    rope_scaling:
+      scaling_factor: 32.0
+      high_freq_factor: 4.0
+      low_freq_factor: 1.0
+      original_context_length: 8192
 eval_config:
   repetition_penalty: 1.0
   temperature: 0.7

--- a/tt-train/configs/training_shakespeare_tinyllama.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama.yaml
@@ -12,7 +12,6 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  #tokenizer_path: "/home/ubuntu/git/TinyLlama-1.1B-intermediate-step-1431k-3T/tokenizer.json"
   tokenizer_path: "data/tinyllama-tokenizer.json"
   tokenizer_type: "bpe"
   transformer_config:

--- a/tt-train/configs/training_shakespeare_tinyllama.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama.yaml
@@ -12,8 +12,8 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  tokenizer_path: "/home/ubuntu/git/TinyLlama-1.1B-intermediate-step-1431k-3T/tokenizer.json"
-  #tokenizer_path: "data/tinyllama-tokenizer.json"
+  #tokenizer_path: "/home/ubuntu/git/TinyLlama-1.1B-intermediate-step-1431k-3T/tokenizer.json"
+  tokenizer_path: "data/tinyllama-tokenizer.json"
   tokenizer_type: "bpe"
   transformer_config:
     num_heads: 32

--- a/tt-train/configs/training_shakespeare_tinyllama.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama.yaml
@@ -12,7 +12,8 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  tokenizer_path: "data/tinyllama-tokenizer.json"
+  tokenizer_path: "/home/ubuntu/git/TinyLlama-1.1B-intermediate-step-1431k-3T/tokenizer.json"
+  #tokenizer_path: "data/tinyllama-tokenizer.json"
   tokenizer_type: "bpe"
   transformer_config:
     num_heads: 32
@@ -24,8 +25,9 @@ training_config:
     max_sequence_length: 2048
     runner_type: memory_efficient
     theta: 10000.0
+    weight_tying: "disabled"
 eval_config:
   repetition_penalty: 1.0
-  temperature: 0.7
+  temperature: 0.0
   top_k: 50
   top_p: 1.0

--- a/tt-train/configs/training_shakespeare_tinyllama_ddp.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama_ddp.yaml
@@ -25,7 +25,7 @@ training_config:
     max_sequence_length: 2048
     runner_type: memory_efficient
     theta: 10000.0
-
+    weight_tying: "disabled"
 eval_config:
   repetition_penalty: 1.0
   temperature: 0.7

--- a/tt-train/configs/training_shakespeare_tinyllama_tensor_parallel_3tier_fabric.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama_tensor_parallel_3tier_fabric.yaml
@@ -25,7 +25,7 @@ training_config:
     max_sequence_length: 2048
     runner_type: memory_efficient
     theta: 10000.0
-
+    weight_tying: "disabled"
 multihost_config:
   enabled: true
   num_workers: 3

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -221,10 +221,7 @@ void load_model_from_safetensors(const std::filesystem::path &path, serializatio
         [&parameters, &get_parameter](
             const serialization::SafetensorSerialization::TensorInfo &info, std::span<const std::byte> bytes) {
             fmt::print("Loading tensor: {}, shape:{}, format: {}\n", info.name, info.shape, info.dtype);
-            if (info.dtype != "F32") {
-                throw std::runtime_error(fmt::format("Unsupported dtype: {}", info.dtype));
-            }
-            auto float_vec = serialization::SafetensorSerialization::bytes_to_floats_copy(bytes);
+            auto float_vec = serialization::SafetensorSerialization::bytes_to_float_vec(bytes, info.dtype);
             if (info.name == "wte.weight") {
                 auto out_tensor1 = get_parameter("transformer/fc/weight");
                 fmt::print("Original shape {}, {}", info.shape[0], info.shape[1]);

--- a/tt-train/sources/ttml/models/llama.cpp
+++ b/tt-train/sources/ttml/models/llama.cpp
@@ -15,15 +15,6 @@
 
 namespace {
 
-static std::vector<float> transpose_2d_flat(const std::vector<float>& flat, int64_t rows, int64_t cols) {
-    assert(rows * cols == static_cast<int64_t>(flat.size()));
-    std::vector<int> shape_vec = {static_cast<int>(rows), static_cast<int>(cols)};
-    auto src = xt::adapt(flat, shape_vec);
-    xt::xarray<float> t = xt::transpose(src);
-    auto view = ttml::core::xtensor_to_span(t);
-    return std::vector<float>(view.begin(), view.end());
-}
-
 static std::vector<float> pad_and_resize_flat(
     const std::vector<float>& flat, int64_t rows, int64_t cols, int64_t target_rows, int64_t target_cols) {
     // If dimensions match, return as is
@@ -657,8 +648,6 @@ void load_model_from_safetensors(
                 // v_proj.weight — stage (no unpermute)
                 if (info.name == layer_pfx + ".self_attn.v_proj.weight" ||
                     info.name == layers_pfx + ".self_attn.v_proj.weight") {
-                    // v_weights[i] = float_vec;
-                    // v_shapes[i] = {info.shape[0], info.shape[1]};
                     std::vector<float> src = float_vec;
                     v_weights[i] = std::move(src);
                     v_shapes[i] = {info.shape[0], info.shape[1]};

--- a/tt-train/sources/ttml/models/llama.cpp
+++ b/tt-train/sources/ttml/models/llama.cpp
@@ -5,15 +5,155 @@
 #include "llama.hpp"
 
 #include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
 #include "modules/embedding_module.hpp"
 #include "modules/llama_block.hpp"
 #include "modules/rms_norm_module.hpp"
 #include "ops/rope_op.hpp"
 #include "ops/unary_ops.hpp"
+#include "serialization/safetensors.hpp"
+
+namespace {
+
+static std::vector<float> transpose_2d_flat(const std::vector<float>& flat, int64_t rows, int64_t cols) {
+    assert(rows * cols == static_cast<int64_t>(flat.size()));
+    std::vector<int> shape_vec = {static_cast<int>(rows), static_cast<int>(cols)};
+    auto src = xt::adapt(flat, shape_vec);
+    xt::xarray<float> t = xt::transpose(src);
+    auto view = ttml::core::xtensor_to_span(t);
+    return std::vector<float>(view.begin(), view.end());
+}
+
+static std::vector<float> pad_and_resize_flat(
+    const std::vector<float>& flat, int64_t rows, int64_t cols, int64_t target_rows, int64_t target_cols) {
+    // If dimensions match, return as is
+    if (rows == target_rows && cols == target_cols) {
+        return flat;
+    }
+
+    // Create output tensor with target dimensions
+    std::vector<float> out(static_cast<size_t>(target_rows * target_cols), 0.0f);
+
+    // Copy data from source to target, handling both row and column differences
+    int64_t copy_rows = std::min(rows, target_rows);
+    int64_t copy_cols = std::min(cols, target_cols);
+
+    for (int64_t r = 0; r < copy_rows; ++r) {
+        for (int64_t c = 0; c < copy_cols; ++c) {
+            out[r * target_cols + c] = flat[r * cols + c];
+        }
+    }
+
+    // Initialize random number generator once if we need to fill additional space
+    bool need_random_fill = (target_rows > rows) || (target_cols > cols);
+    std::mt19937 gen;
+    std::normal_distribution<float> dist(0.0f, 0.02f);  // Small random values
+
+    if (need_random_fill) {
+        std::random_device rd;
+        gen.seed(rd());
+    }
+
+    // For additional rows (if target_rows > rows), use small random initialization
+    // instead of zeros to avoid dead neurons
+    if (target_rows > rows) {
+        for (int64_t r = copy_rows; r < target_rows; ++r) {
+            for (int64_t c = 0; c < target_cols; ++c) {
+                out[r * target_cols + c] = dist(gen);
+            }
+        }
+    }
+
+    // For additional columns (if target_cols > cols), use small random initialization
+    if (target_cols > cols) {
+        for (int64_t r = 0; r < copy_rows; ++r) {
+            for (int64_t c = copy_cols; c < target_cols; ++c) {
+                out[r * target_cols + c] = dist(gen);
+            }
+        }
+    }
+
+    return out;
+}
+
+static std::vector<float> unpermute_proj_rows(
+    const std::vector<float>& w, int64_t rows, int64_t cols, int64_t n_heads) {
+    // Reorder rows within each head: [0..D/2-1, D/2..D-1] → interleave → [0, D/2, 1, D/2+1, ...]
+    if (rows % n_heads != 0) {
+        throw std::runtime_error(
+            fmt::format("unpermute_proj_rows: rows {} not divisible by n_heads {}", rows, n_heads));
+    }
+    const int64_t D = rows / n_heads;  // rows per head
+    if (D % 2 != 0) {
+        throw std::runtime_error(fmt::format("unpermute_proj_rows: rows per head {} must be even", D));
+    }
+
+    std::vector<float> out(w.size());
+    for (int64_t h = 0; h < n_heads; ++h) {
+        const int64_t head_row0 = h * D;
+        const int64_t half = D / 2;
+        for (int64_t i = 0; i < half; ++i) {
+            const int64_t src_even = head_row0 + i;
+            const int64_t src_odd = head_row0 + half + i;
+            const int64_t dst_even = head_row0 + (2 * i);
+            const int64_t dst_odd = head_row0 + (2 * i + 1);
+
+            std::memcpy(&out[dst_even * cols], &w[src_even * cols], sizeof(float) * cols);
+            std::memcpy(&out[dst_odd * cols], &w[src_odd * cols], sizeof(float) * cols);
+        }
+    }
+    return out;
+}
+
+static void validate_weight_distribution(const std::vector<float>& weights, const std::string& weight_name) {
+    if (weights.empty()) {
+        fmt::print("[WARNING] Weight {} is empty\n", weight_name);
+        return;
+    }
+
+    // Calculate basic statistics
+    float min_val = *std::min_element(weights.begin(), weights.end());
+    float max_val = *std::max_element(weights.begin(), weights.end());
+    float sum = std::accumulate(weights.begin(), weights.end(), 0.0f);
+    float mean = sum / weights.size();
+
+    // Calculate standard deviation
+    float sq_sum = std::inner_product(weights.begin(), weights.end(), weights.begin(), 0.0f);
+    float variance = sq_sum / weights.size() - mean * mean;
+    float std_dev = std::sqrt(variance);
+
+    // Count zeros and extreme values
+    int zero_count = std::count(weights.begin(), weights.end(), 0.0f);
+    int extreme_count = std::count_if(weights.begin(), weights.end(), [](float val) { return std::abs(val) > 10.0f; });
+
+    fmt::print(
+        "[WEIGHT_VALIDATION] {}: min={:.6f}, max={:.6f}, mean={:.6f}, std={:.6f}, zeros={}/{}, extreme_vals={}\n",
+        weight_name,
+        min_val,
+        max_val,
+        mean,
+        std_dev,
+        zero_count,
+        weights.size(),
+        extreme_count);
+
+    // Check for potential issues
+    if (zero_count > weights.size() * 0.5) {
+        fmt::print("[WARNING] Weight {} has >50% zeros, this may cause issues\n", weight_name);
+    }
+    if (extreme_count > 0) {
+        fmt::print(
+            "[WARNING] Weight {} has {} extreme values (>10.0), this may cause issues\n", weight_name, extreme_count);
+    }
+    if (std::abs(mean) > 1.0f) {
+        fmt::print("[WARNING] Weight {} has large mean ({:.6f}), this may cause issues\n", weight_name, mean);
+    }
+}
+}  // namespace
 
 namespace ttml::models::llama {
 
-Llama::Llama(const LlamaConfig& config) {
+Llama::Llama(const LlamaConfig& config) : m_config(config) {
     uint32_t vocab_size = config.vocab_size;
     uint32_t max_sequence_length = config.max_sequence_length;
     uint32_t embedding_dim = config.embedding_dim;
@@ -187,4 +327,424 @@ std::shared_ptr<Llama> create(const YAML::Node& config) {
     return std::make_shared<Llama>(llama_config);
 }
 
+void Llama::load_from_safetensors(const std::filesystem::path& model_path) {
+    for (const auto& entry : std::filesystem::directory_iterator(model_path)) {
+        if (entry.path().extension() == ".safetensors") {
+            auto path = entry.path();
+            fmt::print("Loading model from: {}\n", path.string());
+            auto parameters = this->parameters();
+            load_model_from_safetensors(path, parameters, m_config);
+        }
+    }
+}
+
+// For LINEAR weights (everything except embeddings and tied-lm_head): require exact shape match.
+static std::vector<float> strict_copy_linear(
+    const std::vector<float>& flat,
+    int64_t rows,
+    int64_t cols,
+    int64_t target_rows,
+    int64_t target_cols,
+    fmt::string_view debug_name) {
+    if (rows != target_rows || cols != target_cols) {
+        throw std::runtime_error(fmt::format(
+            "[{}] Linear weight shape mismatch: src=({}x{}), tgt=({}x{})",
+            debug_name,
+            rows,
+            cols,
+            target_rows,
+            target_cols));
+    }
+    return flat;  // exact fit
+}
+
+void load_model_from_safetensors(
+    const std::filesystem::path& path, serialization::NamedParameters& parameters, const LlamaConfig& config) {
+    // Keep your working setting
+    const bool meta_style = false;
+
+    // --- helpers -------------------------------------------------------------
+    auto transpose_flat_ = [](const std::vector<float>& x, int64_t r, int64_t c) -> std::vector<float> {
+        std::vector<float> y(x.size());
+        for (int64_t i = 0; i < r; ++i)
+            for (int64_t j = 0; j < c; ++j) y[(size_t)j * r + i] = x[(size_t)i * c + j];
+        return y;
+    };
+
+    auto strict_copy_linear = [&](const std::vector<float>& src,
+                                  int64_t src_r,
+                                  int64_t src_c,
+                                  int64_t tgt_r,
+                                  int64_t tgt_c,
+                                  const std::string& dbg) -> std::vector<float> {
+        if (src_r == tgt_r && src_c == tgt_c) {
+            return src;  // as-is fits
+        }
+        if (src_c == tgt_r && src_r == tgt_c) {
+            fmt::print("[{}] transposing weights\n", dbg);
+            return transpose_flat_(src, src_r, src_c);  // transposed fits
+        }
+        throw std::runtime_error(fmt::format(
+            "[{}] shape mismatch: src=({}x{}), src^T=({}x{}), tgt=({}x{})",
+            dbg,
+            src_r,
+            src_c,
+            src_c,
+            src_r,
+            tgt_r,
+            tgt_c));
+    };
+    // ------------------------------------------------------------------------
+
+    std::set<std::string> used_parameters;
+    std::set<std::string> ignored_parameters;
+
+    // Stage K/V for row-wise concat into kv_linear
+    std::map<int, std::vector<float>> k_weights, v_weights;
+    std::map<int, std::array<int64_t, 2>> k_shapes, v_shapes;
+
+    auto get_parameter = [&parameters, &used_parameters](const std::string& name) -> ttml::autograd::TensorPtr {
+        auto it = parameters.find(name);
+
+        if (it == parameters.end()) {
+            throw std::runtime_error(fmt::format("Parameter {} not found in the model", name));
+        }
+        fmt::print("Using parameter: {} with shape: {}\n", name, it->second->get_value().logical_shape());
+        used_parameters.insert(name);
+        return it->second;
+    };
+
+    auto try_combine_kv_weights = [&](int layer_idx) {
+        if (k_weights.find(layer_idx) == k_weights.end() || v_weights.find(layer_idx) == v_weights.end())
+            return;
+
+        auto block_name = fmt::format("llama/llama_block_{}/attention/kv_linear/weight", layer_idx);
+        auto out_tensor = get_parameter(block_name);
+
+        const auto tgt = out_tensor->get_value().logical_shape();
+        const int64_t tr = tgt[-2], tc = tgt[-1];
+
+        auto K = k_weights[layer_idx];
+        auto V = v_weights[layer_idx];
+        auto Ks = k_shapes[layer_idx];  // {rows, cols}
+        auto Vs = v_shapes[layer_idx];
+
+        // Try all four (K,V) orientation combos to match target exactly.
+        auto try_orient = [&](bool kT, bool vT) -> bool {
+            std::vector<float> Kx = kT ? transpose_flat_(K, Ks[0], Ks[1]) : K;
+            std::vector<float> Vx = vT ? transpose_flat_(V, Vs[0], Vs[1]) : V;
+            int64_t Kr = kT ? Ks[1] : Ks[0], Kc = kT ? Ks[0] : Ks[1];
+            int64_t Vr = vT ? Vs[1] : Vs[0], Vc = vT ? Vs[0] : Vs[1];
+            if (Kc != Vc)
+                return false;
+            int64_t cr = Kr + Vr, cc = Kc;
+            if (cr != tr || cc != tc)
+                return false;
+
+            std::vector<float> combined;
+            combined.reserve(Kx.size() + Vx.size());
+            combined.insert(combined.end(), Kx.begin(), Kx.end());
+            combined.insert(combined.end(), Vx.begin(), Vx.end());
+            out_tensor->set_value(core::from_vector(combined, tgt, out_tensor->get_value().device()));
+            return true;
+        };
+
+        if (!(try_orient(false, false) || try_orient(true, false) || try_orient(false, true) ||
+              try_orient(true, true))) {
+            throw std::runtime_error(fmt::format(
+                "KV concat: cannot align at layer {}. "
+                "K=({}x{}), V=({}x{}), tgt=({}x{})",
+                layer_idx,
+                Ks[0],
+                Ks[1],
+                Vs[0],
+                Vs[1],
+                tr,
+                tc));
+        }
+
+        // cleanup
+        k_weights.erase(layer_idx);
+        v_weights.erase(layer_idx);
+        k_shapes.erase(layer_idx);
+        v_shapes.erase(layer_idx);
+
+        fmt::print("Combined k_proj + v_proj → kv_linear for layer {}\n", layer_idx);
+    };
+
+    serialization::SafetensorSerialization::TensorCallback loading_callback =
+        [&](const serialization::SafetensorSerialization::TensorInfo& info, std::span<const std::byte> bytes) {
+            fmt::print("Loading tensor: {}, shape:{}, dtype:{}\n", info.name, info.shape, info.dtype);
+
+            // --- dtype decode (add F16 support) ---
+            std::vector<float> float_vec;
+            std::string dtype = info.dtype;
+            for (auto& c : dtype) c = std::toupper(static_cast<unsigned char>(c));
+
+            if (dtype == "BF16" || dtype == "BFLOAT16") {
+                if (bytes.size_bytes() % 2 != 0)
+                    throw std::runtime_error("BF16 data size must be even");
+                const std::size_t n = bytes.size_bytes() / 2;
+                float_vec.reserve(n);
+                const uint16_t* bf16_data = reinterpret_cast<const uint16_t*>(bytes.data());
+                for (std::size_t i = 0; i < n; ++i) {
+                    uint32_t tmp = static_cast<uint32_t>(bf16_data[i]) << 16;
+                    float value;
+                    std::memcpy(&value, &tmp, sizeof(value));
+                    float_vec.push_back(value);
+                }
+            } else if (dtype == "F16" || dtype == "FLOAT16") {
+                if (bytes.size_bytes() % 2 != 0)
+                    throw std::runtime_error("F16 data size must be even");
+                const std::size_t n = bytes.size_bytes() / 2;
+                float_vec.resize(n);
+                const uint16_t* p = reinterpret_cast<const uint16_t*>(bytes.data());
+                auto half2float = [](uint16_t h) -> float {
+                    uint16_t he = (h & 0x7C00u) >> 10;  // exp
+                    uint16_t hm = (h & 0x03FFu);        // mant
+                    uint32_t s = (h & 0x8000u) << 16;
+                    uint32_t e, m;
+                    if (he == 0) {  // subnorm/zero
+                        if (hm == 0) {
+                            e = 0;
+                            m = 0;
+                        } else {
+                            int shift = 0;
+                            while ((hm & 0x0400u) == 0) {
+                                hm <<= 1;
+                                ++shift;
+                            }
+                            hm &= 0x03FFu;
+                            e = 127 - 15 - shift;
+                            m = (uint32_t)hm << 13;
+                        }
+                    } else if (he == 0x1Fu) {  // inf/NaN
+                        e = 255;
+                        m = (uint32_t)hm << 13;
+                    } else {
+                        e = (uint32_t)(he - 15 + 127);
+                        m = (uint32_t)hm << 13;
+                    }
+                    uint32_t u = s | (e << 23) | m;
+                    float f;
+                    std::memcpy(&f, &u, sizeof(f));
+                    return f;
+                };
+                for (size_t i = 0; i < n; ++i) float_vec[i] = half2float(p[i]);
+            } else if (dtype == "F32" || dtype == "FLOAT32") {
+                float_vec = serialization::SafetensorSerialization::bytes_to_floats_copy(bytes);
+            } else {
+                throw std::runtime_error(fmt::format("Unsupported dtype: {}", info.dtype));
+            }
+
+            // ---- Embeddings (allow pad/resize) ----
+            if (info.name == "embed_tokens.weight" || info.name == "model.embed_tokens.weight" ||
+                info.name == "transformer.wte.weight" || info.name == "wte.weight" || info.name == "model.wte.weight" ||
+                info.name == "embeddings.word_embeddings.weight") {
+                auto weight_tying = config.weight_tying;
+                auto embedding_weights_name =
+                    (weight_tying == WeightTyingType::Enabled) ? "llama/fc/weight" : "llama/tok_emb/weight";
+                auto out_tensor1 = get_parameter(embedding_weights_name);
+
+                auto tgt = out_tensor1->get_value().logical_shape();
+
+                auto resized_emb = pad_and_resize_flat(float_vec, info.shape[0], info.shape[1], tgt[-2], tgt[-1]);
+                out_tensor1->set_value(core::from_vector(resized_emb, tgt, out_tensor1->get_value().device()));
+
+                return true;
+            }
+            if (info.name == "lm_head.weight") {
+                if (config.weight_tying == WeightTyingType::Disabled) {
+                    auto out_tensor2 = get_parameter("llama/fc/weight");
+                    auto tgt2 = out_tensor2->get_value().logical_shape();
+
+                    auto resized_emb2 =
+                        pad_and_resize_flat(float_vec, info.shape[0], info.shape[1], tgt2[-2], tgt2[-1]);
+                    out_tensor2->set_value(core::from_vector(resized_emb2, tgt2, out_tensor2->get_value().device()));
+                }
+                return true;
+            }
+            // ---- Final LayerNorm (vector) ----
+            if (info.name == "norm.weight" || info.name == "model.norm.weight") {
+                auto out = get_parameter("llama/ln_fc/gamma");
+                auto tgt = out->get_value().logical_shape();
+                const int64_t N = tgt[-1];
+
+                if (static_cast<int64_t>(float_vec.size()) != N) {
+                    throw std::runtime_error(
+                        fmt::format("[final LN] length mismatch: src={}, tgt={}", float_vec.size(), N));
+                }
+                out->set_value(core::from_vector(float_vec, tgt, out->get_value().device()));
+                return true;
+            }
+
+            // ---- Per-block ----
+            for (int i = 0; i < static_cast<int>(config.num_blocks); ++i) {
+                const std::string layer_pfx = "model.layers." + std::to_string(i);
+                const std::string layers_pfx = "layers." + std::to_string(i);
+
+                // input_layernorm
+                if (info.name == layer_pfx + ".input_layernorm.weight" ||
+                    info.name == layers_pfx + ".input_layernorm.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/attention_norm/gamma", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t N = tgt[-1];
+
+                    if (static_cast<int64_t>(float_vec.size()) != N) {
+                        throw std::runtime_error(
+                            fmt::format("[attn LN] layer {} length mismatch: src={}, tgt={}", i, float_vec.size(), N));
+                    }
+                    out->set_value(core::from_vector(float_vec, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                // post_attention_layernorm
+                if (info.name == layer_pfx + ".post_attention_layernorm.weight" ||
+                    info.name == layers_pfx + ".post_attention_layernorm.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/mlp_norm/gamma", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t N = tgt[-1];
+
+                    if (static_cast<int64_t>(float_vec.size()) != N) {
+                        throw std::runtime_error(
+                            fmt::format("[mlp LN] layer {} length mismatch: src={}, tgt={}", i, float_vec.size(), N));
+                    }
+                    out->set_value(core::from_vector(float_vec, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                // q_proj.weight — optional unpermute (only if meta_style==false), then try T if needed
+                if (info.name == layer_pfx + ".self_attn.q_proj.weight" ||
+                    info.name == layers_pfx + ".self_attn.q_proj.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/attention/q_linear/weight", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t tr = tgt[-2], tc = tgt[-1];
+
+                    std::vector<float> src = float_vec;
+                    if (!meta_style) {
+                        const int64_t rows = info.shape[0];  // num_heads * head_dim
+                        const int64_t cols = info.shape[1];  // hidden_size
+                        const int64_t n_h = static_cast<int64_t>(config.num_heads);
+                        src = unpermute_proj_rows(src, rows, cols, n_h);
+                    }
+
+                    auto exact = strict_copy_linear(
+                        src, info.shape[0], info.shape[1], tr, tc, fmt::format("q_proj layer {}", i));
+
+                    out->set_value(core::from_vector(exact, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                // k_proj.weight — stage; optional unpermute (GQA: use num_groups as kv heads)
+                if (info.name == layer_pfx + ".self_attn.k_proj.weight" ||
+                    info.name == layers_pfx + ".self_attn.k_proj.weight") {
+                    std::vector<float> src = float_vec;
+                    if (!meta_style) {
+                        const int64_t rows = info.shape[0];  // num_kv_heads * head_dim
+                        const int64_t cols = info.shape[1];  // hidden_size
+                        const int64_t n_kv = static_cast<int64_t>(config.num_groups);
+                        src = unpermute_proj_rows(src, rows, cols, n_kv);
+                    }
+                    k_weights[i] = std::move(src);
+                    k_shapes[i] = {info.shape[0], info.shape[1]};
+                    try_combine_kv_weights(i);
+                    return true;
+                }
+
+                // v_proj.weight — stage (no unpermute)
+                if (info.name == layer_pfx + ".self_attn.v_proj.weight" ||
+                    info.name == layers_pfx + ".self_attn.v_proj.weight") {
+                    // v_weights[i] = float_vec;
+                    // v_shapes[i] = {info.shape[0], info.shape[1]};
+                    std::vector<float> src = float_vec;
+                    v_weights[i] = std::move(src);
+                    v_shapes[i] = {info.shape[0], info.shape[1]};
+                    try_combine_kv_weights(i);
+                    return true;
+                }
+
+                // o_proj.weight — try transpose if needed
+                if (info.name == layer_pfx + ".self_attn.o_proj.weight" ||
+                    info.name == layers_pfx + ".self_attn.o_proj.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/attention/out_linear/weight", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t tr = tgt[-2], tc = tgt[-1];
+
+                    auto exact = strict_copy_linear(
+                        float_vec, info.shape[0], info.shape[1], tr, tc, fmt::format("o_proj layer {}", i));
+                    out->set_value(core::from_vector(exact, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                // MLP: w1 (gate), w3 (up), w2 (down) — try transpose if needed
+                if (info.name == layer_pfx + ".mlp.gate_proj.weight" ||
+                    info.name == layers_pfx + ".mlp.gate_proj.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/mlp/w1/weight", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t tr = tgt[-2], tc = tgt[-1];
+
+                    auto exact = strict_copy_linear(
+                        float_vec, info.shape[0], info.shape[1], tr, tc, fmt::format("mlp.w1 layer {}", i));
+                    out->set_value(core::from_vector(exact, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                if (info.name == layer_pfx + ".mlp.up_proj.weight" || info.name == layers_pfx + ".mlp.up_proj.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/mlp/w3/weight", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t tr = tgt[-2], tc = tgt[-1];
+
+                    auto exact = strict_copy_linear(
+                        float_vec, info.shape[0], info.shape[1], tr, tc, fmt::format("mlp.w3 layer {}", i));
+                    out->set_value(core::from_vector(exact, tgt, out->get_value().device()));
+                    return true;
+                }
+
+                if (info.name == layer_pfx + ".mlp.down_proj.weight" ||
+                    info.name == layers_pfx + ".mlp.down_proj.weight") {
+                    auto name = fmt::format("llama/llama_block_{}/mlp/w2/weight", i);
+                    auto out = get_parameter(name);
+                    auto tgt = out->get_value().logical_shape();
+                    const int64_t tr = tgt[-2], tc = tgt[-1];
+
+                    auto exact = strict_copy_linear(
+                        float_vec, info.shape[0], info.shape[1], tr, tc, fmt::format("mlp.w2 layer {}", i));
+                    out->set_value(core::from_vector(exact, tgt, out->get_value().device()));
+                    return true;
+                }
+            }
+
+            // Unhandled tensor: ignore (e.g., lm_head.weight in some exports)
+            ignored_parameters.insert(info.name);
+            return true;
+        };
+
+    serialization::SafetensorSerialization::visit_safetensors_file(path, loading_callback);
+
+    // Report unused parameters
+    std::vector<std::string> unused_parameters;
+    for (const auto& [param_name, _] : parameters) {
+        if (used_parameters.find(param_name) == used_parameters.end())
+            unused_parameters.push_back(param_name);
+    }
+
+    if (!unused_parameters.empty()) {
+        fmt::print("Warning: The following parameters were not used during loading:\n");
+        for (const auto& param_name : unused_parameters) fmt::print("  - {}\n", param_name);
+        fmt::print("Total unused parameters: {}\n", unused_parameters.size());
+    } else {
+        fmt::print("All {} parameters were successfully loaded and used.\n", parameters.size());
+    }
+    if (!ignored_parameters.empty()) {
+        fmt::print("Note: The following parameters were ignored during loading:\n");
+        for (const auto& param_name : ignored_parameters) fmt::print("  - {}\n", param_name);
+        fmt::print("Total ignored parameters: {}\n", ignored_parameters.size());
+    }
+}
 }  // namespace ttml::models::llama

--- a/tt-train/sources/ttml/models/llama.cpp
+++ b/tt-train/sources/ttml/models/llama.cpp
@@ -467,66 +467,11 @@ void load_model_from_safetensors(
         [&](const serialization::SafetensorSerialization::TensorInfo& info, std::span<const std::byte> bytes) {
             fmt::print("Loading tensor: {}, shape:{}, dtype:{}\n", info.name, info.shape, info.dtype);
 
-            // --- dtype decode (add F16 support) ---
             std::vector<float> float_vec;
             std::string dtype = info.dtype;
             for (auto& c : dtype) c = std::toupper(static_cast<unsigned char>(c));
 
-            if (dtype == "BF16" || dtype == "BFLOAT16") {
-                if (bytes.size_bytes() % 2 != 0)
-                    throw std::runtime_error("BF16 data size must be even");
-                const std::size_t n = bytes.size_bytes() / 2;
-                float_vec.reserve(n);
-                const uint16_t* bf16_data = reinterpret_cast<const uint16_t*>(bytes.data());
-                for (std::size_t i = 0; i < n; ++i) {
-                    uint32_t tmp = static_cast<uint32_t>(bf16_data[i]) << 16;
-                    float value;
-                    std::memcpy(&value, &tmp, sizeof(value));
-                    float_vec.push_back(value);
-                }
-            } else if (dtype == "F16" || dtype == "FLOAT16") {
-                if (bytes.size_bytes() % 2 != 0)
-                    throw std::runtime_error("F16 data size must be even");
-                const std::size_t n = bytes.size_bytes() / 2;
-                float_vec.resize(n);
-                const uint16_t* p = reinterpret_cast<const uint16_t*>(bytes.data());
-                auto half2float = [](uint16_t h) -> float {
-                    uint16_t he = (h & 0x7C00u) >> 10;  // exp
-                    uint16_t hm = (h & 0x03FFu);        // mant
-                    uint32_t s = (h & 0x8000u) << 16;
-                    uint32_t e, m;
-                    if (he == 0) {  // subnorm/zero
-                        if (hm == 0) {
-                            e = 0;
-                            m = 0;
-                        } else {
-                            int shift = 0;
-                            while ((hm & 0x0400u) == 0) {
-                                hm <<= 1;
-                                ++shift;
-                            }
-                            hm &= 0x03FFu;
-                            e = 127 - 15 - shift;
-                            m = (uint32_t)hm << 13;
-                        }
-                    } else if (he == 0x1Fu) {  // inf/NaN
-                        e = 255;
-                        m = (uint32_t)hm << 13;
-                    } else {
-                        e = (uint32_t)(he - 15 + 127);
-                        m = (uint32_t)hm << 13;
-                    }
-                    uint32_t u = s | (e << 23) | m;
-                    float f;
-                    std::memcpy(&f, &u, sizeof(f));
-                    return f;
-                };
-                for (size_t i = 0; i < n; ++i) float_vec[i] = half2float(p[i]);
-            } else if (dtype == "F32" || dtype == "FLOAT32") {
-                float_vec = serialization::SafetensorSerialization::bytes_to_floats_copy(bytes);
-            } else {
-                throw std::runtime_error(fmt::format("Unsupported dtype: {}", info.dtype));
-            }
+            float_vec = serialization::SafetensorSerialization::bytes_to_float_vec(bytes, dtype);
 
             // ---- Embeddings (allow pad/resize) ----
             if (info.name == "embed_tokens.weight" || info.name == "model.embed_tokens.weight" ||

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -68,37 +68,46 @@ void validate_rope_input_and_params(const autograd::TensorPtr& input, const Rota
 }
 
 template <typename E>
-E apply_rope_scaling(const E& freqs, const RopeScalingParams& scaling_params) {
-    // Typical values for low_freq_factor and high_freq_factor are 1 and 4, respectively.
-    assert(scaling_params.low_freq_factor != scaling_params.high_freq_factor);
-    assert(scaling_params.low_freq_factor < scaling_params.high_freq_factor);
+E apply_rope_scaling(const E& freqs, const RopeScalingParams& p) {
+    using T = typename std::decay_t<E>::value_type;
 
-    // These wavelengths are used as thresholds to determine whether to scale the frequency.
-    // For example, if the low_freq_factor is 1, then every frequency after the
-    auto low_freq_wavelength = scaling_params.original_context_length / scaling_params.low_freq_factor;
-    auto high_freq_wavelength = scaling_params.original_context_length / scaling_params.high_freq_factor;
-    if (low_freq_wavelength == high_freq_wavelength) {
-        throw std::invalid_argument("RoPE scaling requires low and high frequency wavelengths to be different.");
+    // Typical: low=1, high=4, factor>=1
+    assert(p.low_freq_factor != p.high_freq_factor);
+    assert(p.low_freq_factor < p.high_freq_factor);
+    assert(p.scaling_factor > T(0));
+
+    // Period (wavelength) in tokens for each channel: 2π / ω
+    const E wavelengths = T(2) * T(M_PI) / freqs;
+
+    // Threshold wavelengths (tokens). Cast to T to avoid integer division.
+    const T low_wl = T(p.original_context_length) / T(p.low_freq_factor);    // e.g., N / 1 = N
+    const T high_wl = T(p.original_context_length) / T(p.high_freq_factor);  // e.g., N / 4
+
+    if (low_wl == high_wl) {
+        throw std::invalid_argument("RoPE scaling requires distinct low/high wavelengths.");
     }
 
-    auto wavelengths = 2 * std::numbers::pi / freqs;
+    // Unscaled (high-frequency / short-range) and fully-scaled (low-frequency / long-range)
+    const E high_freqs = freqs;
+    const E low_freqs = freqs / T(p.scaling_factor);
 
-    // for high frequencies, we're capturing short-range dependencies and needn't scale.
-    auto high_freqs = freqs;
-    // for low frequencies, we're capturing long-range dependencies and need to scale by the full scaling factor.
-    auto low_freqs = freqs / scaling_params.scaling_factor;
+    // Mid-band linear blend between fully-scaled and unscaled.
+    // Using cycles across the original context: c = original_ctx / period
+    // period == wavelengths, so c = N / wavelength.
+    E cycles = T(p.original_context_length) / wavelengths;  // dimensionless
+    E smooths = (cycles - T(p.low_freq_factor)) / (T(p.high_freq_factor) - T(p.low_freq_factor));
 
-    // for frequencies in between, we smoothly interpolate.
-    auto smooths = (scaling_params.original_context_length / wavelengths - scaling_params.low_freq_factor) /
-                   (scaling_params.high_freq_factor - scaling_params.low_freq_factor);
-    auto mid_freqs = (1.0F - smooths) * freqs / scaling_params.scaling_factor + smooths * freqs;
+    // (Optional) clamp for numerical safety
+    smooths = xt::clip(smooths, T(0), T(1));
 
-    // if we're between the low and high freqs, use the smoothly interpolated mid-freqs,
-    // otherwise use low_freqs for the low freq wavelengths and high_freqs otherwise.
-    return xt::where(
-        (wavelengths < low_freq_wavelength) && (wavelengths > high_freq_wavelength),
-        mid_freqs,
-        xt::where(wavelengths > low_freq_wavelength, low_freqs, high_freqs));
+    const E mid_freqs = (T(1) - smooths) * (freqs / T(p.scaling_factor)) + smooths * freqs;
+
+    // Masks
+    const auto in_mid = (wavelengths < low_wl) & (wavelengths > high_wl);
+    const auto is_low = (wavelengths > low_wl);  // very long periods → fully scaled
+    // else: high band (wavelengths <= high_wl) → unscaled
+
+    return xt::where(in_mid, mid_freqs, xt::where(is_low, low_freqs, high_freqs));
 }
 
 // trans_mat, sin_cache, cos_cache are all precomputed and stored somewhere in
@@ -162,33 +171,40 @@ autograd::TensorPtr rope(const autograd::TensorPtr& input, const RotaryEmbedding
 }
 
 std::pair<ttnn::Tensor, ttnn::Tensor> gen_freqs(
-    uint32_t head_dim, uint32_t sequence_length, float theta, const RopeScalingParams& scaling_params) {
-    // compute freqs: 1.0 / (theta ** (2 * (i-1) / head_dim)) for i in [1, head_dim/2]
-    xt::xarray<uint32_t> expt_data = xt::arange(0, static_cast<int>(head_dim)) / 2;
-    xt::xarray<float> expt_xt = xt::cast<float>(expt_data);
+    uint32_t head_dim, uint32_t sequence_length, float theta, const RopeScalingParams& p) {
+    // pair indices: 0,0,1,1,2,2,... size=head_dim
+    xt::xarray<uint32_t> pair_idx_u = xt::arange<uint32_t>(head_dim) / 2u;  // integer divide
+    xt::xarray<float> pair_idx = xt::cast<float>(pair_idx_u);
 
-    expt_xt *= 2.0F / static_cast<float>(head_dim);
-    xt::xarray<float> theta_pow = xt::pow(theta, expt_xt);
+    // exponent = 2 * floor(i/2) / head_dim
+    pair_idx *= 2.0f / static_cast<float>(head_dim);
 
-    auto freqs = xt::ones_like(theta_pow) / theta_pow;
+    // inv_freq[i] = 1 / (theta ** exponent[i])
+    xt::xarray<float> inv_freq = 1.0f / xt::pow(theta, pair_idx);  // [D]
 
-    xt::xarray<float> seq_pos = xt::arange<float>(sequence_length);
-    xt::xarray<float> seq_pos_repeated_to_head = xt::repeat(seq_pos, head_dim, seq_pos.dimension() - 1U);
-    xt::xarray<float> scales = seq_pos_repeated_to_head.reshape({sequence_length, head_dim});
-
-    xt::xarray<float> scaled_freqs = scales * freqs;
-
-    if (scaling_params.scaling_factor != 0.0F) {
-        scaled_freqs = apply_rope_scaling(scaled_freqs, scaling_params);
+    // Apply NTK scaling to base frequencies (recommended)
+    if (p.scaling_factor != 1.0f) {
+        inv_freq = apply_rope_scaling(inv_freq, p);  // [D]
     }
 
-    // take the scaled freqs mod 2π to satisfy ttnn inputs constraints for sin/cos
-    auto pi = static_cast<float>(std::numbers::pi);
-    scaled_freqs = xt::fmod(scaled_freqs, 2.0F * pi);
-    scaled_freqs = scaled_freqs.reshape({1, 1, sequence_length, head_dim});
+    // positions column vector [L,1]
+    // positions column vector [L,1]
+    xt::xarray<float> pos = xt::arange<float>(static_cast<float>(sequence_length));
+    pos.reshape({sequence_length, 1u});  // member reshape
 
-    xt::xarray<float> sin_freqs = xt::sin(scaled_freqs);
-    xt::xarray<float> cos_freqs = xt::cos(scaled_freqs);
+    // θ = pos * inv_freq  -> broadcast to [L,D]
+    xt::xarray<float> theta_mat = pos * inv_freq;  // [L,D]
+
+    // keep in principal range
+    theta_mat = xt::fmod(theta_mat, 2.0f * std::numbers::pi_v<float>);
+
+    // expand to [1,1,L,D]
+    xt::xarray<float> theta_4d = theta_mat;                 // copy shape metadata from theta_mat
+    theta_4d.reshape({1u, 1u, sequence_length, head_dim});  // member reshape
+
+    // trig caches
+    xt::xarray<float> sin_freqs = xt::sin(theta_4d);
+    xt::xarray<float> cos_freqs = xt::cos(theta_4d);
 
     auto* device = &autograd::ctx().get_device();
     return {core::from_xtensor(sin_freqs, device), core::from_xtensor(cos_freqs, device)};

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -177,7 +177,7 @@ std::pair<ttnn::Tensor, ttnn::Tensor> gen_freqs(
     xt::xarray<float> pair_idx = xt::cast<float>(pair_idx_u);
 
     // exponent = 2 * floor(i/2) / head_dim
-    pair_idx *= 2.0f / static_cast<float>(head_dim);
+    pair_idx *= 2.0F / static_cast<float>(head_dim);
 
     // inv_freq[i] = 1 / (theta ** exponent[i])
     xt::xarray<float> inv_freq = 1.0f / xt::pow(theta, pair_idx);  // [D]
@@ -196,7 +196,7 @@ std::pair<ttnn::Tensor, ttnn::Tensor> gen_freqs(
     xt::xarray<float> theta_mat = pos * inv_freq;  // [L,D]
 
     // keep in principal range
-    theta_mat = xt::fmod(theta_mat, 2.0f * std::numbers::pi_v<float>);
+    theta_mat = xt::fmod(theta_mat, 2.0F * std::numbers::pi_v<float>);
 
     // expand to [1,1,L,D]
     xt::xarray<float> theta_4d = theta_mat;                 // copy shape metadata from theta_mat

--- a/tt-train/sources/ttml/ops/rope_op.hpp
+++ b/tt-train/sources/ttml/ops/rope_op.hpp
@@ -9,10 +9,10 @@
 namespace ttml::ops {
 
 struct RopeScalingParams {
-    uint32_t original_context_length = 0U;
-    float scaling_factor = 0.0F;
-    float high_freq_factor = 0.0F;
-    float low_freq_factor = 0.0F;
+    uint32_t original_context_length = 2048U;
+    float scaling_factor = 1.0F;
+    float high_freq_factor = 1.0F;
+    float low_freq_factor = 1.0F;
 };
 
 struct RotaryEmbeddingParams {

--- a/tt-train/sources/ttml/serialization/safetensors.cpp
+++ b/tt-train/sources/ttml/serialization/safetensors.cpp
@@ -119,4 +119,64 @@ std::vector<float> SafetensorSerialization::bytes_to_floats_copy(std::span<const
     std::memcpy(out.data(), bytes.data(), n * sizeof(float));
     return out;
 }
+std::vector<float> SafetensorSerialization::bytes_to_float_vec(
+    const std::span<const std::byte>& bytes, const std::string& dtype) {
+    std::vector<float> float_vec;
+    if (dtype == "BF16" || dtype == "BFLOAT16") {
+        if (bytes.size_bytes() % 2 != 0)
+            throw std::runtime_error("BF16 data size must be even");
+        const std::size_t n = bytes.size_bytes() / 2;
+        float_vec.reserve(n);
+        const uint16_t* bf16_data = reinterpret_cast<const uint16_t*>(bytes.data());
+        for (std::size_t i = 0; i < n; ++i) {
+            uint32_t tmp = static_cast<uint32_t>(bf16_data[i]) << 16;
+            float value;
+            std::memcpy(&value, &tmp, sizeof(value));
+            float_vec.push_back(value);
+        }
+    } else if (dtype == "F16" || dtype == "FLOAT16") {
+        if (bytes.size_bytes() % 2 != 0)
+            throw std::runtime_error("F16 data size must be even");
+        const std::size_t n = bytes.size_bytes() / 2;
+        float_vec.resize(n);
+        const uint16_t* p = reinterpret_cast<const uint16_t*>(bytes.data());
+        auto half2float = [](uint16_t h) -> float {
+            uint16_t he = (h & 0x7C00u) >> 10;  // exp
+            uint16_t hm = (h & 0x03FFu);        // mant
+            uint32_t s = (h & 0x8000u) << 16;
+            uint32_t e, m;
+            if (he == 0) {  // subnorm/zero
+                if (hm == 0) {
+                    e = 0;
+                    m = 0;
+                } else {
+                    int shift = 0;
+                    while ((hm & 0x0400u) == 0) {
+                        hm <<= 1;
+                        ++shift;
+                    }
+                    hm &= 0x03FFu;
+                    e = 127 - 15 - shift;
+                    m = (uint32_t)hm << 13;
+                }
+            } else if (he == 0x1Fu) {  // inf/NaN
+                e = 255;
+                m = (uint32_t)hm << 13;
+            } else {
+                e = (uint32_t)(he - 15 + 127);
+                m = (uint32_t)hm << 13;
+            }
+            uint32_t u = s | (e << 23) | m;
+            float f;
+            std::memcpy(&f, &u, sizeof(f));
+            return f;
+        };
+        for (size_t i = 0; i < n; ++i) float_vec[i] = half2float(p[i]);
+    } else if (dtype == "F32" || dtype == "FLOAT32") {
+        float_vec = serialization::SafetensorSerialization::bytes_to_floats_copy(bytes);
+    } else {
+        throw std::runtime_error(fmt::format("Unsupported dtype: {}", dtype));
+    }
+    return float_vec;
+};
 }  // namespace ttml::serialization

--- a/tt-train/sources/ttml/serialization/safetensors.hpp
+++ b/tt-train/sources/ttml/serialization/safetensors.hpp
@@ -28,5 +28,7 @@ public:
         Span can point to the unaligned memory, so it is not safe to copy it to the float buffer before using it.
     */
     static std::vector<float> bytes_to_floats_copy(std::span<const std::byte> bytes);
+
+    static std::vector<float> bytes_to_float_vec(const std::span<const std::byte>& bytes, const std::string& dtype);
 };
 }  // namespace ttml::serialization


### PR DESCRIPTION
### Problem description
Previously we were able to load gpt2 only.

### What's changed
* rewrote rope scaling to improve accuracy and overall better logic.
* Added a lot of checks to the safetensor loader.
* Fixed some yaml files.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes