### PR TITLE
Fix ccl semaphores initialization in DeepSeek

### DIFF
--- a/models/demos/deepseek_v3/tt/ccl.py
+++ b/models/demos/deepseek_v3/tt/ccl.py
@@ -17,14 +17,10 @@ class CCL:
         self.core_range_set = ttnn.num_cores_to_corerangeset(self.num_cores, self.grid, row_wise=True)
 
         self.gather_sems = []
-        self.from_sems = []
-        self.to_sems = []
         self.reduce_scatter_sems = []
         self.barrier_sems = []
         for _ in range(len(list(mesh_device.shape))):
             self.gather_sems.append([])
-            self.from_sems.append([])
-            self.to_sems.append([])
             self.reduce_scatter_sems.append([])
             self.barrier_sems.append([])
             for _ in range(2):
@@ -34,8 +30,7 @@ class CCL:
                         ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
                     ]
                 )  # use two semaphores to use minimal version of all_gather_async
-                self.from_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
-                self.to_sems[-1].append(ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0))
+
                 self.reduce_scatter_sems[-1].append(
                     [
                         ttnn.create_global_semaphore(self.mesh_device, self.core_range_set, 0),
@@ -66,22 +61,6 @@ class CCL:
         Get a semaphore for the given axis.
         """
         sem = self.gather_sems[axis][self.sem_cnt[axis]]
-        self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
-        return sem
-
-    def get_from_sem(self, axis):
-        """
-        Get a semaphore for the given axis.
-        """
-        sem = self.from_sems[axis][self.sem_cnt[axis]]
-        self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
-        return sem
-
-    def get_to_sem(self, axis):
-        """
-        Get a semaphore for the given axis.
-        """
-        sem = self.to_sems[axis][self.sem_cnt[axis]]
         self.sem_cnt[axis] = (self.sem_cnt[axis] + 1) % 2
         return sem
 

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_1d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_1d.py
@@ -104,7 +104,6 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
         }
 
     @classmethod
-    @abstractmethod
     def create_mlp_state(
         cls,
         hf_config: PretrainedConfig,
@@ -117,10 +116,7 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
                 None if is_padding else MoE.create_state(hf_config, mesh_device, ccl) for is_padding in is_padding_layer
             ],
             "shared_expert": SharedExpert.create_state(hf_config, mesh_device, ccl),
-            "revert_dp": {
-                "multi_device_global_semaphore": ccl.get_gather_sem(0),
-                "barrier_semaphore": ccl.get_barrier_sem(0),
-            },
+            "ccl": ccl,
         }
 
     @classmethod
@@ -185,10 +181,13 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
         return tt_out_tensor
 
     @classmethod
-    def revert_data_parallelism(cls, x: ttnn.Tensor, row_idx: int, **cfg) -> ttnn.Tensor:
+    def revert_data_parallelism(
+        cls, x: ttnn.Tensor, row_idx: int, cfg: RunDecodeConfig | RunPrefillConfig
+    ) -> ttnn.Tensor:
         """Revert data parallelism by gathering partitioned tensor back to original form."""
         # Gather tensor along specified dimension across mesh cluster axis
-        tt_out_tensor = ttnn.experimental.all_gather_async(x, **cfg)
+        ccl = cfg["ccl"]
+        tt_out_tensor = ttnn.experimental.all_gather_async(x, **ccl.populate_all_gather_runtime_args(cfg["revert_dp"]))
         return tt_out_tensor
 
     @classmethod
@@ -204,7 +203,6 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
         }
 
     @classmethod
-    @abstractmethod
     def forward_mlp_prefill(cls, x: ttnn.Tensor, row_idx: int, cfg: RunPrefillConfig) -> ttnn.Tensor:
         num_tokens_to_route = x.shape[-3] * x.shape[-2]
         DP_FACTOR = cfg["moe"][row_idx]["num_dispatch_devices"]
@@ -216,7 +214,7 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
         mlp_out = MoE.forward_prefill(x_dp if apply_dp else x, cfg["moe"][row_idx])
         if apply_dp:
             ttnn.deallocate(x_dp)
-            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, **cfg["revert_dp"])
+            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, cfg)
         mlp_out += SharedExpert.forward_prefill(x, cfg["shared_expert"])
         return mlp_out
 
@@ -233,6 +231,6 @@ class MoEDecoderBlock1D(DecoderBlock1DBase):
         mlp_out = MoE.forward_decode(x_dp if apply_dp else x, cfg["moe"][row_idx])
         if apply_dp:
             ttnn.deallocate(x_dp)
-            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, **cfg["revert_dp"])
+            mlp_out = cls.revert_data_parallelism(mlp_out, row_idx, cfg)
         mlp_out += SharedExpert.forward_decode(x, cfg["shared_expert"])
         return mlp_out

--- a/models/demos/deepseek_v3/tt/embedding/embedding1d.py
+++ b/models/demos/deepseek_v3/tt/embedding/embedding1d.py
@@ -156,13 +156,10 @@ class Embedding1D(AbstractModule):
     @classmethod
     def create_state(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, ccl: CCL) -> dict[str, ttnn.Tensor]:
         """Create the state for the embedding module."""
+        # Store CCL object for runtime semaphore initialization
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
-            "all_gather": {
-                "multi_device_global_semaphore": ccl.get_gather_sem(0),
-                "barrier_semaphore": ccl.get_barrier_sem(0),
-                "num_links": ccl.get_max_links(0),
-            },
+            "ccl": ccl,
         }
 
     @classmethod
@@ -192,7 +189,12 @@ class Embedding1D(AbstractModule):
         embeddings_tc = ttnn.typecast(embeddings, **cfg["typecast"])
         ttnn.deallocate(embeddings)
 
-        embeddings_ag = ttnn.experimental.all_gather_async(embeddings_tc, **cfg["all_gather"])
+        # CCL runtime initialization in execution order
+        ccl = cfg["ccl"]
+
+        embeddings_ag = ttnn.experimental.all_gather_async(
+            embeddings_tc, **ccl.populate_all_gather_runtime_args(cfg["all_gather"])
+        )
         ttnn.deallocate(embeddings_tc)
 
         assert len(embeddings_ag.shape) == 4

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -253,12 +253,10 @@ class LMHead(AbstractModule):
 
     @classmethod
     def create_state(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, ccl: CCL) -> ModelState:
+        # Store CCL object for runtime semaphore initialization
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
-            "all_gather": {
-                "multi_device_global_semaphore": ccl.get_gather_sem(1),
-                "num_links": ccl.get_max_links(1),
-            },
+            "ccl": ccl,
         }
 
     @classmethod

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -737,41 +737,21 @@ class MLA1D(AbstractModule):
         if caches is None:
             caches = (torch.zeros(cache_shape),) * mesh_device.shape[0]
 
-        # CCL states setup (Must be in order of execution)
-        get_rs_params = lambda axis: {
-            "multi_device_global_semaphore": ccl.get_reduce_scatter_sem(axis=axis),
-            "barrier_semaphore": ccl.get_barrier_sem(axis=axis),
-            "num_links": ccl.get_max_links(axis=axis),
-        }
-        get_ag_params = lambda axis: {
-            "multi_device_global_semaphore": ccl.get_gather_sem(axis=axis),
-            "barrier_semaphore": ccl.get_barrier_sem(axis=axis),
-            "num_links": ccl.get_max_links(axis=axis),
-        }
-        ccl_states_prefill = {
-            "wq_a_rs_prefill": get_rs_params(1),
-            "wq_a_ag_prefill": get_ag_params(1),
-            "wkv_a_ag_prefill": get_ag_params(1),
-            "wo_ag_prefill": get_ag_params(1),
-        }
-        ccl_states_decode = {
-            "wq_a_rs_decode": get_rs_params(1),
-            "wq_a_ag_decode": get_ag_params(1),
-            "wq_a2a_ag_decode": get_ag_params(1),
-            "wq_a2a_rs_decode": get_rs_params(1),
-            "wkv_a_ag_decode": get_ag_params(1),
-            "wkv_a_rs_decode": get_rs_params(1),
-            "flash_mla_ag_decode": get_ag_params(1),
-            "flash_mla_rs_decode": get_rs_params(1),
-            "wo_ag_decode": get_ag_params(1),
-        }
+        tt_cache = ttnn.as_tensor(
+            torch.concatenate(tuple(caches)),
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, 0),
+        )
 
+        # Store CCL object for runtime semaphore initialization
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
             "mesh_shape": mesh_device.shape,
             "kvpe_cache": cls._convert_cache(tuple(caches), mesh_device),
-            **ccl_states_prefill,
-            **ccl_states_decode,
+            "ccl": ccl,
         }
 
     @classmethod
@@ -822,14 +802,17 @@ class MLA1D(AbstractModule):
         v_head_dim = cfg["v_head_dim"]
 
         kvpe_cache = cfg["kvpe_cache"]
+        ccl = cfg["ccl"]
 
         bsz = x.shape[2]
         scale = 1.0 / mla_tp_factor
 
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
-        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a_rs_decode"])
-        tt_q = ttnn.experimental.all_gather_async(tt_q, **cfg["wq_a_ag_decode"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_q, **ccl.populate_reduce_scatter_runtime_args(cfg["wq_a_rs_decode"])
+        )
+        tt_q = ttnn.experimental.all_gather_async(tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a_ag_decode"]))
 
         tt_q = RMSNorm.forward_decode(tt_q, cfg["q_norm"])
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"])
@@ -870,10 +853,12 @@ class MLA1D(AbstractModule):
         # Using the following algorithm: 1. AG on in_dim, 2. Scale by number of devices, 3. RS on out_dim
         tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, num_heads_local, bsz_local, kv_lora_rank + qk_rope_head_dim]
         tt_q = ttnn.experimental.all_gather_async(
-            tt_q, **cfg["wq_a2a_ag_decode"]
+            tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a2a_ag_decode"])
         )  # [1, num_heads, bsz_local, kv_lora_rank + qk_rope_head_dim]
         tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, bsz_local, num_heads, kv_lora_rank + qk_rope_head_dim]
-        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a2a_rs_decode"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_q, **ccl.populate_reduce_scatter_runtime_args(cfg["wq_a2a_rs_decode"])
+        )
         tt_q = tt_q * scale  # Scale the input tensor
 
         # KVPE Stuff
@@ -881,7 +866,7 @@ class MLA1D(AbstractModule):
 
         # AG + Reduce b/c sub-tile RS not supported
         tt_kv = ttnn.experimental.all_gather_async(
-            tt_kv, **cfg["wkv_a_ag_decode"]
+            tt_kv, **ccl.populate_all_gather_runtime_args(cfg["wkv_a_ag_decode"])
         )  # [1, num_devices, bsz, kv_lora_rank + qk_rope_head_dim]
         tt_kv = ttnn.experimental.fast_reduce_nc(
             tt_kv, **cfg["wkv_a_r_decode"]
@@ -914,7 +899,9 @@ class MLA1D(AbstractModule):
         # FIXME: Reduce-Scatter here!! (tt_kvpe)
         tt_kvpe = ttnn.pad(tt_kvpe, [(0, 0), (0, ttnn.TILE_SIZE - 1), (0, 0), (0, 0)], 0)
         tt_kvpe = ttnn.permute(tt_kvpe, (0, 2, 1, 3))  # [1, bsz, ttnn.TILE_SIZE, kv_lora_rank + qk_rope_head_dim]
-        tt_kvpe = ttnn.experimental.reduce_scatter_minimal_async(tt_kvpe, **cfg["wkv_a_rs_decode"])
+        tt_kvpe = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_kvpe, **ccl.populate_reduce_scatter_runtime_args(cfg["wkv_a_rs_decode"])
+        )
         tt_kvpe = tt_kvpe[:, :, :1, :]  # [1, bsz_local, 1, kv_lora_rank + qk_rope_head_dim]
         tt_kvpe = tt_kvpe * scale  # Scale the input tensor
 
@@ -946,11 +933,11 @@ class MLA1D(AbstractModule):
         # FIXME: All-to-All here!! (attn_out)
         # TODO: add deallocation of intermediate tensors
         attn_out = ttnn.experimental.all_gather_async(
-            attn_out, **cfg["flash_mla_ag_decode"]
+            attn_out, **ccl.populate_all_gather_runtime_args(cfg["flash_mla_ag_decode"])
         )  # [1, bsz, num_heads, kv_lora_rank]
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, num_heads, bsz, kv_lora_rank]
         attn_out = ttnn.experimental.reduce_scatter_minimal_async(
-            attn_out, **cfg["flash_mla_rs_decode"]
+            attn_out, **ccl.populate_reduce_scatter_runtime_args(cfg["flash_mla_rs_decode"])
         )  # [1, num_heads_local, bsz, kv_lora_rank]
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, bsz, num_heads_local, kv_lora_rank]
         attn_out = attn_out * scale  # Scale the output tensor
@@ -960,7 +947,9 @@ class MLA1D(AbstractModule):
         v_out = ttnn.linear(attn_out, **cfg["wkv_b2"])  # [1, num_heads_local, bsz, v_head_dim]
 
         # wo
-        v_out = ttnn.experimental.all_gather_async(v_out, **cfg["wo_ag_decode"])  # [1, num_heads, bsz, v_head_dim]
+        v_out = ttnn.experimental.all_gather_async(
+            v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_decode"])
+        )  # [1, num_heads, bsz, v_head_dim]
         v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, bsz, num_heads, v_head_dim]
 
         # Bug: https://github.com/tenstorrent/tt-metal/issues/29932
@@ -1007,14 +996,17 @@ class MLA1D(AbstractModule):
         v_head_dim = cfg["v_head_dim"]
 
         kvpe_cache = cfg["kvpe_cache"]
+        ccl = cfg["ccl"]
 
         seq_len = x.shape[2]
 
         # wq_a and wq_b
         tt_q = ttnn.linear(x, **cfg["wq_a"])
 
-        tt_q = ttnn.experimental.reduce_scatter_minimal_async(tt_q, **cfg["wq_a_rs_prefill"])
-        tt_q = ttnn.experimental.all_gather_async(tt_q, **cfg["wq_a_ag_prefill"])
+        tt_q = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_q, **ccl.populate_reduce_scatter_runtime_args(cfg["wq_a_rs_prefill"])
+        )
+        tt_q = ttnn.experimental.all_gather_async(tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a_ag_prefill"]))
 
         # Bug: https://github.com/tenstorrent/tt-metal/issues/29935
         ttnn.synchronize_device(cfg["mesh_device"])
@@ -1047,7 +1039,7 @@ class MLA1D(AbstractModule):
         tt_kv = ttnn.linear(x, **cfg["wkv_a"])
 
         tt_kv = ttnn.experimental.all_gather_async(
-            tt_kv, **cfg["wkv_a_ag_prefill"]
+            tt_kv, **ccl.populate_all_gather_runtime_args(cfg["wkv_a_ag_prefill"])
         )  # [1, 1, seq_len / num_devices, kv_lora_rank + qk_rope_head_dim]
         tt_kv = ttnn.experimental.fast_reduce_nc(
             tt_kv, **cfg["wkv_a_r_prefill"]
@@ -1097,7 +1089,9 @@ class MLA1D(AbstractModule):
 
         # wkv_b2
         v_out = ttnn.linear(attn_out, **cfg["wkv_b2"])  # [1, num_heads_local, seq_len, v_head_dim]
-        v_out = ttnn.experimental.all_gather_async(v_out, **cfg["wo_ag_prefill"])  # [1, num_heads, seq_len, v_head_dim]
+        v_out = ttnn.experimental.all_gather_async(
+            v_out, **ccl.populate_all_gather_runtime_args(cfg["wo_ag_prefill"])
+        )  # [1, num_heads, seq_len, v_head_dim]
 
         # wo
         v_out = ttnn.permute(v_out, (0, 2, 1, 3))  # [1, seq_len, num_heads, v_head_dim]

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -91,6 +91,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
+        # Store CCL object for runtime semaphore initialization
         return {
             "expert_mapping_tensors": expert_mapping_tensors,
             # CCL-specific parameters (semaphores and num_links)
@@ -100,15 +101,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             "all_to_all_combine": {
                 "num_links": 1,
             },
-            "final_output_reduce_scatter": {
-                "multi_device_global_semaphore": ccl.get_reduce_scatter_sem(1),
-                "barrier_semaphore": ccl.get_barrier_sem(1),
-                "num_links": ccl.get_max_links(1),
-            },
-            "revert_tp": {
-                "multi_device_global_semaphore": ccl.get_gather_sem(1),
-                "num_links": ccl.get_max_links(1),
-            },
+            "ccl": ccl,
         }
 
     @classmethod
@@ -184,7 +177,10 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
-        x = ttnn.experimental.all_gather_async(x, **cfg["revert_tp"])
+        # CCL runtime initialization in execution order
+        ccl = cfg["ccl"]
+
+        x = ttnn.experimental.all_gather_async(x, **ccl.populate_all_gather_runtime_args(cfg["revert_tp"]))
 
         seq_len = 1  # a2a dispatch and combine require DP=num_dispatch_devices, hence in prefill for bs=1, we interchange the seq_len with batch_size dimensions
         batch_size_per_device = x.shape[
@@ -239,7 +235,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         )
         post_combine_output_tensor = ttnn.sum(post_combine_output_tensor, dim=0, keepdim=True)
         post_combine_output_tensor = ttnn.experimental.reduce_scatter_minimal_async(
-            post_combine_output_tensor, **cfg["final_output_reduce_scatter"]
+            post_combine_output_tensor, **ccl.populate_reduce_scatter_runtime_args(cfg["final_output_reduce_scatter"])
         )
 
         return post_combine_output_tensor

--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -158,10 +158,7 @@ class DistributedRMSNorm(RMSNormBase):
         """
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
-            "all_gather": {
-                "multi_device_global_semaphore": ccl.get_gather_sem(1),
-                "barrier_semaphore": ccl.get_barrier_sem(1),
-            },
+            "ccl": ccl,
         }
 
     @classmethod
@@ -181,7 +178,10 @@ class DistributedRMSNorm(RMSNormBase):
         tt_stats = ttnn.rms_norm_pre_all_gather(x, program_config=program_config, **cfg["rms_norm_pre_all_gather"])
 
         # AllGather stats
-        tt_gathered_stats = ttnn.experimental.all_gather_async(tt_stats, **cfg["all_gather"])
+        ccl = cfg["ccl"]
+        tt_gathered_stats = ttnn.experimental.all_gather_async(
+            tt_stats, **ccl.populate_all_gather_runtime_args(cfg["all_gather"])
+        )
         ttnn.deallocate(tt_stats)
 
         # Run distributed rmsnorm part 2

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -126,21 +126,6 @@ class AllGatherAsyncConfig(OpConfigBase):
 
 
 @dataclass
-class ReduceScatterAsyncConfig(OpConfigBase):
-    """Common parameters for a ttnn.experimental.reduce_scatter_async op"""
-
-    mesh_device: ConfigDevice | None = None
-    cluster_axis: int | None = None
-    dim: int | None = None
-    from_remote_multi_device_global_semaphore: object | None = None
-    to_remote_multi_device_global_semaphore: object | None = None
-    math_op: ttnn.ReduceType | None = None
-    num_links: int | None = None
-    memory_config: ttnn.MemoryConfig | None = None
-    topology: ttnn.Topology | None = None
-
-
-@dataclass
 class ReduceScatterAsyncMinimalConfig(OpConfigBase):
     """Common parameters for a ttnn.experimental.reduce_scatter_minimal_async op"""
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #30015 

This PR refactors the CCL (Collective Communications Library) initialization in the DeepSeek model to fix semaphore management by moving from static initialization to runtime initialization.

Replaces static CCL parameter initialization at state creation with runtime initialization during forward passes
Introduces new helper methods in the CCL class to populate runtime arguments for all_gather and reduce_scatter operations
Updates all modules to store the CCL object instead of pre-initialized semaphores and use runtime parameter population

### Checklist
- [x] [DeepSeek Galaxy ](https://github.com/tenstorrent/tt-metal/actions/runs/18304239136) CI passes