### PR TITLE
#26591: Migrate distributed Trace APIs

### DIFF
--- a/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
+++ b/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
@@ -1630,13 +1630,13 @@ The functions listed below allow a MeshTrace to be captured, binarized and run/r
 // Maps to BeginTraceCapture
 void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
 
-// Maps to EndTraceCapture
+
 void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id);
 
-// Maps to ReplayTrace
+
 void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking);
 
-// Maps to ReleaseTrace
+
 void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id);
 
 // Get the underlying MeshTrace metadata corresponding to an ID.

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -299,15 +299,15 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseAddTest) {
 
     auto trace_id = BeginTraceCapture(mesh_device_.get(), cq.id());
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
-    EndTraceCapture(mesh_device_.get(), cq.id(), trace_id);
+    mesh_device_->end_mesh_trace(cq.id(), trace_id);
 
     EnqueueWriteMeshBuffer(cq, a_buffer, a_data, false /* blocking */);
     // Block to prevent wriitng during trace, which is illegal
     EnqueueWriteMeshBuffer(cq, b_buffer, b_data, true /* blocking */);
 
-    ReplayTrace(mesh_device_.get(), cq.id(), trace_id, false);
+    mesh_device_->replay_mesh_trace(cq.id(), trace_id, false);
 
-    ReleaseTrace(mesh_device_.get(), trace_id);
+    mesh_device_->release_mesh_trace(trace_id);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
     EnqueueReadMeshBuffer(cq, result_data, out_buffer, true /* blocking */);
@@ -363,15 +363,15 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseMulTest) {
 
     auto trace_id = BeginTraceCapture(mesh_device_.get(), cq.id());
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
-    EndTraceCapture(mesh_device_.get(), cq.id(), trace_id);
+    mesh_device_->end_mesh_trace(cq.id(), trace_id);
 
     EnqueueWriteMeshBuffer(cq, a_buffer, a_data, false /* blocking */);
     // Block to prevent wriitng during trace, which is illegal
     EnqueueWriteMeshBuffer(cq, b_buffer, b_data, true /* blocking */);
 
-    ReplayTrace(mesh_device_.get(), cq.id(), trace_id, false);
+    mesh_device_->replay_mesh_trace(cq.id(), trace_id, false);
 
-    ReleaseTrace(mesh_device_.get(), trace_id);
+    mesh_device_->release_mesh_trace(trace_id);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
     EnqueueReadMeshBuffer(cq, result_data, out_buffer, true /* blocking */);
@@ -481,7 +481,7 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     auto trace_id = BeginTraceCapture(mesh_device_.get(), kWorkloadCqId);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), add_mesh_workload, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), multiply_and_subtract_mesh_workload, false);
-    EndTraceCapture(mesh_device_.get(), kWorkloadCqId, trace_id);
+    mesh_device_->end_mesh_trace(kWorkloadCqId, trace_id);
 
     uint32_t workload_0_src0_val = 2;
     uint32_t workload_0_src1_val = 3;
@@ -507,7 +507,7 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
 
-    ReplayTrace(mesh_device_.get(), kWorkloadCqId, trace_id, false);
+    mesh_device_->replay_mesh_trace(kWorkloadCqId, trace_id, false);
 
     // Synchronize
     MeshEvent trace_event = workload_cq.enqueue_record_event();

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -131,19 +131,19 @@ TEST_F(MeshTraceTestSuite, Sanity) {
                     *mesh_workloads[(trace_idx * num_workloads_per_trace) + workload_idx],
                     false);
             }
-            EndTraceCapture(mesh_device_.get(), 0, trace_id);
+            mesh_device_->end_mesh_trace(0, trace_id);
             trace_ids.push_back(trace_id);
         }
 
         for (int i = 0; i < num_iters; i++) {
             for (auto trace_id : trace_ids) {
-                ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+                mesh_device_->replay_mesh_trace(0, trace_id, false);
             }
         }
         Finish(mesh_device_->mesh_command_queue());
 
         for (auto trace_id : trace_ids) {
-            ReleaseTrace(mesh_device_.get(), trace_id);
+            mesh_device_->release_mesh_trace(trace_id);
         }
     }
 }
@@ -208,11 +208,11 @@ TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload_1, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload_2, false);
-    EndTraceCapture(mesh_device_.get(), 0, trace_id);
+    mesh_device_->end_mesh_trace(0, trace_id);
 
     // Run workload multiple times
     for (int i = 0; i < 1000; i++) {
-        ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+        mesh_device_->replay_mesh_trace(0, trace_id, false);
     }
     // Verify outputs
     std::vector<uint32_t> expected_values = {18, 18, 45, 12, 12, 12, 27, 6};
@@ -234,7 +234,7 @@ TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
             }
         }
     }
