### PR TITLE
MPWI Support Stick Sizes > 16 on Blackhole

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -13,7 +13,7 @@ def test_max_pool2d_with_indices(device):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 32
+    in_c = 1
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]
@@ -52,13 +52,13 @@ def test_max_pool2d_with_indices(device):
     # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
 
     # Create tensor where each element equals its HW coordinate (h * in_w + w)
-    # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
-    torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-    for n in range(in_n):
-        for c in range(in_c):
-            for h in range(in_h):
-                for w in range(in_w):
-                    torch_input[n, c, h, w] = c
+    torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    # torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
+    # for n in range(in_n):
+    #     for c in range(in_c):
+    #         for h in range(in_h):
+    #             for w in range(in_w):
+    #                 torch_input[n, c, h, w] = c
 
     ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -13,7 +13,7 @@ def test_max_pool2d_with_indices(device):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 1
+    in_c = 32
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]
@@ -52,13 +52,13 @@ def test_max_pool2d_with_indices(device):
     # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
 
     # Create tensor where each element equals its HW coordinate (h * in_w + w)
-    torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
-    # torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-    # for n in range(in_n):
-    #     for c in range(in_c):
-    #         for h in range(in_h):
-    #             for w in range(in_w):
-    #                 torch_input[n, c, h, w] = h * in_w + w
+    # torch_input = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    torch_input = torch.zeros(tensor_shape, dtype=torch.bfloat16)
+    for n in range(in_n):
+        for c in range(in_c):
+            for h in range(in_h):
+                for w in range(in_w):
+                    torch_input[n, c, h, w] = c
 
     ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -58,7 +58,7 @@ def test_max_pool2d_with_indices(device):
     #     for c in range(in_c):
     #         for h in range(in_h):
     #             for w in range(in_w):
-    #                 torch_input[n, c, h, w] = c
+    #                 torch_input[n, c, h, w] = h * in_w + w
 
     ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -9,11 +9,11 @@ import pytest
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
-def test_max_pool2d_with_indices(device):
+@pytest.mark.parametrize("in_c", [1, 16, 24, 32, 40, 48, 56, 64])
+def test_max_pool2d_with_indices(device, in_c):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 56
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]
@@ -68,12 +68,14 @@ def test_max_pool2d_with_indices(device):
         ttnn_layout = ttnn.TILE_LAYOUT
 
     # Memory configuration for ttnn_input
+    # Calculate shard width as the nearest multiple of 32 that is >= in_c
+    shard_width = math.ceil(in_c / 32) * 32
     memory_config = ttnn.MemoryConfig(
         memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         buffer_type=ttnn.BufferType.L1,
         shard_spec=ttnn.ShardSpec(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 3))}),
-            [1280, 64],
+            [1280, shard_width],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
@@ -107,24 +109,24 @@ def test_max_pool2d_with_indices(device):
     # print("Indices:\n", ttnn.to_torch(indices))
 
     # Check that ttnn_output_base is exactly equal to ttnn_output
-    ttnn_output_base = ttnn.max_pool2d(
-        input_tensor=ttnn_input,
-        batch_size=in_n,
-        input_h=in_h,
-        input_w=in_w,
-        channels=in_c,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        # applied_shard_scheme=shard_scheme,
-        ceil_mode=ceil_mode,
-        in_place_halo=True,  # test the base with IPH for a little more IPH coverage
-        deallocate_input=False,
-        reallocate_halo_output=True,
-        return_indices=False,
-    )
-    ttnn_outputs_exactly_equal = torch.equal(ttnn.to_torch(ttnn_output_base), ttnn.to_torch(ttnn_output))
+    # ttnn_output_base = ttnn.max_pool2d(
+    #     input_tensor=ttnn_input,
+    #     batch_size=in_n,
+    #     input_h=in_h,
+    #     input_w=in_w,
+    #     channels=in_c,
+    #     kernel_size=kernel_size,
+    #     stride=stride,
+    #     padding=padding,
+    #     dilation=dilation,
+    #     # applied_shard_scheme=shard_scheme,
+    #     ceil_mode=ceil_mode,
+    #     in_place_halo=True,  # test the base with IPH for a little more IPH coverage
+    #     deallocate_input=False,
+    #     reallocate_halo_output=True,
+    #     return_indices=False,
+    # )
+    # ttnn_outputs_exactly_equal = torch.equal(ttnn.to_torch(ttnn_output_base), ttnn.to_torch(ttnn_output))
     print(f"ttnn_output_base exactly equals ttnn_output: {ttnn_outputs_exactly_equal}")
 
     # Run PyTorch max pool for reference

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_mpwi.py
@@ -13,7 +13,7 @@ def test_max_pool2d_with_indices(device):
     in_n = 1
     in_h = 159
     in_w = 159
-    in_c = 1
+    in_c = 56
     kernel_size = [3, 3]
     stride = [1, 1]
     padding = [1, 1]
@@ -73,7 +73,7 @@ def test_max_pool2d_with_indices(device):
         buffer_type=ttnn.BufferType.L1,
         shard_spec=ttnn.ShardSpec(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 3))}),
-            [1280, 32],
+            [1280, 64],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -12,7 +12,7 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
-#define DEBUG_PRINT 0
+#define DEBUG_PRINT 1
 
 #if DEBUG_PRINT == 1
 #include "debug/dprint.h"
@@ -89,19 +89,27 @@ void MAIN {
     // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
-    constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
+    // #ifdef ARCH_BLACKHOLE
+    constexpr bool use_tilize_dest = in_c <= FACE_WIDTH;
+    constexpr bool pack_untilize_reinit = !use_tilize_dest;
+    // #else
+    //     constexpr bool use_tilize_dest = true;
+    //     constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
+    // #endif
     if constexpr (!return_indices) {
         constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
         tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
             in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb, num_faces_in_input_tile, face_r_dim);
         pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb, num_out_sticks, num_faces_in_output_tile);
     } else {
-        unary_op_init_common(in_cb_id_0, in_cb_id_0);
-        tilize_init_no_pack(in_cb_id_0, topk_output_tiles);
-        if constexpr (!pack_untilize_reinit) {
-            const uint32_t output_faces =
-                last_tile_is_partial ? num_faces_in_last_output_tile : num_faces_in_output_tile;
-            pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
+        if constexpr (use_tilize_dest) {
+            unary_op_init_common(in_cb_id_0, in_cb_id_0);
+            tilize_init_no_pack(in_cb_id_0, topk_output_tiles);
+            if constexpr (!pack_untilize_reinit) {
+                const uint32_t output_faces =
+                    last_tile_is_partial ? num_faces_in_last_output_tile : num_faces_in_output_tile;
+                pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
+            }
         }
 
         // this can be done here because we do not use the SFPU for anything else so it does not get reprogrammed
@@ -178,14 +186,66 @@ void MAIN {
                 if constexpr (return_indices) {
                     cb_wait_front(curr_in_idx_cb_id, 1);
 
-                    tilize_init_short_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles);
-                    tilize_block_no_pack(curr_in_idx_cb_id, topk_output_tiles, index_dst_idx, topk_cb_tile_idx);
-                    tilize_uninit_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id);
-                    tilize_init_short_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id, topk_output_tiles);
-                    tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
-                    tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
+                    auto tilize_dest = [&]() __attribute__((always_inline)) {
+                        tilize_init_short_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles);
+                        tilize_block_no_pack(curr_in_idx_cb_id, topk_output_tiles, index_dst_idx, topk_cb_tile_idx);
+                        tilize_uninit_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id);
+                        tilize_init_short_with_dt_no_pack(curr_in_idx_cb_id, curr_in_cb_id, topk_output_tiles);
+                        tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
+                        tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
+                    };
+
+                    auto tilize_copy = [&]() __attribute__((always_inline)) {
+                        tensix_sync();
+                        unary_op_init_common(curr_in_cb_id, tile_tmp_cb_id);
+                        tensix_sync();
+
+                        tensix_sync();
+                        tilize_init(curr_in_cb_id, topk_output_tiles, tile_tmp_cb_id);
+                        tensix_sync();
+
+                        cb_reserve_back(tile_tmp_cb_id, topk_output_tiles);
+
+                        tilize_block(
+                            curr_in_cb_id, topk_output_tiles, tile_tmp_cb_id, topk_cb_tile_idx, topk_cb_tile_idx);
+
+                        cb_push_back(tile_tmp_cb_id, topk_output_tiles);
+                        cb_wait_front(tile_tmp_cb_id, topk_output_tiles);
+                        cb_reserve_back(tile_idx_tmp_cb_id, topk_output_tiles);
+
+                        tilize_uninit_with_dt(curr_in_cb_id, curr_in_idx_cb_id, tile_idx_tmp_cb_id);
+                        tilize_init_short_with_dt(
+                            curr_in_cb_id, curr_in_idx_cb_id, topk_output_tiles, tile_idx_tmp_cb_id);
+                        tilize_block(
+                            curr_in_idx_cb_id,
+                            topk_output_tiles,
+                            tile_idx_tmp_cb_id,
+                            topk_cb_tile_idx,
+                            topk_cb_tile_idx);
+
+                        cb_push_back(tile_idx_tmp_cb_id, topk_output_tiles);
+                        cb_wait_front(tile_idx_tmp_cb_id, topk_output_tiles);
+
+                        tilize_uninit(curr_in_idx_cb_id, tile_idx_tmp_cb_id);
+
+                        copy_tile_init(tile_tmp_cb_id);
+                        copy_tile(tile_tmp_cb_id, 0, data_dst_idx);
+                        copy_tile(tile_idx_tmp_cb_id, 0, index_dst_idx);
+
+                        cb_pop_front(tile_tmp_cb_id, topk_output_tiles);
+                        cb_pop_front(tile_idx_tmp_cb_id, topk_output_tiles);
+                    };
+
+                    if constexpr (use_tilize_dest) {
+                        tilize_dest();
+                    } else {
+                        tilize_copy();
+                    }
 
                     max_reduce_with_indices<window_size_hw>(data_dst_idx, index_dst_idx);
+
+                    dprint_tensix_dest_reg(0);
+                    dprint_tensix_dest_reg(2);
 
                     cb_pop_front(curr_in_idx_cb_id, 1);
                 } else {
@@ -257,6 +317,7 @@ void MAIN {
             } else {
                 if constexpr (pack_untilize_reinit) {
                     tensix_sync();
+                    PACK(DPRINT << "Pack untilize init with : " << output_faces << " faces" << ENDL());
                     pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
                     tensix_sync();
                 }
@@ -264,6 +325,9 @@ void MAIN {
                 pack_reconfig_data_format(out_cb_id);
                 pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, data_dst_idx>(
                     out_cb_id, 1, 0, num_out_sticks, output_faces);
+
+                PACK(tt::compute::common::print_tile_rows(out_cb_id, 1));
+
                 pack_reconfig_data_format(out_idx_cb_id);
                 pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, index_dst_idx>(
                     out_idx_cb_id, 1, 0, num_out_sticks, output_faces);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -50,6 +50,7 @@ template <
     uint32_t num_out_sticks,
     bool pack_untilize_reinit>
 ALWI void tilize_copy_function(uint32_t curr_in_cb_id, uint32_t curr_in_idx_cb_id, uint32_t output_faces) {
+    // tensix syncs are necessary here until https://github.com/tenstorrent/tt-metal/issues/30399 is resolved
     tensix_sync();
     unary_op_init_common(curr_in_cb_id, tile_tmp_cb_id);
     tensix_sync();
@@ -76,6 +77,9 @@ ALWI void tilize_copy_function(uint32_t curr_in_cb_id, uint32_t curr_in_idx_cb_i
     if constexpr (pack_untilize_reinit) {
 // note pack_untilize_dest_init must be called immediately after copy_tile_init see issue
 // https://github.com/tenstorrent/tt-metal/issues/#27314
+// also note we don't actually call pack_untilize_dest_init here, but instead call all it
+// contents without the llk_pack_untilize_hw_configure_disaggregated call so that
+// we can avoid tensix_syncs
 #ifdef ARCH_BLACKHOLE
         // Needed for setting swizzle_32b:
         MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -89,13 +89,13 @@ void MAIN {
     // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
                                      window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
-    // #ifdef ARCH_BLACKHOLE
+#ifdef ARCH_BLACKHOLE
     constexpr bool use_tilize_dest = in_c <= FACE_WIDTH;
     constexpr bool pack_untilize_reinit = !use_tilize_dest;
-    // #else
-    //     constexpr bool use_tilize_dest = true;
-    //     constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
-    // #endif
+#else
+    constexpr bool use_tilize_dest = true;
+    constexpr bool pack_untilize_reinit = last_tile_is_partial && in_ntiles_c > 1;
+#endif
     if constexpr (!return_indices) {
         constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
         tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -319,6 +319,14 @@ void MAIN {
                     tile_regs_release();
                 }
             } else {
+                if constexpr (use_tilize_dest) {
+                    if constexpr (pack_untilize_reinit) {
+                        tensix_sync();
+                        pack_untilize_dest_init<topk_output_tiles>(out_cb_id, num_out_sticks, output_faces);
+                        tensix_sync();
+                    }
+                }
+
                 pack_reconfig_data_format(out_cb_id);
                 pack_untilize_dest<topk_output_tiles, topk_output_tiles, false, false, TILE_C_DIM, data_dst_idx>(
                     out_cb_id, 1, 0, num_out_sticks, output_faces);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27314
https://github.com/tenstorrent/tt-metal/issues/27845 - number 3

### Problem description
MPWI did not work with stick sizes larger than 16 on blackhole.

### What's changed
The pack_untilize_dest_init calls have been moved immediately after copy_tile_init to get around the issue described in issue #27314. However, this does not fix the hardware based tilize bug on BH. Additionally, the reader kernel based workaround used to hack tilize -> dest on BH does not work for larger stick sizes. Thus for, blackhole we sometimes now use tilize to temp CB for larger sticks.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384747543
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384755512
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384792879
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384798158
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384764390
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384780226
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18384802345
- [x] New/Existing tests provide coverage for changes