### PR TITLE
#29958: Add uint16 support to pad op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -20,7 +20,7 @@ torch.manual_seed(0)
 
 def random_torch_tensor(dtype, shape):
     if dtype == ttnn.uint16:
-        return torch.randint(0, 100, shape).to(torch.int16)
+        return torch.randint(0, 2**15, shape, dtype=torch.int16)
     if dtype == ttnn.int32:
         return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
     if dtype == ttnn.uint32:
@@ -41,7 +41,7 @@ def random_torch_tensor(dtype, shape):
     ],
 )
 @pytest.mark.parametrize("value", [0, 1])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16])
 def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     torch.manual_seed(0)
 
@@ -273,7 +273,7 @@ def test_pad_rm_sharded_stickwise(
 @pytest.mark.parametrize("padding,torch_padding", [(((1, 1), (2, 32), (0, 0)), (0, 0, 2, 32, 1, 1))])
 @pytest.mark.parametrize("value", [8])
 @pytest.mark.parametrize("shard_orient", [ttnn.ShardOrientation.COL_MAJOR, ttnn.ShardOrientation.ROW_MAJOR])
-@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.bfloat16, ttnn.uint16])
 def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient, dtype):
     if device.core_grid.y < 8:
         pytest.skip("n300 does not have 8x8 grid")
@@ -454,7 +454,7 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
     assert torch.equal(in_torch, out_torch)
 
 
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32, ttnn.uint16])
 @pytest.mark.parametrize("shape", [[1, 1, 18, 13]])
 @pytest.mark.parametrize("padshape", [[1, 1, TILE_HEIGHT, TILE_WIDTH]])
 @pytest.mark.parametrize("use_multicore", [False, True])
@@ -483,7 +483,7 @@ def _unsqueeze(smaller, larger, fill):
 @pytest.mark.parametrize(
     "padding", [[25, 1], [5, 4], [64], [32, 32], [1, 0, 0, 0], [1, 0, 0], [32, 32, 32, 64], [0, 64], [0, 0, 0, 64]]
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16])
 def test_pad_tile(shape, padding, dtype, device):
     if (shape, padding) in [([5, 4, 3, 2, 1], [1, 0, 0, 0]), ([5, 4, 3, 2, 1], [32, 32, 32, 64])]:
         pytest.xfail("Can't pad upper dims with rank>4")

--- a/tests/ttnn/unit_tests/operations/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/test_sort.py
@@ -209,6 +209,7 @@ def test_sort_program_cache(shape, dim, descending, device):
         ([32, 64], -1, False, torch.bfloat16, ttnn.bfloat16, ttnn.uint32),
         ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16),
         ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint32),
+        ([1, 8], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16),
     ],
 )
 def test_sort_datatypes(shape, dim, descending, torch_value_dtype, ttnn_value_dtype, ttnn_index_dtype, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -525,6 +525,39 @@ ttnn::Tensor pad_to_tile_vol(
 }
 uint32_t wrap_index(int index, int size) { return index < 0 ? size + index : index; }
 
+uint16_t float_to_uint16(float f) {
+    // For positive infinity, return the maximum uint16_t value
+    // For negative infinity, return the minimum uint16_t value
+    if (std::isinf(f)) {
+        return (f > 0) ? std::numeric_limits<uint16_t>::max() : std::numeric_limits<uint16_t>::min();
+    }
+
+    // For Not-a-Number (NaN), return 0
+    if (std::isnan(f)) {
+        return 0;
+    }
+
+    // Handle overflow and underflow
+    const float max_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::max());
+    const float min_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::min());
+    if (f >= max_uint16) {
+        return std::numeric_limits<uint16_t>::max();
+    }
+    if (f <= min_uint16) {
+        return std::numeric_limits<uint16_t>::min();
+    }
+
+    // For all other finite values, safely cast after rounding
+    return static_cast<uint16_t>(std::round(f));
+}
+
+// based off pack_two_bfloat16_into_uint32
+uint32_t pack_two_uint16_into_uint32(std::pair<uint16_t, uint16_t> two_uint16s) {
+    // first -> lower 16
+    // second -> upper 16
+    return (uint32_t)two_uint16s.first | ((uint32_t)two_uint16s.second << 16);
+}
+
 ttnn::Shape compute_padded_shape(
     const ttnn::Shape& logical_shape, const uint32_t tile_height, const uint32_t tile_width) {
     if (logical_shape.rank() == 1) {

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -525,6 +525,7 @@ ttnn::Tensor pad_to_tile_vol(
 }
 uint32_t wrap_index(int index, int size) { return index < 0 ? size + index : index; }
 
+// not unit tested, use with caution
 uint16_t float_to_uint16(float f) {
     // For positive infinity, return the maximum uint16_t value
     // For negative infinity, return the minimum uint16_t value

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -67,6 +67,10 @@ ttnn::Tensor pad_to_tile_vol(
 
 uint32_t wrap_index(int index, int size);
 
+uint16_t float_to_uint16(float f);
+
+uint32_t pack_two_uint16_into_uint32(std::pair<uint16_t, uint16_t> two_uint16s);
+
 template <typename OpOutputType, typename... OpInputTypes>
 struct MassagedOperationParams {
     using OwnedArgsType = std::tuple<std::decay_t<OpInputTypes>...>;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
 #include "fill_pad_program_factory.hpp"
@@ -17,13 +18,6 @@ bool is_power_of_two_at_least_32(uint32_t value) { return value >= 32 && (value 
 using namespace tt;
 
 namespace ttnn::operations::data_movement::detail {
-
-// based off pack_two_bfloat16_into_uint32
-uint32_t pack_two_uint16_into_uint32(std::pair<uint16_t, uint16_t> two_uint16s) {
-    // first -> lower 16
-    // second -> upper 16
-    return (uint32_t)two_uint16s.first | ((uint32_t)two_uint16s.second << 16);
-}
 
 tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, float fill_value) {
     tt::tt_metal::IDevice* device = input_tensor.device();

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -47,12 +47,14 @@ void Pad::validate_with_output_tensors(
         TT_FATAL((this->output_padded_shape[3] % TILE_WIDTH == 0), "Can only pad tilized tensor with full tiles");
         TT_FATAL(
             input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
-                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32,
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                input_tensor.dtype() == DataType::UINT16,
             "Cannot pad tilized tensor with specified format");
     } else if (input_tensor.layout() == Layout::ROW_MAJOR) {
         TT_FATAL(
             input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
-                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32,
+                input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+                input_tensor.dtype() == DataType::UINT16,
             "Cannot pad RM tensor with specified format");
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -70,13 +70,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     TensorAccessorArgs(*pad_value_const_tensor.buffer()).append_to(reader_ct_args);
     const std::vector<uint32_t>& writer_ct_args = reader_ct_args;
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    bfloat16 bfloat_zero = bfloat16(0.0f);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
     } else {
-        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
     KernelHandle reader_kernel_id = CreateKernel(
@@ -213,12 +213,13 @@ operation::ProgramWithCallbacks pad_tile(
             .set_page_size(src1_cb_index, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {
-        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
     uint32_t num_unpadded_Xt = a.padded_shape()[3] / TILE_WIDTH;
@@ -516,13 +517,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
     TensorAccessorArgs(*pad_value_const_tensor.buffer()).append_to(reader_ct_args);
     std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
-    bfloat16 bfloat_zero = bfloat16(0.0f);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
     } else {
-        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_zero, bfloat_pad_value});
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
     KernelHandle reader_kernel_id = CreateKernel(
@@ -843,12 +844,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {
-        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
     std::vector<uint32_t> reader_ct_args = {
@@ -1252,12 +1254,13 @@ operation::ProgramWithCallbacks pad_rm_sharded_height_only(
             .set_page_size(src1_cb_index, stick_size_padded);
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::UINT16) {
+        packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {
-        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+        packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
     std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
@@ -1399,6 +1402,8 @@ operation::ProgramWithCallbacks pad_rm_sharded_width_only(
         padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&bfloat_pad_value_bits);
     } else if (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32) {
         padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&pad_value);
+    } else if (input_tensor.dtype() == tt::tt_metal::DataType::UINT16) {
+        padding_value_as_u32 = pack_two_uint16_into_uint32({0, float_to_uint16(pad_value)});
     } else if (
         input_tensor.dtype() == tt::tt_metal::DataType::INT32 ||
         input_tensor.dtype() == tt::tt_metal::DataType::UINT32) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29958)

### Problem description
Add uint16 support to `ttnn.pad`.
This also resolves https://github.com/tenstorrent/tt-metal/issues/29937, i.e. running `ttnn.sort` with uint16 when the tensor requires padding.

### What's changed
- Added uint16 support to `ttnn.pad`, didn't require kernel changes
- Added `float_to_uint16` and `pack_two_uint16_into_uint32` helper functions
- Added pytests for uint16

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18293673027) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18293848318) CI passes (if applicable)