### PR TITLE
Add Fabric Geomean Speedup Statistics

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -67,6 +67,7 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
             PRIVATE
                 routing/tt_fabric_test_common_types.cpp
                 routing/tt_fabric_test_config.cpp
+                routing/tt_fabric_test_results.cpp
                 routing/tt_fabric_test_context.cpp
         )
         target_link_libraries(${TEST_TARGET} PRIVATE yaml-cpp::yaml-cpp)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -4,8 +4,6 @@
 
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp"
 
-#include <unordered_map>
-
 static double calc_bw_bytes_per_cycle(uint32_t total_words, uint64_t cycles) {
     constexpr uint32_t bytes_per_eth_word = 16;
     return (total_words * bytes_per_eth_word) / static_cast<double>(cycles);
@@ -263,8 +261,7 @@ std::vector<GoldenCsvEntry>::iterator TestContext::fetch_corresponding_golden_en
     return golden_it;
 }
 
-ComparisonResult TestContext::create_comparison_result(
-    const BandwidthResultSummary& test_result, double test_result_avg_bandwidth) {
+ComparisonResult TestContext::create_comparison_result(const BandwidthResultSummary& test_result) {
     std::string num_devices_str = convert_num_devices_to_string(test_result.num_devices);
     ComparisonResult comp_result;
     comp_result.test_name = test_result.test_name;
@@ -275,7 +272,6 @@ ComparisonResult TestContext::create_comparison_result(
     comp_result.num_links = test_result.num_links;
     comp_result.packet_size = test_result.packet_size;
     comp_result.num_iterations = test_result.num_iterations;
-    comp_result.current_bandwidth_GB_s = test_result_avg_bandwidth;
     return comp_result;
 }
 
@@ -319,110 +315,9 @@ std::string TestContext::generate_failed_test_format_string(const BandwidthResul
     return csv_format_string;
 }
 
-void TestContext::organize_speedups_by_topology() {
-    // Go through each comparison result and add its speedup to the corresponding topology->packet_size and
-    // topology->ntype combination
-    for (const auto& result : comparison_results_) {
-        const std::optional<Topology> result_topology = enchantum::cast<Topology>(result.topology);
-        TT_FATAL(result_topology.has_value(), "Invalid topology in comparison result: {}", result.topology);
-        const double result_speedup = result.speedup();
-        speedups_per_topology_[result_topology.value()].speedups_by_packet_size[result.packet_size].push_back(
-            result_speedup);
-        std::optional<NocSendType> result_ntype = enchantum::cast<NocSendType>(result.ntype);
-        TT_FATAL(result_ntype.has_value(), "Invalid ntype in comparison result: {}", result.ntype);
-        speedups_per_topology_[result_topology.value()].speedups_by_ntype[result_ntype.value()].push_back(
-            result_speedup);
-    }
-}
-
-double TestContext::calculate_geomean_speedup(const std::vector<double>& speedups) {
-    if (speedups.empty()) {
-        log_error(tt::LogTest, "No speedups found to calculate geomean speedup, is the speedups vector empty?");
-        return 1.0;
-    }
-    double log_geomean_speedup = 0.0;
-    for (const auto& speedup : speedups) {
-        log_geomean_speedup += std::log(speedup);
-    }
-    log_geomean_speedup /= speedups.size();
-    double geomean_speedup = std::exp(log_geomean_speedup);
-    return geomean_speedup;
-}
-
-void TestContext::calculate_overall_geomean_speedup() {
-    std::vector<double> speedups(comparison_results_.size());
-    std::transform(
-        comparison_results_.begin(), comparison_results_.end(), speedups.begin(), [](const ComparisonResult& result) {
-            return result.speedup();
-        });
-    overall_geomean_speedup_ = calculate_geomean_speedup(speedups);
-    log_info(tt::LogTest, "Overall Geomean Speedup: {:.6f}", overall_geomean_speedup_);
-}
-
-std::vector<double> TestContext::concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups) {
-    // Figure out how many speedups we have
-    int num_speedups = 0;
-    for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
-        num_speedups += speedups.size();
-    }
-    if (num_speedups == 0) {
-        log_error(tt::LogTest, "No speedups found to concatenate, was topology_speedups correctly populated?");
-        return std::vector<double>();
-    }
-    std::vector<double> concatenated_speedups;
-    concatenated_speedups.reserve(num_speedups);
-    for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
-        concatenated_speedups.insert(concatenated_speedups.end(), speedups.begin(), speedups.end());
-    }
-    return concatenated_speedups;
-}
-
-void TestContext::calculate_geomean_speedup_by_topology() {
-    for (auto& [topology, topology_speedups] : speedups_per_topology_) {
-        // Calculate geomean speedup by packet size and ntype
-        for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
-            topology_speedups.geomean_speedup_by_packet_size[packet_size] = calculate_geomean_speedup(speedups);
-            log_info(
-                tt::LogTest,
-                "Topology: {}, Packet Size: {}, Geomean Speedup: {:.6f}",
-                topology,
-                packet_size,
-                topology_speedups.geomean_speedup_by_packet_size[packet_size]);
-        }
-        for (const auto& [ntype, speedups] : topology_speedups.speedups_by_ntype) {
-            topology_speedups.geomean_speedup_by_ntype[ntype] = calculate_geomean_speedup(speedups);
-            log_info(
-                tt::LogTest,
-                "Topology: {}, NType: {}, Geomean Speedup: {:.6f}",
-                topology,
-                ntype,
-                topology_speedups.geomean_speedup_by_ntype[ntype]);
-        }
-        // To calculate overall geomean speedup for this topology, we need to merge the speedups of one sub-category
-        const std::vector<double> concatenated_speedups = concatenate_topology_speedups(topology_speedups);
-        topology_speedups.topology_geomean_speedup = calculate_geomean_speedup(concatenated_speedups);
-        log_info(
-            tt::LogTest,
-            "Topology: {}, Overall Geomean Speedup: {:.6f}",
-            topology,
-            topology_speedups.topology_geomean_speedup);
-    }
-}
-
-void TestContext::generate_comparison_statistics() {
-    // This function calculates overall post-comparison statistics such as geomean speedup, etc.
-    // Per-test speedup was calculated in populate_comparison_result_bandwidth()
-    // Classify speedup values by topology
-    organize_speedups_by_topology();
-
-    // Calculate geometric mean speedup by topology, packet size, and ntype
-    calculate_geomean_speedup_by_topology();
-
-    // Calculate geometric mean speedup
-    calculate_overall_geomean_speedup();
-}
-
-void TestContext::generate_comparison_statistics_csv() {
+void TestContext::set_comparison_statistics_csv_file_path() {
+    // Bandwidth summary CSV file is generated separately from Bandwidth CSV because we need to wait for all multirun
+    // tests to complete Generate detailed CSV filename
     std::ostringstream comparison_statistics_oss;
     auto arch_name = tt::tt_metal::hal::get_arch_name();
     comparison_statistics_oss << "bandwidth_comparison_statistics_" << arch_name << ".csv";
@@ -430,41 +325,4 @@ void TestContext::generate_comparison_statistics_csv() {
     std::filesystem::path output_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
     comparison_statistics_csv_file_path_ = output_path / comparison_statistics_oss.str();
-
-    // Create detailed CSV file with header
-    std::ofstream comparison_statistics_csv_stream(
-        comparison_statistics_csv_file_path_, std::ios::out | std::ios::trunc);
-    if (!comparison_statistics_csv_stream.is_open()) {
-        log_error(
-            tt::LogTest,
-            "Failed to create comparison statistics CSV file: {}",
-            comparison_statistics_csv_file_path_.string());
-        return;
-    }
-    // Write detailed header
-    comparison_statistics_csv_stream << "topology,packet_size,ntype,geomean_speedup\n";
-    log_info(
-        tt::LogTest, "Initialized comparison statistics CSV file: {}", comparison_statistics_csv_file_path_.string());
-
-    // Write most specific speedups first, then overall geomean speedup
-    for (const auto& [topology, topology_speedups] : speedups_per_topology_) {
-        std::string topology_str = std::string(enchantum::to_string(topology));
-        for (const auto& [packet_size, speedup] : topology_speedups.geomean_speedup_by_packet_size) {
-            comparison_statistics_csv_stream << topology_str << "," << packet_size << "," << "ALL" << "," << speedup
-                                             << "\n";
-        }
-        for (const auto& [ntype, speedup] : topology_speedups.geomean_speedup_by_ntype) {
-            std::string ntype_str = std::string(enchantum::to_string(ntype));
-            comparison_statistics_csv_stream << topology_str << "," << "ALL" << "," << ntype_str << "," << speedup
-                                             << "\n";
-        }
-        comparison_statistics_csv_stream << topology_str << "," << "ALL" << "," << "ALL" << ","
-                                         << topology_speedups.topology_geomean_speedup << "\n";
-    }
-    comparison_statistics_csv_stream << "Overall," << "ALL" << "," << "ALL" << "," << overall_geomean_speedup_ << "\n";
-    comparison_statistics_csv_stream.close();
-    log_info(
-        tt::LogTest,
-        "Comparison statistics CSV results appended to: {}",
-        comparison_statistics_csv_file_path_.string());
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -325,7 +325,7 @@ void TestContext::organize_speedups_by_topology() {
     for (const auto& result : comparison_results_) {
         const std::optional<Topology> result_topology = enchantum::cast<Topology>(result.topology);
         TT_FATAL(result_topology.has_value(), "Invalid topology in comparison result: {}", result.topology);
-        const double result_speedup = result.speedup;
+        const double result_speedup = result.speedup();
         speedups_per_topology_[result_topology.value()].speedups_by_packet_size[result.packet_size].push_back(
             result_speedup);
         std::optional<NocSendType> result_ntype = enchantum::cast<NocSendType>(result.ntype);
@@ -353,7 +353,7 @@ void TestContext::calculate_overall_geomean_speedup() {
     std::vector<double> speedups(comparison_results_.size());
     std::transform(
         comparison_results_.begin(), comparison_results_.end(), speedups.begin(), [](const ComparisonResult& result) {
-            return result.speedup;
+            return result.speedup();
         });
     overall_geomean_speedup_ = calculate_geomean_speedup(speedups);
     log_info(tt::LogTest, "Overall Geomean Speedup: {:.6f}", overall_geomean_speedup_);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -419,7 +419,7 @@ void TestContext::generate_comparison_statistics() {
 void TestContext::generate_comparison_statistics_csv() {
     std::ostringstream comparison_statistics_oss;
     auto arch_name = tt::tt_metal::hal::get_arch_name();
-    comparison_statistics_oss << "comparison_statistics_" << arch_name << ".csv";
+    comparison_statistics_oss << "bandwidth_comparison_statistics_" << arch_name << ".csv";
     // Output directory already set in initialize_bandwidth_results_csv_file()
     std::filesystem::path output_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -336,11 +336,16 @@ void TestContext::organize_speedups_by_topology() {
 }
 
 double TestContext::calculate_geomean_speedup(const std::vector<double>& speedups) {
-    double geomean_speedup = 1.0;
-    for (const auto& speedup : speedups) {
-        geomean_speedup *= speedup;
+    if (speedups.empty()) {
+        log_error(tt::LogTest, "No speedups found to calculate geomean speedup, is the speedups vector empty?");
+        return 1.0;
     }
-    geomean_speedup = std::pow(geomean_speedup, 1.0 / speedups.size());
+    double log_geomean_speedup = 0.0;
+    for (const auto& speedup : speedups) {
+        log_geomean_speedup += std::log(speedup);
+    }
+    log_geomean_speedup /= speedups.size();
+    double geomean_speedup = std::exp(log_geomean_speedup);
     return geomean_speedup;
 }
 
@@ -361,6 +366,7 @@ std::vector<double> TestContext::concatenate_topology_speedups(const SpeedupsByT
         num_speedups += speedups.size();
     }
     if (num_speedups == 0) {
+        log_error(tt::LogTest, "No speedups found to concatenate, was topology_speedups correctly populated?");
         return std::vector<double>();
     }
     std::vector<double> concatenated_speedups;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -142,6 +142,8 @@ struct GoldenCsvEntry {
 };
 
 struct ComparisonResult {
+    double speedup() const { return current_bandwidth_GB_s / golden_bandwidth_GB_s; }
+
     std::string test_name;
     std::string ftype;
     std::string ntype;
@@ -153,7 +155,6 @@ struct ComparisonResult {
     double current_bandwidth_GB_s{};
     double golden_bandwidth_GB_s{};
     double difference_percent{};
-    double speedup{};
     bool within_tolerance{};
     std::string status;
 };
@@ -1371,7 +1372,6 @@ private:
             comp_result.difference_percent = ((comp_result.current_bandwidth_GB_s - comp_result.golden_bandwidth_GB_s) /
                                               comp_result.golden_bandwidth_GB_s) *
                                              100.0;
-            comp_result.speedup = comp_result.current_bandwidth_GB_s / comp_result.golden_bandwidth_GB_s;
 
             // Use per-test tolerance from golden CSV instead of global tolerance
             test_tolerance = golden_it->tolerance_percent;
@@ -1386,7 +1386,6 @@ private:
             log_warning(tt::LogTest, "Golden CSV entry not found for test {}", comp_result.test_name);
             comp_result.golden_bandwidth_GB_s = 0.0;
             comp_result.difference_percent = 0.0;
-            comp_result.speedup = 1.0;
             comp_result.within_tolerance = false;
             comp_result.status = "NO_GOLDEN";
         }
@@ -1460,7 +1459,7 @@ private:
         }
         // Write diff header
         diff_csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,num_iterations,"
-                           "current_avg_bandwidth_gb_s,golden_avg_bandwidth_gb_s,speedup,difference_percent,status\n";
+                           "current_avg_bandwidth_gb_s,golden_avg_bandwidth_gb_s,difference_percent,status\n";
         log_info(tt::LogTest, "Initialized diff CSV file: {}", diff_csv_file_path_.string());
 
         for (const auto& result : comparison_results_) {
@@ -1468,8 +1467,7 @@ private:
                             << ",\"" << result.num_devices << "\"," << result.num_links << "," << result.packet_size
                             << "," << result.num_iterations << "," << std::fixed << std::setprecision(6)
                             << result.current_bandwidth_GB_s << "," << result.golden_bandwidth_GB_s << ","
-                            << std::setprecision(6) << result.speedup << "," << std::setprecision(2)
-                            << result.difference_percent << "," << result.status << "\n";
+                            << std::setprecision(2) << result.difference_percent << "," << result.status << "\n";
         }
         diff_csv_stream.close();
         log_info(tt::LogTest, "Comparison diff CSV results appended to: {}", diff_csv_file_path_.string());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -153,6 +153,7 @@ struct ComparisonResult {
     double current_bandwidth_GB_s{};
     double golden_bandwidth_GB_s{};
     double difference_percent{};
+    double speedup{};
     bool within_tolerance{};
     std::string status;
 };
@@ -1353,6 +1354,7 @@ private:
             comp_result.difference_percent = ((comp_result.current_bandwidth_GB_s - comp_result.golden_bandwidth_GB_s) /
                                               comp_result.golden_bandwidth_GB_s) *
                                              100.0;
+            comp_result.speedup = comp_result.current_bandwidth_GB_s / comp_result.golden_bandwidth_GB_s;
 
             // Use per-test tolerance from golden CSV instead of global tolerance
             test_tolerance = golden_it->tolerance_percent;
@@ -1367,6 +1369,7 @@ private:
             log_warning(tt::LogTest, "Golden CSV entry not found for test {}", comp_result.test_name);
             comp_result.golden_bandwidth_GB_s = 0.0;
             comp_result.difference_percent = 0.0;
+            comp_result.speedup = 1.0;
             comp_result.within_tolerance = false;
             comp_result.status = "NO_GOLDEN";
         }
@@ -1440,15 +1443,16 @@ private:
         }
         // Write diff header
         diff_csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,num_iterations,"
-                           "current_avg_bandwidth_gb_s,golden_avg_bandwidth_gb_s,difference_percent,status\n";
+                           "current_avg_bandwidth_gb_s,golden_avg_bandwidth_gb_s,speedup,difference_percent,status\n";
         log_info(tt::LogTest, "Initialized diff CSV file: {}", diff_csv_file_path_.string());
 
         for (const auto& result : comparison_results_) {
             diff_csv_stream << result.test_name << "," << result.ftype << "," << result.ntype << "," << result.topology
-                     << ",\"" << result.num_devices << "\"," << result.num_links << "," << result.packet_size << "," << result.num_iterations << ","
-                     << std::fixed << std::setprecision(6) << result.current_bandwidth_GB_s << ","
-                     << result.golden_bandwidth_GB_s << "," << std::setprecision(2) << result.difference_percent << ","
-                     << result.status << "\n";
+                            << ",\"" << result.num_devices << "\"," << result.num_links << "," << result.packet_size
+                            << "," << result.num_iterations << "," << std::fixed << std::setprecision(6)
+                            << result.current_bandwidth_GB_s << "," << result.golden_bandwidth_GB_s << ","
+                            << std::setprecision(6) << result.speedup << "," << std::setprecision(2)
+                            << result.difference_percent << "," << result.status << "\n";
         }
         diff_csv_stream.close();
         log_info(tt::LogTest, "Comparison diff CSV results appended to: {}", diff_csv_file_path_.string());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -468,7 +468,7 @@ public:
         generate_comparison_statistics();
 
         // Generate comparison statistics CSV file
-        generate_comparison_summary_csv();
+        generate_comparison_statistics_csv();
 
         validate_against_golden();
     }
@@ -576,7 +576,8 @@ public:
         }
 
         // Copy CSV files to CI artifacts directory
-        for (const std::filesystem::path& csv_filepath : {csv_file_path_, csv_summary_file_path_, diff_csv_file_path_}) {
+        for (const std::filesystem::path& csv_filepath :
+             {csv_file_path_, csv_summary_file_path_, diff_csv_file_path_, comparison_statistics_csv_file_path_}) {
             try {
                 std::filesystem::copy_file(
                     csv_filepath,
@@ -1486,7 +1487,7 @@ private:
 
     void generate_comparison_statistics();
 
-    void generate_comparison_summary_csv();
+    void generate_comparison_statistics_csv();
 
     void validate_against_golden() {
         if (comparison_results_.empty()) {
@@ -1551,4 +1552,5 @@ private:
     // Golden CSV comparison statistics
     std::unordered_map<Topology, SpeedupsByTopology> speedups_per_topology_;
     double overall_geomean_speedup_ = 1.0;
+    std::filesystem::path comparison_statistics_csv_file_path_;
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -24,6 +24,7 @@
 #include "tt_fabric_test_allocator.hpp"
 #include "tt_fabric_test_memory_map.hpp"
 #include "tt_fabric_telemetry.hpp"
+#include "tt_fabric_test_results.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -63,6 +64,12 @@ using FabricConfig = tt::tt_fabric::FabricConfig;
 using RoutingType = tt::tt_fabric::fabric_tests::RoutingType;
 using FabricTensixConfig = tt::tt_fabric::FabricTensixConfig;
 
+using BandwidthResult = tt::tt_fabric::fabric_tests::BandwidthResult;
+using BandwidthResultSummary = tt::tt_fabric::fabric_tests::BandwidthResultSummary;
+using GoldenCsvEntry = tt::tt_fabric::fabric_tests::GoldenCsvEntry;
+using ComparisonResult = tt::tt_fabric::fabric_tests::ComparisonResult;
+using PostComparisonAnalyzer = tt::tt_fabric::fabric_tests::PostComparisonAnalyzer;
+
 // Helper functions for parsing traffic pattern parameters
 using tt::tt_fabric::fabric_tests::fetch_first_traffic_pattern;
 using tt::tt_fabric::fabric_tests::fetch_pattern_ftype;
@@ -92,81 +99,6 @@ const std::unordered_map<BandwidthStatistics, std::string> BandwidthStatisticsHe
 
 // Access to internal API: ProgramImpl::num_kernel
 #include "impl/program/program_impl.hpp"
-
-// Bandwidth measurement result structures
-struct BandwidthResult {
-    uint32_t num_devices;
-    uint32_t device_id;
-    RoutingDirection direction;
-    uint32_t total_traffic_count;
-    uint32_t num_packets;
-    uint32_t packet_size;
-    uint64_t cycles;
-    double bandwidth_GB_s;
-    double packets_per_second;
-    std::optional<double> telemetry_bw_GB_s_min;
-    std::optional<double> telemetry_bw_GB_s_avg;
-    std::optional<double> telemetry_bw_GB_s_max;
-};
-
-struct BandwidthResultSummary {
-    std::string test_name;
-    uint32_t num_iterations;
-    std::string ftype;
-    std::string ntype;
-    std::string topology;
-    uint32_t num_links;
-    uint32_t num_packets;
-    std::vector<uint32_t> num_devices;
-    uint32_t packet_size;
-    std::vector<double> cycles_vector;
-    std::vector<double> bandwidth_vector_GB_s;
-    std::vector<double> packets_per_second_vector;
-    std::vector<double> statistics_vector; // Stores the calculated statistics for each test
-};
-
-// Golden CSV comparison structures
-struct GoldenCsvEntry {
-    std::string test_name;
-    std::string ftype;
-    std::string ntype;
-    std::string topology;
-    std::string num_devices;
-    uint32_t num_links{};
-    uint32_t packet_size{};
-    uint32_t num_iterations{};
-    double cycles{};
-    double bandwidth_GB_s{};
-    double packets_per_second{};
-    double tolerance_percent{};  // Per-test tolerance percentage
-};
-
-struct ComparisonResult {
-    double speedup() const { return current_bandwidth_GB_s / golden_bandwidth_GB_s; }
-
-    std::string test_name;
-    std::string ftype;
-    std::string ntype;
-    std::string topology;
-    std::string num_devices;
-    uint32_t num_links{};
-    uint32_t packet_size{};
-    uint32_t num_iterations{};
-    double current_bandwidth_GB_s{};
-    double golden_bandwidth_GB_s{};
-    double difference_percent{};
-    bool within_tolerance{};
-    std::string status;
-};
-
-struct SpeedupsByTopology {
-    Topology topology;
-    double topology_geomean_speedup{};
-    std::unordered_map<uint32_t, std::vector<double>> speedups_by_packet_size;
-    std::unordered_map<uint32_t, double> geomean_speedup_by_packet_size;
-    std::unordered_map<NocSendType, std::vector<double>> speedups_by_ntype;
-    std::unordered_map<NocSendType, double> geomean_speedup_by_ntype;
-};
 
 class TestContext {
 public:
@@ -466,10 +398,12 @@ public:
         compare_summary_results_with_golden();
 
         // Generate statistics based on golden comparison
-        generate_comparison_statistics();
+        PostComparisonAnalyzer post_comparison_analyzer(comparison_results_);
+        post_comparison_analyzer.generate_comparison_statistics();
 
         // Generate comparison statistics CSV file
-        generate_comparison_statistics_csv();
+        set_comparison_statistics_csv_file_path();
+        post_comparison_analyzer.generate_comparison_statistics_csv(comparison_statistics_csv_file_path_);
 
         validate_against_golden();
     }
@@ -1369,13 +1303,9 @@ private:
         double test_tolerance = 1.0;  // Default tolerance for no golden case
         if (golden_it != golden_csv_entries_.end()) {
             comp_result.golden_bandwidth_GB_s = golden_it->bandwidth_GB_s;
-            comp_result.difference_percent = ((comp_result.current_bandwidth_GB_s - comp_result.golden_bandwidth_GB_s) /
-                                              comp_result.golden_bandwidth_GB_s) *
-                                             100.0;
-
             // Use per-test tolerance from golden CSV instead of global tolerance
             test_tolerance = golden_it->tolerance_percent;
-            comp_result.within_tolerance = std::abs(comp_result.difference_percent) <= test_tolerance;
+            comp_result.within_tolerance = std::abs(comp_result.difference_percent()) <= test_tolerance;
 
             if (comp_result.within_tolerance) {
                 comp_result.status = "PASS";
@@ -1385,14 +1315,14 @@ private:
         } else {
             log_warning(tt::LogTest, "Golden CSV entry not found for test {}", comp_result.test_name);
             comp_result.golden_bandwidth_GB_s = 0.0;
-            comp_result.difference_percent = 0.0;
+            // Set within_tolerance explicitly to prevent an edge case, where golden is not found and test result is
+            // 0.0, which would cause subsequent within_tolerance checks to be true
             comp_result.within_tolerance = false;
             comp_result.status = "NO_GOLDEN";
         }
     }
 
-    ComparisonResult create_comparison_result(
-        const BandwidthResultSummary& test_result, double test_result_avg_bandwidth);
+    ComparisonResult create_comparison_result(const BandwidthResultSummary& test_result);
 
     std::string convert_num_devices_to_string(const std::vector<uint32_t>& num_devices);
 
@@ -1428,7 +1358,7 @@ private:
             auto golden_it = fetch_corresponding_golden_entry(test_result);
 
             // Compare the test result with the golden entry
-            ComparisonResult comp_result = create_comparison_result(test_result, test_result_avg_bandwidth);
+            ComparisonResult comp_result = create_comparison_result(test_result);
             populate_comparison_result_bandwidth(test_result_avg_bandwidth, comp_result, golden_it);
             comparison_results_.push_back(comp_result);
 
@@ -1438,7 +1368,7 @@ private:
                     acceptable_tolerance = golden_it->tolerance_percent;
                 }
                 std::string csv_format_string = generate_failed_test_format_string(
-                    test_result, test_result_avg_bandwidth, comp_result.difference_percent, acceptable_tolerance);
+                    test_result, test_result_avg_bandwidth, comp_result.difference_percent(), acceptable_tolerance);
                 all_failed_tests_.push_back(csv_format_string);
             }
         }
@@ -1467,25 +1397,11 @@ private:
                             << ",\"" << result.num_devices << "\"," << result.num_links << "," << result.packet_size
                             << "," << result.num_iterations << "," << std::fixed << std::setprecision(6)
                             << result.current_bandwidth_GB_s << "," << result.golden_bandwidth_GB_s << ","
-                            << std::setprecision(2) << result.difference_percent << "," << result.status << "\n";
+                            << std::setprecision(2) << result.difference_percent() << "," << result.status << "\n";
         }
         diff_csv_stream.close();
         log_info(tt::LogTest, "Comparison diff CSV results appended to: {}", diff_csv_file_path_.string());
     }
-
-    void organize_speedups_by_topology();
-
-    double calculate_geomean_speedup(const std::vector<double>& speedups);
-
-    void calculate_overall_geomean_speedup();
-
-    std::vector<double> concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups);
-
-    void calculate_geomean_speedup_by_topology();
-
-    void generate_comparison_statistics();
-
-    void generate_comparison_statistics_csv();
 
     void validate_against_golden() {
         if (comparison_results_.empty()) {
@@ -1503,6 +1419,8 @@ private:
             log_info(tt::LogTest, "All tests passed golden comparison using per-test tolerance values");
         }
     }
+
+    void set_comparison_statistics_csv_file_path();
 
     // Track sync cores for each device
     std::unordered_map<FabricNodeId, CoreCoord> device_global_sync_cores_;
@@ -1548,7 +1466,5 @@ private:
     bool has_test_failures_ = false;  // Track if any tests failed validation
 
     // Golden CSV comparison statistics
-    std::unordered_map<Topology, SpeedupsByTopology> speedups_per_topology_;
-    double overall_geomean_speedup_ = 1.0;
     std::filesystem::path comparison_statistics_csv_file_path_;
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp"
+
+namespace tt::tt_fabric::fabric_tests {
+
+void PostComparisonAnalyzer::organize_speedups_by_topology() {
+    // Go through each comparison result and add its speedup to the corresponding topology->packet_size and
+    // topology->ntype combination
+    for (const auto& result : comparison_results_) {
+        const std::optional<Topology> result_topology = enchantum::cast<Topology>(result.topology);
+        TT_FATAL(result_topology.has_value(), "Invalid topology in comparison result: {}", result.topology);
+        const double result_speedup = result.speedup();
+        speedups_per_topology_[result_topology.value()].speedups_by_packet_size[result.packet_size].push_back(
+            result_speedup);
+        std::optional<NocSendType> result_ntype = enchantum::cast<NocSendType>(result.ntype);
+        TT_FATAL(result_ntype.has_value(), "Invalid ntype in comparison result: {}", result.ntype);
+        speedups_per_topology_[result_topology.value()].speedups_by_ntype[result_ntype.value()].push_back(
+            result_speedup);
+    }
+}
+
+double PostComparisonAnalyzer::calculate_geomean_speedup(const std::vector<double>& speedups) {
+    if (speedups.empty()) {
+        log_error(tt::LogTest, "No speedups found to calculate geomean speedup, is the speedups vector empty?");
+        return 1.0;
+    }
+    double log_geomean_speedup = 0.0;
+    for (const auto& speedup : speedups) {
+        log_geomean_speedup += std::log(speedup);
+    }
+    log_geomean_speedup /= speedups.size();
+    double geomean_speedup = std::exp(log_geomean_speedup);
+    return geomean_speedup;
+}
+
+void PostComparisonAnalyzer::calculate_overall_geomean_speedup() {
+    std::vector<double> speedups(comparison_results_.size());
+    std::transform(
+        comparison_results_.begin(), comparison_results_.end(), speedups.begin(), [](const ComparisonResult& result) {
+            return result.speedup();
+        });
+    overall_geomean_speedup_ = calculate_geomean_speedup(speedups);
+    log_info(tt::LogTest, "Overall Geomean Speedup: {:.6f}", overall_geomean_speedup_);
+}
+
+std::vector<double> PostComparisonAnalyzer::concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups) {
+    // Figure out how many speedups we have
+    int num_speedups = 0;
+    for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
+        num_speedups += speedups.size();
+    }
+    if (num_speedups == 0) {
+        log_error(tt::LogTest, "No speedups found to concatenate, was topology_speedups correctly populated?");
+        return std::vector<double>();
+    }
+    std::vector<double> concatenated_speedups;
+    concatenated_speedups.reserve(num_speedups);
+    for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
+        concatenated_speedups.insert(concatenated_speedups.end(), speedups.begin(), speedups.end());
+    }
+    return concatenated_speedups;
+}
+
+void PostComparisonAnalyzer::calculate_geomean_speedup_by_topology() {
+    for (auto& [topology, topology_speedups] : speedups_per_topology_) {
+        // Calculate geomean speedup by packet size and ntype
+        for (const auto& [packet_size, speedups] : topology_speedups.speedups_by_packet_size) {
+            topology_speedups.geomean_speedup_by_packet_size[packet_size] = calculate_geomean_speedup(speedups);
+            log_info(
+                tt::LogTest,
+                "Topology: {}, Packet Size: {}, Geomean Speedup: {:.6f}",
+                topology,
+                packet_size,
+                topology_speedups.geomean_speedup_by_packet_size[packet_size]);
+        }
+        for (const auto& [ntype, speedups] : topology_speedups.speedups_by_ntype) {
+            topology_speedups.geomean_speedup_by_ntype[ntype] = calculate_geomean_speedup(speedups);
+            log_info(
+                tt::LogTest,
+                "Topology: {}, NType: {}, Geomean Speedup: {:.6f}",
+                topology,
+                ntype,
+                topology_speedups.geomean_speedup_by_ntype[ntype]);
+        }
+        // To calculate overall geomean speedup for this topology, we need to merge the speedups of one sub-category
+        const std::vector<double> concatenated_speedups = concatenate_topology_speedups(topology_speedups);
+        topology_speedups.topology_geomean_speedup = calculate_geomean_speedup(concatenated_speedups);
+        log_info(
+            tt::LogTest,
+            "Topology: {}, Overall Geomean Speedup: {:.6f}",
+            topology,
+            topology_speedups.topology_geomean_speedup);
+    }
+}
+
+void PostComparisonAnalyzer::generate_comparison_statistics() {
+    // This function calculates overall post-comparison statistics such as geomean speedup, etc.
+    // Per-test speedup was calculated in populate_comparison_result_bandwidth()
+    // Classify speedup values by topology
+    organize_speedups_by_topology();
+
+    // Calculate geometric mean speedup by topology, packet size, and ntype
+    calculate_geomean_speedup_by_topology();
+
+    // Calculate geometric mean speedup
+    calculate_overall_geomean_speedup();
+}
+
+void PostComparisonAnalyzer::generate_comparison_statistics_csv(const std::filesystem::path& csv_file_path) {
+    // Create detailed CSV file with header
+    std::ofstream comparison_statistics_csv_stream(csv_file_path, std::ios::out | std::ios::trunc);
+    if (!comparison_statistics_csv_stream.is_open()) {
+        log_error(tt::LogTest, "Failed to create comparison statistics CSV file: {}", csv_file_path.string());
+        return;
+    }
+    // Write detailed header
+    comparison_statistics_csv_stream << "topology,packet_size,ntype,geomean_speedup\n";
+    log_info(tt::LogTest, "Initialized comparison statistics CSV file: {}", csv_file_path.string());
+
+    // Write most specific speedups first, then overall geomean speedup
+    for (const auto& [topology, topology_speedups] : speedups_per_topology_) {
+        std::string topology_str = std::string(enchantum::to_string(topology));
+        for (const auto& [packet_size, speedup] : topology_speedups.geomean_speedup_by_packet_size) {
+            comparison_statistics_csv_stream << topology_str << "," << packet_size << "," << "ALL" << "," << speedup
+                                             << "\n";
+        }
+        for (const auto& [ntype, speedup] : topology_speedups.geomean_speedup_by_ntype) {
+            std::string ntype_str = std::string(enchantum::to_string(ntype));
+            comparison_statistics_csv_stream << topology_str << "," << "ALL" << "," << ntype_str << "," << speedup
+                                             << "\n";
+        }
+        comparison_statistics_csv_stream << topology_str << "," << "ALL" << "," << "ALL" << ","
+                                         << topology_speedups.topology_geomean_speedup << "\n";
+    }
+    comparison_statistics_csv_stream << "Overall," << "ALL" << "," << "ALL" << "," << overall_geomean_speedup_ << "\n";
+    comparison_statistics_csv_stream.close();
+    log_info(tt::LogTest, "Comparison statistics CSV results appended to: {}", csv_file_path.string());
+}
+
+}  // namespace tt::tt_fabric::fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <enchantum/enchantum.hpp>
+
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+#include <tt-metalium/mesh_graph.hpp>
+
+using Topology = tt::tt_fabric::Topology;
+using NocSendType = tt::tt_fabric::NocSendType;
+using RoutingDirection = tt::tt_fabric::RoutingDirection;
+
+namespace tt::tt_fabric::fabric_tests {
+
+// Bandwidth measurement result structures
+struct BandwidthResult {
+    uint32_t num_devices;
+    uint32_t device_id;
+    RoutingDirection direction;
+    uint32_t total_traffic_count;
+    uint32_t num_packets;
+    uint32_t packet_size;
+    uint64_t cycles;
+    double bandwidth_GB_s;
+    double packets_per_second;
+    std::optional<double> telemetry_bw_GB_s_min;
+    std::optional<double> telemetry_bw_GB_s_avg;
+    std::optional<double> telemetry_bw_GB_s_max;
+};
+
+struct BandwidthResultSummary {
+    std::string test_name;
+    uint32_t num_iterations;
+    std::string ftype;
+    std::string ntype;
+    std::string topology;
+    uint32_t num_links;
+    uint32_t num_packets;
+    std::vector<uint32_t> num_devices;
+    uint32_t packet_size;
+    std::vector<double> cycles_vector;
+    std::vector<double> bandwidth_vector_GB_s;
+    std::vector<double> packets_per_second_vector;
+    std::vector<double> statistics_vector;  // Stores the calculated statistics for each test
+};
+
+// Golden CSV comparison structures
+struct GoldenCsvEntry {
+    std::string test_name;
+    std::string ftype;
+    std::string ntype;
+    std::string topology;
+    std::string num_devices;
+    uint32_t num_links{};
+    uint32_t packet_size{};
+    uint32_t num_iterations{};
+    double cycles{};
+    double bandwidth_GB_s{};
+    double packets_per_second{};
+    double tolerance_percent{};  // Per-test tolerance percentage
+};
+
+struct ComparisonResult {
+    double speedup() const { return current_bandwidth_GB_s / golden_bandwidth_GB_s; }
+    double difference_percent() const {
+        return ((current_bandwidth_GB_s - golden_bandwidth_GB_s) / golden_bandwidth_GB_s) * 100.0;
+    }
+
+    std::string test_name;
+    std::string ftype;
+    std::string ntype;
+    std::string topology;
+    std::string num_devices;
+    uint32_t num_links{};
+    uint32_t packet_size{};
+    uint32_t num_iterations{};
+    double current_bandwidth_GB_s{};
+    double golden_bandwidth_GB_s{};
+    bool within_tolerance{};
+    std::string status;
+};
+
+// Used to organize per-test speedups by test topology, packet size, and ntype
+struct SpeedupsByTopology {
+    Topology topology;
+    double topology_geomean_speedup{};
+    std::unordered_map<uint32_t, std::vector<double>> speedups_by_packet_size;
+    std::unordered_map<uint32_t, double> geomean_speedup_by_packet_size;
+    std::unordered_map<NocSendType, std::vector<double>> speedups_by_ntype;
+    std::unordered_map<NocSendType, double> geomean_speedup_by_ntype;
+};
+
+class PostComparisonAnalyzer {
+public:
+    PostComparisonAnalyzer(const std::vector<ComparisonResult>& comparison_results) :
+        comparison_results_(comparison_results) {};
+
+    void generate_comparison_statistics();
+
+    void generate_comparison_statistics_csv(const std::filesystem::path& csv_file_path);
+
+private:
+    void organize_speedups_by_topology();
+
+    double calculate_geomean_speedup(const std::vector<double>& speedups);
+
+    void calculate_overall_geomean_speedup();
+
+    std::vector<double> concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups);
+
+    void calculate_geomean_speedup_by_topology();
+
+    const std::vector<ComparisonResult> comparison_results_;
+    std::unordered_map<Topology, SpeedupsByTopology> speedups_per_topology_;
+    double overall_geomean_speedup_ = 1.0;
+};
+
+}  // namespace tt::tt_fabric::fabric_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
@@ -25,15 +25,15 @@ namespace tt::tt_fabric::fabric_tests {
 
 // Bandwidth measurement result structures
 struct BandwidthResult {
-    uint32_t num_devices;
-    uint32_t device_id;
-    RoutingDirection direction;
-    uint32_t total_traffic_count;
-    uint32_t num_packets;
-    uint32_t packet_size;
-    uint64_t cycles;
-    double bandwidth_GB_s;
-    double packets_per_second;
+    uint32_t num_devices{};
+    uint32_t device_id{};
+    RoutingDirection direction = RoutingDirection::NONE;
+    uint32_t total_traffic_count{};
+    uint32_t num_packets{};
+    uint32_t packet_size{};
+    uint64_t cycles{};
+    double bandwidth_GB_s{};
+    double packets_per_second{};
     std::optional<double> telemetry_bw_GB_s_min;
     std::optional<double> telemetry_bw_GB_s_avg;
     std::optional<double> telemetry_bw_GB_s_max;
@@ -41,14 +41,14 @@ struct BandwidthResult {
 
 struct BandwidthResultSummary {
     std::string test_name;
-    uint32_t num_iterations;
+    uint32_t num_iterations{};
     std::string ftype;
     std::string ntype;
     std::string topology;
-    uint32_t num_links;
-    uint32_t num_packets;
+    uint32_t num_links{};
+    uint32_t num_packets{};
     std::vector<uint32_t> num_devices;
-    uint32_t packet_size;
+    uint32_t packet_size{};
     std::vector<double> cycles_vector;
     std::vector<double> bandwidth_vector_GB_s;
     std::vector<double> packets_per_second_vector;
@@ -93,7 +93,7 @@ struct ComparisonResult {
 
 // Used to organize per-test speedups by test topology, packet size, and ntype
 struct SpeedupsByTopology {
-    Topology topology;
+    Topology topology = Topology::Linear;
     double topology_geomean_speedup{};
     std::unordered_map<uint32_t, std::vector<double>> speedups_by_packet_size;
     std::unordered_map<uint32_t, double> geomean_speedup_by_packet_size;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29040

### Problem description
The TT-Fabric test infra currently verifies test results against golden results using percent-difference comparisons. While this helps users verify whether test results are consistent, it does not give users any idea of the overall impact of their changes (to fabric, metal, etc). on fabric performance. 

### What's changed
- Added post-comparison statistics generation in `generate_comparison_statistics`, which is called by  `generate_bandwidth_summary` after golden comparisons
- Modified `populate_comparison_result_bandwidth` to calculate per-test speedup compared to golden results, in addition to difference_percent.
- `generate_comparison_statistics` groups the per-test speedups by topology, sub-grouped by `packet_size` and `ntype`.
- Then, the function computes the geometric mean speedup for the following groups:
1. Overall Geomean Speedup 
2. Geomean Speedup per topology
    1. Geomean Speedup per topology, per packet size
    2. Geomean Speedup per topology, per ntype
- Per-test speedups added to `bandwidth_summary_results...diff.csv`, geomean results are written to `stdout`. 
- Added `generate_comparison_statistics_csv`, which writes the results to `comparison_statistics_<arch_name>.csv` in the `generated/fabric` folder, forming a table like the one below:

| topology | packet_size | ntype                        | geomean_speedup |
|:--------:|:-----------:|:----------------------------:|:---------------:|
| Mesh     |        2048 | ALL                          |        0.998264 |
| Mesh     |        4096 | ALL                          |        0.998243 |
| Mesh     | ALL         | NOC_UNICAST_WRITE            |        0.998548 |
| Mesh     | ALL         | NOC_FUSED_UNICAST_ATOMIC_INC |        0.997715 |
| Mesh     | ALL         | NOC_UNICAST_SCATTER_WRITE    |        0.998498 |
| Mesh     | ALL         | ALL                          |        0.998254 |
| Ring     |        2048 | ALL                          |        0.999444 |
| Ring     |        4096 | ALL                          |         1.00364 |
| Ring     | ALL         | NOC_UNICAST_WRITE            |         1.00026 |
| Ring     | ALL         | NOC_FUSED_UNICAST_ATOMIC_INC |         1.00435 |
| Ring     | ALL         | NOC_UNICAST_SCATTER_WRITE    |         1.00002 |
| Ring     | ALL         | ALL                          |         1.00154 |
| Linear   |        2048 | ALL                          |        0.999877 |
| Linear   |        4096 | ALL                          |         1.00004 |
| Linear   | ALL         | NOC_UNICAST_WRITE            |         0.99996 |
| Linear   | ALL         | NOC_FUSED_UNICAST_ATOMIC_INC |         1.00007 |
| Linear   | ALL         | NOC_UNICAST_SCATTER_WRITE    |        0.999844 |
| Linear   | ALL         | ALL                          |        0.999957 |
| Overall  | ALL         | ALL                          |        0.999916 |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18502921513
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18502930168
- [x] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18502936667
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18502942708