-    ReleaseTrace(mesh_device_.get(), trace_id);
+    mesh_device_->release_mesh_trace(trace_id);
 }
 
 TEST_F(MeshTraceTestSuite, SyncWorkloadsOnSubDeviceTrace) {
@@ -325,14 +325,14 @@ TEST_F(MeshTraceTestSuite, SyncWorkloadsOnSubDeviceTrace) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_2, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_2, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), incrementer_2, false);
-    EndTraceCapture(mesh_device_.get(), 0, trace_id);
+    mesh_device_->end_mesh_trace(0, trace_id);
 
     // Run trace on all SubDevices in the Mesh
     for (uint32_t i = 0; i < num_iters; i++) {
-        ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+        mesh_device_->replay_mesh_trace(0, trace_id, false);
     }
     Finish(mesh_device_->mesh_command_queue());
-    ReleaseTrace(mesh_device_.get(), trace_id);
+    mesh_device_->release_mesh_trace(trace_id);
 }
 
 TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
@@ -469,10 +469,10 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_mesh_workload, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), datacopy_mesh_workload, false);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), add_mesh_workload, false);
-    EndTraceCapture(mesh_device_.get(), 0, trace_id);
+    mesh_device_->end_mesh_trace(0, trace_id);
     // Run trace and verify outputs
     for (int i = 0; i < 50; i++) {
-        ReplayTrace(mesh_device_.get(), 0, trace_id, false);
+        mesh_device_->replay_mesh_trace(0, trace_id, false);
 
         std::vector<uint32_t> src_vec(input_buf->size() / sizeof(uint32_t));
         std::iota(src_vec.begin(), src_vec.end(), i);
@@ -501,7 +501,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
             }
         }
     }
-    ReleaseTrace(mesh_device_.get(), trace_id);
+    mesh_device_->release_mesh_trace(trace_id);
 }
 
 TEST_F(MeshTraceTestSuite, MeshTraceAsserts) {
@@ -517,7 +517,7 @@ TEST_F(MeshTraceTestSuite, MeshTraceAsserts) {
     auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
     EXPECT_THROW(EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, true), std::runtime_error);
     EXPECT_THROW(Finish(mesh_device_->mesh_command_queue()), std::runtime_error);
-    EndTraceCapture(mesh_device_.get(), 0, trace_id);
+    mesh_device_->end_mesh_trace(0, trace_id);
 }
 
 // Sweep Tests on T3K and TG
@@ -549,12 +549,12 @@ void run_heterogenous_trace_sweep(
     for (auto& workload : mesh_workloads) {
         EnqueueMeshWorkload(mesh_device->mesh_command_queue(), *workload, false);
     }
-    EndTraceCapture(mesh_device.get(), 0, trace_id);
+    mesh_device->end_mesh_trace(0, trace_id);
     for (int i = 0; i < 50; i++) {
-        ReplayTrace(mesh_device.get(), 0, trace_id, false);
+        mesh_device->replay_mesh_trace(0, trace_id, false);
     }
     Finish(mesh_device->mesh_command_queue());
-    ReleaseTrace(mesh_device.get(), trace_id);
+    mesh_device->release_mesh_trace(trace_id);
 }
 
 class MeshTraceSweepTest2x4 : public MeshTraceTest2x4,

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/bench_unicast_main.cpp
@@ -63,8 +63,8 @@ Notes:
 - --src-type/--dst-type are accepted for future use; current code uses DRAM src and L1/DRAM dst.
 - Trace semantics: each measured iteration does
     1) warm-up (outside trace),
-    2) BeginTraceCapture → enqueue the workload N=--trace-iters times → EndTraceCapture,
-    3) ReplayTrace once and time it, then divides by N to get per-iter time.
+    2) BeginTraceCapture → enqueue the workload N=--trace-iters times → end_mesh_trace,
+    3) replay_mesh_trace once and time it, then divides by N to get per-iter time.
   Thus:
     * --trace-iters controls how many enqueues are captured per trace.
     * --iters controls how many times the capture+replay cycle is repeated to collect stats (p50/mean, etc.).

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -292,13 +292,13 @@ Notes:
         Dist::EnqueueMeshWorkload(mcq, receiver_workload, /*blocking=*/false);
         Dist::EnqueueMeshWorkload(mcq, sender_workload, /*blocking=*/false);
     }
-    Dist::EndTraceCapture(mesh.get(), mcq.id(), trace_id);
+    mesh->end_mesh_trace(mcq.id(), trace_id);
     // 3) Replay measured section
     auto t0 = std::chrono::steady_clock::now();
-    Dist::ReplayTrace(mesh.get(), mcq.id(), trace_id, /*blocking=*/false);
+    mesh->replay_mesh_trace(mcq.id(), trace_id, /*blocking=*/false);
     Dist::Finish(mcq);
     auto t1 = std::chrono::steady_clock::now();
-    Dist::ReleaseTrace(mesh.get(), trace_id);
+    mesh->release_mesh_trace(trace_id);
 
     // Read back (single shard) and verify
     std::vector<uint32_t> rx(n_words, 0u);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -56,12 +56,12 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms) 
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload, false);
-    distributed::EndTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_1);
+    mesh_device->end_mesh_trace(mesh_device->mesh_command_queue().id(), tid_1);
 
     auto tid_2 = distributed::BeginTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id());
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload, false);
-    distributed::EndTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_2);
+    mesh_device->end_mesh_trace(mesh_device->mesh_command_queue().id(), tid_2);
 
     // Capture trace on one sub-device while another sub-device is running a program
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload, false);
@@ -69,7 +69,7 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms) 
     auto tid_3 = distributed::BeginTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id());
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload, false);
-    distributed::EndTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_3);
+    mesh_device->end_mesh_trace(mesh_device->mesh_command_queue().id(), tid_3);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload, false);
     mesh_device->reset_sub_device_stall_group();
@@ -83,14 +83,14 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms) 
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload, false);
 
         // Full trace execution
-        distributed::ReplayTrace(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_1, false);
+        mesh_device->replay_mesh_trace(mesh_device->mesh_command_queue().id(), tid_1, false);
 
         // Partial trace execution
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload, false);
-        distributed::ReplayTrace(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_2, false);
+        mesh_device->replay_mesh_trace(mesh_device->mesh_command_queue().id(), tid_2, false);
 
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload, false);
-        distributed::ReplayTrace(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_3, false);
+        mesh_device->replay_mesh_trace(mesh_device->mesh_command_queue().id(), tid_3, false);
     }
     distributed::Finish(mesh_device->mesh_command_queue());
     ReadMeshDeviceProfilerResults(*mesh_device, ProfilerReadState::NORMAL);
@@ -138,7 +138,7 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations) {
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload_1, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload_1, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload_1, false);
-    distributed::EndTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_1);
+    mesh_device->end_mesh_trace(mesh_device->mesh_command_queue().id(), tid_1);
 
     mesh_device->load_sub_device_manager(sub_device_manager_2);
     auto [waiter_program_2, syncer_program_2, incrementer_program_2, global_sem_2] =
@@ -160,15 +160,13 @@ TEST_F(UnitMeshCQSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations) {
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), waiter_workload_2, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), syncer_workload_2, false);
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), incrementer_workload_2, false);
-    distributed::EndTraceCapture(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_2);
+    mesh_device->end_mesh_trace(mesh_device->mesh_command_queue().id(), tid_2);
 
     // Full trace execution
-    distributed::ReplayTrace(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_2, false);
+    mesh_device->replay_mesh_trace(mesh_device->mesh_command_queue().id(), tid_2, false);
 
     // Can not replay a trace on a different sub-device manager
-    EXPECT_THROW(
-        distributed::ReplayTrace(mesh_device.get(), mesh_device->mesh_command_queue().id(), tid_1, false),
-        std::exception);
+    EXPECT_THROW(mesh_device->replay_mesh_trace(mesh_device->mesh_command_queue().id(), tid_1, false), std::exception);
 
     distributed::Finish(mesh_device->mesh_command_queue());
 

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -405,14 +405,14 @@ private:
         for (auto& workload : this->workloads) {
             distributed::EnqueueMeshWorkload(mesh_command_queue, workload, false);
         }
-        distributed::EndTraceCapture(this->device_.get(), mesh_command_queue.id(), trace_id);
+        this->device_->end_mesh_trace(mesh_command_queue.id(), trace_id);
         return trace_id;
     }
 
     void run_trace(const distributed::MeshTraceId trace_id) {
         auto& mesh_command_queue = this->device_->mesh_command_queue();
         for (uint32_t i = 0; i < NUM_TRACE_ITERATIONS; i++) {
-            distributed::ReplayTrace(this->device_.get(), mesh_command_queue.id(), trace_id, false);
+            this->device_->replay_mesh_trace(mesh_command_queue.id(), trace_id, false);
         }
     }
 };

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -446,14 +446,14 @@
 //     // Now enable Metal Trace and run program again for capture.
 //     // uint32_t tid = BeginTraceCapture(device_, command_queue.id());
 //     EnqueueProgram(command_queue, simple_program, false);
-//     // EndTraceCapture(device_, command_queue.id(), tid);
+//     // device_->end_mesh_trace(command_queue.id(), tid);
 
 //     // Verify trace output during replay matches expected output from original capture.
 //     // LightMetalCompareToGolden(command_queue, *output, eager_output_data.data());
 
 //     // Done
 //     Finish(command_queue);
-//     // ReleaseTrace(device_, tid);
+//     // device_->release_mesh_trace(tid);
 // }
 
 // // Test simple compute test with metal trace, but no explicit trace replay (added automatically by light metal trace).
@@ -494,14 +494,14 @@
 //     // uint32_t tid = BeginTraceCapture(device_, command_queue.id());
 //     EnqueueProgram(command_queue, op0, false);
 //     EnqueueProgram(command_queue, op1, false);
-//     // EndTraceCapture(device_, command_queue.id(), tid);
+//     // device_->end_mesh_trace(command_queue.id(), tid);
 
 //     // Verify trace output during replay matches expected output from original capture.
 //     // LightMetalCompareToGolden(command_queue, *output, eager_output_data.data());
 
 //     // Done
 //     Finish(command_queue);
-//     // ReleaseTrace(device_, tid);
+//     // device_->release_mesh_trace(tid);
 // }
 
 // }  // namespace

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -487,7 +487,7 @@ MeshTraceId setup_trace_if_enabled(
         const std::size_t cq_id = 0;
         tid = BeginTraceCapture(mesh_device.get(), cq_id);
         executor.execute_programs();
-        EndTraceCapture(mesh_device.get(), cq_id, tid);
+        mesh_device->end_mesh_trace(cq_id, tid);
         Finish(mesh_device->mesh_command_queue(cq_id));
     }
     return tid;
@@ -507,7 +507,7 @@ void run_benchmark_timing_loop(
     for ([[maybe_unused]] auto _ : state) {
         auto start = std::chrono::system_clock::now();
         if (info.use_trace) {
-            ReplayTrace(mesh_device.get(), cq_id, tid, false);
+            mesh_device->replay_mesh_trace(cq_id, tid, false);
         } else {
             execute_func();
         }

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -111,12 +111,6 @@ bool EventQuery(const MeshEvent& event);
 
 MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id);
 
-void EndTraceCapture(MeshDevice* device, uint8_t cq_id, const MeshTraceId& trace_id);
-
-void ReplayTrace(MeshDevice* device, uint8_t cq_id, const MeshTraceId& trace_id, bool blocking);
-
-void ReleaseTrace(MeshDevice* device, const MeshTraceId& trace_id);
-
 void Synchronize(
     MeshDevice* device, std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -51,16 +51,6 @@ MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id) {
     return trace_id;
 }
 
-void EndTraceCapture(MeshDevice* device, uint8_t cq_id, const MeshTraceId& trace_id) {
-    device->end_mesh_trace(cq_id, trace_id);
-}
-
-void ReplayTrace(MeshDevice* device, uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
-    device->replay_mesh_trace(cq_id, trace_id, blocking);
-}
-
-void ReleaseTrace(MeshDevice* device, const MeshTraceId& trace_id) { device->release_mesh_trace(trace_id); }
-
 void Synchronize(MeshDevice* device, std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     if (!device->is_initialized()) {
         return;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -227,7 +227,7 @@ int main() {
     auto trace_id = BeginTraceCapture(mesh_device.get(), workload_cq_id);
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), add_mesh_workload, false);
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), multiply_and_subtract_mesh_workload, false);
-    EndTraceCapture(mesh_device.get(), workload_cq_id, trace_id);
+    mesh_device->end_mesh_trace(workload_cq_id, trace_id);
 
     // =========== Step 6: Populate inputs ===========
     uint32_t workload_0_src0_val = 2;
@@ -255,7 +255,7 @@ int main() {
     MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
     // =========== Step 8: Run MeshTrace on MeshCQ0 ===========
-    ReplayTrace(mesh_device.get(), workload_cq_id, trace_id, false);
+    mesh_device->replay_mesh_trace(workload_cq_id, trace_id, false);
     // Synchronize
     MeshEvent trace_event = workload_cq.enqueue_record_event();
     data_movement_cq.enqueue_wait_for_event(trace_event);
@@ -277,7 +277,7 @@ int main() {
             pass &= (static_cast<float>(mul_sub_dst_vec[i]) == workload_1_src0_val - workload_1_src1_val);
         }
     }
-    ReleaseTrace(mesh_device.get(), trace_id);
+    mesh_device->release_mesh_trace(trace_id);
     if (pass) {
         std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Passed!" << std::endl;
         return 0;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26591)

### Problem description
N/A

### What's changed

- Migration of `EndTraceCapture` API to `MeshDevice::end_mesh_trace`
- Migration of `ReplayTrace` API to `MeshDevice::replay_mesh_trace`
- Migration of `ReleaseTrace` API to `MeshDevice::release_mesh_trace`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18292146916))
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18292152037))