### PR TITLE
Extend argmax to support inputs with tile layout

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -73,26 +73,31 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_shape"][0] != 1:
+    input_shape = test_vector["input_shape"]
+    input_dtype = test_vector["input_a_dtype"]
+    input_layout = test_vector["input_layout"]
+    dim = test_vector["dim"]
+
+    # Shape
+    if input_shape[0] != 1:
         return True, "dim 0 must be 1"
-    if test_vector["input_shape"][1] != 1:
+    if len(input_shape) > 1 and input_shape[1] != 1:
         return True, "dim 1 must be 1"
-    if test_vector["dim"] != 3:
+
+    # Reduction dimension
+    if dim != 3:
         return True, "Only argmax on last dim is supported"
-    if test_vector["dim"] is not None:
-        if test_vector["dim"] * (-1) > (len(test_vector["input_shape"])):
+    if dim is not None:
+        if dim * (-1) > len(input_shape):
             return True, "Absolute value of dim must be less or equal than the rank of input tensor"
-    if test_vector["input_layout"] == ttnn.TILE_LAYOUT:
-        return True, "Tiled layout not supported"
-    supported_dtypes = [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32, ttnn.uint16]
+
+    # Data type
+    supported_dtypes = [ttnn.bfloat16, ttnn.float32, ttnn.int32]
     if test_vector["input_a_dtype"] not in supported_dtypes:
         return True, "Only BFLOAT16, FLOAT32, INT32, UINT32, and UINT16 are supported for inputs!"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and not (
-        test_vector["input_a_dtype"] == ttnn.float32 or test_vector["input_a_dtype"] == ttnn.bfloat16
-    ):
-        return True, "Row major is only supported for fp32 & fp16"
-    if not test_vector["keepdim"]:
-        return True, "keepdim = false is not supported"
+    if input_layout == ttnn.TILE_LAYOUT:
+        if input_dtype != ttnn.float32 and input_dtype != ttnn.bfloat16:
+            return True, "For TILE_LAYOUT only fp32 and bloat16 data types are supported"
 
     return False, None
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -11,39 +11,47 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 
 
 @pytest.mark.parametrize(
-    argnames="tensor_shape, dim, keepdim, use_multicore, dtype",
+    argnames="tensor_shape, tensor_layout, dim, keepdim, use_multicore, dtype",
     argvalues=[
-        ([], None, True, True, torch.bfloat16),
-        ([32], -1, False, False, torch.float32),
-        ([32, 0], 1, True, True, torch.bfloat16),
-        ([64], -1, True, False, torch.bfloat16),
-        ([1, 512], -1, True, True, torch.float32),
-        ([1, 1024], -1, True, True, torch.int32),
-        ([1, 65], -1, True, True, torch.uint8),
-        ([8, 10, 129], 2, True, False, torch.bfloat16),
-        ([1, 8, 160], -1, False, True, torch.bfloat16),
-        ([1, 256, 1024 * 8], -1, False, True, torch.float32),
-        ([32, 32, 32, 1], -1, True, True, torch.float32),
-        ([128], -1, True, True, torch.float32),
-        ([256], -1, False, False, torch.bfloat16),
-        ([64, 128], -1, True, True, torch.float32),
-        ([64, 128], -1, False, True, torch.int32),
-        ([32, 64, 128], -1, True, True, torch.float32),
-        ([32, 64, 128], -1, True, False, torch.bfloat16),
-        ([16, 32, 64, 128], -1, True, True, torch.bfloat16),
-        ([16, 32, 64, 128], -1, True, False, torch.float32),
-        ([16, 32, 64, 128], -1, True, True, torch.int32),
-        ([8, 16, 32, 64], -1, True, True, torch.float32),
-        ([8, 16, 32, 64], -1, False, True, torch.bfloat16),
-        ([4, 8, 16, 32], -1, False, False, torch.float32),
-        ([100, 200], -1, True, True, torch.bfloat16),
-        ([100, 200], -1, False, False, torch.float32),
-        ([50, 100, 200], -1, True, True, torch.int32),
-        ([25, 50, 100], -1, False, True, torch.uint8),
-        ([12, 24, 48, 96], -1, True, False, torch.bfloat16),
+        ([], ttnn.ROW_MAJOR_LAYOUT, None, True, True, torch.bfloat16),
+        ([32], ttnn.ROW_MAJOR_LAYOUT, -1, False, False, torch.float32),
+        ([32, 0], ttnn.ROW_MAJOR_LAYOUT, 1, True, True, torch.bfloat16),
+        ([64], ttnn.ROW_MAJOR_LAYOUT, -1, True, False, torch.bfloat16),
+        ([1, 512], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([1, 1024], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.int32),
+        ([1, 65], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.uint8),
+        ([8, 10, 129], ttnn.ROW_MAJOR_LAYOUT, 2, True, False, torch.bfloat16),
+        ([1, 8, 160], ttnn.ROW_MAJOR_LAYOUT, -1, False, True, torch.bfloat16),
+        ([1, 256, 1024 * 8], ttnn.ROW_MAJOR_LAYOUT, -1, False, True, torch.float32),
+        ([32, 32, 32, 1], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([128], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([256], ttnn.ROW_MAJOR_LAYOUT, -1, False, False, torch.bfloat16),
+        ([128], ttnn.TILE_LAYOUT, -1, True, False, torch.float32),
+        ([256], ttnn.TILE_LAYOUT, -1, False, False, torch.bfloat16),
+        ([64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, False, True, torch.int32),
+        ([64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, False, torch.float32),
+        ([32, 64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([32, 64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, False, torch.bfloat16),
+        ([32, 64, 128], ttnn.TILE_LAYOUT, -1, False, False, torch.bfloat16),
+        ([16, 32, 64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.bfloat16),
+        ([16, 32, 64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, False, torch.float32),
+        ([16, 32, 64, 128], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.int32),
+        ([16, 32, 64, 128], ttnn.TILE_LAYOUT, -1, True, False, torch.bfloat16),
+        ([16, 32, 64, 128], ttnn.TILE_LAYOUT, -1, False, False, torch.float32),
+        ([16, 32, 70, 130], ttnn.TILE_LAYOUT, -1, True, False, torch.bfloat16),
+        ([16, 32, 70, 130], ttnn.TILE_LAYOUT, -1, False, False, torch.bfloat16),
+        ([8, 16, 32, 64], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.float32),
+        ([8, 16, 32, 64], ttnn.ROW_MAJOR_LAYOUT, -1, False, True, torch.bfloat16),
+        ([4, 8, 16, 32], ttnn.ROW_MAJOR_LAYOUT, -1, False, False, torch.float32),
+        ([100, 200], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.bfloat16),
+        ([100, 200], ttnn.ROW_MAJOR_LAYOUT, -1, False, False, torch.float32),
+        ([50, 100, 200], ttnn.ROW_MAJOR_LAYOUT, -1, True, True, torch.int32),
+        ([25, 50, 100], ttnn.ROW_MAJOR_LAYOUT, -1, False, True, torch.uint8),
+        ([12, 24, 48, 96], ttnn.ROW_MAJOR_LAYOUT, -1, True, False, torch.bfloat16),
     ],
 )
-def test_argmax(device, tensor_shape, dim, keepdim, use_multicore, dtype):
+def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, use_multicore, dtype):
     """
     Test the compatibility of the torch and ttnn output for argmax of different
     tensor shapes, dim values, and data types.
@@ -66,9 +74,9 @@ def test_argmax(device, tensor_shape, dim, keepdim, use_multicore, dtype):
     # Convert torch uint8 to appropriate ttnn type
     if dtype == torch.uint8:  # PyTorch does not have uint32/uint16, so we use uint8
         ttnn_dtype = ttnn.uint32
-        ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, dtype=ttnn_dtype)
+        ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, dtype=ttnn_dtype, layout=tensor_layout)
     else:
-        ttnn_tensor = ttnn.from_torch(torch_tensor, device=device)
+        ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=tensor_layout)
 
     torch_op, ttnn_op = getattr(torch, "argmax"), getattr(ttnn, "argmax")
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -41,19 +41,15 @@ void bind_reduction_argmax_operation(py::module& module) {
                     * - dtype
                       - layout
                     * - FLOAT32
-                      - ROW_MAJOR
+                      - ROW_MAJOR, TILE
                     * - BFLOAT16
-                      - ROW_MAJOR
+                      - ROW_MAJOR, TILE
                     * - UINT32
                       - ROW_MAJOR
                     * - INT32
                       - ROW_MAJOR
                     * - UINT16
                       - ROW_MAJOR
-                    * - FLOAT32
-                      - TILE
-                    * - BFLOAT16
-                      - TILE
 
                 The output tensor will be of the following data type and layout:
 
@@ -73,6 +69,7 @@ void bind_reduction_argmax_operation(py::module& module) {
                 - Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
                 - Sharding is not supported for this operation
                 - Reduction over all elements (when dim=None) is not supported with the TILE input tensor layout
+                - The (optional) preallocated output tensor must have ROW_MAJOR layout
 
             Example:
               .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.cpp
@@ -50,6 +50,10 @@ void bind_reduction_argmax_operation(py::module& module) {
                       - ROW_MAJOR
                     * - UINT16
                       - ROW_MAJOR
+                    * - FLOAT32
+                      - TILE
+                    * - BFLOAT16
+                      - TILE
 
                 The output tensor will be of the following data type and layout:
 
@@ -68,6 +72,7 @@ void bind_reduction_argmax_operation(py::module& module) {
                 - All input tensors must be on-device.
                 - Currently this op only supports dimension-specific reduction on the last dimension (i.e. :attr:`dim` = -1).
                 - Sharding is not supported for this operation
+                - Reduction over all elements (when dim=None) is not supported with the TILE input tensor layout
 
             Example:
               .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -246,7 +246,7 @@ operation::ProgramWithCallbacks argmax_single_core(
 
     const std::map<std::string, std::string> kernel_defines;
     const tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, kernel_path.c_str(), all_cores, tt::tt_metal::ReaderDataMovementConfig(ctime_args, kernel_defines));
+        program, kernel_path, all_cores, tt::tt_metal::ReaderDataMovementConfig(ctime_args, kernel_defines));
 
     // Runtime args
     const auto cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -173,13 +173,6 @@ auto get_ctime_args_single_core(
             });
     } else {
         const uint32_t logical_rank = input.logical_shape().size();
-        TT_FATAL(reduce_all == false, "reduce_all not supported with TILE_LAYOUT");
-
-        // With TILE layout, padded shape has always at least 2 dims (i.e., also for 1D input tensors).
-        TT_FATAL(rank > 1, "Invalid rank for tiled tensor");
-        TT_FATAL(input_shape[rank - 1] % TILE_WIDTH == 0, "Invalid input tensor shape");
-        TT_FATAL(input_shape[rank - 2] % TILE_HEIGHT == 0, "Invalid input tensor shape");
-
         const uint32_t w_tiles = input_shape[rank - 1] / TILE_WIDTH;
         const uint32_t h_tiles = input_shape[rank - 2] / TILE_HEIGHT;
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#pragma once
 
 #include "dataflow_api.h"
 #include "utils/bfloat16.h"

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "argmax_common.hpp"
+#include "debug/assert.h"
+#include "debug/waypoint.h"
+
+constexpr uint32_t face_width = 16;
+constexpr uint32_t face_height = 16;
+constexpr uint32_t face_size = face_width * face_height;
+
+/**
+ * @brief Struct container that gathers parameters (e.g., shape, data format)
+ * that are related to the input tensor
+ *
+ */
+struct InputContext {
+    // Tensor tile shape
+    const uint32_t tile_height;
+    const uint32_t tile_width;
+
+    // Tensor last two dimensions, in tiles
+    const uint32_t input_height;
+    const uint32_t input_width;
+
+    // Tensor last two dimensions, logical size
+    const uint32_t logical_height;
+    const uint32_t logical_width;
+
+    const DataFormat data_format;
+    const uint32_t cb_addr;
+
+    const bool has_padding;
+
+    InputContext() = delete;
+    InputContext(const InputContext&) = delete;
+
+    InputContext(
+        uint32_t tile_h,
+        uint32_t tile_w,
+        uint32_t tiles_h,
+        uint32_t tiles_w,
+        uint32_t data_h,
+        uint32_t data_w,
+        DataFormat format,
+        uint32_t l1_cb_addr) :
+        tile_height(tile_h),
+        tile_width(tile_w),
+        input_height(tiles_h),
+        input_width(tiles_w),
+        logical_height(data_h),
+        logical_width(data_w),
+        data_format(format),
+        cb_addr(l1_cb_addr),
+        has_padding((input_height % tile_height != 0) || (input_width % tile_width != 0)) {}
+};
+
+/**
+ * @brief Struct container that gathers parameters related to the output tensor
+ *
+ * Since the output tensor parameters
+ * This template function converts a raw memory address to a typed volatile pointer
+ * that corresponds to the underlying data type of the specified DataFormat enum.
+ * The returned pointer is marked as volatile and uses the tt_l1_ptr qualifier,
+ * indicating it points to L1 cache memory that may be modified by hardware.
+ *
+ * @tparam data_format The DataFormat enum value that determines the return type
+ * @param addr The raw memory address to be cast to the appropriate pointer type
+ *
+ * @return A volatile tt_l1_ptr pointer of the appropriate type:
+ *         - uint16_t* for Float16_b and UInt16 formats
+ *         - uint32_t* for Float32 and UInt32 formats
+ *         - int32_t* for Int32 format
+ *
+ * @note This function uses compile-time template specialization to ensure
+ *       type safety and optimal performance. Unsupported data formats will
+ *       trigger a compile-time assertion error.
+ */
+struct OutputContext {
+    uint32_t collected_count;
+    uint32_t output_page_id;
+
+    uint32_t* const stack_ptr;
+    const uint32_t stack_buffer_size;
+
+    const uint32_t output_cb_addr;
+    const uint32_t write_out_count;
+
+    OutputContext() = delete;
+    OutputContext(const OutputContext&) = delete;
+
+    OutputContext(uint32_t* ptr, uint32_t size, uint32_t dst_cb_addr, uint32_t out_count, bool keep_dim) :
+        collected_count(0),
+        output_page_id(0),
+        stack_ptr(ptr),
+        stack_buffer_size(size),
+        output_cb_addr(dst_cb_addr),
+        write_out_count(out_count) {}
+};
+
+/**
+ * @brief Calculates range of valid data (i.e., not padding) within a face of tile
+ *
+ * @param[out] data_rows Number of rows, within the face, that contain valid data
+ * @param[out] data_cols Number of cols, within the face, that contain valid data
+ *
+ * @param[in] tile_x The x coordinate of the tile this face belongs to
+ * @param[in] tile_y The y coordinate of the tile this face belongs to
+ * @param[in] face_id The index (0..3) of the face within the tile
+ * @param[in] ctx Parameters of the tensor
+ *
+ */
+void get_face_data_range(
+    uint32_t& data_rows,
+    uint32_t& data_cols,
+    uint32_t tile_x,
+    uint32_t tile_y,
+    uint32_t face_id,
+    const InputContext& ctx);
+
+/**
+ * @brief Searches for max values and their locations in one tile of the input tensor
+ *
+ * @tparam DTYPE C++ representation of the input tensor data format
+ * @tparam DataFormat Input tensor data format
+ *
+ * @param[in] ctx Parameters of the input tensor
+ * @param[in] tile_x The x coordinate of the tile
+ * @param[in] tile_y The y coordinate of the tile
+ *
+ * @param max_values Array with the maximal values for a range of input tensor rows
+ * @param arg_max Array with indices (tensor related) of the maximal values
+ * @param[in] max_size The size of max_values and arg_max arrays
+ *
+ * @note This function is invoked for subsequent tiles in a horizontal pass over the input tensor.
+ *       Each call in this pass updates the max_values, arg_max arrays according to the values
+ *       found in the tile.
+ */
+template <typename DTYPE, DataFormat format>
+void process_input_tile(
+    const InputContext& ctx,
+    uint32_t tile_x,
+    uint32_t tile_y,
+    DTYPE max_values[],
+    uint32_t arg_max[],
+    uint32_t max_size) {
+    const bool has_padding = ctx.has_padding;
+    const DataFormat src_data_format = ctx.data_format;
+    auto src_ptr = get_tt_l1_ptr_based_on_data_format<format>(ctx.cb_addr);
+
+    // Iterate over faces of the tile
+    for (uint32_t face_id = 0; face_id < 4; face_id++) {
+        uint32_t rows_to_process = face_width;
+        uint32_t cols_to_process = face_height;
+
+        // Update for when face intersects the boundary with padding
+        if (has_padding) {
+            get_face_data_range(rows_to_process, cols_to_process, tile_x, tile_y, face_id, ctx);
+        }
+
+        if (rows_to_process == 0 && cols_to_process == 0) {
+            // Face with padding data only
+            continue;
+        }
+
+        // Offset to the face within the tile
+        uint32_t face_offset = face_id * face_size;
+        volatile tt_l1_ptr DTYPE* face_ptr = src_ptr + face_offset;
+
+        // Go over the rows of the face. Update the maximum values in each row.
+        for (uint32_t row = 0; row < rows_to_process; row++) {
+            // Row index in the tile.
+            const uint32_t row_index = (face_id < 2) ? row : row + face_height;
+
+            if (!(row_index < max_size)) {
+                WAYPOINT("AST1");
+                ASSERT(false);
+                continue;
+            }
+
+            DTYPE curr_max = max_values[row_index];
+            uint32_t curr_arg_max = arg_max[row_index];
+
+            // Go over elements in the current row, current face.
+            for (uint32_t col = 0; col < cols_to_process; col++) {
+                // Index within the face
+                uint32_t index = row * face_width + col;
+
+                DTYPE value = face_ptr[index];
+
+                bool new_max = false;
+                if constexpr (format == DataFormat::Float16_b) {
+                    new_max = bfloat16_greater(value, curr_max);
+                } else if constexpr (format == DataFormat::Float32) {
+                    new_max = float32_greater(value, curr_max);
+                }
+
+                if (new_max) {
+                    const bool is_left_side_face = (face_id == 0 || face_id == 2);
+                    const uint32_t new_arg_max = tile_x * ctx.tile_width + (is_left_side_face ? 0 : face_width) + col;
+                    curr_max = value;
+                    curr_arg_max = new_arg_max;
+                }
+            }
+            max_values[row_index] = curr_max;
+            arg_max[row_index] = curr_arg_max;
+        }
+    }
+}
+
+/**
+ * @brief Stores a sequence of argmax values into a staging area.
+ *
+ * @tparam keepdim The keepdim parameter of the ttnn argmax call
+ *
+ * @param[in] new_values Argmax values to be stored
+ * @param[in] count Number of the values to be stored
+ * @param[in] ctx Parameters related to the output tensor
+ *
+ * @note The location of where values are stored is managed by the OutputContext object
+ */
+template <bool keepdim>
+void collect_row_major_output(uint32_t new_values[], uint32_t count, OutputContext& ctx) {
+    const uint32_t curr_collected = ctx.collected_count;
+
+    if constexpr (keepdim) {
+        if (curr_collected + count > ctx.stack_buffer_size) {
+            WAYPOINT("AST2");
+            ASSERT(false);
+            return;
+        }
+    } else {
+        if (curr_collected + count > ctx.write_out_count) {
+            WAYPOINT("AST3");
+            ASSERT(false);
+            return;
+        }
+    }
+
+    auto stack_ptr = ctx.stack_ptr;
+    auto cb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctx.output_cb_addr);
+
+    for (uint32_t idx = 0; idx < count; idx++) {
+        uint32_t write_index = curr_collected + idx;
+        if constexpr (keepdim) {
+            // Accumulate into the on stack array
+            stack_ptr[write_index] = new_values[idx];
+        } else {
+            // Write directly into the output CB
+            cb_ptr[write_index] = new_values[idx];
+        }
+    }
+
+    ctx.collected_count += count;
+}
+
+/**
+ * @brief Writes argmax values to the output tensor
+ *
+ * @tparam AccessorType Type of the output tensor TensorAccessor object
+ * @tparam keepdim The keepdim parameter of the ttnn argmax call
+ *
+ * @param[in] output_accessor TensorAccessor of the output tensor
+ * @param[in] output_ctx Parameters related to the output tensor
+ */
+template <typename AccessorType, bool keepdim>
+void write_to_output(AccessorType& output_accessor, OutputContext& output_ctx) {
+    const uint32_t output_page_elements = output_ctx.write_out_count;
+    uint32_t collected_count = output_ctx.collected_count;
+    uint32_t output_page_id = output_ctx.output_page_id;
+
+    auto dst_cb_addr = output_ctx.output_cb_addr;
+
+    uint32_t sent_count = 0;
+    while (collected_count > 0) {
+        // When keepdim is true, argmax values are accumulated in an on-stack buffer.
+        // Otherwise, argmax values are accumulated directly in the outut CB.
+        if constexpr (keepdim) {
+            auto stack_ptr = output_ctx.stack_ptr;
+            auto dst_cb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr);
+            // Copy one page of output data into the output CB.
+            for (uint32_t idx = 0; idx < output_page_elements; idx++) {
+                dst_cb_ptr[idx] = stack_ptr[sent_count + idx];
+            }
+        }
+
+        const uint32_t write_size = output_page_elements * sizeof(uint32_t);
+        uint64_t dst_noc_addr = get_noc_addr(output_page_id, output_accessor);
+        noc_async_write(dst_cb_addr, dst_noc_addr, write_size);
+
+        sent_count += output_page_elements;
+        collected_count -= output_page_elements;
+        output_page_id++;
+
+        noc_async_write_barrier();
+    }
+
+    output_ctx.collected_count = 0;
+    output_ctx.output_page_id = output_page_id;
+}

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "argmax_tile_layout.hpp"
+#include "argmax_common.hpp"
+#include "accessor/tensor_accessor.h"
+#include "dataflow_api.h"
+
+#include <stdint.h>
+
+void kernel_main() {
+    // Compile time args
+    // -----------------
+    constexpr uint32_t src_cb_idx = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_cb_idx = get_compile_time_arg_val(1);
+
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(3);
+
+    constexpr uint32_t tile_height = get_compile_time_arg_val(4);
+    constexpr uint32_t tile_width = get_compile_time_arg_val(5);
+
+    // Input padded size (last two dims) in tiles
+    constexpr uint32_t input_height = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+
+    // Input logical size (last two dims) in data elements
+    constexpr uint32_t logical_height = get_compile_time_arg_val(8);
+    constexpr uint32_t logical_width = get_compile_time_arg_val(9);
+
+    // Size of all dims combined, excluding the last two dims.
+    constexpr uint32_t outer_dim_size = get_compile_time_arg_val(10);
+
+    constexpr bool reduce_all = (bool)get_compile_time_arg_val(11);
+    constexpr bool keepdim = (bool)get_compile_time_arg_val(12);
+
+    constexpr uint32_t num_c_time_args = 13;
+
+    // Runtime args
+    // ------------
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
+
+    // Tensor Accessors
+    // ----------------
+    constexpr auto s_src_args = TensorAccessorArgs<num_c_time_args>();
+    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
+
+    auto s_src = TensorAccessor(s_src_args, src_base_addr, src_page_size);
+    auto s_dst = TensorAccessor(s_dst_args, dst_base_addr, dst_page_size);
+
+    using dst_accessor_type = decltype(s_dst);
+
+    // CB for input data.
+    const uint32_t src_cb_addr = get_write_ptr(src_cb_idx);
+    constexpr DataFormat src_data_format = get_dataformat(src_cb_idx);
+
+    // CB for output data.
+    const uint32_t dst_cb_addr = get_write_ptr(dst_cb_idx);
+
+    auto default_val = get_default_value<src_data_format>();
+    // C++ type representation of the src/dst data formats
+    using src_element_type = decltype(default_val);
+
+    // This assumes the reduction is along the 'W' dimension
+    src_element_type max_values[tile_height] = {default_val};
+    uint32_t arg_max[tile_height] = {0};
+
+    // Only ROW_MAJOR output layout is supported.
+    //
+    // When keep_dim==true
+    // Each output row contains 1 element. We will accumulate tile_height output rows,
+    // and then write them out in one pass.
+    //
+    // When keep_dim=false
+    // Each output row contains logical_height elements. We will accumulate values
+    // for a single output row, then write all of them out in a single noc message.
+
+    // Number of data elements in one output page (ROW_MAJOR layout)
+    constexpr uint32_t output_page_elements = keepdim ? 1 : logical_height;
+    // Number of data elements to accumulate before writing data to the output tensor.
+    constexpr uint32_t stage_size = keepdim ? tile_height : logical_height;
+    uint32_t accumulated_arg_max[stage_size] = {0};
+
+    const InputContext input_ctx(
+        tile_height,
+        tile_width,
+        input_height,
+        input_width,
+        logical_height,
+        logical_width,
+        src_data_format,
+        src_cb_addr);
+
+    OutputContext output_ctx((uint32_t*)accumulated_arg_max, stage_size, dst_cb_addr, output_page_elements, keepdim);
+
+    // Iterate over the initial dimensions combined together
+    for (uint32_t outer_index = 0; outer_index < outer_dim_size; outer_index++) {
+        // For a given outer index,
+        // iterate over the tiles of the input tensor, in (tile) row-major order.
+        // Each horizontal pass over the input generates tile_height output values,
+        // or 'no more than tile_height' when padding is considered.
+        for (uint32_t i = 0; i < input_height; i++) {
+            // Initialize max values and index buffers
+            for (uint32_t row = 0; row < tile_height; row++) {
+                max_values[row] = default_val;
+                arg_max[row] = 0;
+            }
+
+            // Count output units to be generated in this iteration.
+            constexpr uint32_t height_rem = logical_height % tile_height;
+            uint32_t units_generated = 0;
+            if (height_rem == 0 || i < input_height - 1) {
+                units_generated = tile_height;
+            } else {
+                units_generated = height_rem;
+            }
+
+            for (uint32_t j = 0; j < input_width; j++) {
+                // Number of input tiles in the last two dimensions.
+                constexpr uint32_t inner_size = input_height * input_width;
+                const int src_tile_id = outer_index * inner_size + i * input_width + j;
+
+                // Fetch the next tile
+                const uint64_t src_noc_addr = get_noc_addr(src_tile_id, s_src);
+                noc_async_read(src_noc_addr, src_cb_addr, src_page_size);
+                noc_async_read_barrier();
+
+                process_input_tile<src_element_type, src_data_format>(
+                    input_ctx, j, i, max_values, arg_max, tile_height);
+            }
+
+            // The rate at which argmax values are generated in the loop above
+            // might be different than the rate of writing them out to the output tensor.
+            // Buffer the data into an intermediate storage.
+            collect_row_major_output<keepdim>(arg_max, units_generated, output_ctx);
+
+            if (output_ctx.collected_count >= output_page_elements) {
+                write_to_output<dst_accessor_type, keepdim>(s_dst, output_ctx);
+            }
+        }
+    }
+}
+
+void get_face_data_range(
+    uint32_t& data_rows,
+    uint32_t& data_cols,
+    uint32_t tile_x,
+    uint32_t tile_y,
+    uint32_t face_id,
+    const InputContext& ctx) {
+    const bool is_bottom_tile = tile_y == (ctx.input_height - 1);
+    const bool is_right_most_tile = tile_x == (ctx.input_width - 1);
+
+    // Initialize the range as full face
+    data_rows = face_width;
+    data_cols = face_height;
+
+    // Check if there is any padding data
+    const uint32_t height_rem = ctx.logical_height % ctx.tile_height;
+    const uint32_t width_rem = ctx.logical_width % ctx.tile_width;
+    if (height_rem == 0 && width_rem == 0) {
+        return;
+    }
+
+    if (!is_bottom_tile && !is_right_most_tile) {
+        // Only marginal tiles may contain the padding
+        return;
+    }
+
+    const bool is_right_face = (face_id == 1 || face_id == 3);
+    const bool is_bottom_face = (face_id == 2 || face_id == 3);
+
+    int face_w_rem = 0;
+    int face_h_rem = 0;
+    if (is_bottom_tile || is_right_most_tile) {
+        if (width_rem != 0 || height_rem != 0) {
+            face_w_rem = ctx.logical_width % face_width;
+            face_h_rem = ctx.logical_height % face_height;
+        }
+    }
+
+    if (is_bottom_tile) {
+        if (is_bottom_face) {
+            const bool skip_bottom_face = height_rem != 0 && (height_rem < face_height);
+            if (skip_bottom_face) {
+                data_rows = 0;
+                data_cols = 0;
+                return;
+            }
+            if (height_rem != 0) {
+                data_rows = face_h_rem;
+            }
+        } else {
+            // One of the upper faces
+            if (height_rem != 0 && height_rem < face_height) {
+                data_rows = height_rem;
+            }
+        }
+    }
+
+    if (is_right_most_tile) {
+        if (is_right_face) {
+            const bool skip_right_face = width_rem != 0 && (width_rem < face_width);
+            if (skip_right_face) {
+                data_rows = 0;
+                data_cols = 0;
+                return;
+            }
+            if (width_rem != 0) {
+                data_cols = face_w_rem;
+            }
+        } else {
+            if (width_rem != 0 && width_rem < face_width) {
+                data_cols = face_w_rem;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23005

### Problem description
Argmax operation was missing support for tiled tensor layout.

### What's changed
Tiled tensor support is added by adding a dedicated device kernel, see the reader_argmax_tile_layout.cpp file.
Tile layout is available only with single core. For multicore version, i.e. when use_muticore=True, only row major layout is available. The case of reduce_all (when dim parameter is not given) is not implemented. Only fp32 and bfloat16 data types are supported.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).