### PR TITLE
Matmul Docs - Expand Memory Support Info

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -547,10 +547,35 @@ void py_module(py::module& module) {
                   - TILE
 
         Memory Support:
-            - Interleaved: DRAM and L1
-            - Input A also supports sharding (width, height, block), with row major orientation, depending on the program config
-            - Input B also supports sharding (width, height, block), with row major orientation depending on the program config, although in a more limited manner than Input A
-            - Sharded outputs (when used): must match Input A buffer type and memory layout; some configs disallow width sharded outputs
+            The supported memory configurations for the two input tensors are program config dependent, as described below:
+
+            .. list-table:: Supported Memory Configurations
+                :header-rows: 1
+
+                * - Config
+                  - Input A
+                  - Input B
+                * - MatmulMultiCoreReuseProgramConfig
+                  - Interleaved (L1/DRAM), Height/Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height/Block Sharded (L1)
+                * - MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+                  - Width Sharded (L1)
+                  - Width Sharded (DRAM)
+                * - MatmulMultiCoreReuseMultiCastProgramConfig
+                  - Interleaved (L1/DRAM), Block Sharded (L1)
+                  - Interleaved (L1/DRAM)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in1
+                  - Interleaved (L1/DRAM), Height Sharded (L1)
+                  - Interleaved (L1/DRAM)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (DRAM)
+
+
+            For :class:`MatmulMultiCoreReuseMultiCastProgramConfig`, a special case exists when :attr:`input_tensor_a` is single column (height sharded or interleaved) and :attr:`input_tensor_b` is a single row (width sharded or interleaved).
+            This setup only supports row major orientation without transpose multicast.
+
+            When sharded output tensors are provided, they should match :attr:`input_tensor_a`'s buffer type and memory layout.
 
         Example:
             >>> # matrix x matrix - no batch dimensions

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -564,10 +564,10 @@ void py_module(py::module& module) {
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
                   - Interleaved (L1/DRAM)
-                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in1
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0=False
                   - Interleaved (L1/DRAM), Height Sharded (L1)
                   - Interleaved (L1/DRAM)
-                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0=True
                   - Interleaved (L1/DRAM), Width Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1)
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -556,8 +556,8 @@ void py_module(py::module& module) {
                   - Input A
                   - Input B
                 * - MatmulMultiCoreReuseProgramConfig
-                  - Interleaved (L1/DRAM), Height/Block Sharded (L1)
-                  - Interleaved (L1/DRAM), Height/Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height or Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height or Block Sharded (L1)
                 * - MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
                   - Width Sharded (L1)
                   - Width Sharded (DRAM)
@@ -569,7 +569,7 @@ void py_module(py::module& module) {
                   - Interleaved (L1/DRAM)
                 * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0
                   - Interleaved (L1/DRAM), Width Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (DRAM)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
 
 
             For :class:`MatmulMultiCoreReuseMultiCastProgramConfig`, a special case exists when :attr:`input_tensor_a` is single column (height sharded or interleaved) and :attr:`input_tensor_b` is a single row (width sharded or interleaved).

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -564,16 +564,17 @@ void py_module(py::module& module) {
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
                   - Interleaved (L1/DRAM)
-                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0=False
+                * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
+                  - Interleaved (L1/DRAM), Height Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=True)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
                   - Interleaved (L1/DRAM)
-                * - MatmulMultiCoreReuseMultiCast1DProgramConfig mcast_in0=True
-                  - Interleaved (L1/DRAM), Width Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (L1)
 
 
-            For :class:`MatmulMultiCoreReuseMultiCastProgramConfig`, a special case exists when :attr:`input_tensor_a` is single column (height sharded or interleaved) and :attr:`input_tensor_b` is a single row (width sharded or interleaved).
-            This setup only supports row major orientation without transpose multicast.
 
             When sharded output tensors are provided, they should match :attr:`input_tensor_a`'s buffer type and memory layout.
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -556,8 +556,8 @@ void py_module(py::module& module) {
                   - Input A
                   - Input B
                 * - MatmulMultiCoreReuseProgramConfig
-                  - Interleaved (L1/DRAM), Height or Block Sharded (L1)
-                  - Interleaved (L1/DRAM), Height or Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height Sharded (L1), or Block Sharded (L1)
+                  - Interleaved (L1/DRAM), Height Sharded (L1), or Block Sharded (L1)
                 * - MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
                   - Width Sharded (L1)
                   - Width Sharded (DRAM)


### PR DESCRIPTION
### Ticket
#29861 

### Problem description
Matmul's memory config info was kept too high-level while awaiting a tech report.

### What's changed
Added a table to the memory support section, detailing the program config dependent requirements. New section will look like the following (roughly, since local generation doesn't perfectly match the actual docs)

<img width="1958" height="508" alt="image" src="https://github.com/user-attachments/assets/d36b0166-30ee-41e0-9c3a-3f1f547c3d96" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18294417692)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes