### PR TITLE
Cleanup buffer related APIs

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/allocator.hpp>
+#include "impl/buffers/buffer_page_mapping.hpp"
 
 namespace distribution_spec_tests {
 using tt::tt_metal::BufferDistributionSpec;

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -95,7 +95,7 @@ std::pair<std::shared_ptr<Buffer>, std::vector<uint32_t>> l1_buffer_write_wait(
                                             .buffer_type = test_config.buffer_type,
                                             .buffer_layout = test_config.buffer_layout,
                                             .shard_parameters = test_config.shard_spec()})
-                                      : CreateBuffer(tt::tt_metal::BufferConfig{
+                                      : CreateBuffer(tt::tt_metal::InterleavedBufferConfig{
                                             .device = device,
                                             .size = test_config.size_bytes,
                                             .page_size = test_config.page_size_bytes,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -32,6 +32,8 @@
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 #include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
 
+#include "impl/buffers/buffer_page_mapping.hpp"
+
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshShape = tt::tt_metal::distributed::MeshShape;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -8,6 +8,8 @@
 #include "ttnn_test_fixtures.hpp"
 #include <tt-metalium/distributed.hpp>
 
+#include "impl/buffers/buffer_page_mapping.hpp"
+
 namespace {
 struct NDShardingParams {
     Shape shape;
@@ -357,8 +359,8 @@ TEST_P(NDShardingSqueezeRankTests, TestSqueezeRank) {
     EXPECT_EQ(dspec.shard_shape_in_pages(), params.expected_shard_shape_pages);
 
     if (params.tensor_shape_pages.rank() == params.shard_shape_pages.rank()) {
-        auto expected_page_mapping =
-            detail::compute_page_mapping(params.tensor_shape_pages, params.shard_shape_pages, dspec.cores());
+        BufferDistributionSpec expected_dspec(params.tensor_shape_pages, params.shard_shape_pages, dspec.cores());
+        auto expected_page_mapping = expected_dspec.compute_page_mapping();
         EXPECT_EQ(dspec.compute_page_mapping().core_host_page_indices, expected_page_mapping.core_host_page_indices);
     }
 }
@@ -413,8 +415,8 @@ TEST_F(NDShardingSqueezeRankStressTests, TestSqueezeRankStress) {
     iterate_shapes(Shape({4, 4, 4, 4}), [&](const Shape& tensor_shape) {
         iterate_shapes(tensor_shape, [&](const Shape& shard_shape) {
             BufferDistributionSpec dspec(tensor_shape, shard_shape, cores, ShardOrientation::ROW_MAJOR);
-            auto expected_page_mapping =
-                tt::tt_metal::detail::compute_page_mapping(tensor_shape, shard_shape, dspec.cores());
+            BufferDistributionSpec expected_dspec(tensor_shape, shard_shape, dspec.cores());
+            auto expected_page_mapping = expected_dspec.compute_page_mapping();
             EXPECT_EQ(
                 dspec.compute_page_mapping().core_host_page_indices, expected_page_mapping.core_host_page_indices);
         });

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -217,47 +217,60 @@ public:
     void set_page_size(DeviceAddr page_size);
 
     uint32_t num_pages() const;
+
+    // Internal
     uint32_t num_dev_pages() const;
 
     BufferType buffer_type() const { return buffer_type_; }
+    // Internal
     HalMemType memory_type() const;
     CoreType core_type() const;
 
     bool is_l1() const;
     bool is_dram() const;
+    // Internal/ removal
     bool is_trace() const;
 
+    // Internal
     bool is_valid_region(const BufferRegion& region) const;
+    // Internal/ removal
     bool is_valid_partial_region(const BufferRegion& region) const;
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 
+    // Internal
     bool bottom_up() const { return bottom_up_; }
 
     DeviceAddr page_address(DeviceAddr bank_id, DeviceAddr page_index) const;
 
     uint32_t alignment() const;
     DeviceAddr aligned_page_size() const;
+    // Internal
     DeviceAddr aligned_size() const;
     DeviceAddr aligned_size_per_bank() const;
 
     // SHARDED API STARTS HERE
     const std::optional<BufferDistributionSpec>& buffer_distribution_spec() const;
+    // removal?
     bool has_shard_spec() const { return shard_spec_.has_value(); }
     ShardSpecBuffer shard_spec() const;
     void set_shard_spec(const ShardSpecBuffer& shard_spec);
     std::optional<uint32_t> num_cores() const;
     const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
 
+    // Internal
     // Returns the buffer that owns the underlying device memory.
     // Typically returns itself unless the buffer was created with a view method.
     std::shared_ptr<Buffer> root_buffer();
+    // Internal
     BufferRegion root_buffer_region() const { return BufferRegion(root_buffer_offset_, size_); }
 
+    // Internal/ Removal
     std::optional<SubDeviceId> sub_device_id() const { return sub_device_id_; }
 
     size_t unique_id() const { return unique_id_; }
 
+    // Internal
     // Mark the buffer as deallocated, without releasing underlying device memory
     void mark_as_deallocated();
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -320,8 +320,6 @@ private:
     static std::atomic<size_t> next_unique_id;
 };
 
-UncompressedBufferPageMapping generate_buffer_page_mapping(const Buffer& buffer);
-
 using HostDataType = std::variant<
     const std::shared_ptr<std::vector<uint8_t>>,
     const std::shared_ptr<std::vector<uint16_t>>,

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -8,17 +8,12 @@
 #include <tt_stl/concepts.hpp>
 #include <array>
 #include <atomic>
-#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <ostream>
 #include <tuple>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -106,14 +101,12 @@ struct ShardSpecBuffer {
     DeviceAddr num_pages() const;
 };
 
-struct BufferConfig {
+struct InterleavedBufferConfig {
     IDevice* device;
     DeviceAddr size;       // Size in bytes
     DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type;
 };
-
-using InterleavedBufferConfig = BufferConfig;
 
 // copied from above instead of using inheritance such that we can use
 // designator constructor

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -12,11 +12,6 @@
 
 namespace tt::tt_metal {
 
-namespace detail {
-UncompressedBufferPageMapping compute_page_mapping(
-    const Shape& tensor_shape, const Shape& shard_shape, const std::vector<CoreCoord>& cores);
-}
-
 class BufferDistributionSpec {
 public:
     static BufferDistributionSpec from_shard_spec(
@@ -64,9 +59,8 @@ public:
     // number of shards per core in group 1, number of shards per core in group 2.
     std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
-    UncompressedBufferPageMapping compute_page_mapping() const {
-        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);
-    }
+    // Internal facing function as UncompressedBufferPageMapping has definition behind impl.
+    UncompressedBufferPageMapping compute_page_mapping() const;
 
 private:
     static std::vector<CoreCoord> compute_core_list(

--- a/tt_metal/api/tt-metalium/buffer_page_mapping.hpp
+++ b/tt_metal/api/tt-metalium/buffer_page_mapping.hpp
@@ -13,14 +13,7 @@
 
 namespace tt::tt_metal {
 
-struct UncompressedBufferPageMapping {
-    // Represents a page on device which doesn't match any host page within core_host_page_indices.
-    static constexpr uint32_t PADDING = std::numeric_limits<uint32_t>::max();
-
-    std::vector<CoreCoord> all_cores;
-    // For each core, a vector of host page indices (or PADDING if there's no corresponding host page).
-    std::vector<std::vector<uint32_t>> core_host_page_indices;
-};
+struct UncompressedBufferPageMapping;
 
 // Represents a contiguous range of device pages for a single core.
 struct BufferCorePageMapping {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -506,7 +506,6 @@ CoreType Buffer::core_type() const {
 
 bool Buffer::is_l1() const { return is_l1_impl(buffer_type()); }
 bool Buffer::is_dram() const { return buffer_type() == BufferType::DRAM || buffer_type() == BufferType::TRACE; }
-bool Buffer::is_trace() const { return buffer_type() == BufferType::TRACE; }
 
 bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -21,6 +21,8 @@
 #include <string_view>
 #include <utility>
 
+#include "impl/buffers/buffer_page_mapping.hpp"
+
 #include "fmt/base.h"
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include <tt_stl/strong_type.hpp>

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include <tt-metalium/device.hpp>
+
+namespace tt::tt_metal::detail {
+
+class BufferImpl {
+    // Used in public BufferImpl constructors so they are only callable within BufferImpl
+    // BufferImpl constructors are public so we can call std::make_shared on BufferImpl
+    struct Private {
+        explicit Private() = default;
+    };
+
+public:
+    static std::shared_ptr<BufferImpl> create(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    static std::shared_ptr<BufferImpl> create(
+        IDevice* device,
+        DeviceAddr address,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+
+    // Creates a view of the region of the buffer.
+    // The view is a new buffer (unless the region is the entire buffer) that shares the same underlying device memory.
+    // The view keeps the underlying buffer alive as long as the view is alive.
+    std::shared_ptr<BufferImpl> view(const BufferRegion& region);
+
+    BufferImpl(const BufferImpl& other) = delete;
+    BufferImpl& operator=(const BufferImpl& other) = delete;
+    BufferImpl(BufferImpl&& other) = delete;
+    BufferImpl& operator=(BufferImpl&& other) = delete;
+    ~BufferImpl();
+
+    IDevice* device() const { return device_; }
+    Allocator* allocator() const { return allocator_; }
+    DeviceAddr size() const { return size_; }
+    bool is_allocated() const;
+
+    // Returns address of buffer in the first bank
+    uint32_t address() const;
+
+    DeviceAddr page_size() const;
+    void set_page_size(DeviceAddr page_size);
+
+    uint32_t num_pages() const;
+
+    // Internal
+    uint32_t num_dev_pages() const;
+
+    BufferType buffer_type() const { return buffer_type_; }
+    // Internal
+    HalMemType memory_type() const;
+    CoreType core_type() const;
+
+    bool is_l1() const;
+    bool is_dram() const;
+    // Internal/ removal
+    bool is_trace() const;
+
+    // Internal
+    bool is_valid_region(const BufferRegion& region) const;
+    // Internal/ removal
+    bool is_valid_partial_region(const BufferRegion& region) const;
+
+    TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
+
+    // Internal
+    bool bottom_up() const { return bottom_up_; }
+
+    DeviceAddr page_address(DeviceAddr bank_id, DeviceAddr page_index) const;
+
+    uint32_t alignment() const;
+    DeviceAddr aligned_page_size() const;
+    // Internal
+    DeviceAddr aligned_size() const;
+    DeviceAddr aligned_size_per_bank() const;
+
+    // SHARDED API STARTS HERE
+    const std::optional<BufferDistributionSpec>& buffer_distribution_spec() const;
+    // removal?
+    bool has_shard_spec() const { return shard_spec_.has_value(); }
+    ShardSpecBuffer shard_spec() const;
+    void set_shard_spec(const ShardSpecBuffer& shard_spec);
+    std::optional<uint32_t> num_cores() const;
+    const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
+
+    // Internal
+    // Returns the buffer that owns the underlying device memory.
+    // Typically returns itself unless the buffer was created with a view method.
+    std::shared_ptr<BufferImpl> root_buffer();
+    // Internal
+    BufferRegion root_buffer_region() const { return BufferRegion(root_buffer_offset_, size_); }
+
+    // Internal/ Removal
+    std::optional<SubDeviceId> sub_device_id() const { return sub_device_id_; }
+
+    size_t unique_id() const { return unique_id_; }
+
+    // Internal
+    // Mark the buffer as deallocated, without releasing underlying device memory
+    void mark_as_deallocated();
+
+    BufferImpl(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args,
+        std::optional<bool> bottom_up,
+        std::optional<SubDeviceId> sub_device_id,
+        bool owns_data,
+        Private);
+
+private:
+    enum class AllocationStatus : uint8_t {
+        ALLOCATION_REQUESTED,
+        ALLOCATED,
+        DEALLOCATED,
+    };
+
+    void allocate_impl();
+
+    // Deallocate is allowed to be called multiple times on the same buffer
+    void deallocate();
+    void deallocate_impl();
+    friend void DeallocateBufferImpl(BufferImpl& buffer);
+
+    DeviceAddr translate_page_address(DeviceAddr offset, uint32_t bank_id) const;
+
+    IDevice* const device_;
+    const DeviceAddr size_;  // Size in bytes
+    const BufferType buffer_type_;
+    const TensorMemoryLayout buffer_layout_;
+    const bool bottom_up_;
+    const std::optional<SubDeviceId> sub_device_id_;
+    const bool owns_data_;
+
+    std::optional<SubDeviceManagerId> sub_device_manager_id_;
+    Allocator* allocator_;
+
+    AllocationStatus allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
+    bool hooked_allocation_ = false;
+    DeviceAddr address_ = 0;
+
+    // These members must be only accessed on the device worker thread
+    DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    std::optional<ShardSpecBuffer> shard_spec_;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
+
+    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
+
+    // The root buffer is the buffer that owns the underlying device memory.
+    // The root buffer is populated only when the buffer was created with a view method.
+    std::shared_ptr<BufferImpl> root_buffer_;
+    // Offset of the current view buffer in the root buffer
+    DeviceAddr root_buffer_offset_ = 0;
+
+    size_t unique_id_ = 0;
+    static std::atomic<size_t> next_unique_id;
+};
+
+};  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "buffer_distribution_spec.hpp"
+#include "impl/buffers/buffer_page_mapping.hpp"
 #include <tt_stl/assert.hpp>
 
 #include <tt-metalium/math.hpp>
@@ -349,5 +350,9 @@ UncompressedBufferPageMapping compute_page_mapping(
     return page_mapping;
 }
 }  // namespace detail
+
+UncompressedBufferPageMapping BufferDistributionSpec::compute_page_mapping() const {
+    return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_page_mapping.hpp"
 #include <tt-metalium/buffer_page_mapping.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/buffers/buffer_page_mapping.hpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+
+#include <vector>
+#include <limits>
+
+namespace tt::tt_metal {
+
+struct UncompressedBufferPageMapping {
+    // Represents a page on device which doesn't match any host page within core_host_page_indices.
+    static constexpr uint32_t PADDING = std::numeric_limits<uint32_t>::max();
+
+    std::vector<CoreCoord> all_cores;
+    // For each core, a vector of host page indices (or PADDING if there's no corresponding host page).
+    std::vector<std::vector<uint32_t>> core_host_page_indices;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -20,7 +20,6 @@ struct ComputeConfig;
 struct EthernetConfig;
 
 class IDevice;
-struct BufferConfig;
 class CircularBufferConfig;
 using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
 


### PR DESCRIPTION
### Ticket
Closes #29717

### Problem description
Runtime Team is cleaning up our Metal API exposure,
I have checked over all the classes and functions related to Buffer and moved them to `impl` if they are implementation details (not used).

### What's changed
See Write up in: #29717

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes