### PR TITLE
#28436: Add P300 vIOMMU runners to BH post-commit and nightly CI

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -64,8 +64,11 @@ jobs:
         HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - "${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data${{ inputs.regenerate-ttnn-cache == true && ':rw' || ':ro' }}"
+        - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
+        # If extra-tag is pipeline-yyz2-lfc, we don't need to mount the model cache volume
+        # If extra-tag is pipeline-functional, we need to mount the model cache volume from /mnt/MLPerf/tt_dnn-models
+        # If extra-tag is pipeline-perf, we need to mount the model cache volume from /localdev/blackhole_demos/huggingface_data
+        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || /no_hf_cache }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -81,6 +84,12 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         with:
           runner-label: ${{ inputs.runner-label }}
+      - name: Download Llama model weights from LFC
+        if: ${{ inputs.extra-tag == 'pipeline-yyz2-lfc' && contains(matrix.test-group.name, 'llama') }}
+        timeout-minutes: 15
+        run: |
+          mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
+          wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run demo regression tests
         timeout-minutes: 70
         run: |
@@ -144,8 +153,8 @@ jobs:
         HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-        - "${{ inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data' }}:/localdev/blackhole_demos/huggingface_data${{ inputs.regenerate-ttnn-cache == true && ':rw' || ':ro' }}"
+        - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
+        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || /no_hf_cache }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -68,7 +68,7 @@ jobs:
         # If extra-tag is pipeline-yyz2-lfc, we don't need to mount the model cache volume
         # If extra-tag is pipeline-functional, we need to mount the model cache volume from /mnt/MLPerf/tt_dnn-models
         # If extra-tag is pipeline-perf, we need to mount the model cache volume from /localdev/blackhole_demos/huggingface_data
-        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || /no_hf_cache }}"
+        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || '/no_hf_cache' }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -154,7 +154,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
-        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || /no_hf_cache }}"
+        - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || '/no_hf_cache' }}"
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
         - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
         # If extra-tag is pipeline-yyz2-lfc, we don't need to mount the model cache volume
         # If extra-tag is pipeline-functional, we need to mount the model cache volume from /mnt/MLPerf/tt_dnn-models
-        # If extra-tag is pipeline-perf, we need to mount the model cache volume from /localdev/blackhole_demos/huggingface_data
+        # If extra-tag is pipeline-perf, we need to mount the model cache volume from /localdev/blackhole_demos/huggingface_data because it's in CIv1 GH VLAN, so not on Cloud
         - "${{ inputs.extra-tag != 'pipeline-yyz2-lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', inputs.extra-tag == 'pipeline-functional' && '/mnt/MLPerf/tt_dnn-models' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || '/no_hf_cache' }}"
       options: "--device /dev/tenstorrent"
     defaults:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -88,6 +88,7 @@ jobs:
         if: ${{ inputs.extra-tag == 'pipeline-yyz2-lfc' && contains(matrix.test-group.name, 'llama') }}
         timeout-minutes: 15
         run: |
+          set -e
           mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run demo regression tests

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -44,6 +44,10 @@ jobs:
             runner-label: BH-LoudBox
             extra-tag: pipeline-perf
             num_devices: 8
+          - name: P300 Demo tests
+            runner-label: P300-viommu
+            extra-tag: pipeline-yyz2-lfc
+            num_devices: 2
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -50,7 +50,7 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
+        - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -30,6 +30,8 @@ jobs:
             runner-label: BH-DeskBox
           - name: LoudBox unit tests
             runner-label: BH-LoudBox
+          - name: P300 unit tests
+            runner-label: P300-viommu
         test-group:
           - name: fabric 1D unit tests
             cmd: |
@@ -86,7 +88,7 @@ jobs:
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
+        - ${{ (!contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -72,6 +72,10 @@ jobs:
             runner-label: BH-LoudBox
             extra-tag: pipeline-perf
             num_devices: 8
+          - name: P300 Demo tests
+            runner-label: P300-viommu
+            extra-tag: pipeline-yyz2-lfc
+            num_devices: 2
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -374,7 +374,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [ "BH-LLMBox", "BH-LoudBox" ]
+        test-group: [ "BH-LLMBox", "BH-LoudBox", "P300-viommu" ]
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -131,6 +131,10 @@ jobs:
             runner-label: BH-LoudBox
             extra-tag: pipeline-perf
             num_devices: 8
+          - name: P300 Demo tests
+            runner-label: P300-viommu
+            extra-tag: pipeline-yyz2-lfc
+            num_devices: 2
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}


### PR DESCRIPTION
### Ticket
Closes #28436

### Problem description
P300 viommu-only runners are available now

### What's changed
Add to BH post commit and nightly pipelines
Add handling for viommu runners (no hugepages) and large-file-cache downloads (no local/mlperf model cache)

### Checklist
- [x] BH post commit https://github.com/tenstorrent/tt-metal/actions/runs/18292686905
- [x] BH nightly (demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/18292176784/job/52082549632
unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/18292304175)