### PR TITLE
Add prefill mode in deepseek demo

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -57,6 +57,12 @@ def create_parser() -> argparse.ArgumentParser:
         type=int,
         help="Teacher-forcing prompt length in tokens (from reference file). Defaults to half+1 if omitted.",
     )
+    p.add_argument(
+        "--early_print_first_user",
+        action="store_true",
+        default=False,
+        help="Print generated tokens for the first user token as they are produced, instead of waiting until the end.",
+    )
     return p
 
 
@@ -110,6 +116,7 @@ def run_demo(
     token_accuracy: bool = False,
     reference_file: str | Path | None = None,
     tf_prompt_len: int | None = None,
+    early_print_first_user: bool = True,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -195,6 +202,7 @@ def run_demo(
             prompts,
             max_new_tokens=max_new_tokens,
             teacher_forcing=token_acc,
+            early_print_first_user=early_print_first_user,
         )
         result = {"tokens": generations[0], "text": None}
         if gen.tokenizer is not None:
@@ -228,15 +236,17 @@ def main() -> None:
         token_accuracy=bool(args.token_accuracy),
         reference_file=args.reference_file,
         tf_prompt_len=args.tf_prompt_len,
+        early_print_first_user=args.early_print_first_user,
     )
 
-    print("\n===== Generated =====\n")
-    if result.get("text") is not None:
-        print(result["text"])  # type: ignore
-    else:
-        print("[random-weights mode] token IDs:")
-        print(result["tokens"])  # type: ignore
-    print("\n=====================\n")
+    if not args.early_print_first_user:
+        print("\n===== Generated =====\n")
+        if result.get("text") is not None:
+            print(result["text"])  # type: ignore
+        else:
+            print("[random-weights mode] token IDs:")
+            print(result["tokens"])  # type: ignore
+        print("\n=====================\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29488

### Problem description
So far, we were doing prefill using a loop with decode. Now this PR adds support for doing prefill in correct way.

Prompt: Summarize the history of RISC architectures.

Generation: 
Okay, the user asked me to summarize the history of RISC architectures. This seems like a straightforward request about computer architecture history, likely from a student, tech enthusiast, or professional brushing up on fundamentals. They probably want a concise yet comprehensive timeline rather than deep technical dives. 

Hmm, I should start by clarifying what RISC even means—it's easy to forget how revolutionary "Reduced Instruction Set" was when everything ran on complex CISC designs. The classic Berkeley vs Stanford rivalry makes for a good narrative hook too. 

Wait, should I mention the precursors like IBM 801? Yes, absolutely—it shows this wasn't just academia but had industry roots. And Seymour Cray's CDC designs! That'll surprise people who think RISC=1980s. 

For the 80s boom, listing actual chips (SPARC, MIPS, POWER) makes it tangible. Oh, and ARM's humble beginnings—funny to contrast with its current dominance.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes