### PR TITLE
[skip ci] Fix test filter for P300 upstream test

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -32,9 +32,9 @@ test_suite_bh_umd_unit_tests() {
     # Add more tests to exclude if hw_topology is blackhole_p300
     # Issue: https://github.com/tenstorrent/tt-umd/issues/1412
     if [[ "$hw_topology" == "blackhole_p300" ]]; then
-        gtest_filter+=":-ApiClusterDescriptorTest.VerifyStandardTopology"
-        gtest_filter+=":-ApiClusterTest.OpenChipsByPciId"
-        gtest_filter+=":-ApiClusterTest.OpenClusterByLogicalID"
+        gtest_filter+=":ApiClusterDescriptorTest.VerifyStandardTopology"
+        gtest_filter+=":ApiClusterTest.OpenChipsByPciId"
+        gtest_filter+=":ApiClusterTest.OpenClusterByLogicalID"
     fi
     ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
Gtest filter was not applied correctly

### What's changed
Remove extra `-`'s
Correct the filter to be the following
```
Running main() from /work/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/src/gtest_main.cc
Note: Google Test filter = -ApiClusterTest.DifferentConstructors:ApiClusterDescriptorTest.VerifyStandardTopology:ApiClusterTest.OpenChipsByPciId:ApiClusterTest.OpenClusterByLogicalID
```

### Checklist
- [x] Verified in container