### PR TITLE
[skip ci] Update timeouts in ttsim.yaml

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -91,7 +91,7 @@ jobs:
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Build and Run Metal Examples
-        timeout-minutes: 15
+        timeout-minutes: 2
         run: |
           working_examples=(
             "add_2_integers_in_compute"
@@ -177,6 +177,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Run TTNN Pytests
+        timeout-minutes: 5
         run: |
           pytest \
             tests/ttnn/unit_tests/operations/ccl/blackhole_CI/all_post_commit/test_all_gather_apc.py \

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -91,7 +91,7 @@ jobs:
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Build and Run Metal Examples
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           working_examples=(
             "add_2_integers_in_compute"


### PR DESCRIPTION
### Ticket
NA

# Pull Request Overview
This PR updates timeout configurations in the ttsim.yaml GitHub Actions workflow file. The changes adjust existing timeout values and add a new timeout for better CI pipeline management.

Reduced timeout for "Build and Run Metal Examples" step from 15 to 3 minutes
Added a new 5-minute timeout for the "Run TTNN Pytests" step