### PR TITLE
[skip ci] Instrument ttnn pytests with tt-triage hang detection

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -74,33 +74,33 @@ jobs:
         os: ["ubuntu-22.04"]
         test-group:
           - name: ttnn group 1
-            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"
+            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 2 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 3 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 3 -m "not disable_fast_runtime_mode"
           - name: ttnn group 4
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 4 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 4 -m "not disable_fast_runtime_mode"
           - name: ttnn group 5
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 5 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 5 -m "not disable_fast_runtime_mode"
           - name: ttnn group 6
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 6 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 6 -m "not disable_fast_runtime_mode"
           - name: ttnn group 7
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 7 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 7 -m "not disable_fast_runtime_mode"
           - name: ttnn group 8
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 8 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 8 -m "not disable_fast_runtime_mode"
           - name: ttnn group 9
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 9 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 9 -m "not disable_fast_runtime_mode"
           - name: ttnn group 10
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 10 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 10 -m "not disable_fast_runtime_mode"
           - name: ttnn group 11
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 11 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 11 -m "not disable_fast_runtime_mode"
           - name: ttnn group 12
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 12 -m "not disable_fast_runtime_mode"
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 12 -m "not disable_fast_runtime_mode"
           - name: ttnn notebook
-            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest tests/ttnn/notebook_tests -xv -m "not disable_fast_runtime_mode"
+            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto --timeout 300 tests/ttnn/notebook_tests -xv -m "not disable_fast_runtime_mode"
           - name: ttnn fast runtime off
-            cmd: pytest tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
+            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh

--- a/conftest.py
+++ b/conftest.py
@@ -1033,7 +1033,7 @@ def run_debug_script():
         extra_env = {
             "LD_LIBRARY_PATH": None,
         }
-        debug_result = run_process_and_get_result(f"python {debug_script_path} --active_cores", extra_env)
+        debug_result = run_process_and_get_result(f"python {debug_script_path} --active-cores", extra_env)
 
         logger.info(f"Debug script status: {debug_result.returncode}")
         if debug_result.stdout:

--- a/conftest.py
+++ b/conftest.py
@@ -1021,7 +1021,7 @@ def run_debug_script():
         )
         return
 
-    debug_script_path = os.path.join(".", "tools", "triage", "tt-triage.py")
+    debug_script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tools", "tt-triage.py")
 
     if not os.path.exists(debug_script_path):
         logger.warning(f"Debug script not found at {debug_script_path}. Skipping debug collection.")

--- a/conftest.py
+++ b/conftest.py
@@ -960,53 +960,44 @@ def pytest_runtest_teardown(item, nextitem):
             reset_tensix(set(item.pci_ids))
 
 
-# This is overriding the timer setup hook from pytest-timeout
-# If --metal-timeout is passed, we define a new timeout method that spawns a timer process
-# At timeout, the process kills it's parent (the test process) and then itself
+def _metal_alarm_handler(signum, frame):
+    """Alarm handler for test timeouts; collects debug info then force-kills the process."""
+    try:
+        logger.warning("This test seems to have hung... Timing out test case")
+        run_debug_script()
+    except Exception as e:
+        logger.error(f"Failed to run debug script after timeout: {e}")
+    finally:
+        # Ensure the process is terminated even if debug collection fails
+        os.kill(os.getpid(), signal.SIGKILL)
+
+
+# This overrides the timer setup hook from pytest-timeout.
+# If --metal-timeout is passed or when using xdist, we arm a POSIX itimer.
+# On expiry, the alarm handler runs debug collection and kills the process.
 @pytest.hookimpl(tryfirst=True)
 def pytest_timeout_set_timer(item, settings):
     metal_timeout_enabled = item.config.getoption("--metal-timeout")
     using_xdist = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", "0"))
 
     if metal_timeout_enabled is not None or using_xdist:
-        parent_pid = os.getpid()
-        logger.info(f"Metal timeout {settings.timeout} seconds {parent_pid} for {item.nodeid}")
+        current_pid = os.getpid()
+        logger.info(f"Metal timeout {settings.timeout} seconds {current_pid} for {item.nodeid}")
 
-        def get_parent_status():
-            try:
-                parent = psutil.Process(parent_pid)
-            except:
-                return "already dead"
-            return parent.status()
+        # Install handler (idempotent is fine)
+        signal.signal(signal.SIGALRM, _metal_alarm_handler)
 
-        def run_timer(settings):
-            logger.info(f"Timer started for {item.nodeid}")
-            dead_status = ["zombie", "dead", "already dead"]
-            timeout = settings.timeout
-            parent_status = "running"
-            while parent_status not in dead_status and timeout > 0:
-                time.sleep(5)
-                timeout -= 5
-                parent_status = get_parent_status()
-            if parent_status != "already dead":
-                logger.warning(f"This test seems to have hung... Timing out test case")
-                # Run debug script before killing the test process
-                try:
-                    run_debug_script()
-                except Exception as e:
-                    logger.error(f"Failed to run debug script after timeout: {e}")
+        # Arm the REAL timer for this test
+        secs = float(settings.timeout)
+        signal.setitimer(signal.ITIMER_REAL, secs, 0.0)
 
-                os.kill(parent_pid, signal.SIGKILL)
-            logger.info(f"Killing timer")
-            os._exit(1)
-
+        # Provide a canceller for pytest-timeout
         def cancel():
-            logger.info(f"Cancelling timer")
-            metal_timer.terminate()
+            logger.info("Cancelling timer")
+            # Disarm the timer
+            signal.setitimer(signal.ITIMER_REAL, 0.0, 0.0)
 
-        metal_timer = multiprocess.Process(target=run_timer, args=(settings,), daemon=True)
         item.cancel_timeout = cancel
-        metal_timer.start()
     return True
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1021,7 +1021,7 @@ def run_debug_script():
         )
         return
 
-    debug_script_path = os.path.join(os.getenv("TT_METAL_HOME", "."), "tools", "triage", "tt-triage.py")
+    debug_script_path = os.path.join(".", "tools", "triage", "tt-triage.py")
 
     if not os.path.exists(debug_script_path):
         logger.warning(f"Debug script not found at {debug_script_path}. Skipping debug collection.")

--- a/conftest.py
+++ b/conftest.py
@@ -982,7 +982,7 @@ def pytest_timeout_set_timer(item, settings):
 
     if metal_timeout_enabled is not None or using_xdist:
         current_pid = os.getpid()
-        logger.info(f"Metal timeout {settings.timeout} seconds {current_pid} for {item.nodeid}")
+        logger.debug(f"Metal timeout {settings.timeout} seconds {current_pid} for {item.nodeid}")
 
         # Install handler (idempotent is fine)
         signal.signal(signal.SIGALRM, _metal_alarm_handler)
@@ -993,7 +993,7 @@ def pytest_timeout_set_timer(item, settings):
 
         # Provide a canceller for pytest-timeout
         def cancel():
-            logger.info("Cancelling timer")
+            logger.debug("Cancelling timer")
             # Disarm the timer
             signal.setitimer(signal.ITIMER_REAL, 0.0, 0.0)
 

--- a/tests/ttnn/unit_tests/test_copy.py
+++ b/tests/ttnn/unit_tests/test_copy.py
@@ -19,6 +19,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 def test_copy(shape, layout, dtype, device):
     torch.manual_seed(2005)
     torch_dtype = torch.int32
+    print("INFINITE LOOP")
+    while True:
+        continue
 
     input = torch.randint(1, 100, shape, dtype=torch_dtype)
     input = ttnn.from_torch(input, dtype, layout=layout, device=device)

--- a/tests/ttnn/unit_tests/test_copy.py
+++ b/tests/ttnn/unit_tests/test_copy.py
@@ -19,9 +19,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 def test_copy(shape, layout, dtype, device):
     torch.manual_seed(2005)
     torch_dtype = torch.int32
-    print("INFINITE LOOP")
-    while True:
-        continue
 
     input = torch.randint(1, 100, shape, dtype=torch_dtype)
     input = ttnn.from_torch(input, dtype, layout=layout, device=device)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### PR Description

This PR refactors the pytest timeout mechanism for ttnn tests from a process-based approach to a signal-based approach using POSIX timers. It also adds parallel execution and timeout settings to GitHub workflow commands.

- Replaces multiprocess timer with POSIX SIGALRM signal handling for better reliability
- Adds `-n auto` (parallel execution) and `--timeout 300` to all ttnn pytest commands in CI
- Simplifies timeout cancellation logic by disarming the signal timer

THIS SOLUTION PROVIDES 3X Performance Improvement

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18232243151) CI passes
- [x] [It actually works for a hang see ttnn pytests group 1](https://github.com/tenstorrent/tt-metal/actions/runs/18246133945)
- [x] New/Existing tests provide coverage for changes