### PR TITLE
cleanup some fabric datastructure usage

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -339,9 +339,7 @@ struct FabricEriscDatamoverConfig {
     static_assert(sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo) % field_size == 0);
 
     // ----------- Receiver Channels
-    std::array<std::size_t, max_downstream_edms> receiver_channels_local_buffer_index_address = {};
     // persistent mode field
-    std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_flow_control_semaphore_address = {};
     std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_teardown_semaphore_address = {};
 
     // Conditionally used fields. BlackHole with 2-erisc uses these fields for sending credits back to sender.
@@ -512,8 +510,6 @@ public:
         const FabricNodeId& peer_fabric_node_id,
 
         const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
-            receiver_channels_downstream_flow_control_semaphore_id,
-        const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
             receiver_channels_downstream_teardown_semaphore_id,
         const std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels>&
             sender_channels_flow_control_semaphore_id,
@@ -620,22 +616,18 @@ public:
     // Semaphore IDs
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
     std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
-        receiver_channels_downstream_flow_control_semaphore_id = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
         receiver_channels_downstream_teardown_semaphore_id = {};
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_flow_control_semaphore_id = {};
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_connection_semaphore_id = {};
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_buffer_index_semaphore_id = {};
-    std::array<size_t, FabricEriscDatamoverConfig::max_downstream_edms> receiver_channels_local_buffer_index_address =
-        {};
 
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms> downstream_edm_vcs_noc_x = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms> downstream_edm_vcs_noc_y = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels> downstream_edm_vcs_noc_x = {};
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels> downstream_edm_vcs_noc_y = {};
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>
         downstream_edm_vcs_buffer_base_address = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>
         downstream_edm_vcs_worker_registration_address = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>
         downstream_edm_vcs_worker_location_info_address = {};
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels>
         downstream_vcs_sender_channel_buffer_index_semaphore_id = {};

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp
@@ -74,7 +74,6 @@ struct RouterStaticSizedChannelWriterAdapter {
             from_remote_buffer_free_slots_ptr,  // For worker to locally track downstream EDM's read counter. Only used
                                                 // by Worker. Downstream EDM increments over noc when a slot is freed.
         volatile uint32_t* const worker_teardown_addr,
-        uint32_t local_buffer_index_addr,
         uint32_t sender_channel_credits_stream_id,  // To update the downstream EDM's free slots. Sending worker or edm
                                                     // decrements over noc.
         StreamId
@@ -127,7 +126,6 @@ struct RouterStaticSizedChannelWriterAdapter {
         size_t edm_buffer_index_id,
         volatile uint32_t* const from_remote_buffer_free_slots_ptr,
         volatile uint32_t* const worker_teardown_addr,
-        uint32_t local_buffer_index_addr,
         uint32_t sender_channel_credits_stream_id,
         StreamId worker_credits_stream_id,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
@@ -144,7 +142,6 @@ struct RouterStaticSizedChannelWriterAdapter {
             edm_buffer_index_id,
             from_remote_buffer_free_slots_ptr,
             worker_teardown_addr,
-            local_buffer_index_addr,
             sender_channel_credits_stream_id,
             worker_credits_stream_id,
             data_noc_cmd_buf,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2478,7 +2478,6 @@ void kernel_main() {
 
     const auto downstream_edm_vc0_worker_registration_id = get_arg_val<uint32_t>(arg_idx++);
     const auto downstream_edm_vc0_worker_location_info_address = get_arg_val<uint32_t>(arg_idx++);
-    const auto downstream_vc0_noc_interface_buffer_index_local_addr = get_arg_val<uint32_t>(arg_idx++);
 
     // downstream EDM semaphore location
     const auto has_downstream_edm_vc1_buffer_connection = get_arg_val<uint32_t>(arg_idx++);
@@ -2488,7 +2487,6 @@ void kernel_main() {
 
     const auto downstream_edm_vc1_worker_registration_id = get_arg_val<uint32_t>(arg_idx++);
     const auto downstream_edm_vc1_worker_location_info_address = get_arg_val<uint32_t>(arg_idx++);
-    const auto downstream_vc1_noc_interface_buffer_index_local_addr = get_arg_val<uint32_t>(arg_idx++);
 
     const auto my_sem_for_teardown_from_edm_0 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_1 = get_arg_val<uint32_t>(arg_idx++);
@@ -2680,8 +2678,6 @@ void kernel_main() {
                         // Router that a Worker adapter is connected to writes its read counter to this address. The
                         // worker uses this to calculate free slots in the router's sender channel.
                     reinterpret_cast<volatile uint32_t* const>(teardown_sem_address),
-                    downstream_vc0_noc_interface_buffer_index_local_addr,  // keep common, since its a scratch noc read
-                                                                           // dest.
                     // Since we are the same direction, we're always going to send to the same stream
                     // reg for each downstream router because we are allocating sender channels by
                     // producer direction.
@@ -2737,7 +2733,6 @@ void kernel_main() {
                     // Router that a Worker adapter is connected to writes its read counter to this address. The
                     // worker uses this to calculate free slots in the router's sender channel.
                 reinterpret_cast<volatile uint32_t* const>(teardown_sem_address),
-                downstream_vc1_noc_interface_buffer_index_local_addr,
 
                 // remote (downstream) sender channel credits stream ID
                 downstream_sender_channel_credit_stream_id,


### PR DESCRIPTION
As I was refactoring some of the erisc datamover builder code to introduce a separate channel allocator scheme, I found some code paths and datastructures that could be removed/resized/reorganized. In response, I've moved some of these changes to an isolated PR.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18301051072
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): 
- [ ] Galaxy Quick: 
- [ ] T3K Nightly: 
- [ ] BH Nightly: 