### PR TITLE
Changed Linear to Ring topology for attention and MLP all-gather

### DIFF
--- a/models/demos/gemma3/tt/gemma_image_attention.py
+++ b/models/demos/gemma3/tt/gemma_image_attention.py
@@ -373,7 +373,7 @@ class TtGemmaImageAttention(LightweightModule):
                 dim=3,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                 num_links=1,
-                topology=ttnn.Topology.Linear,
+                topology=ttnn.Topology.Ring,
                 barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
                 chunks_per_sync=10,
                 num_workers_per_link=2,

--- a/models/demos/gemma3/tt/gemma_image_mlp.py
+++ b/models/demos/gemma3/tt/gemma_image_mlp.py
@@ -118,7 +118,7 @@ class TtGemmaImageFeedForward(LightweightModule):
                 dim=1,
                 multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
                 num_links=1,
-                topology=ttnn.Topology.Linear,
+                topology=ttnn.Topology.Ring,
                 barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
                 chunks_per_sync=10,
                 num_workers_per_link=2,


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/28519)

### Problem description
All_gather_async has previously used Linear topology in all 3
all_gather operation in Gemma3 (attention, pre-MLP and MLP),
which was bad for performance.

### What's changed

**Attention**:

- Utilization of ideal time for all_gather increased from 43.65% to 65.65%.
- Device time has been improved from 1009.3us to 671us measured in test_vision_attention.

**MLP**:

- Utilization of ideal time for all_gather increased from 45.9% to 68.06%.
- Device time has been improved from 23208.7us to 15652us measured in test_vision_mlp.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18276113291) CI passes
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18276106030) CI passes (if applicable, since this is required for release)
- [x] [(Single-card) Demo tests (with perf runs) ](https://github.com/tenstorrent/tt-metal/actions/runs/18276124078)