### PR TITLE
[skip ci] ci: provide url for every post-commit run

### DIFF
--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -285,7 +285,7 @@ jobs:
                     echo "$output_var=success:$run_url" >> $GITHUB_OUTPUT
                     return 0
                   else
-                    echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url"
+                    echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url/attempts/$(($retries + 1))"
                     if [ $retries -ge $((MAX_RETRIES - 1)) ]; then
                       echo "$output_var=failure:$run_url" >> $GITHUB_OUTPUT
                       return 1

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -45,13 +45,13 @@ on:
         default: 480
     outputs:
       all-post-commit-result:
-        description: 'Result of all post-commit tests (status:url format)'
+        description: 'Result of All post-commit tests (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.all-post-commit-result }}
       blackhole-result:
-        description: 'Result of blackhole tests (status:url format)'
+        description: 'Result of Blackhole post-commit tests (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.blackhole-result }}
       tt-metal-l2-nightly-result:
-        description: 'Result of TT-Metal L2 Nightly APC tests (status:url format)'
+        description: 'Result of All post-commit C++ tests (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.tt-metal-l2-nightly-result }}
 
 concurrency:
@@ -182,7 +182,7 @@ jobs:
 
           declare -A run_ids
 
-          # Function to trigger workflow and get run ID
+          # Function to trigger workflow and get run ID and URL
           trigger_and_get_id() {
             local workflow_file="$1"
             local display_name="$2"
@@ -194,16 +194,16 @@ jobs:
               gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
             fi
 
-            # Poll for run ID
-            local run_id=""
+            # Poll for run ID and URL
+            local run_data=""
             for i in {1..12}; do
               sleep 5
-              run_id=$(gh run list --workflow "$workflow_file" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId --jq '.[0].databaseId' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
-              if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+              run_data=$(gh run list --workflow "$workflow_file" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId,url --jq '.[0] | select(.databaseId != null) | "\(.databaseId)|\(.url)"' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
+              if [ -n "$run_data" ] && [ "$run_data" != "null" ]; then
                 break
               fi
             done
-            echo "$run_id"
+            echo "$run_data"
           }
 
           # Trigger enabled workflows
@@ -212,16 +212,28 @@ jobs:
               echo "🚀 Triggering $workflow..."
               case "$workflow" in
                 "all-post-commit-workflows.yaml")
-                  run_ids["all-post-commit"]=$(trigger_and_get_id "$workflow" "All post-commit")
-                  [ -n "${run_ids[all-post-commit]}" ] && echo "✅ All post-commit run ID: ${run_ids[all-post-commit]}"
+                  run_data=$(trigger_and_get_id "$workflow" "All post-commit")
+                  if [ -n "$run_data" ]; then
+                    run_ids["all-post-commit"]=$(echo "$run_data" | cut -d'|' -f1)
+                    run_url=$(echo "$run_data" | cut -d'|' -f2)
+                    echo "✅ All post-commit run: $run_url"
+                  fi
                   ;;
                 "blackhole-post-commit.yaml")
-                  run_ids["blackhole"]=$(trigger_and_get_id "$workflow" "Blackhole")
-                  [ -n "${run_ids[blackhole]}" ] && echo "✅ Blackhole run ID: ${run_ids[blackhole]}"
+                  run_data=$(trigger_and_get_id "$workflow" "Blackhole")
+                  if [ -n "$run_data" ]; then
+                    run_ids["blackhole"]=$(echo "$run_data" | cut -d'|' -f1)
+                    run_url=$(echo "$run_data" | cut -d'|' -f2)
+                    echo "✅ Blackhole post-commit run: $run_url"
+                  fi
                   ;;
                 "tt-metal-l2-nightly.yaml")
-                  run_ids["tt-metal-l2-nightly"]=$(trigger_and_get_id "$workflow" "TT-Metal L2 Nightly APC")
-                  [ -n "${run_ids[tt-metal-l2-nightly]}" ] && echo "✅ TT-Metal L2 Nightly APC run ID: ${run_ids[tt-metal-l2-nightly]}"
+                  run_data=$(trigger_and_get_id "$workflow" "TT-Metal L2 Nightly APC")
+                  if [ -n "$run_data" ]; then
+                    run_ids["tt-metal-l2-nightly"]=$(echo "$run_data" | cut -d'|' -f1)
+                    run_url=$(echo "$run_data" | cut -d'|' -f2)
+                    echo "✅ All post-commit C++ tests run: $run_url"
+                  fi
                   ;;
               esac
             fi


### PR DESCRIPTION
### Ticket
None

### Problem description
Right now it's hard to track workflow status manually. When this workflow gets triggered from tt-llk repo, we get run IDs but not URLs, so checking on them requires going to tt-metal actions and finding triggered workflows by hand. This should automate that and make it easier for the developer to track progress.

This is what we have so far:
<img width="424" height="116" alt="image" src="https://github.com/user-attachments/assets/6df6d1ef-b506-4497-9175-810611600de7" />

With the update, instead of run ID, a user would be served with a URL leading them to the workflow in question.

### What's changed
Enhanced output of workflow triggering step with URL information.