### PR TITLE
#28623: [skip ci] Remove docker-run and containerize BH single card demos

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -77,9 +77,6 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
-        with:
-          runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests
         timeout-minutes: 70
         run: |

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "BH"
+      regenerate-ttnn-cache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   single-card-demo-tests:
@@ -44,85 +48,67 @@ jobs:
           }
         ]
     name: ${{ matrix.test-group.name }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
+    runs-on:
+      - "in-service"
+      - "${{ inputs.runner-label }}"
+      - "pipeline-perf"
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        LD_LIBRARY_PATH: /work/build/lib
+        PYTHONPATH: /work
+        TT_METAL_HOME: /work
+        HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - "/localdev/blackhole_demos/huggingface_data:/localdev/blackhole_demos/huggingface_data${{ inputs.regenerate-ttnn-cache == true && ':rw' || ':ro' }}"
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
-          name: ${{ inputs.build-artifact-name }}
-      - name: Extract files
-        run: tar -xvf ttm_any.tar
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
-          name: ${{ inputs.wheel-artifact-name }}
-      - name: Enable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') }}
-        run: |
-          sudo cpupower frequency-set -g performance
+          runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests
-        uses: ./.github/actions/docker-run
         timeout-minutes: 70
-        env:
-          LOGURU_LEVEL: INFO
-        with:
-          docker_image: ${{ inputs.docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=${{ matrix.test-group.arch }}
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
-          install_wheel: true
-          run_args: |
-            if [[ "${{ matrix.test-group.name }}" == *"llama"* ]]; then
-              pip install -r ${{ github.workspace }}/models/tt_transformers/requirements.txt
-            fi
-            ${{ matrix.test-group.cmd }}
-
+        run: |
+          if [[ "${{ matrix.test-group.name }}" == *"llama"* ]]; then
+            pip install -r /work/models/tt_transformers/requirements.txt
+          fi
+          ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 'llama3-8b performance') && !cancelled() }}
-        uses: ./.github/actions/docker-run
+        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        timeout-minutes: 15
         env:
-          LOGURU_LEVEL: INFO
-        with:
-          docker_image: ${{ inputs.docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=${{ matrix.test-group.arch }}
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev/blackhole_demos:/localdev/blackhole_demos:ro
-          install_wheel: true
-          run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          ARCH_NAME: ${{ matrix.test-group.arch }}
+        run: python3 /work/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
 
       - name: Upload benchmark data
-        if: ${{ ( matrix.test-group.name == 'llama3-8b performance') && !cancelled() }}
-        uses: ./.github/actions/upload-data-via-sftp
+        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
-          path: generated/test_reports/
           prefix: "test_reports_"
-      - name: Disable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') }}
-        run: |
-          sudo cpupower frequency-set -g ondemand
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -111,3 +111,5 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -2,7 +2,18 @@ name: "(Blackhole) Demo tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      regenerate-ttnn-cache:
+        description: "Mount model cache volume read-write to regenerate TTNN cache (otherwise read-only)."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      regenerate-ttnn-cache:
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: "0 4 * * *"  # Every day at 4:00 UTC
 
@@ -28,3 +39,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      regenerate-ttnn-cache: ${{ inputs.regenerate-ttnn-cache || false  }}

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -39,4 +39,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      regenerate-ttnn-cache: ${{ inputs.regenerate-ttnn-cache || false  }}
+      regenerate-ttnn-cache: ${{ inputs.regenerate-ttnn-cache || false }}

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -115,6 +115,8 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
   multi-card-demo-tests-large:
     if: ${{ inputs.num_devices >= 4 }}
     strategy:
@@ -194,3 +196,5 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/28623

### Problem description
BH single card demo still uses docker-run when cpupower/perf governor already switches between perf mode and ondemand mode in reset-default.sh and cleanup-default.sh.
Therefore we can remove docker-run usage and containerize the entire workflow.

### What's changed
Switch to container, remove docker-run usage.

### Checklist
- [x] BH demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/18288119218