### PR TITLE
Fix firmware cache key to account for erisc_iram toggling (#27810)

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -26,6 +26,10 @@ foreach(PROTO_FILE ${PROTO_SCHEMAS})
     list(APPEND GENERATED_PROTO_SRCS ${PROTO_SRCS})
 endforeach()
 
+# Ensure protobufs are generated before compiling the executable
+add_custom_target(scaleout_generated_protos DEPENDS ${GENERATED_PROTO_SRCS})
+add_dependencies(run_cluster_validation scaleout_generated_protos)
+
 # TODO: Should refactor into an API directory
 target_sources(
     scaleout_tools

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -26,10 +26,6 @@ foreach(PROTO_FILE ${PROTO_SCHEMAS})
     list(APPEND GENERATED_PROTO_SRCS ${PROTO_SRCS})
 endforeach()
 
-# Ensure protobufs are generated before compiling the executable
-add_custom_target(scaleout_generated_protos DEPENDS ${GENERATED_PROTO_SRCS})
-add_dependencies(run_cluster_validation scaleout_generated_protos)
-
 # TODO: Should refactor into an API directory
 target_sources(
     scaleout_tools

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -56,8 +56,6 @@ class DispatcherData:
     def __init__(self, inspector_data: InspectorData, context: Context, elfs_cache: ElfsCache, run_checks: RunChecks):
         self.inspector_data = inspector_data
         self.programs = inspector_data.getPrograms().programs
-        if self.programs is None or len(self.programs) == 0:
-            raise TTTriageError("No programs found in inspector data.")
         self.kernels = {kernel.watcherKernelId: kernel for program in self.programs for kernel in program.kernels}
         self.use_rpc_kernel_find = True
         if len(self.kernels) == 0:

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -295,7 +295,7 @@ class DispatcherData:
         elif proc_name.lower() == "erisc1":
             firmware_path = os.path.join(build_env.firmwarePath, "subordinate_idle_erisc", "subordinate_idle_erisc.elf")
         else:
-            firmware_path = os.path.join(build_env.firmwarePath, f"{proc_name.lower()}/{proc_name.lower()}.elf")
+            firmware_path = os.path.join(build_env.firmwarePath, proc_name.lower(), f"{proc_name.lower()}.elf")
         firmware_path = os.path.realpath(firmware_path)
 
         if kernel:

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -61,8 +61,25 @@ class DispatcherData:
         if len(self.kernels) == 0:
             raise TTTriageError("No kernels found in inspector data.")
         self._a_kernel_path = next(iter(self.kernels.values())).path
-        brisc_elf_path = DispatcherData.get_firmware_elf_path(self._a_kernel_path, "brisc")
-        idle_erisc_elf_path = DispatcherData.get_firmware_elf_path(self._a_kernel_path, "idle_erisc")
+        # Cache build_env per device to avoid multiple RPC calls
+        # Each device needs to have its own build_env to get the correct firmware path
+        self._build_env_cache = {}
+
+        # Get the firmware paths from Inspector RPC build environment instead of relative paths
+        # This ensures correct firmware paths for all devices and build configs
+        try:
+            device_id = 0
+            self._build_env_cache[device_id] = inspector_data.getBuildEnv(deviceId=device_id).buildInfo
+            brisc_elf_path = os.path.join(self._build_env_cache[device_id].firmwarePath, "brisc", "brisc.elf")
+            idle_erisc_elf_path = os.path.join(
+                self._build_env_cache[device_id].firmwarePath, "idle_erisc", "idle_erisc.elf"
+            )
+        except Exception as e:
+            raise TTTriageError(
+                f"Failed to get firmware path from Inspector RPC: {e}\n"
+                "Make sure Inspector RPC is available or serialized RPC data exists.\n"
+                "Set TT_METAL_INSPECTOR_RPC=1 when running your Metal application."
+            )
 
         # Check if firmware elf paths exist
         if not os.path.exists(brisc_elf_path):
@@ -133,6 +150,12 @@ class DispatcherData:
         }
         self._launch_msg_buffer_num_entries = get_const_value("launch_msg_buffer_num_entries")
 
+    def _get_build_env_for_device(self, device_id: int):
+        """Get build_env for a specific device, with caching"""
+        if device_id not in self._build_env_cache:
+            self._build_env_cache[device_id] = self.inspector_data.getBuildEnv(deviceId=device_id).buildInfo
+        return self._build_env_cache[device_id]
+
     def find_kernel(self, watcher_kernel_id):
         # Try to get kernel from RPC inspector data first, then fallback to cached kernels
         # RPC kernel find won't work if we are not connected to RPC, but are reading serialized data or logs
@@ -159,6 +182,13 @@ class DispatcherData:
             programmable_core_type = self._ProgrammableCoreTypes_IDLE_ETH
             enum_values = self._enum_values_eth
 
+        # Get the build_env for the device to get the correct firmware path
+        # Each device may have different firmware paths based on its build configuration
+        device_id = location._device._id
+        try:
+            build_env = self._get_build_env_for_device(device_id)
+        except Exception as e:
+            raise TTTriageError(f"Cannot get firmware path for device {device_id}: {e}")
         proc_name = risc_name.upper()
         proc_type = enum_values["ProcessorTypes"][proc_name]
 
@@ -258,12 +288,14 @@ class DispatcherData:
         except:
             pass
 
+        # Construct the firmware path from the build_env instead of relative paths
+        # This ensures we get the correct firmware path for this device and build config
         if proc_name.lower() == "erisc" or proc_name.lower() == "erisc0":
-            firmware_path = self._a_kernel_path + "../../../firmware/idle_erisc/idle_erisc.elf"
+            firmware_path = os.path.join(build_env.firmwarePath, "idle_erisc", "idle_erisc.elf")
         elif proc_name.lower() == "erisc1":
-            firmware_path = self._a_kernel_path + "../../../firmware/subordinate_idle_erisc/subordinate_idle_erisc.elf"
+            firmware_path = os.path.join(build_env.firmwarePath, "subordinate_idle_erisc", "subordinate_idle_erisc.elf")
         else:
-            firmware_path = self._a_kernel_path + f"../../../firmware/{proc_name.lower()}/{proc_name.lower()}.elf"
+            firmware_path = os.path.join(build_env.firmwarePath, f"{proc_name.lower()}/{proc_name.lower()}.elf")
         firmware_path = os.path.realpath(firmware_path)
 
         if kernel:

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -56,6 +56,8 @@ class DispatcherData:
     def __init__(self, inspector_data: InspectorData, context: Context, elfs_cache: ElfsCache, run_checks: RunChecks):
         self.inspector_data = inspector_data
         self.programs = inspector_data.getPrograms().programs
+        if self.programs is None or len(self.programs) == 0:
+            raise TTTriageError("No programs found in inspector data.")
         self.kernels = {kernel.watcherKernelId: kernel for program in self.programs for kernel in program.kernels}
         self.use_rpc_kernel_find = True
         if len(self.kernels) == 0:

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -174,9 +174,11 @@ void MetalContext::initialize(
         // fw_build_key is a combination of build_key and fw_compile_hash
         // If fw_compile_hash changes, the fw_build_key will change and FW will be rebuilt
         // if it's not already in firmware_built_keys_
+        // Note: Truncate fw_compile_hash to 32 bits to match the hash used in firmware paths
+        // and prevent corruption when bit-packing into the 64-bit fw_build_key
         uint64_t fw_build_key =
             (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key) << 32) |
-            static_cast<uint64_t>(fw_compile_hash);
+            static_cast<uint32_t>(fw_compile_hash);
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -110,23 +110,8 @@ void MetalContext::initialize(
 
     // Initialize inspector
     inspector_data_ = Inspector::initialize();
-
-    // Inspector RPC callback registration for getting build environment info
-    // This allows Inspector clients (e.g. tt-triage) to get the correct firmware path
-    // for each device and build config, enabling correct firmware path resolution
-    // without relying on relative paths
-    Inspector::get_rpc_server().setGetBuildEnvCallback([fw_compile_hash](auto params, auto results) {
-        const auto device_id = params.getDeviceId();
-        // Get device-specific firmware path from BuildEnvManager
-        const auto& firmware_path = BuildEnvManager::get_instance().get_out_firmware_root_path(device_id);
-        const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device_id);
-
-        // Populate RPC response with build environment info
-        auto build_info = results.initBuildInfo();
-        build_info.setBuildKey(build_env.build_key);
-        build_info.setFirmwarePath(firmware_path);
-        build_info.setFwCompileHash(fw_compile_hash);
-    });
+    // Set fw_compile_hash for Inspector RPC build environment info
+    Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
 
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -109,8 +109,6 @@ void MetalContext::initialize(
 
     // Initialize inspector
     inspector_data_ = Inspector::initialize();
-    // Set fw_compile_hash for Inspector RPC build environment info
-    Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
 
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
@@ -155,14 +153,7 @@ void MetalContext::initialize(
 
         // Create build env for this device, and build FW if it's not built already
         BuildEnvManager::get_instance().add_build_env(device_id, num_hw_cqs_);
-        // fw_build_key is a combination of build_key and fw_compile_hash
-        // If fw_compile_hash changes, the fw_build_key will change and FW will be rebuilt
-        // if it's not already in firmware_built_keys_
-        // Combine build_key and fw_compile_hash using XOR to create unique firmware build key
-        // Uses full 64-bit fw_compile_hash for proper change detection
-        uint64_t fw_build_key =
-            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key)) ^
-            fw_compile_hash;
+        uint32_t fw_build_key = BuildEnvManager::get_instance().get_device_build_env(device_id).build_key;
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -13,6 +13,7 @@
 #include "dispatch/dispatch_settings.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
+#include "impl/debug/inspector/rpc_server_generated.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -110,6 +110,8 @@ void MetalContext::initialize(
 
     // Initialize inspector
     inspector_data_ = Inspector::initialize();
+    // Set fw_compile_hash for Inspector RPC build environment info
+    Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
 
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
@@ -154,7 +156,14 @@ void MetalContext::initialize(
 
         // Create build env for this device, and build FW if it's not built already
         BuildEnvManager::get_instance().add_build_env(device_id, num_hw_cqs_);
-        uint32_t fw_build_key = BuildEnvManager::get_instance().get_device_build_env(device_id).build_key;
+        // fw_build_key is a combination of build_key and fw_compile_hash
+        // If fw_compile_hash changes, the fw_build_key will change and FW will be rebuilt
+        // if it's not already in firmware_built_keys_
+        // Combine build_key and fw_compile_hash using XOR to create unique firmware build key
+        // Uses full 64-bit fw_compile_hash for proper change detection
+        uint64_t fw_build_key =
+            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key)) ^
+            fw_compile_hash;
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -13,7 +13,6 @@
 #include "dispatch/dispatch_settings.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
-#include "impl/debug/inspector/rpc_server_generated.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -74,7 +74,7 @@ void MetalContext::initialize(
         force_reinit_ = true;
     }
     // Settings that affect FW build can also trigger a re-initialization
-    auto fw_compile_hash = std::hash<std::string>{}(rtoptions_.get_compile_hash_string());
+    const size_t fw_compile_hash = std::hash<std::string>{}(rtoptions_.get_compile_hash_string());
     validate_worker_l1_size(worker_l1_size, *hal_);
     if (initialized_) {
         if (dispatch_core_config_ != dispatch_core_config or num_hw_cqs != num_hw_cqs_ or
@@ -174,11 +174,11 @@ void MetalContext::initialize(
         // fw_build_key is a combination of build_key and fw_compile_hash
         // If fw_compile_hash changes, the fw_build_key will change and FW will be rebuilt
         // if it's not already in firmware_built_keys_
-        // Note: Truncate fw_compile_hash to 32 bits to match the hash used in firmware paths
-        // and prevent corruption when bit-packing into the 64-bit fw_build_key
+        // Combine build_key and fw_compile_hash using XOR to create unique firmware build key
+        // Uses full 64-bit fw_compile_hash for proper change detection
         uint64_t fw_build_key =
-            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key) << 32) |
-            static_cast<uint32_t>(fw_compile_hash);
+            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key)) ^
+            fw_compile_hash;
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -153,7 +153,12 @@ void MetalContext::initialize(
 
         // Create build env for this device, and build FW if it's not built already
         BuildEnvManager::get_instance().add_build_env(device_id, num_hw_cqs_);
-        uint32_t fw_build_key = BuildEnvManager::get_instance().get_device_build_env(device_id).build_key;
+        // fw_build_key is a combination of build_key and fw_compile_hash
+        // If fw_compile_hash changes, the fw_build_key will change and FW will be rebuilt
+        uint64_t fw_build_key =
+            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key) << 32) |
+            static_cast<uint64_t>(fw_compile_hash);
+
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);
             firmware_built_keys_.insert(fw_build_key);

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -150,7 +150,7 @@ private:
     size_t fw_compile_hash_ = 0;  // To check if FW recompilation is needed
 
     // Used to track which FW has been built already
-    std::unordered_set<uint32_t> firmware_built_keys_;
+    std::unordered_set<uint64_t> firmware_built_keys_;
 
     // Written to device as part of FW init, device-specific
     std::unordered_map<chip_id_t, std::vector<int32_t>> dram_bank_offset_map_;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -150,7 +150,7 @@ private:
     size_t fw_compile_hash_ = 0;  // To check if FW recompilation is needed
 
     // Used to track which FW has been built already
-    std::unordered_set<uint64_t> firmware_built_keys_;
+    std::unordered_set<uint32_t> firmware_built_keys_;
 
     // Written to device as part of FW init, device-specific
     std::unordered_map<chip_id_t, std::vector<int32_t>> dram_bank_offset_map_;

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -8,6 +8,7 @@
 #include "impl/debug/inspector/logger.hpp"
 #include "impl/context/metal_context.hpp"
 #include "distributed/mesh_workload_impl.hpp"
+#include "jit_build/build_env_manager.hpp"
 
 namespace tt::tt_metal::inspector {
 
@@ -28,6 +29,9 @@ Data::Data()
             get_rpc_server().setGetMeshWorkloadsCallback([this](auto result) { this->rpc_get_mesh_workloads(result); });
             get_rpc_server().setGetDevicesInUseCallback([this](auto result) { this->rpc_get_devices_in_use(result); });
             get_rpc_server().setGetKernelCallback([this](auto params, auto result) { this->rpc_get_kernel(params, result); });
+            get_rpc_server().setGetBuildEnvCallback(
+                [this](auto params, auto result) { this->rpc_get_build_env(params, result); });
+            get_rpc_server().setGetAllBuildEnvsCallback([this](auto result) { this->rpc_get_all_build_envs(result); });
         } catch (const std::exception& e) {
             TT_INSPECTOR_THROW("Failed to start Inspector RPC server: {}", e.what());
         }
@@ -205,6 +209,77 @@ void Data::rpc_get_kernel(rpc::Inspector::GetKernelParams::Reader params, rpc::I
     kernel.setPath(kernel_data.path);
     kernel.setSource(kernel_data.source);
     kernel.setProgramId(program_id);
+}
+
+// Get build environment information for a specific device
+// This allows Inspector clients (e.g. tt-triage) to get the correct firmware path
+// for each device and build config, enabling correct firmware path resolution
+// without relying on relative paths
+// Declared here in Data to centralize Inspector RPC callback registration and
+// tie it to Inspector Data's lifetime
+void Data::rpc_get_build_env(
+    rpc::Inspector::GetBuildEnvParams::Reader params, rpc::Inspector::GetBuildEnvResults::Builder results) {
+    const auto device_id = params.getDeviceId();
+    // Get device-specific firmware path from BuildEnvManager
+    // Calls to BuildEnvManager are thread-safe as its getters are protected by an internal mutex
+    const auto& firmware_path = BuildEnvManager::get_instance().get_out_firmware_root_path(device_id);
+    const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device_id);
+    const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);
+
+    // Populate RPC response with build environment info
+    auto build_info = results.initBuildInfo();
+    build_info.setBuildKey(build_env.build_key);
+    build_info.setFirmwarePath(firmware_path);
+    build_info.setFwCompileHash(fw_compile_hash);
+}
+
+// Get build environment information for all devices
+void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builder results) {
+    std::scoped_lock locks(programs_mutex, mesh_devices_mutex, mesh_workloads_mutex);
+    std::set<uint64_t> device_ids;
+
+    // First add all devices from mesh workloads
+    for (const auto& [mesh_workload_id, mesh_workload_data] : mesh_workloads_data) {
+        for (const auto& [mesh_device_id, status] : mesh_workload_data.binary_status_per_device) {
+            if (status != ProgramBinaryStatus::NotSent) {
+                auto mesh_device_it = mesh_devices_data.find(mesh_device_id);
+                if (mesh_device_it != mesh_devices_data.end()) {
+                    auto* mesh_device = mesh_device_it->second.mesh_device;
+                    for (auto& device : mesh_device->get_devices()) {
+                        device_ids.insert(static_cast<uint64_t>(device->id()));
+                    }
+                }
+            }
+        }
+    }
+
+    // Add all devices from programs
+    for (const auto& [program_id, program_data] : programs_data) {
+        for (const auto& [device_id, status] : program_data.binary_status_per_device) {
+            if (status != ProgramBinaryStatus::NotSent) {
+                device_ids.insert(static_cast<uint64_t>(device_id));
+            }
+        }
+    }
+
+    // Populate RPC response with build environment info for all devices
+    auto result_build_envs = results.initBuildEnvs(device_ids.size());
+    size_t i = 0;
+    for (const auto& device_id : device_ids) {
+        auto item = result_build_envs[i++];
+        item.setDeviceId(device_id);
+        // Get device-specific firmware path from BuildEnvManager
+        // Calls to BuildEnvManager are thread-safe as its getters are protected by an internal mutex
+        const auto& firmware_path = BuildEnvManager::get_instance().get_out_firmware_root_path(device_id);
+        const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device_id);
+        const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);
+
+        // Populate RPC response with build environment info
+        auto build_info = item.initBuildInfo();
+        build_info.setBuildKey(build_env.build_key);
+        build_info.setFirmwarePath(firmware_path);
+        build_info.setFwCompileHash(fw_compile_hash);
+    }
 }
 
 // Helper function to convert internal enum to Cap'n Proto enum

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -222,7 +222,6 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
     const auto& build_envs_info = BuildEnvManager::get_instance().get_all_build_envs_info();
     // Populate RPC response with build environment info for all devices
     auto result_build_envs = results.initBuildEnvs(build_envs_info.size());
-    const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);
     size_t i = 0;
     for (const auto& build_env : build_envs_info) {
         auto item = result_build_envs[i++];
@@ -231,7 +230,6 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
         auto build_info = item.initBuildInfo();
         build_info.setBuildKey(build_env.build_key);
         build_info.setFirmwarePath(build_env.firmware_root_path);
-        build_info.setFwCompileHash(fw_compile_hash);
     }
 }
 

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -222,6 +222,7 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
     const auto& build_envs_info = BuildEnvManager::get_instance().get_all_build_envs_info();
     // Populate RPC response with build environment info for all devices
     auto result_build_envs = results.initBuildEnvs(build_envs_info.size());
+    const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);
     size_t i = 0;
     for (const auto& build_env : build_envs_info) {
         auto item = result_build_envs[i++];
@@ -230,6 +231,7 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
         auto build_info = item.initBuildInfo();
         build_info.setBuildKey(build_env.build_key);
         build_info.setFirmwarePath(build_env.firmware_root_path);
+        build_info.setFwCompileHash(fw_compile_hash);
     }
 }
 

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -22,9 +22,8 @@ private:
     void rpc_get_mesh_devices(rpc::Inspector::GetMeshDevicesResults::Builder& results);
     void rpc_get_mesh_workloads(rpc::Inspector::GetMeshWorkloadsResults::Builder& results);
     void rpc_get_devices_in_use(rpc::Inspector::GetDevicesInUseResults::Builder& results);
-    void rpc_get_kernel(rpc::Inspector::GetKernelParams::Reader params, rpc::Inspector::GetKernelResults::Builder results);
-    void rpc_get_build_env(
-        rpc::Inspector::GetBuildEnvParams::Reader params, rpc::Inspector::GetBuildEnvResults::Builder results);
+    void rpc_get_kernel(
+        rpc::Inspector::GetKernelParams::Reader params, rpc::Inspector::GetKernelResults::Builder results);
     void rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builder results);
 
     static rpc::BinaryStatus convert_binary_status(ProgramBinaryStatus status);

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -38,8 +38,6 @@ private:
     std::unordered_map<int, inspector::MeshDeviceData> mesh_devices_data{};
     std::unordered_map<uint64_t, inspector::MeshWorkloadData> mesh_workloads_data{};
 
-    // fw_compile_hash needs to be atomic because it is set in MetalContext::initialize()
-    std::atomic<uint64_t> fw_compile_hash{};
     friend class tt::tt_metal::Inspector;
 };
 

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -38,6 +38,8 @@ private:
     std::unordered_map<int, inspector::MeshDeviceData> mesh_devices_data{};
     std::unordered_map<uint64_t, inspector::MeshWorkloadData> mesh_workloads_data{};
 
+    // fw_compile_hash needs to be atomic because it is set in MetalContext::initialize()
+    std::atomic<uint64_t> fw_compile_hash{};
     friend class tt::tt_metal::Inspector;
 };
 

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -23,6 +23,9 @@ private:
     void rpc_get_mesh_workloads(rpc::Inspector::GetMeshWorkloadsResults::Builder& results);
     void rpc_get_devices_in_use(rpc::Inspector::GetDevicesInUseResults::Builder& results);
     void rpc_get_kernel(rpc::Inspector::GetKernelParams::Reader params, rpc::Inspector::GetKernelResults::Builder results);
+    void rpc_get_build_env(
+        rpc::Inspector::GetBuildEnvParams::Reader params, rpc::Inspector::GetBuildEnvResults::Builder results);
+    void rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builder results);
 
     static rpc::BinaryStatus convert_binary_status(ProgramBinaryStatus status);
 
@@ -36,6 +39,8 @@ private:
     std::unordered_map<int, inspector::MeshDeviceData> mesh_devices_data{};
     std::unordered_map<uint64_t, inspector::MeshWorkloadData> mesh_workloads_data{};
 
