### PR TITLE
[TT-Train] Fixed import typo in utils.py

### DIFF
--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -38,7 +38,7 @@ def initialize_device(yaml_config: dict):
     Args:
         yaml_config: Dictionary containing device configuration
     """
-    from config import DeviceConfig
+    from ttml.common.config import DeviceConfig
 
     device_config = DeviceConfig(yaml_config)
     ttml.core.distributed.enable_fabric(device_config.total_devices())


### PR DESCRIPTION
### Problem description
Previous PR broke the Python transformers example in TT-Train

### What's changed
Quick one-line fix for the import statements in Python transformers example

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes