### PR TITLE
Bump resnet perf threshold on T3K and TG

### DIFF
--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -15,10 +15,10 @@ PERF_EXPECTATIONS = {
         "test_perf_trace_2cqs": {"inference_time": 0.005, "compile_time": 60},
     },
     "tg": {
-        "test_perf": {"inference_time": 0.0500, "compile_time": 60},
-        "test_perf_trace": {"inference_time": 0.0081, "compile_time": 60},
-        "test_perf_2cqs": {"inference_time": 0.0530, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.0085, "compile_time": 60},
+        "test_perf": {"inference_time": 0.025, "compile_time": 60},
+        "test_perf_trace": {"inference_time": 0.0068, "compile_time": 60},
+        "test_perf_2cqs": {"inference_time": 0.026, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0052, "compile_time": 60},
     },
 }
 

--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -9,10 +9,10 @@ from models.demos.ttnn_resnet.tests.common.perf_e2e_resnet50 import run_perf_res
 
 PERF_EXPECTATIONS = {
     "t3000": {
-        "test_perf": {"inference_time": 0.015, "compile_time": 60},
-        "test_perf_trace": {"inference_time": 0.0057, "compile_time": 60},
-        "test_perf_2cqs": {"inference_time": 0.014, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.007, "compile_time": 60},
+        "test_perf": {"inference_time": 0.0125, "compile_time": 60},
+        "test_perf_trace": {"inference_time": 0.0048, "compile_time": 60},
+        "test_perf_2cqs": {"inference_time": 0.013, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.005, "compile_time": 60},
     },
     "tg": {
         "test_perf": {"inference_time": 0.0500, "compile_time": 60},


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Resnet T3k model perf tests are failing for some time on main with the error that perf is **better** than expected.
Ref t3k: https://github.com/tenstorrent/tt-metal/actions/runs/18280121906/job/52041969515.
Ref tg: https://github.com/tenstorrent/tt-metal/actions/runs/18280302924/job/52042399529

### What's changed
Bumped perf thresholds to be **better**.

### Checklist
- [x] [T3k perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/18312286217) CI passes 🟢 
- [x] [Galaxy model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/18312301358) CI passes 🟢 