### PR TITLE
#0: Auto enable kernel folding

### DIFF
--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -302,7 +302,6 @@ def run_conv2d_short_sweep(
         return_output_dim=True,
         return_weights_and_bias=True,
         dtype=conv_output_dtype,
-        # slice_config=ttnn.Conv2dL1FullSliceConfig,
     )
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)

--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -259,8 +259,6 @@ def run_conv2d_short_sweep(
     tt_bias_tensor = None
     conv_config = ttnn.Conv2dConfig()
     conv_output_dtype = ttnn.bfloat16
-    if stride_h == kernel_height and stride_w == kernel_width and stride_h >= 14 and pad_h == 0 and pad_w == 0:
-        conv_config.enable_kernel_stride_folding = True
     if is_forge_suite:
         input_layout = ttnn.Layout(input_layout)
         input_dtype = ttnn.DataType(input_dtype)
@@ -304,6 +302,7 @@ def run_conv2d_short_sweep(
         return_output_dim=True,
         return_weights_and_bias=True,
         dtype=conv_output_dtype,
+        # slice_config=ttnn.Conv2dL1FullSliceConfig,
     )
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
@@ -519,7 +519,8 @@ parameters = {
             [2, 320, 640, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
             [2, 640, 640, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
             [2, 320, 960, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
-        ],
+            [1, 1280, 3, 518, 518, 14, 14, 14, 14, 0, 0, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)]],
+       ],
         "is_conv1d": [False], },
     }
 # fmt: on

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
@@ -234,7 +234,7 @@ parameters = {
             [1, 32, 3, 224, 224, 3, 3, 2, 2, 1, 1, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 64, 3, 224, 224, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 64, 3, 224, 224, 7, 7, 2, 2, 3, 3, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
-            [1, 768, 3, 224, 224, 16, 16, 16, 16, 0, 0, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
+            [1, 768, 3, 224, 224, 16, 16, 16, 16, 0, 0, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ], #Added from Issue 29981
             [1, 768, 3, 224, 224, 32, 32, 32, 32, 0, 0, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 32, 3, 256, 256, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 16, 3, 320, 320, 3, 3, 2, 2, 1, 1, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)], ],
@@ -519,7 +519,7 @@ parameters = {
             [2, 320, 640, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
             [2, 640, 640, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
             [2, 320, 960, 64, 64, 3, 3, 1, 1, 1, 1, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.float32)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.float32)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.float32)]],
-            [1, 1280, 3, 518, 518, 14, 14, 14, 14, 0, 0, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)]],
+            [1, 1280, 3, 518, 518, 14, 14, 14, 14, 0, 0, 1, 1, 1, False, [int(ttnn.ROW_MAJOR_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)]], #Added from Issue 29981
        ],
         "is_conv1d": [False], },
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -82,7 +82,7 @@ ResultWithOptions conv2d(
     bool return_weights_and_bias) {
     if (dram_slice_config_.has_value()) {
         if (dram_slice_config_.value().slice_type == Conv2dSliceConfig::SliceType::L1_FULL) {
-            log_warning(tt::LogOp, "Conv2d L1 with slice config {}", dram_slice_config_);
+            log_trace(tt::LogOp, "Conv2d L1 with slice config {}", dram_slice_config_);
             return result_to_result_with_options(
                 conv2d_L1(
                     input_tensor,
@@ -106,7 +106,7 @@ ResultWithOptions conv2d(
                 return_output_dim,
                 return_weights_and_bias);
         } else {
-            log_warning(tt::LogOp, "Conv2d DRAM with slice config {}", dram_slice_config_);
+            log_trace(tt::LogOp, "Conv2d DRAM with slice config {}", dram_slice_config_);
             return result_to_result_with_options(
                 conv2d_DRAM(
                     input_tensor,
@@ -134,7 +134,7 @@ ResultWithOptions conv2d(
     } else {
         bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor);
         if (input_is_on_device && input_tensor.memory_config().is_l1()) {
-            log_warning(tt::LogOp, "Conv2d L1 without slice config");
+            log_trace(tt::LogOp, "Conv2d L1 without slice config");
             return result_to_result_with_options(
                 conv2d_L1(
                     input_tensor,
@@ -158,7 +158,7 @@ ResultWithOptions conv2d(
                 return_output_dim,
                 return_weights_and_bias);
         }
-        log_warning(tt::LogOp, "Conv2d DRAM without slice config");
+        log_trace(tt::LogOp, "Conv2d DRAM without slice config");
         return result_to_result_with_options(
             conv2d_DRAM(
                 input_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -259,7 +259,7 @@ Result conv2d_DRAM(
             true,  // DRAM MM Convs are always interleaved
             bias_tensor.has_value(),
             true,  // parameters_on_device
-            conv_config.enable_kernel_stride_folding,
+            conv_config.enable_kernel_stride_folding.value(),
             conv_config.full_inner_dim,
             conv_config.enable_activation_reuse,
             kernel_size,
@@ -769,7 +769,7 @@ Result conv2d_L1(
         mm_conv && auto_shard,
         bias_tensor.has_value(),
         true,  // parameters_on_device
-        conv_config.enable_kernel_stride_folding,
+        conv_config.enable_kernel_stride_folding.value(),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
         kernel_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -82,6 +82,7 @@ ResultWithOptions conv2d(
     bool return_weights_and_bias) {
     if (dram_slice_config_.has_value()) {
         if (dram_slice_config_.value().slice_type == Conv2dSliceConfig::SliceType::L1_FULL) {
+            log_warning(tt::LogOp, "Conv2d L1 with slice config {}", dram_slice_config_);
             return result_to_result_with_options(
                 conv2d_L1(
                     input_tensor,
@@ -105,6 +106,7 @@ ResultWithOptions conv2d(
                 return_output_dim,
                 return_weights_and_bias);
         } else {
+            log_warning(tt::LogOp, "Conv2d DRAM with slice config {}", dram_slice_config_);
             return result_to_result_with_options(
                 conv2d_DRAM(
                     input_tensor,
@@ -132,6 +134,7 @@ ResultWithOptions conv2d(
     } else {
         bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor);
         if (input_is_on_device && input_tensor.memory_config().is_l1()) {
+            log_warning(tt::LogOp, "Conv2d L1 without slice config");
             return result_to_result_with_options(
                 conv2d_L1(
                     input_tensor,
@@ -155,6 +158,7 @@ ResultWithOptions conv2d(
                 return_output_dim,
                 return_weights_and_bias);
         }
+        log_warning(tt::LogOp, "Conv2d DRAM without slice config");
         return result_to_result_with_options(
             conv2d_DRAM(
                 input_tensor,
@@ -216,7 +220,6 @@ Result conv2d_DRAM(
     bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
     DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
     const auto compute_grid_size = device->compute_with_storage_grid_size();
-
     ttnn::Tensor input_tensor_on_device = fold_input_tensor_if_required(
         input_tensor,
         device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -318,7 +318,7 @@ void py_bind_conv2d(py::module& module) {
             bool,
             bool,
             bool,
-            bool,
+            std::optional<bool>,
             bool,
             std::optional<bool>>(),
         py::kw_only(),
@@ -339,7 +339,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("enable_weights_double_buffer") = false,
         py::arg("full_inner_dim") = false,
         py::arg("in_place") = false,
-        py::arg("enable_kernel_stride_folding") = false,
+        py::arg("enable_kernel_stride_folding") = std::nullopt,
         py::arg("enable_activation_reuse") = false,
         py::arg("force_split_reader") = std::nullopt);
     py_conv_config.def_readwrite("weights_dtype", &Conv2dConfig::weights_dtype, R"doc(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1558,11 +1558,14 @@ bool conv2d::determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint3
 bool auto_enable_kernel_folding(
     std::optional<bool> enable_folding_,
     bool is_dram,
+    uint32_t input_height,
+    uint32_t input_width,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
     std::array<uint32_t, 4>& padding_n4) {
     if (!enable_folding_.has_value()) {
-        if (stride[0] == kernel_size[0] && stride[1] == kernel_size[1] &&
+        if (stride[0] == kernel_size[0] && stride[1] == kernel_size[1] && (input_height % stride[0] == 0) &&
+            (input_width % stride[1] == 0) &&
             (padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0) && is_dram) {
             log_debug(tt::LogOp, "Auto enabling kernel folding");
             return true;
@@ -1589,6 +1592,8 @@ Tensor fold_input_tensor_if_required(
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
         conv_config.enable_kernel_stride_folding,
         input_tensor.memory_config().is_dram(),
+        input_height,
+        input_width,
         kernel_size,
         stride,
         padding_n4);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1564,7 +1564,7 @@ bool auto_enable_kernel_folding(
     if (!enable_folding_.has_value()) {
         if (stride[0] == kernel_size[0] && stride[1] == kernel_size[1] &&
             (padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0) && is_dram) {
-            log_info(tt::LogOp, "Auto enabling kernel folding");
+            log_debug(tt::LogOp, "Auto enabling kernel folding");
             return true;
         } else {
             return false;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1555,6 +1555,24 @@ bool conv2d::determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint3
     return packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
 }
 
+bool auto_enable_kernel_folding(
+    std::optional<bool> enable_folding_,
+    bool is_dram,
+    std::array<uint32_t, 2>& kernel_size,
+    std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 4>& padding_n4) {
+    if (!enable_folding_.has_value()) {
+        if (kernel_size[0] > 12 && kernel_size[1] > 12 && stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1] &&
+            (padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0) && is_dram) {
+            log_info(tt::LogOp, "Auto enabling kernel folding");
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return enable_folding_.value();
+    }
+}
 Tensor fold_input_tensor_if_required(
     const ttnn::Tensor& input_tensor,
     MeshDevice* device,
@@ -1568,7 +1586,14 @@ Tensor fold_input_tensor_if_required(
     Conv2dConfig& conv_config) {
     // Conv DRAM would fold the input tensor, but conv_config.enable_kernel_stride_folding would stil be true as weights
     // also need to be folded.
-    if (conv_config.enable_kernel_stride_folding && (stride[0] > 1 || stride[1] > 1)) {
+    conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
+        conv_config.enable_kernel_stride_folding,
+        input_tensor.memory_config().is_dram(),
+        kernel_size,
+        stride,
+        padding_n4);
+
+    if (conv_config.enable_kernel_stride_folding.value() && (stride[0] > 1 || stride[1] > 1)) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
         auto folded_input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1562,7 +1562,7 @@ bool auto_enable_kernel_folding(
     std::array<uint32_t, 2>& stride,
     std::array<uint32_t, 4>& padding_n4) {
     if (!enable_folding_.has_value()) {
-        if (kernel_size[0] > 12 && kernel_size[1] > 12 && stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1] &&
+        if (stride[0] == kernel_size[0] && stride[1] == kernel_size[1] &&
             (padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0) && is_dram) {
             log_info(tt::LogOp, "Auto enabling kernel folding");
             return true;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -192,6 +192,13 @@ shard_or_reshard_tensor_if_required(
     bool is_mm_conv,
     bool auto_shard);
 
+bool auto_enable_kernel_folding(
+    std::optional<bool> enable_folding_,
+    bool is_dram,
+    std::array<uint32_t, 2>& kernel_size,
+    std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 4>& padding_n4);
+
 Tensor fold_input_tensor_if_required(
     const ttnn::Tensor& input_tensor,
     MeshDevice* device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -195,6 +195,8 @@ shard_or_reshard_tensor_if_required(
 bool auto_enable_kernel_folding(
     std::optional<bool> enable_folding_,
     bool is_dram,
+    uint32_t input_height,
+    uint32_t input_width,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
     std::array<uint32_t, 4>& padding_n4);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -103,7 +103,7 @@ struct Conv2dConfig {
     //    4. Input tensor's padding must be zero.
     //    5. Input tensor data type is not BFLOAT8_B.
 
-    bool enable_kernel_stride_folding = false;
+    std::optional<bool> enable_kernel_stride_folding = std::nullopt;
 
     // Activation reuse is a feature that enables reusing data between consecutive image rows.
     // It can be enabled for height sharding only and boosts im2col performance,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1113,7 +1113,8 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
     auto orig_stride = stride;
     const bool is_conv1d = is_1d_conv(kernel_size[1], input_width);
-
+    conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
+        conv_config.enable_kernel_stride_folding, input_memory_config.is_dram(), kernel_size, stride, padding_n4);
     if (conv_config.enable_kernel_stride_folding) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1114,7 +1114,13 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     auto orig_stride = stride;
     const bool is_conv1d = is_1d_conv(kernel_size[1], input_width);
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
-        conv_config.enable_kernel_stride_folding, input_memory_config.is_dram(), kernel_size, stride, padding_n4);
+        conv_config.enable_kernel_stride_folding,
+        input_memory_config.is_dram(),
+        input_height,
+        input_width,
+        kernel_size,
+        stride,
+        padding_n4);
     if (conv_config.enable_kernel_stride_folding.value()) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1115,7 +1115,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     const bool is_conv1d = is_1d_conv(kernel_size[1], input_width);
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
         conv_config.enable_kernel_stride_folding, input_memory_config.is_dram(), kernel_size, stride, padding_n4);
-    if (conv_config.enable_kernel_stride_folding) {
+    if (conv_config.enable_kernel_stride_folding.value()) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
 
@@ -1346,7 +1346,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
         mm_conv && auto_shard,
         has_bias,
         true,  // parameters_on_device
-        conv_config.enable_kernel_stride_folding,
+        conv_config.enable_kernel_stride_folding.value(),
         conv_config.full_inner_dim,
         conv_config.enable_activation_reuse,
         kernel_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -133,7 +133,7 @@ struct Conv2dWeightsBiasPrepConfig {
         bool interleaved_mm_conv,
         bool has_bias_ = false,
         bool parameters_on_device_ = true,
-        std::optional<bool> enable_kernel_stride_folding_ = std::nullopt,
+        bool enable_kernel_stride_folding_ = false,
         bool full_inner_dim_ = false,
         bool enable_activation_reuse_ = false,
         std::array<uint32_t, 2> kernel_size_ = {1, 1},

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -133,7 +133,7 @@ struct Conv2dWeightsBiasPrepConfig {
         bool interleaved_mm_conv,
         bool has_bias_ = false,
         bool parameters_on_device_ = true,
-        bool enable_kernel_stride_folding_ = false,
+        std::optional<bool> enable_kernel_stride_folding_ = std::nullopt,
         bool full_inner_dim_ = false,
         bool enable_activation_reuse_ = false,
         std::array<uint32_t, 2> kernel_size_ = {1, 1},


### PR DESCRIPTION
### Ticket
#29981

### Problem description
Default for Conv2D has been changed to DRAM. Conv2D DRAM has a higher input channels alignment than the L1 version. This causes test cases with small input_channels (like 3) to use more memory now. 
These tests also end up using shard configs with small core grids, causing OOM errors even with DRAM slicing. 
Certain forge test cases need folding enable to work correctly. As it has to be explictly enabled, many test cases fail now. 

### What's changed
Automatically enable kernel folding so that test cases that need folding work automatically. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18339464363)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/18444600957)
- [x] Blackhole Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18444592635)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18400871934)
- [x] New/Existing tests provide coverage for changes