+    // fw_compile_hash needs to be atomic because it is set in MetalContext::initialize()
+    std::atomic<uint64_t> fw_compile_hash{};
     friend class tt::tt_metal::Inspector;
 };
 

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -303,4 +303,16 @@ inspector::RpcServer& Inspector::get_rpc_server() {
     return empty_rpc_server;
 }
 
+void Inspector::set_build_env_fw_compile_hash(const uint64_t fw_compile_hash) {
+    if (!is_enabled()) {
+        return;
+    }
+    try {
+        auto* data = get_inspector_data();
+        data->fw_compile_hash.store(fw_compile_hash, std::memory_order_release);
+    } catch (const std::exception& e) {
+        TT_INSPECTOR_LOG("Failed to set FW compile hash: {}", e.what());
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -302,17 +302,4 @@ inspector::RpcServer& Inspector::get_rpc_server() {
     static inspector::RpcServer empty_rpc_server;
     return empty_rpc_server;
 }
-
-void Inspector::set_build_env_fw_compile_hash(const uint64_t fw_compile_hash) {
-    if (!is_enabled()) {
-        return;
-    }
-    try {
-        auto* data = get_inspector_data();
-        data->fw_compile_hash.store(fw_compile_hash, std::memory_order_release);
-    } catch (const std::exception& e) {
-        TT_INSPECTOR_LOG("Failed to set FW compile hash: {}", e.what());
-    }
-}
-
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -302,4 +302,17 @@ inspector::RpcServer& Inspector::get_rpc_server() {
     static inspector::RpcServer empty_rpc_server;
     return empty_rpc_server;
 }
+
+void Inspector::set_build_env_fw_compile_hash(const uint64_t fw_compile_hash) {
+    if (!is_enabled()) {
+        return;
+    }
+    try {
+        auto* data = get_inspector_data();
+        data->fw_compile_hash.store(fw_compile_hash, std::memory_order_release);
+    } catch (const std::exception& e) {
+        TT_INSPECTOR_LOG("Failed to set FW compile hash: {}", e.what());
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -58,6 +58,8 @@ public:
         const distributed::MeshWorkloadImpl* mesh_workload, std::size_t mesh_id, ProgramBinaryStatus status) noexcept;
 
     static inspector::RpcServer& get_rpc_server();
+
+    static void set_build_env_fw_compile_hash(const uint64_t fw_compile_hash);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -58,8 +58,6 @@ public:
         const distributed::MeshWorkloadImpl* mesh_workload, std::size_t mesh_id, ProgramBinaryStatus status) noexcept;
 
     static inspector::RpcServer& get_rpc_server();
-
-    static void set_build_env_fw_compile_hash(const uint64_t fw_compile_hash);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -59,7 +59,7 @@ public:
 
     static inspector::RpcServer& get_rpc_server();
 
-    static void set_build_env_fw_compile_hash(const uint64_t fw_compile_hash);
+    static void set_build_env_fw_compile_hash(uint64_t fw_compile_hash);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -96,11 +96,9 @@ interface Inspector {
     # Search for a kernel
     getKernel @4 (watcherKernelId :Int32) -> (kernel :KernelData);
 
-    # Get build environment information for a specific device
+    # Get build environment information for all devices
     # Returns device-specific firmware paths and build configuration.
     # This replaces the old approach of constructing relative paths,
     # providing correct firmware locations for each device
-    getBuildEnv @5 (deviceId :UInt64) -> (buildInfo :BuildEnvData);
-
-    getAllBuildEnvs @6 () -> (buildEnvs :List(BuildEnvPerDevice));
+    getAllBuildEnvs @5 () -> (buildEnvs :List(BuildEnvPerDevice));
 }

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -72,6 +72,7 @@ struct MeshWorkloadData {
 struct BuildEnvData {
     buildKey @0 :UInt32; # Unique identifier for the build configuration
     firmwarePath @1 :Text; # Absolute path to the firmware directory for this device
+    fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
 }
 
 struct BuildEnvPerDevice {

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -72,7 +72,6 @@ struct MeshWorkloadData {
 struct BuildEnvData {
     buildKey @0 :UInt32; # Unique identifier for the build configuration
     firmwarePath @1 :Text; # Absolute path to the firmware directory for this device
-    fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
 }
 
 struct BuildEnvPerDevice {

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -65,6 +65,16 @@ struct MeshWorkloadData {
     binaryStatusPerMeshDevice @2 :List(MeshDeviceBinaryStatus);
 }
 
+# Build environment info for a specific device
+# Used to get correct firmware path for each device and build config,
+# enabling correct firmware path resolution without relying on relative
+# paths
+struct BuildEnvData {
+    buildKey @0 :UInt32; # Unique identifier for the build configuration
+    firmwarePath @1 :Text; # Absolute path to the firmware directory for this device
+    fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
+}
+
 interface Inspector {
     # Get programs currently alive
     getPrograms @0 () -> (programs :List(ProgramData));
@@ -80,4 +90,10 @@ interface Inspector {
 
     # Search for a kernel
     getKernel @4 (watcherKernelId :Int32) -> (kernel :KernelData);
+
+    # Get build environment information for a specific device
+    # Returns device-specific firmware paths and build configuration.
+    # This replaces the old approach of constructing relative paths,
+    # providing correct firmware locations for each device
+    getBuildEnv @5 (deviceId :UInt64) -> (buildInfo :BuildEnvData);
 }

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -75,6 +75,11 @@ struct BuildEnvData {
     fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
 }
 
+struct BuildEnvPerDevice {
+    deviceId @0 :UInt64;
+    buildInfo @1 :BuildEnvData;
+}
+
 interface Inspector {
     # Get programs currently alive
     getPrograms @0 () -> (programs :List(ProgramData));
@@ -96,4 +101,6 @@ interface Inspector {
     # This replaces the old approach of constructing relative paths,
     # providing correct firmware locations for each device
     getBuildEnv @5 (deviceId :UInt64) -> (buildInfo :BuildEnvData);
+
+    getAllBuildEnvs @6 () -> (buildEnvs :List(BuildEnvPerDevice));
 }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -93,7 +93,7 @@ JitBuildEnv::JitBuildEnv() = default;
 
 void JitBuildEnv::init(
     uint32_t build_key,
-    uint32_t fw_compile_hash,
+    size_t fw_compile_hash,
     tt::ARCH arch,
     const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -122,6 +122,7 @@ void JitBuildEnv::init(
 #endif
     // Firmware build path is a combination of build_key and fw_compile_hash
     // If either change, the firmware build path will change and FW will be rebuilt
+    // if it's not already in MetalContext::firmware_built_keys_
     this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/" + to_string(fw_compile_hash) + "/firmware/";
     this->out_kernel_root_ = this->out_root_ + to_string(build_key) + "/kernels/";
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -92,7 +92,10 @@ std::string get_default_root_path() {
 JitBuildEnv::JitBuildEnv() = default;
 
 void JitBuildEnv::init(
-    uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines) {
+    uint32_t build_key,
+    size_t fw_compile_hash,
+    tt::ARCH arch,
+    const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     this->root_ = rtoptions.get_root_dir();
@@ -117,9 +120,11 @@ void JitBuildEnv::init(
 
     this->out_root_ = this->out_root_  + git_hash + "/";
 #endif
-
-    const std::filesystem::path firmware_path =
-        std::filesystem::path(this->out_root_) / std::to_string(build_key) / "firmware/";
+    // Firmware build path is a combination of build_key and fw_compile_hash
+    // If either change, the firmware build path will change and FW will be rebuilt
+    // if it's not already in MetalContext::firmware_built_keys_
+    const std::filesystem::path firmware_path = std::filesystem::path(this->out_root_) / std::to_string(build_key) /
+                                                std::to_string(fw_compile_hash) / "firmware/";
     this->out_firmware_root_ = firmware_path.string();
     const std::filesystem::path kernel_path =
         std::filesystem::path(this->out_root_) / std::to_string(build_key) / "kernels/";

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -123,8 +123,12 @@ void JitBuildEnv::init(
     // Firmware build path is a combination of build_key and fw_compile_hash
     // If either change, the firmware build path will change and FW will be rebuilt
     // if it's not already in MetalContext::firmware_built_keys_
-    this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/" + to_string(fw_compile_hash) + "/firmware/";
-    this->out_kernel_root_ = this->out_root_ + to_string(build_key) + "/kernels/";
+    const std::filesystem::path firmware_path = std::filesystem::path(this->out_root_) / std::to_string(build_key) /
+                                                std::to_string(fw_compile_hash) / "firmware/";
+    this->out_firmware_root_ = firmware_path.string();
+    const std::filesystem::path kernel_path =
+        std::filesystem::path(this->out_root_) / std::to_string(build_key) / "kernels/";
+    this->out_kernel_root_ = kernel_path.string();
 
     // Tools
     const static bool use_ccache = std::getenv("TT_METAL_CCACHE_KERNEL_SUPPORT") != nullptr;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -92,7 +92,10 @@ std::string get_default_root_path() {
 JitBuildEnv::JitBuildEnv() = default;
 
 void JitBuildEnv::init(
-    uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines) {
+    uint32_t build_key,
+    uint32_t fw_compile_hash,
+    tt::ARCH arch,
+    const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     this->root_ = rtoptions.get_root_dir();
@@ -117,8 +120,9 @@ void JitBuildEnv::init(
 
     this->out_root_ = this->out_root_  + git_hash + "/";
 #endif
-
-    this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/firmware/";
+    // Firmware build path is a combination of build_key and fw_compile_hash
+    // If either change, the firmware build path will change and FW will be rebuilt
+    this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/" + to_string(fw_compile_hash) + "/firmware/";
     this->out_kernel_root_ = this->out_root_ + to_string(build_key) + "/kernels/";
 
     // Tools

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -92,10 +92,7 @@ std::string get_default_root_path() {
 JitBuildEnv::JitBuildEnv() = default;
 
 void JitBuildEnv::init(
-    uint32_t build_key,
-    size_t fw_compile_hash,
-    tt::ARCH arch,
-    const std::map<std::string, std::string>& device_kernel_defines) {
+    uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     this->root_ = rtoptions.get_root_dir();
@@ -120,11 +117,9 @@ void JitBuildEnv::init(
 
     this->out_root_ = this->out_root_  + git_hash + "/";
 #endif
-    // Firmware build path is a combination of build_key and fw_compile_hash
-    // If either change, the firmware build path will change and FW will be rebuilt
-    // if it's not already in MetalContext::firmware_built_keys_
-    const std::filesystem::path firmware_path = std::filesystem::path(this->out_root_) / std::to_string(build_key) /
-                                                std::to_string(fw_compile_hash) / "firmware/";
+
+    const std::filesystem::path firmware_path =
+        std::filesystem::path(this->out_root_) / std::to_string(build_key) / "firmware/";
     this->out_firmware_root_ = firmware_path.string();
     const std::filesystem::path kernel_path =
         std::filesystem::path(this->out_root_) / std::to_string(build_key) / "kernels/";

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -57,6 +57,9 @@ public:
     const std::string& get_root_path() const { return root_; }
     const std::string& get_out_root_path() const { return out_root_; }
     const std::string& get_out_kernel_root_path() const { return out_kernel_root_; }
+    const std::string& get_out_firmware_root_path() const {
+        return out_firmware_root_;
+    }  // Path to the firmware directory for this device
 
 private:
     tt::ARCH arch_{tt::ARCH::Invalid};

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -49,7 +49,7 @@ public:
     JitBuildEnv();
     void init(
         uint32_t build_key,
-        uint32_t fw_compile_hash,
+        size_t fw_compile_hash,
         tt::ARCH arch,
         const std::map<std::string, std::string>& device_kernel_defines);
 

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -47,7 +47,11 @@ class JitBuildEnv {
 
 public:
     JitBuildEnv();
-    void init(uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines);
+    void init(
+        uint32_t build_key,
+        size_t fw_compile_hash,
+        tt::ARCH arch,
+        const std::map<std::string, std::string>& device_kernel_defines);
 
     tt::ARCH get_arch() const { return arch_; }
     const std::string& get_root_path() const { return root_; }

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -47,11 +47,7 @@ class JitBuildEnv {
 
 public:
     JitBuildEnv();
-    void init(
-        uint32_t build_key,
-        size_t fw_compile_hash,
-        tt::ARCH arch,
-        const std::map<std::string, std::string>& device_kernel_defines);
+    void init(uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines);
 
     tt::ARCH get_arch() const { return arch_; }
     const std::string& get_root_path() const { return root_; }

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -47,7 +47,11 @@ class JitBuildEnv {
 
 public:
     JitBuildEnv();
-    void init(uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines);
+    void init(
+        uint32_t build_key,
+        uint32_t fw_compile_hash,
+        tt::ARCH arch,
+        const std::map<std::string, std::string>& device_kernel_defines);
 
     tt::ARCH get_arch() const { return arch_; }
     const std::string& get_root_path() const { return root_; }

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -233,8 +233,14 @@ void BuildEnvManager::build_firmware(chip_id_t device_id) {
     jit_build_subset(get_device_build_env(device_id).firmware_build_states, nullptr);
 }
 
-// Get device-specific firmware path for each device and build config
-const std::string& BuildEnvManager::get_out_firmware_root_path(chip_id_t device_id) {
-    return get_device_build_env(device_id).build_env.get_out_firmware_root_path();
+// Get build environment info for all devices
+std::vector<BuildEnvInfo> BuildEnvManager::get_all_build_envs_info() {
+    const std::lock_guard<std::mutex> lock(this->lock);
+    std::vector<BuildEnvInfo> build_env_info;
+    build_env_info.reserve(device_id_to_build_env_.size());
+    for (const auto& [device_id, build_env] : device_id_to_build_env_) {
+        build_env_info.emplace_back(device_id, build_env.build_key, build_env.build_env.get_out_firmware_root_path());
+    }
+    return build_env_info;
 }
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -233,4 +233,8 @@ void BuildEnvManager::build_firmware(chip_id_t device_id) {
     jit_build_subset(get_device_build_env(device_id).firmware_build_states, nullptr);
 }
 
+// Get device-specific firmware path for each device and build config
+const std::string& BuildEnvManager::get_out_firmware_root_path(chip_id_t device_id) {
+    return get_device_build_env(device_id).build_env.get_out_firmware_root_path();
+}
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -130,8 +130,6 @@ uint32_t compute_build_key(chip_id_t device_id, uint8_t num_hw_cqs) {
         hash ^= uint32_hasher(harvested_core_count) << 4;
     }
 
-    hash ^= std::hash<std::string>{}(MetalContext::instance().rtoptions().get_compile_hash_string());
-
     // Convert the hash to a 32-bit value
     return static_cast<uint32_t>(hash);
 }

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -177,10 +177,12 @@ void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
     const std::lock_guard<std::mutex> lock(this->lock);
     uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
+    const uint32_t fw_compile_hash =
+        std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
 
     device_id_to_build_env_[device_id].build_key = build_key;
     device_id_to_build_env_[device_id].build_env.init(
-        build_key, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
+        build_key, fw_compile_hash, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
     device_id_to_build_env_[device_id].firmware_build_states =
         create_build_state(device_id_to_build_env_[device_id].build_env, device_id, num_hw_cqs, true);
     device_id_to_build_env_[device_id].kernel_build_states =

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -177,10 +177,12 @@ void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
     const std::lock_guard<std::mutex> lock(this->lock);
     uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
+    const size_t fw_compile_hash =
+        std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
 
     device_id_to_build_env_[device_id].build_key = build_key;
     device_id_to_build_env_[device_id].build_env.init(
-        build_key, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
+        build_key, fw_compile_hash, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
     device_id_to_build_env_[device_id].firmware_build_states =
         create_build_state(device_id_to_build_env_[device_id].build_env, device_id, num_hw_cqs, true);
     device_id_to_build_env_[device_id].kernel_build_states =

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -177,12 +177,10 @@ void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
     const std::lock_guard<std::mutex> lock(this->lock);
     uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
-    const size_t fw_compile_hash =
-        std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
 
     device_id_to_build_env_[device_id].build_key = build_key;
     device_id_to_build_env_[device_id].build_env.init(
-        build_key, fw_compile_hash, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
+        build_key, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
     device_id_to_build_env_[device_id].firmware_build_states =
         create_build_state(device_id_to_build_env_[device_id].build_env, device_id, num_hw_cqs, true);
     device_id_to_build_env_[device_id].kernel_build_states =

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -177,7 +177,7 @@ void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
     const std::lock_guard<std::mutex> lock(this->lock);
     uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
-    const uint32_t fw_compile_hash =
+    const size_t fw_compile_hash =
         std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
 
     device_id_to_build_env_[device_id].build_key = build_key;

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -51,6 +51,7 @@ public:
         chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class);
 
     void build_firmware(chip_id_t device_id);
+    const std::string& get_out_firmware_root_path(chip_id_t device_id);
 
     // Helper function to get the unique build id and number of states for a given programmable_core and
     // processor_class.

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -28,6 +28,13 @@ struct DeviceBuildEnv {
     std::vector<JitBuildState> kernel_build_states;
 };
 
+// A struct to hold device-specific build environment info (lightweight version of DeviceBuildEnv)
+struct BuildEnvInfo {
+    chip_id_t device_id;
+    uint32_t build_key;
+    std::string firmware_root_path;
+};
+
 // Singleton class to generate and hold build environments, build keys, and build states.
 class BuildEnvManager {
 public:
@@ -51,11 +58,13 @@ public:
         chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class);
 
     void build_firmware(chip_id_t device_id);
-    const std::string& get_out_firmware_root_path(chip_id_t device_id);
 
     // Helper function to get the unique build id and number of states for a given programmable_core and
     // processor_class.
     BuildIndexAndTypeCount get_build_index_and_state_count(uint32_t programmable_core, uint32_t processor_class);
+
+    // Method to get the build environment info for all devices
+    std::vector<BuildEnvInfo> get_all_build_envs_info();
 
 private:
     BuildEnvManager();


### PR DESCRIPTION
### Ticket
Fixes #27810
Link to Github Issue:
https://github.com/tenstorrent/tt-metal/issues/27810

### Problem description
Resolves the hang in `TestUnicastConnAPI2DSmoke` that occurred when Fabric2DFixture tests ran after MeshDeviceFixture or UnitMeshCQFixture tests.

**Root Cause:**
The firmware cache tracking key (`MetalContext::firmware_built_keys_`) only used `build_key`, which didn't capture firmware compilation setting changes. When `MetalContext::set_fabric_config()` toggled `rtoptions.erisc_iram_enabled` mid-process (between test fixtures), the firmware cache incorrectly considered the firmware already built and reused the cached firmware compiled with the wrong linker script.  This caused:

1. First few tests: ERISC firmware compiled without `ENABLE_IRAM` macro (erisc_iram disabled)
2. TestUnicastConnAPI2DSmoke: runtime enabled erisc_iram, but `build_key` unchanged -> already cached firmware with wrong linker script was used (runtime/hw/toolchain/wormhole/erisc-b0-app.ld instead of runtime/hw/toolchain/wormhole/erisc-b0-app_iram.ld)
3. Result: Wrong firmware causes ethernet cores to become inaccessible via NoC-reads -> fabric hangs.

The firmware path remained the same for both tests because only `build_key` was used.


### What's changed

#### 1. Fix Firmware Cache Tracking (Core Fix)
Changed firmware cache key to use full 64-bit `fw_compile_hash` combined with `build_key` using XOR.
This ensures the firmware cache correctly detects when firmware compilation settings change and rebuilds ERISC firmware with the appropriate linker script and `ENABLE_IRAM` macro.

- `metal_context.cpp/hpp` : Changed `fw_build_key` to use XOR combining : `(build_key ^ fw_compile_hash)`, updated `firmware_built_keys_` from `uint32_t` to `uint64_t`
- `jit_build/build.cpp/hpp` : Added `fw_compile_hash` parameter to `JitBuildEnv::init()`, firmware path now includes both: `.../build_key/fw_compile_hash/firmware/`
- `build_env_manager.cpp` : Passes `fw_compile_hash` (computed from `rtoptions().get_compile_hash_string()`) to `JitBuildEnv::init`


- Use `std::filesystem::path` to compose `out_firmware_root_` and `out_kernel_root_`



#### 2. Add Inspector RPC for Device-Specific Firmware Path Resolution (Required Support)

Since the firmware paths now include `fw_compile_hash` in the directory structure, triage tools can no longer use hardcoded relative paths.

To avoid hardcoded relative paths and support multiple device/build variants, added an Inspector RPC interface to dynamically query device-specific firmware paths.

Previously, `dispatcher_data.py` constructed firmware paths using relative paths (e.g., `../../../firmware/brisc/brisc.elf`), which breaks with the new path structure and doesn't work when build configuration changes result in different firmware locations.

- Centralized RPC callback registration in `tt::tt_metal::inspector::Data`; call `Inspector::set_build_env_fw_compile_hash(...)` from `MetalContext::initialize()`
- Added `BuildEnvManager::get_all_build_envs_info()` returning `std::vector<BuildEnvInfo>` copies with proper mutex locking to avoid race conditions with concurrent `add_build_env()` calls during initialization
- Inspector RPC now exposes only `getAllBuildEnvs()` returning all device build environments upfront (removed per-device `getBuildEnv()` to prevent lazy build env creation)
- Updated Inspector RPC interface (`rpc.capnp`): removed `getBuildEnv()` method, kept only `getAllBuildEnvs()` returning `List(BuildEnvPerDevice)` with `BuildEnvData` structs
- RPC thread-safety: `fw_compile_hash` stored as `std::atomic<uint64_t>` in tt::tt_metal::inspector::Data
- Updated `dispatcher_data.py` to query firmware paths via RPC instead of constructing relative paths; prefill cache via `getAllBuildEnvs()`\
- Python side: prefills `_build_env_cache` at initialization, requires `RunChecks.devices` with no fallback logic, fails fast with clear errors if device not in cache; removed unused `get_firmware_elf_path()` and `_a_kernel_path`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes