### PR TITLE
Add missing API headers

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
             tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
             transpose/transpose.hpp
             untilize/untilize.hpp
+            untilize_with_unpadding/untilize_with_unpadding.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
         BASE_DIRS ${FixmeOpAPIDir}
         FILES
             all_broadcast_async/device/all_broadcast_async_op.hpp
+            all_reduce_async/all_reduce_async.hpp
             all_gather_async/all_gather_async.hpp
             all_gather_async/device/all_gather_async_op.hpp
             composite_common.hpp


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Building TT-Train from packages revealed that these headers are part of the public API but weren't packaged.

### What's changed
Package them.