### PR TITLE
fix stable diffusion 3.5 breaking change

### DIFF
--- a/models/experimental/tt_dit/layers/conv2d.py
+++ b/models/experimental/tt_dit/layers/conv2d.py
@@ -161,7 +161,7 @@ class Conv2d:
         b, h, w, c = x.shape
         slice_config = ttnn.Conv2dSliceConfig(
             num_slices=self.slice_params[tuple(self.mesh_device.shape)][(h, w, self.in_channels, self.out_channels)],
-            slice_type=ttnn.Conv2dSliceWidth,
+            slice_type=ttnn.Conv2dDRAMSliceWidth,
         )
 
         output_tensor, [_out_height, _out_width] = ttnn.conv2d(


### PR DESCRIPTION
### Ticket
[Stable diffusion 3.5 model breaking change](https://github.com/tenstorrent/tt-metal/issues/29943)

### Problem description
On the on-nighly run CI we got this error:
```
[SERVER] 2025-10-02 19:37:44,133 - ERROR - Failed to get device runner: module 'ttnn' has no attribute 'Conv2dSliceWidth'
[SERVER] 2025-10-02 19:37:44,136 - WARNING - Worker  error cound is : 1
[SERVER] 2025-10-02 19:37:44,136 - ERROR - Error in worker -1: module 'ttnn' has no attribute 'Conv2dSliceWidth'
```

### What's changed
Used the changed `Conv2dDRAMSliceWidth = ttnn._ttnn.operations.conv.Conv2dSliceConfig.SliceTypeEnum.DRAMSliceWidth`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes