### PR TITLE
reduce_scatter handles sharded intermediate

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_op.cpp
@@ -162,7 +162,7 @@ tt::tt_metal::operation::Hash MatmulReduceScatterAsync::compute_program_hash(
         this->reduce_scatter_minimal_async_struct.num_links,
         this->reduce_scatter_minimal_async_struct.ring_size,
         this->reduce_scatter_minimal_async_struct.output_mem_config,
-        this->reduce_scatter_minimal_async_struct.intermediate_mem_config,
+        this->reduce_scatter_minimal_async_struct.optional_intermediate_mem_config.value(),
         this->reduce_scatter_minimal_async_struct.topology,
         this->reduce_scatter_minimal_async_struct.sub_device_id.has_value(),
         this->reduce_scatter_minimal_async_struct.sub_device_id.has_value()

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -177,11 +177,13 @@ void ReduceScatterMinimalAsync::validate_with_output_tensors(
                 intermediate_tensor.tensor_spec().page_config() == input_tensor.tensor_spec().page_config(),
                 "Error, intermediate tensor page config should be same as input tensor page config but has {}",
                 intermediate_tensor.tensor_spec().page_config());
-            TT_FATAL(
-                this->optional_intermediate_mem_config.has_value() &&
+
+            if (this->optional_intermediate_mem_config.has_value()) {
+                TT_FATAL(
                     intermediate_tensor.memory_config() == this->optional_intermediate_mem_config.value(),
-                "Error, intermediate tensor memory config should be same as intermediate_mem_config but has {}",
-                intermediate_tensor.memory_config());
+                    "Error, intermediate tensor memory config should be same as intermediate_mem_config but has {}",
+                    intermediate_tensor.memory_config());
+            }
 
             // Don't support DRAM block sharding
             if (intermediate_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
@@ -31,7 +31,7 @@ struct ReduceScatterMinimalAsync {
     uint32_t num_links;
     uint32_t ring_size;
     const MemoryConfig output_mem_config;
-    const MemoryConfig intermediate_mem_config;
+    const std::optional<MemoryConfig> optional_intermediate_mem_config;
     const ccl::Topology topology;
     const std::vector<GlobalSemaphore> semaphore;
     const std::optional<GlobalSemaphore>& barrier_semaphore;
@@ -47,7 +47,7 @@ struct ReduceScatterMinimalAsync {
         uint32_t num_links,
         uint32_t ring_size,
         MemoryConfig output_mem_config,
-        MemoryConfig intermediate_mem_config,
+        const std::optional<MemoryConfig>& intermediate_mem_config,
         ccl::Topology topology,
         std::vector<GlobalSemaphore> semaphore,
         const std::optional<GlobalSemaphore>& barrier_semaphore,
@@ -61,7 +61,7 @@ struct ReduceScatterMinimalAsync {
         num_links(num_links),
         ring_size(ring_size),
         output_mem_config(std::move(output_mem_config)),
-        intermediate_mem_config(std::move(intermediate_mem_config)),
+        optional_intermediate_mem_config(intermediate_mem_config),
         topology(topology),
         semaphore(std::move(semaphore)),
         barrier_semaphore(barrier_semaphore),
@@ -81,7 +81,7 @@ struct ReduceScatterMinimalAsync {
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("ring_size", ring_size);
         attrs.emplace_back("output_mem_config", output_mem_config);
-        attrs.emplace_back("intermediate_mem_config", intermediate_mem_config);
+        attrs.emplace_back("optional_intermediate_mem_config", optional_intermediate_mem_config);
         attrs.emplace_back("topology", topology);
         attrs.emplace_back("semaphore", semaphore);
         attrs.emplace_back("barrier_semaphore", barrier_semaphore);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29980

### Problem description
- In certain cases, reduce scatter would fail with sharded memory configs because the intermediate tensor was not compatible with the input shard spec.

### What's changed
- Dynamically adjust shard spec for intermediate tensor when appropriate

### Checklist

- [x] T3K nightly. https://github.com/tenstorrent/tt-metal/actions/runs/18327256932 (Same failures as main)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/18295525341
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)https://github.com/tenstorrent/tt-metal/actions/runs/18321343104 (no more failures than main)
- [x] New/Existing tests provide coverage for changes