### PR TITLE
Fixing T3K Big Mesh 1x4 test

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -144,7 +144,6 @@ run_t3000_ttnn_multiprocess_tests() {
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/unit_tests_ttnn --gtest_filter="*LaunchOperation*"
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_data_parallel_example.py
-  # skipping because of https://github.com/tenstorrent/tt-metal/issues/29828
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py::test_all_broadcast_sharded_2x4

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -143,14 +143,13 @@ run_t3000_ttnn_multiprocess_tests() {
   local mesh2x4_rank_binding="tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/unit_tests_ttnn --gtest_filter="*LaunchOperation*"
-  # Being worked on Oct 3 morning by Scaleout + CCLs
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_data_parallel_example.py
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_data_parallel_example.py
   # skipping because of https://github.com/tenstorrent/tt-metal/issues/29828
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_2x4
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_2x4
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py::test_all_broadcast_sharded_2x4
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py::test_all_to_all_combine_no_trace_submesh
-  # tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv "tests/ttnn/unit_tests/operations/point_to_point/test_point_to_point.py::test_point_to_point[silicon_arch_name=wormhole_b0-dtype=torch.bfloat16-shape_coords=((1, 1, 1, 16), ((0, 0), (0, 1)))-tile-mesh_device=(2, 4)-device_params={'fabric_config': <FabricConfig.FABRIC_1D: 1>}]"
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_2x4
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_2x4
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py::test_all_broadcast_sharded_2x4
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py::test_all_to_all_combine_no_trace_submesh
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv "tests/ttnn/unit_tests/operations/point_to_point/test_point_to_point.py::test_point_to_point[silicon_arch_name=wormhole_b0-dtype=torch.bfloat16-shape_coords=((1, 1, 1, 16), ((0, 0), (0, 1)))-tile-mesh_device=(2, 4)-device_params={'fabric_config': <FabricConfig.FABRIC_1D: 1>}]"
 }
 
 run_t3000_falcon7b_tests() {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_control_plane_logical_to_physical.cpp
@@ -28,11 +28,11 @@ namespace fabric_router_tests {
 // LogicalToPhysicalConversionFixture for adjacency map and lookup
 class LogicalToPhysicalConversionFixture : public ::testing::Test {
 protected:
-    std::unordered_map<chip_id_t, std::vector<chip_id_t>> test_adjacency_map;
+    std::unordered_map<chip_id_t, std::vector<chip_id_t>> test_adjacency_map_;
 
     std::vector<chip_id_t> get_adjacent_chips(chip_id_t chip_id) const {
-        auto it = test_adjacency_map.find(chip_id);
-        if (it != test_adjacency_map.end()) {
+        auto it = test_adjacency_map_.find(chip_id);
+        if (it != test_adjacency_map_.end()) {
             return it->second;
         }
         return {};
@@ -73,7 +73,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsWithConfigu
     //        3-4-5
     //        | | |
     //        6-7-8
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},
         {1, {0, 2, 4}},
         {2, {1, 5}},
@@ -116,7 +116,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds3x2Rectangl
     //        2-3
     //        | |
     //        4-5
-    test_adjacency_map = {{0, {1, 2}}, {1, {0, 3}}, {2, {0, 3, 4}}, {3, {1, 2, 5}}, {4, {2, 5}}, {5, {3, 4}}};
+    test_adjacency_map_ = {{0, {1, 2}}, {1, {0, 3}}, {2, {0, 3, 4}}, {3, {1, 2, 5}}, {4, {2, 5}}, {5, {3, 4}}};
 
     std::set<chip_id_t> user_chip_ids = {0, 1, 2, 3, 4, 5};
     tt::tt_metal::distributed::MeshShape mesh_shape(3, 2);
@@ -149,7 +149,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds4x8LargeMes
     //        G-H-I-J-K-L-M-N
     //        | | | | | | | |
     //        O-P-Q-R-S-T-U-V
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 8}},
         {1, {0, 2, 9}},
         {2, {1, 3, 10}},
@@ -222,7 +222,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsOverlapping
     // This creates a topology where some chips have more than 4 neighbors,
     // which breaks the corner detection logic. This test demonstrates that
     // the current algorithm doesn't handle irregular topologies well.
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3, 4}},        // Extra connection to 4
         {1, {0, 2, 3, 4, 5}},  // Extra connections to 3 and 5
         {2, {1, 5}},
@@ -267,7 +267,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsMissingConn
     // - Expected vs actual corner count
     // - Adjacency matrix showing all connections
     // - Grid visualization attempt
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},
         {1, {0, 2, 4}},
         {2, {1, 5}},
@@ -304,7 +304,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsMissingChip
     // All connections involving chip 4 are removed from the topology
     // This creates a topology where the remaining chips have irregular
     // connectivity patterns that don't match the expected 4-corner pattern.
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},  // No connection to 4
         {1, {0, 2}},  // No connection to 4
         {2, {1, 5}},  // No connection to 4
@@ -340,7 +340,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds4x1Mesh) {
     //        2
     //        |
     //        3
-    test_adjacency_map = {{0, {1}}, {1, {0, 2}}, {2, {1, 3}}, {3, {2}}};
+    test_adjacency_map_ = {{0, {1}}, {1, {0, 2}}, {2, {1, 3}}, {3, {2}}};
 
     std::set<chip_id_t> user_chip_ids = {0, 1, 2, 3};
     tt::tt_metal::distributed::MeshShape mesh_shape(4, 1);
@@ -366,7 +366,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds4x1Mesh) {
 TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds1x8Mesh) {
     // Test 1x8 large 1D mesh shape
     // Shape: 0-1-2-3-4-5-6-7
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1}}, {1, {0, 2}}, {2, {1, 3}}, {3, {2, 4}}, {4, {3, 5}}, {5, {4, 6}}, {6, {5, 7}}, {7, {6}}};
 
     std::set<chip_id_t> user_chip_ids = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -395,7 +395,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds1x8MeshOn2x
     // Shape: 4-0-3-6
     //        | | | |
     //        5-1-2-7
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 4, 3}},
         {1, {0, 2, 5}},
         {2, {1, 7, 3}},
@@ -429,7 +429,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIds1x1Mesh) {
     // Test 1x1 single chip mesh shape
     // Shape: 0
     // Single chip with no neighbors
-    test_adjacency_map = {{0, {}}};
+    test_adjacency_map_ = {{0, {}}};
 
     std::set<chip_id_t> user_chip_ids = {0};
     tt::tt_metal::distributed::MeshShape mesh_shape(1, 1);
@@ -460,7 +460,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsLooped1DMes
     //        |       |
     //        --------
     // All chips have 2 neighbors (no corners in looped topology)
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},  // Connected to both ends
         {1, {0, 2}},
         {2, {1, 3}},
@@ -485,7 +485,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsLooped2DMes
     //        | |
     //        2-3
     // All chips have 4 neighbors (no corners in torus topology)
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 2, 1, 2}},  // Connected to all 4 directions (wrapped)
         {1, {0, 3, 0, 3}},  // Connected to all 4 directions (wrapped)
         {2, {3, 0, 3, 0}},  // Connected to all 4 directions (wrapped)
@@ -510,7 +510,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsWithStartin
     //        3-4-5
     //        | | |
     //        6-7-8
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},
         {1, {0, 2, 4}},
         {2, {1, 5}},
@@ -544,7 +544,7 @@ TEST_F(LogicalToPhysicalConversionFixture, TestGetMeshPhysicalChipIdsWithStartin
 
 TEST_F(LogicalToPhysicalConversionFixture, TestConvert2DUsesProvidedNECorner) {
     // 3x3 mesh
-    test_adjacency_map = {
+    test_adjacency_map_ = {
         {0, {1, 3}},
         {1, {0, 2, 4}},
         {2, {1, 5}},

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -245,7 +245,8 @@ private:
 
     std::vector<chip_id_t> get_mesh_physical_chip_ids(
         const tt::tt_metal::distributed::MeshContainer<chip_id_t>& mesh_container,
-        std::optional<chip_id_t> nw_corner_chip_id = std::nullopt) const;
+        std::optional<chip_id_t> nw_corner_chip_id = std::nullopt,
+        std::optional<chip_id_t> ne_corner_chip_id = std::nullopt) const;
 
     std::map<FabricNodeId, chip_id_t> get_logical_chip_to_physical_chip_mapping(
         const std::string& mesh_graph_desc_file);

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -356,7 +356,9 @@ std::vector<chip_id_t> convert_1d_mesh_adjacency_to_row_major_vector(
 }
 
 std::vector<chip_id_t> convert_2d_mesh_adjacency_to_row_major_vector(
-    const IntraMeshAdjacencyMap& topology_info, std::optional<chip_id_t> nw_corner_chip_id) {
+    const IntraMeshAdjacencyMap& topology_info,
+    std::optional<chip_id_t> nw_corner_chip_id,
+    std::optional<chip_id_t> ne_corner_chip_id) {
     // Check number of corners for 2D meshes
     TT_FATAL(
         topology_info.corners.size() == 4, "Error during physical chip discovery: missing connections in 2D mesh. Please check ethernet connection status");
@@ -405,28 +407,38 @@ std::vector<chip_id_t> convert_2d_mesh_adjacency_to_row_major_vector(
     // 1) Distances from NW corner.
     auto dist_from_nw = compute_distances(nw_corner, topology_info.adjacency_map);
 
-    // 2) Identify the NE corner (distance of mesh_ew_size-1 from NW) and run a second
-    //    BFS from it to obtain dNE[chip].
+    // 2) Determine the NE corner: if provided, validate and use it; otherwise identify based on distances.
     chip_id_t ne_corner = nw_corner;  // initialise
     bool ne_found = false;
-    for (auto corner : topology_info.corners) {
-        if (corner == nw_corner) {
-            continue;
-        }
-        auto it = dist_from_nw.find(corner);
-        if (it != dist_from_nw.end() && it->second == topology_info.ew_size - 1) {
-            ne_corner = corner;
-            ne_found = true;
-            break;
-        }
-    }
-    if (!ne_found) {
-        // Fall back: pick any other corner; grid may be square so distance == mesh_ew_size-1 may not hold.
+    if (ne_corner_chip_id.has_value()) {
+        TT_FATAL(
+            std::find(topology_info.corners.begin(), topology_info.corners.end(), *ne_corner_chip_id) !=
+                topology_info.corners.end(),
+            "Provided NE corner chip {} is not a 2D corner",
+            *ne_corner_chip_id);
+        ne_corner = *ne_corner_chip_id;
+        ne_found = true;
+    } else {
+        // Identify the NE corner (distance of mesh_ew_size-1 from NW)
         for (auto corner : topology_info.corners) {
-            if (corner != nw_corner) {
+            if (corner == nw_corner) {
+                continue;
+            }
+            auto it = dist_from_nw.find(corner);
+            if (it != dist_from_nw.end() && it->second == topology_info.ew_size - 1) {
                 ne_corner = corner;
                 ne_found = true;
                 break;
+            }
+        }
+        if (!ne_found) {
+            // Fall back: pick any other corner; grid may be square so distance == mesh_ew_size-1 may not hold.
+            for (auto corner : topology_info.corners) {
+                if (corner != nw_corner) {
+                    ne_corner = corner;
+                    ne_found = true;
+                    break;
+                }
             }
         }
     }

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -54,6 +54,8 @@ std::vector<chip_id_t> convert_1d_mesh_adjacency_to_row_major_vector(
 
 // Helper: Convert 2D mesh adjacency map to row-major vector representation
 std::vector<chip_id_t> convert_2d_mesh_adjacency_to_row_major_vector(
-    const IntraMeshAdjacencyMap& topology_info, std::optional<chip_id_t> nw_corner_chip_id = std::nullopt);
+    const IntraMeshAdjacencyMap& topology_info,
+    std::optional<chip_id_t> nw_corner_chip_id = std::nullopt,
+    std::optional<chip_id_t> ne_corner_chip_id = std::nullopt);
 
 }  // namespace tt::tt_fabric


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/actions/runs/18203733735/job/51829491852

### Problem description
NW Pinning for t3k multi-process big mesh tests failing due to chip pinning

### What's changed
Added a second chip to pin the orientation and permutation of the t3k coordinates when fabric initializes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18292281308)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/18297607339)