### PR TITLE
Blocking Global Semaphore Writes

### DIFF
--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sd_mesh_command_queue.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
@@ -98,7 +99,14 @@ MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
 }
 
 void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {}
-void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {}
+
+void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
+    for (const auto& device : mesh_device_->get_devices()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+    }
+}
+
 void SDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId>) {}
 
 void SDMeshCommandQueue::reset_worker_state(


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
- `GlobalSemaphore` initialization doesn't rely on blocking writes
- In multi-device settings where CCLs rely on these structures for synchronization, this can lead to a race where host clears the semaphore value after a peer device has written to it
- This currently requires explicit synchronization done by the user, which is messy
- This was a source of 3 Tier Training hanging on the ExaBox

### What's changed
- Make `EnqueueWriteMeshBuffer` in the `GlobalSemaphore` constructor blocking
- Also update `SDMeshCommandQueue::finish` to act as a memory barrier, to guard against scenarios mentioned above

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes