### PR TITLE
Adding hidden compile flag for protobuf symbols and adding test example

### DIFF
--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           apt update
+          DEBIAN_FRONTEND=noninteractive TZ=UTC apt install -y -q libprotobuf-dev # this is being installed for testing dependency conflicts with protobuf
           apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb
 
       - name: Run examples

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -71,6 +71,15 @@ CPMAddPackage(
         "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
 
+set_target_properties(
+    libprotobuf
+    PROPERTIES
+        CXX_VISIBILITY_PRESET
+            "hidden"
+        VISIBILITY_INLINES_HIDDEN
+            TRUE
+)
+
 ############################################################################################################################
 # yaml-cpp
 ############################################################################################################################

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -50,6 +50,7 @@ install(
         sfpu_eltwise_chain
         custom_sfpi_add
         custom_sfpi_smoothstep
+        tests
     # DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
     # FIXME(afuller): Something funky is happening when installing files into
     # /usr/share/doc on a default Docker image. Speculation: some dependency for

--- a/tt_metal/programming_examples/tests/CMakeLists.txt
+++ b/tt_metal/programming_examples/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22...3.30)
+project(programming_examples_tests)
+
+find_package(Protobuf REQUIRED)
+
+if(NOT TARGET TT::Metalium)
+    find_package(TT-Metalium REQUIRED)
+endif()
+
+add_executable(package_integration_test)
+target_sources(package_integration_test PRIVATE package_integration_test.cpp)
+target_link_libraries(
+    package_integration_test
+    PUBLIC
+        TT::Metalium
+        protobuf::libprotobuf
+)
+
+# Any other integration tests should be added here

--- a/tt_metal/programming_examples/tests/package_integration_test.cpp
+++ b/tt_metal/programming_examples/tests/package_integration_test.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+
+#include <google/protobuf/empty.pb.h>
+
+#include <iostream>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+int main() {
+    // This example exists to demonstrate how to integrate other third party libraries into a Metalium program.
+    // It exists also to test dependency conflicts between some libraries that might interfere with the build of
+    // tt-metal. https://github.com/tenstorrent/tt-metal/issues/27465
+    // https://github.com/tenstorrent/tt-metal/issues/29442
+
+    // Test Protobuf
+    google::protobuf::Empty empty_msg;
+    std::string serialized;
+    empty_msg.SerializeToString(&serialized);
+    std::cout << "Protobuf: Serialized an empty message of size " << serialized.size() << std::endl;
+
+    // Test TT-Metal Mesh Device
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    std::cout << "TT-Metal: Mesh device created" << std::endl;
+
+    // Close the device
+    mesh_device->close();
+    std::cout << "TT-Metal: Mesh device closed" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29442

### Problem description
Protobuf symbols creating dependency conflict with other libraries like opencv

### What's changed
- [x] Added test in programming examples importing tt-metal with protobuf and other packages
- [x] Compiling protobuf with compiler symbol visibility set to hidden

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes