### PR TITLE
[DM] Read from host performance test

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -20,6 +20,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dram_sharded/test_dram_sharded.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/transaction_id/test_read_after_write.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/direct_write/test_direct_write.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pcie_read_bw/test_pcie_read_bw.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -51,6 +51,7 @@ Both API versions run the same test cases but use different underlying implement
 | I2S Hardcoded               | 400-405              | Tests interleaved to sharded data movement operations for different memory layouts.     |
 | Inline Direct Write         | 500-501              | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602              | Tests the usage and effects of transaction IDs in NOC transactions.                     |
+| PCIe Read Bandwidth         | 603                  | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
 
 
 ## Running Tests

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
@@ -1,0 +1,41 @@
+# PCIe Read Bandwidth Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from Host(PCIe memory) to L1 memory on a single Tensix core.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
+## Test Flow
+A circular buffer is allocated in L1 memory on a worker core. The worker core issues NOC read transactions to retrieve data from PCIe memory. Data is read from PCIe memory into the L1 circular buffer using `noc_async_read`. The kernel executes 1000 iterations, each reading 4 pages of 65536 bytes. The test measures the time taken and calculates bandwidth. Results are logged with detailed performance metrics.
+
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. DeviceTimestampedData is recorded for Python wrapper compatibility.
+
+Test expectations are that sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*PCIeReadBandwidth*"
+```
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| worker_core_coord         | CoreCoord             | Logical coordinates for the worker core. |
+| iterations                | uint32_t              | Number of test iterations to run. |
+| warmup_iterations         | uint32_t              | Number of warmup iterations before timing. |
+| page_size_bytes           | uint32_t              | Size of each page in bytes. Fixed at 65536 bytes. |
+| batch_size_k              | uint32_t              | Batch size in KB. Fixed at 256. |
+| page_count                | uint32_t              | Number of pages to transfer per iteration. Calculated as batch_size_k / page_size_bytes. |
+| l1_data_format            | DataFormat            | Data format for L1 memory. |
+| noc_id                    | NOC                   | NOC to use for data movement. |
+
+## Test Cases
+Test case uses Float32 as L1 data format and 65536 bytes as page size.
+
+1. PCIe Read Bandwidth: Tests PCIe read bandwidth with fixed parameters (batch size 256K, page size 65536 bytes, 1000 iterations).
+
+**Note**: This test is based on the `test_bw_and_latency.cpp` test from the performance microbenchmark dispatch suite, specifically the PCIe read functionality (`-m 0`).

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/README.md
@@ -1,6 +1,6 @@
 # PCIe Read Bandwidth Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions from Host(PCIe memory) to L1 memory on a single Tensix core.
+This test suite implements a test that measures the functionality and performance (i.e. bandwidth) of data movement transactions from Host(PCIe memory) to L1 memory on a single Tensix core.
 
 ## Mesh Device API Support
 This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
@@ -8,11 +8,11 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 **Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
 
 ## Test Flow
-A circular buffer is allocated in L1 memory on a worker core. The worker core issues NOC read transactions to retrieve data from PCIe memory. Data is read from PCIe memory into the L1 circular buffer using `noc_async_read`. The kernel executes 1000 iterations, each reading 4 pages of 65536 bytes. The test measures the time taken and calculates bandwidth. Results are logged with detailed performance metrics.
+The master core issues NOC read transactions to retrieve data from PCIe memory. Data is read from PCIe memory into the L1 using `noc_async_read`. The test measures the time taken and calculates the bandwidth. Results are logged with detailed performance metrics.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. DeviceTimestampedData is recorded for Python wrapper compatibility.
+Test attributes such as transaction sizes and number of transactions, as well as latency measures like kernel and pre-determined scope cycles, are recorded by the profiler. DeviceTimestampedData is recorded for Python wrapper compatibility.
 
-Test expectations are that sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that sufficient test attribute data is captured by the profiler for higher-level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:
@@ -24,18 +24,16 @@ The tests use the Mesh Device API with fast dispatch mode:
 | Parameter                 | Data Type             | Description |
 | ------------------------- | --------------------- | ----------- |
 | test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| worker_core_coord         | CoreCoord             | Logical coordinates for the worker core. |
-| iterations                | uint32_t              | Number of test iterations to run. |
-| warmup_iterations         | uint32_t              | Number of warmup iterations before timing. |
-| page_size_bytes           | uint32_t              | Size of each page in bytes. Fixed at 65536 bytes. |
-| batch_size_k              | uint32_t              | Batch size in KB. Fixed at 256. |
-| page_count                | uint32_t              | Number of pages to transfer per iteration. Calculated as batch_size_k / page_size_bytes. |
-| l1_data_format            | DataFormat            | Data format for L1 memory. |
+| master_core_coord         | CoreCoord             | Logical coordinates for the master core. |
+| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
+| pages_per_transaction     | uint32_t              | Size of the issued noc transactions in pages. |
+| bytes_per_page            | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format            | DataFormat            | Data format data that will be moved. |
 | noc_id                    | NOC                   | NOC to use for data movement. |
 
 ## Test Cases
-Test case uses Float32 as L1 data format and 65536 bytes as page size.
+Test case uses Float32 as L1 data format.
 
-1. PCIe Read Bandwidth: Tests PCIe read bandwidth with fixed parameters (batch size 256K, page size 65536 bytes, 1000 iterations).
+1. PCIe Read Bandwidth: Tests PCIe read bandwidth with the maximum possible bandwidth on the selected device.
 
 **Note**: This test is based on the `test_bw_and_latency.cpp` test from the performance microbenchmark dispatch suite, specifically the PCIe read functionality (`-m 0`).

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp
@@ -2,33 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "compile_time_args.h"
 #include "dataflow_api.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
-    uint32_t test_id = get_arg_val<uint32_t>(0);
-    uint32_t page_size = get_arg_val<uint32_t>(1);
+    // Compile-time arguments
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+    constexpr uint32_t packed_subordinate_core_coordinates = get_compile_time_arg_val(3);
+    constexpr uint32_t pcie_l1_local_addr = get_compile_time_arg_val(4);
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(5);
 
-    cb_reserve_back(0, PAGE_COUNT);
-    uint32_t cb_addr = get_write_ptr(0);
+    uint32_t pcie_x_coord = packed_subordinate_core_coordinates >> 16;
+    uint32_t pcie_y_coord = packed_subordinate_core_coordinates & 0xFFFF;
+
+    uint64_t noc_addr = NOC_XY_PCIE_ENCODING(pcie_x_coord, pcie_y_coord) | pcie_l1_local_addr;
     {
         DeviceZoneScopedN("RISCV0");
-        for (int i = 0; i < ITERATIONS; i++) {
-            uint32_t read_ptr = cb_addr;
-
-            for (int j = 0; j < PAGE_COUNT; j++) {
-                // Read from PCIe memory
-                uint64_t noc_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), NOC_MEM_ADDR);
-                noc_async_read(noc_addr, read_ptr, page_size);
-
-                read_ptr += page_size;
-            }
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            noc_async_read(noc_addr, l1_local_addr, bytes_per_transaction);
         }
-
-        // Wait for all reads to complete
         noc_async_read_barrier();
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", PAGE_COUNT * ITERATIONS);
-    DeviceTimestampedData("Transaction size in bytes", page_size);
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
 }

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t test_id = get_arg_val<uint32_t>(0);
+    uint32_t page_size = get_arg_val<uint32_t>(1);
+
+    cb_reserve_back(0, PAGE_COUNT);
+    uint32_t cb_addr = get_write_ptr(0);
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (int i = 0; i < ITERATIONS; i++) {
+            uint32_t read_ptr = cb_addr;
+
+            for (int j = 0; j < PAGE_COUNT; j++) {
+                // Read from PCIe memory
+                uint64_t noc_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), NOC_MEM_ADDR);
+                noc_async_read(noc_addr, read_ptr, page_size);
+
+                read_ptr += page_size;
+            }
+        }
+
+        // Wait for all reads to complete
+        noc_async_read_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of transactions", PAGE_COUNT * ITERATIONS);
+    DeviceTimestampedData("Transaction size in bytes", page_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "dm_common.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace test_utils;
+
+namespace unit_tests::dm::pcie_read_bw {
+
+// Test config for PCIe read bandwidth test
+struct PCIeReadBwConfig {
+    uint32_t test_id = 0;
+    CoreCoord worker_core_coord = {0, 0};
+    uint32_t iterations = 32;
+    uint32_t warmup_iterations = 2;
+    uint32_t page_size_bytes = 65536;
+    uint32_t batch_size_k = 256;
+    uint32_t size_bytes = batch_size_k * 1024;
+    uint32_t page_count = size_bytes / page_size_bytes;
+    DataFormat l1_data_format = DataFormat::Float32;
+    NOC noc_id = NOC::RISCV_1_default;
+};
+
+/// @brief Runs PCIe read bandwidth test
+/// @param mesh_device Mesh device for execution
+/// @param test_config Configuration for the test
+/// @return true if test passes, false otherwise
+bool run_pcie_read_bw_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeReadBwConfig& test_config) {
+    IDevice* device = mesh_device->get_device(0);
+    auto device_id = device->id();
+
+    // Program
+    Program program = CreateProgram();
+
+    const size_t total_data_size = test_config.page_size_bytes * test_config.page_count;
+
+    // Core range for the worker
+    CoreRange worker_core_range = CoreRange(test_config.worker_core_coord, test_config.worker_core_coord);
+
+    // Get PCIe core coordinates
+    const metal_SocDescriptor& soc_d = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    vector<tt::umd::CoreCoord> pcie_cores = soc_d.get_cores(CoreType::PCIE, CoordSystem::TRANSLATED);
+    TT_ASSERT(!pcie_cores.empty(), "No PCIe cores found");
+
+    // Get PCIe memory addresses
+    uint64_t dev_pcie_base = MetalContext::instance().get_cluster().get_pcie_base_addr_from_device(device_id);
+    constexpr uint64_t PCIE_OFFSET_BYTES = 1024 * 1024 * 50;  // 50MB offset to avoid conflicts
+    uint64_t pcie_offset = PCIE_OFFSET_BYTES;
+    uint64_t noc_mem_addr = dev_pcie_base + pcie_offset;
+
+    tt_metal::CircularBufferConfig cb_config =
+        tt_metal::CircularBufferConfig(total_data_size, {{0, tt::DataFormat::Float32}})
+            .set_page_size(0, test_config.page_size_bytes);
+    tt_metal::CreateCircularBuffer(program, worker_core_range, cb_config);
+
+    std::map<std::string, std::string> defines = {
+        {"ITERATIONS", std::to_string(test_config.iterations)},
+        {"PAGE_COUNT", std::to_string(test_config.page_count)},
+        {"NOC_ADDR_X", std::to_string(pcie_cores[0].x)},
+        {"NOC_ADDR_Y", std::to_string(pcie_cores[0].y)},
+        {"NOC_MEM_ADDR", std::to_string(noc_mem_addr)},
+    };
+
+    auto dm0 = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/pcie_read_bw/kernels/pcie_read_bw.cpp",
+        worker_core_range,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = test_config.noc_id, .defines = defines});
+
+    tt_metal::SetRuntimeArgs(program, dm0, worker_core_range, {test_config.test_id, test_config.page_size_bytes});
+
+    log_info(
+        LogTest, "Running PCIe Read BW Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto mesh_workload = distributed::MeshWorkload();
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate({0, 0}));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+
+    // Warmup iterations
+    for (int i = 0; i < test_config.warmup_iterations; i++) {
+        distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    }
+    distributed::Finish(cq);
+
+    // Actual test iterations
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    distributed::Finish(cq);
+
+    return true;
+}
+
+void pcie_read_bw_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, CoreCoord worker_core_coord = {0, 0}) {
+    PCIeReadBwConfig test_config = {
+        .test_id = test_id,
+        .worker_core_coord = worker_core_coord,
+        .iterations = 1000,
+        .warmup_iterations = 10,
+        .page_size_bytes = 65536,
+        .batch_size_k = 256,
+        .size_bytes = test_config.batch_size_k * 1024,
+        .page_count = test_config.size_bytes / test_config.page_size_bytes,
+        .l1_data_format = DataFormat::Float32,
+        .noc_id = NOC::RISCV_0_default,
+    };
+
+    EXPECT_TRUE(run_pcie_read_bw_test(mesh_device, test_config));
+}
+
+}  // namespace unit_tests::dm::pcie_read_bw
+
+TEST_F(GenericMeshDeviceFixture, PCIeReadBandwidth) {
+    uint32_t test_id = 603;
+    CoreCoord worker_core_coord = {0, 0};
+
+    unit_tests::dm::pcie_read_bw::pcie_read_bw_test(get_mesh_device(), test_id, worker_core_coord);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -311,3 +311,11 @@
   wormhole_b0:
     riscv_1:
       bandwidth: 10.5
+
+"PCIe Read Bandwidth":
+  blackhole:
+    riscv_1:
+      bandwidth: 42
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 25.7

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -314,8 +314,8 @@
 
 "PCIe Read Bandwidth":
   blackhole:
-    riscv_1:
-      bandwidth: 42
+    riscv_0:
+      bandwidth: 42.5
   wormhole_b0:
     riscv_0:
-      bandwidth: 25.7
+      bandwidth: 20.1

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -433,14 +433,6 @@ tests:
       large number of get_noc_addr(stick_id, s0) calls. Without them, we get ~14.3B/cycle, compared
       to the expected ~18B/cycle. The same reasoning as in the previous test applies here.
 
-  600:
-    name: "Transaction ID - Read After Write"
-
-  601:
-    name: "Transaction ID - Read After Write One Packet"
-
-  602:
-    name: "Transaction ID - Read After Write One Packet Stateful"
   500:
     name: "Inline Direct Write Performance Comparison"
     comment: |
@@ -452,3 +444,15 @@ tests:
     comment: |
       Evaluates the performance impact of stateful versus stateless approaches under scenarios
       involving both identical and differing values and destinations.
+
+  600:
+    name: "Transaction ID - Read After Write"
+
+  601:
+    name: "Transaction ID - Read After Write One Packet"
+
+  602:
+    name: "Transaction ID - Read After Write One Packet Stateful"
+
+  603:
+    name: "PCIe Read Bandwidth"


### PR DESCRIPTION
### Ticket
[Github Issue](https://github.com/tenstorrent/tt-metal/issues/23559)

### Problem description
We wanted to add a data movement test which measures the read from host BW on blackhole P100 and P150.

### What's changed
I've added the test in the DM test suite, the test is based on the `test_bw_and_latency.cpp` test from the performance microbenchmark dispatch suite. The test currently doesn't have expected performance since the PCIe version largely impacts the performance. If the PCIe GEN4 is present, the BW cannot be more than 32GB/s. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
