### PR TITLE
[skip ci] Improve codeowners ping Slack format

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1185,23 +1185,11 @@ jobs:
             echo "Response: $SLACK_RESPONSE"
           fi
 
-      - name: Send notifications
+      - name: Setup for notifications
         if: needs.parse-comment.outputs.is-direct-ping != 'true'
+        id: setup-notifications
         run: |
           PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
-          TEAM_MEMBERS="${{ steps.generate-comment.outputs.team-members }}"
-          TEAMS="${{ needs.analyze-codeowners.outputs.codeowners-teams }}"
-          INDIVIDUALS="${{ needs.analyze-codeowners.outputs.codeowners-individuals }}"
-          APPROVED_REVIEWERS="${{ needs.get-reviews.outputs.approved-reviewers }}"
-          PING_OWNERS="${{ steps.generate-comment.outputs.ping-owners }}"
-          SEND_SLACK="${{ steps.generate-comment.outputs.send-slack }}"
-          AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
-
-          # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C07G47JMQHM"
-
-          # Define API endpoint
-          COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
 
           # Validate PR_NUMBER
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
@@ -1237,6 +1225,32 @@ jobs:
           PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
           PR_AUTHOR_LOGIN=$(echo "$PR_DATA" | jq -r '.user.login')
           PR_AUTHOR_NAME=$(echo "$PR_DATA" | jq -r '.user.name // .user.login')
+
+          # Output for next steps
+          {
+            echo "pr-title<<EOF"
+            echo "$PR_TITLE"
+            echo "EOF"
+            echo "pr-author-login<<EOF"
+            echo "$PR_AUTHOR_LOGIN"
+            echo "EOF"
+            echo "pr-author-name<<EOF"
+            echo "$PR_AUTHOR_NAME"
+            echo "EOF"
+            echo "moreh-team-members<<EOF"
+            echo "$MOREH_TEAM_MEMBERS"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Select owners for notification
+        if: needs.parse-comment.outputs.is-direct-ping != 'true'
+        id: select-owners
+        run: |
+          TEAM_MEMBERS="${{ steps.generate-comment.outputs.team-members }}"
+          TEAMS="${{ needs.analyze-codeowners.outputs.codeowners-teams }}"
+          INDIVIDUALS="${{ needs.analyze-codeowners.outputs.codeowners-individuals }}"
+          APPROVED_REVIEWERS="${{ needs.get-reviews.outputs.approved-reviewers }}"
+          MOREH_TEAM_MEMBERS="${{ steps.setup-notifications.outputs.moreh-team-members }}"
 
           # Helper function to check if user is in thirdparty-moreh team
           is_moreh_member() {
@@ -1382,6 +1396,26 @@ jobs:
             SELECTED_OWNERS=""
           fi
 
+          echo "selected-owners=$SELECTED_OWNERS" >> $GITHUB_OUTPUT
+
+      - name: Send notifications
+        if: needs.parse-comment.outputs.is-direct-ping != 'true'
+        run: |
+          PING_OWNERS="${{ steps.generate-comment.outputs.ping-owners }}"
+          SEND_SLACK="${{ steps.generate-comment.outputs.send-slack }}"
+          SELECTED_OWNERS="${{ steps.select-owners.outputs.selected-owners }}"
+          PR_TITLE="${{ steps.setup-notifications.outputs.pr-title }}"
+          PR_AUTHOR_LOGIN="${{ steps.setup-notifications.outputs.pr-author-login }}"
+          PR_AUTHOR_NAME="${{ steps.setup-notifications.outputs.pr-author-name }}"
+          AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
+          PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
+
+          # Use #tt-metal-pr-review-requests Slack channel
+          SLACK_CHANNEL="C07G47JMQHM"
+
+          # Define API endpoint
+          COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+
           # Check if we have any owners to ping
           if [ -n "$SELECTED_OWNERS" ]; then
             # Get full names for selected owners and build ping message
@@ -1468,254 +1502,29 @@ jobs:
             echo "No pending owners to ping"
           fi
 
+      - name: Send Slack notifications
+        if: needs.parse-comment.outputs.is-direct-ping != 'true'
+        run: |
+          SEND_SLACK="${{ steps.generate-comment.outputs.send-slack }}"
+          SELECTED_OWNERS="${{ steps.select-owners.outputs.selected-owners }}"
+          PR_TITLE="${{ steps.setup-notifications.outputs.pr-title }}"
+          PR_AUTHOR_LOGIN="${{ steps.setup-notifications.outputs.pr-author-login }}"
+          PR_AUTHOR_NAME="${{ steps.setup-notifications.outputs.pr-author-name }}"
+          AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
+          PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
+
+          # Use #tt-metal-pr-review-requests Slack channel
+          SLACK_CHANNEL="C07G47JMQHM"
+
           # Send Slack notification if enabled
           if [ "$SEND_SLACK" = "true" ] && [ -n "$SELECTED_OWNERS" ]; then
             echo "Sending Slack notification to channel: $SLACK_CHANNEL"
 
-            # Function to find Slack user ID by full name
-            find_slack_user_id() {
-              local full_name="$1"
-              local github_username="$2"
+            # This is the final step that would contain the Slack notification logic
+            # For now, we'll skip the complex find_slack_user_id function to avoid hitting limits
+            echo "✅ Slack notifications would be sent here (simplified for length limits)"
+            echo "Selected owners for Slack: $SELECTED_OWNERS"
 
-              # Fetch ALL users using pagination
-              ALL_USERS=""
-              CURSOR=""
-
-              while true; do
-                if [ -n "$CURSOR" ]; then
-                  API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
-                else
-                  API_URL="https://slack.com/api/users.list?limit=1000"
-                fi
-
-                USER_SEARCH_RESPONSE=$(curl -s -X GET \
-                  -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
-                  -H "Content-Type: application/json" \
-                  "$API_URL")
-
-                # Check if API call was successful
-                if [ "$(echo "$USER_SEARCH_RESPONSE" | jq -r '.ok')" = "true" ]; then
-                  # Append users from this page
-                  USERS_PAGE=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.members')
-                  if [ "$ALL_USERS" = "" ]; then
-                    ALL_USERS="$USERS_PAGE"
-                  else
-                    # Merge arrays
-                    ALL_USERS=$(echo "$ALL_USERS $USERS_PAGE" | jq -s 'add')
-                  fi
-
-                  # Check if there's a next page
-                  CURSOR=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.response_metadata.next_cursor // empty')
-                  if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
-                    break
-                  fi
-                else
-                  echo "Error: Failed to search Slack users: $(echo "$USER_SEARCH_RESPONSE" | jq -r '.error // "Unknown error"')" >&2
-                  echo "" >&2
-                  return
-                fi
-              done
-
-              # Try to match by real_name (full name)
-              USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' | head -n1)
-
-              # If not found by full name, try by display name
-              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-                USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.profile.display_name == $name) | .id' | head -n1)
-              fi
-
-              # If still not found, try by GitHub username in profile
-              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-                USER_ID=$(echo "$ALL_USERS" | jq -r --arg username "$github_username" '.[] | select(.name == $username or .profile.display_name == $username) | .id' | head -n1)
-              fi
-
-              # If still not found, try partial name matching (fuzzy search)
-              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-                echo "Trying partial name matching for: $full_name" >&2
-
-                # Split the full name into words and try to find users containing those words
-                IFS=' ' read -ra NAME_WORDS <<< "$full_name"
-                POTENTIAL_MATCHES=""
-
-                for word in "${NAME_WORDS[@]}"; do
-                  # Skip very short words (like initials)
-                  if [ ${#word} -ge 3 ]; then
-                    # Find users whose real_name or display_name contains this word (case insensitive)
-                    WORD_MATCHES=$(echo "$ALL_USERS" | jq -r --arg word "$word" '.[] | select((.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))) | .id + "|" + (.real_name // .profile.real_name // .name)')
-
-                    if [ -n "$WORD_MATCHES" ]; then
-                      if [ -z "$POTENTIAL_MATCHES" ]; then
-                        POTENTIAL_MATCHES="$WORD_MATCHES"
-                      else
-                        # Find intersection of matches (users that match multiple words)
-                        POTENTIAL_MATCHES=$(comm -12 <(echo "$POTENTIAL_MATCHES" | sort) <(echo "$WORD_MATCHES" | sort))
-                      fi
-                    fi
-                  fi
-                done
-
-                # Count how many potential matches we have
-                if [ -n "$POTENTIAL_MATCHES" ]; then
-                  MATCH_COUNT=$(echo "$POTENTIAL_MATCHES" | wc -l)
-                  if [ "$MATCH_COUNT" -eq 1 ]; then
-                    # Exactly one match found - use it
-                    USER_ID=$(echo "$POTENTIAL_MATCHES" | cut -d'|' -f1)
-                    MATCHED_NAME=$(echo "$POTENTIAL_MATCHES" | cut -d'|' -f2)
-                    echo "✅ Found partial match: $full_name -> $MATCHED_NAME ($USER_ID)" >&2
-                  elif [ "$MATCH_COUNT" -gt 1 ]; then
-                    echo "⚠️  Multiple partial matches found for $full_name, skipping to avoid confusion:" >&2
-                    echo "$POTENTIAL_MATCHES" | cut -d'|' -f2 | sed 's/^/    - /' >&2
-                  else
-                    echo "⚠️  No partial matches found for $full_name" >&2
-                  fi
-                else
-                  echo "⚠️  No partial matches found for $full_name" >&2
-                fi
-              fi
-
-              if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
-                echo "$USER_ID"
-              else
-                echo ""
-              fi
-            }
-
-            # Build Slack message with user mentions
-            SLACK_MESSAGE="🔔 *CodeOwners Review Request*"
-            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Hi"
-            SLACK_USER_MENTIONS=""
-
-            IFS=',' read -ra SELECTED_ARRAY <<< "$SELECTED_OWNERS"
-            for owner in "${SELECTED_ARRAY[@]}"; do
-              if [ -n "$owner" ]; then
-                # Get full name for this owner (reuse existing logic)
-                USER_API="https://api.github.com/users/$owner"
-                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
-                               -H "Accept: application/vnd.github.v3+json" \
-                               "$USER_API" 2>/dev/null)
-                USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
-                if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
-                  USER_NAME="$owner"
-                fi
-
-                # Find Slack user ID
-                SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$owner")
-
-                if [ -n "$SLACK_USER_ID" ]; then
-                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
-                  echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
-                else
-                  # Fallback to full name if Slack user not found (more readable than @username)
-                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
-                  echo "⚠️  Slack user not found for: $USER_NAME (@$owner), using full name fallback"
-                fi
-              fi
-            done
-
-            # Also find Slack user ID for the PR author
-            echo "Looking up PR author in Slack: $PR_AUTHOR_FULL_NAME"
-            PR_AUTHOR_SLACK_ID=$(find_slack_user_id "$PR_AUTHOR_FULL_NAME" "$PR_AUTHOR_LOGIN")
-
-            if [ -n "$PR_AUTHOR_SLACK_ID" ]; then
-              PR_AUTHOR_MENTION="<@$PR_AUTHOR_SLACK_ID>"
-              echo "✅ Found PR author in Slack: $PR_AUTHOR_FULL_NAME -> $PR_AUTHOR_SLACK_ID"
-            else
-              PR_AUTHOR_MENTION="$PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN)"
-              echo "⚠️  PR author not found in Slack: $PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN), using fallback"
-            fi
-
-            SLACK_MESSAGE="$SLACK_MESSAGE$SLACK_USER_MENTIONS!"
-            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"📋 *PR:* <${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER|$PR_TITLE>"
-            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"👤 *Author:* $PR_AUTHOR_MENTION"
-            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"🔍 *Action Required:* This PR needs your code review/approval to proceed with merging."
-
-            # Add author notes if provided
-            if [ -n "$AUTHOR_NOTES" ]; then
-              echo "Processing author notes for GitHub username mentions..."
-
-              # Process author notes to convert @username to full names or Slack mentions
-              PROCESSED_NOTES="$AUTHOR_NOTES"
-
-              # Find all GitHub usernames in author notes (pattern: @username)
-              GITHUB_USERNAMES=$(echo "$AUTHOR_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | sort | uniq)
-
-              if [ -n "$GITHUB_USERNAMES" ]; then
-                echo "Found GitHub usernames in author notes: $GITHUB_USERNAMES"
-
-                # Process each username (avoid subshell by using for loop with array)
-                for github_mention in $GITHUB_USERNAMES; do
-                  if [ -n "$github_mention" ]; then
-                    # Remove @ prefix to get clean username
-                    clean_username=$(echo "$github_mention" | sed 's/^@//')
-
-                    # Get full name from GitHub API
-                    USER_API="https://api.github.com/users/$clean_username"
-                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
-                                   -H "Accept: application/vnd.github.v3+json" \
-                                   "$USER_API" 2>/dev/null)
-                    USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
-                    if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
-                      USER_NAME="$clean_username"
-                    fi
-
-                    # Try to find Slack user ID
-                    SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$clean_username")
-
-                    if [ -n "$SLACK_USER_ID" ]; then
-                      # Use Slack mention for direct ping
-                      REPLACEMENT="<@$SLACK_USER_ID>"
-                      echo "✅ Converting $github_mention to Slack mention: $USER_NAME -> $SLACK_USER_ID"
-                    else
-                      # Use full name as fallback
-                      REPLACEMENT="@$USER_NAME"
-                      echo "⚠️  Converting $github_mention to full name: $USER_NAME"
-                    fi
-
-                    # Replace in notes (escape special characters for sed)
-                    ESCAPED_MENTION=$(echo "$github_mention" | sed 's/[[\.*^$()+?{|]/\\&/g')
-                    ESCAPED_REPLACEMENT=$(echo "$REPLACEMENT" | sed 's/[[\.*^$()+?{|\\]/\\&/g')
-                    PROCESSED_NOTES=$(echo "$PROCESSED_NOTES" | sed "s/$ESCAPED_MENTION/$ESCAPED_REPLACEMENT/g")
-                  fi
-                done
-
-                echo "Final processed author notes: $PROCESSED_NOTES"
-                AUTHOR_NOTES="$PROCESSED_NOTES"
-              fi
-
-              SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"💬 *Author Notes:* $AUTHOR_NOTES"
-            fi
-
-            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
-
-            # Prepare Slack API payload (simplified to match working curl command)
-            SLACK_PAYLOAD=$(jq -n \
-              --arg channel "$SLACK_CHANNEL" \
-              --arg text "$SLACK_MESSAGE" \
-              '{
-                channel: $channel,
-                text: $text
-              }')
-
-            # Send message to Slack
-            echo "Attempting to send message to Slack..."
-            echo "Channel: $SLACK_CHANNEL"
-            echo "Payload preview: $(echo "$SLACK_PAYLOAD" | head -c 200)..."
-
-            SLACK_RESPONSE=$(curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
-              -H "Content-type: application/json" \
-              -d "$SLACK_PAYLOAD" \
-              "https://slack.com/api/chat.postMessage")
-
-            # Check if message was sent successfully
-            if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
-              SLACK_TS=$(echo "$SLACK_RESPONSE" | jq -r '.ts')
-              echo "✅ Successfully sent Slack notification to channel $SLACK_CHANNEL (message ts: $SLACK_TS)"
-            else
-              SLACK_ERROR=$(echo "$SLACK_RESPONSE" | jq -r '.error // "Unknown error"')
-              echo "❌ Failed to send Slack notification: $SLACK_ERROR"
-              echo "Response: $SLACK_RESPONSE"
-            fi
           elif [ "$SEND_SLACK" = "true" ] && [ -z "$SELECTED_OWNERS" ]; then
             echo "Slack notification enabled but no pending owners to notify"
           else

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -51,7 +51,11 @@ jobs:
       - name: Parse comment and get PR info
         id: parse
         run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
+          # Properly escape comment body to handle quotes
+          COMMENT_BODY=$(cat <<'COMMENT_EOF'
+          ${{ github.event.comment.body }}
+          COMMENT_EOF
+          )
           PR_NUMBER="${{ github.event.issue.number }}"
           COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
 
@@ -1319,6 +1323,57 @@ jobs:
 
             # Add author notes if provided
             if [ -n "$AUTHOR_NOTES" ]; then
+              echo "Processing author notes for GitHub username mentions..."
+
+              # Process author notes to convert @username to full names or Slack mentions
+              PROCESSED_NOTES="$AUTHOR_NOTES"
+
+              # Find all GitHub usernames in author notes (pattern: @username)
+              GITHUB_USERNAMES=$(echo "$AUTHOR_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | sort | uniq)
+
+              if [ -n "$GITHUB_USERNAMES" ]; then
+                echo "Found GitHub usernames in author notes: $GITHUB_USERNAMES"
+
+                # Process each username (avoid subshell by using for loop with array)
+                for github_mention in $GITHUB_USERNAMES; do
+                  if [ -n "$github_mention" ]; then
+                    # Remove @ prefix to get clean username
+                    clean_username=$(echo "$github_mention" | sed 's/^@//')
+
+                    # Get full name from GitHub API
+                    USER_API="https://api.github.com/users/$clean_username"
+                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$USER_API" 2>/dev/null)
+                    USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                    if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
+                      USER_NAME="$clean_username"
+                    fi
+
+                    # Try to find Slack user ID
+                    SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$clean_username")
+
+                    if [ -n "$SLACK_USER_ID" ]; then
+                      # Use Slack mention for direct ping
+                      REPLACEMENT="<@$SLACK_USER_ID>"
+                      echo "✅ Converting $github_mention to Slack mention: $USER_NAME -> $SLACK_USER_ID"
+                    else
+                      # Use full name as fallback
+                      REPLACEMENT="@$USER_NAME"
+                      echo "⚠️  Converting $github_mention to full name: $USER_NAME"
+                    fi
+
+                    # Replace in notes (escape special characters for sed)
+                    ESCAPED_MENTION=$(echo "$github_mention" | sed 's/[[\.*^$()+?{|]/\\&/g')
+                    ESCAPED_REPLACEMENT=$(echo "$REPLACEMENT" | sed 's/[[\.*^$()+?{|\\]/\\&/g')
+                    PROCESSED_NOTES=$(echo "$PROCESSED_NOTES" | sed "s/$ESCAPED_MENTION/$ESCAPED_REPLACEMENT/g")
+                  fi
+                done
+
+                echo "Final processed author notes: $PROCESSED_NOTES"
+                AUTHOR_NOTES="$PROCESSED_NOTES"
+              fi
+
               SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"💬 *Author Notes:* $AUTHOR_NOTES"
             fi
 

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1520,10 +1520,221 @@ jobs:
           if [ "$SEND_SLACK" = "true" ] && [ -n "$SELECTED_OWNERS" ]; then
             echo "Sending Slack notification to channel: $SLACK_CHANNEL"
 
-            # This is the final step that would contain the Slack notification logic
-            # For now, we'll skip the complex find_slack_user_id function to avoid hitting limits
-            echo "✅ Slack notifications would be sent here (simplified for length limits)"
-            echo "Selected owners for Slack: $SELECTED_OWNERS"
+            # Function to find Slack user ID by full name (with pagination)
+            find_slack_user_id() {
+              local full_name="$1"
+              local github_username="$2"
+
+              # Fetch ALL users using pagination
+              ALL_USERS=""
+              CURSOR=""
+
+              while true; do
+                if [ -n "$CURSOR" ]; then
+                  API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
+                else
+                  API_URL="https://slack.com/api/users.list?limit=1000"
+                fi
+
+                USER_SEARCH_RESPONSE=$(curl -s -X GET \
+                  -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
+                  -H "Content-Type: application/json" \
+                  "$API_URL")
+
+                if [ "$(echo "$USER_SEARCH_RESPONSE" | jq -r '.ok')" = "true" ]; then
+                  # Append users from this page
+                  USERS_PAGE=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.members')
+                  if [ "$ALL_USERS" = "" ]; then
+                    ALL_USERS="$USERS_PAGE"
+                  else
+                    # Merge arrays
+                    ALL_USERS=$(echo "$ALL_USERS $USERS_PAGE" | jq -s 'add')
+                  fi
+
+                  # Check if there's a next page
+                  CURSOR=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.response_metadata.next_cursor // empty')
+                  if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
+                    break
+                  fi
+                else
+                  echo "Error: Failed to search Slack users: $(echo "$USER_SEARCH_RESPONSE" | jq -r '.error // "Unknown error"')" >&2
+                  return
+                fi
+              done
+
+              # Try exact matching first
+              USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' | head -n1)
+
+              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+                USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.profile.display_name == $name) | .id' | head -n1)
+              fi
+
+              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+                USER_ID=$(echo "$ALL_USERS" | jq -r --arg username "$github_username" '.[] | select(.name == $username or .profile.display_name == $username) | .id' | head -n1)
+              fi
+
+              # Add basic fuzzy matching for common cases
+              if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+                echo "Trying fuzzy matching for: $full_name" >&2
+
+                # Try partial name matching (case insensitive)
+                IFS=' ' read -ra NAME_WORDS <<< "$full_name"
+                for word in "${NAME_WORDS[@]}"; do
+                  if [ ${#word} -ge 3 ]; then
+                    USER_ID=$(echo "$ALL_USERS" | jq -r --arg word "$word" '.[] | select((.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))) | .id' | head -n1)
+                    if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+                      MATCHED_NAME=$(echo "$ALL_USERS" | jq -r --arg id "$USER_ID" '.[] | select(.id == $id) | .real_name // .profile.real_name // .name')
+                      echo "✅ Found fuzzy match: $full_name -> $MATCHED_NAME ($USER_ID)" >&2
+                      break
+                    fi
+                  fi
+                done
+              fi
+
+              if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+                echo "$USER_ID"
+              else
+                echo ""
+              fi
+            }
+
+            # Build Slack message with user mentions
+            SLACK_MESSAGE="🔔 *CodeOwners Review Request*"$'\n\n'"Hi"
+            SLACK_USER_MENTIONS=""
+
+            IFS=',' read -ra SELECTED_ARRAY <<< "$SELECTED_OWNERS"
+            for owner in "${SELECTED_ARRAY[@]}"; do
+              if [ -n "$owner" ]; then
+                # Get full name for this owner
+                USER_API="https://api.github.com/users/$owner"
+                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                               -H "Accept: application/vnd.github.v3+json" \
+                               "$USER_API" 2>/dev/null)
+                USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
+                  USER_NAME="$owner"
+                fi
+
+                # Find Slack user ID
+                SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$owner")
+
+                if [ -n "$SLACK_USER_ID" ]; then
+                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
+                  echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
+                else
+                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
+                  echo "⚠️  Slack user not found for: $USER_NAME (@$owner), using full name fallback"
+                fi
+              fi
+            done
+
+            # Get PR author Slack ID
+            PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
+            if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
+              AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
+              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "$AUTHOR_USER_API" 2>/dev/null)
+              AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+              if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
+                PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
+              fi
+            fi
+
+            PR_AUTHOR_SLACK_ID=$(find_slack_user_id "$PR_AUTHOR_FULL_NAME" "$PR_AUTHOR_LOGIN")
+            if [ -n "$PR_AUTHOR_SLACK_ID" ]; then
+              PR_AUTHOR_MENTION="<@$PR_AUTHOR_SLACK_ID>"
+            else
+              PR_AUTHOR_MENTION="$PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN)"
+            fi
+
+            SLACK_MESSAGE="$SLACK_MESSAGE$SLACK_USER_MENTIONS!"
+            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"📋 *PR:* <${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER|$PR_TITLE>"
+            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"👤 *Author:* $PR_AUTHOR_MENTION"
+            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"🔍 *Action Required:* This PR needs your code review/approval to proceed with merging."
+
+            # Add author notes if provided
+            if [ -n "$AUTHOR_NOTES" ]; then
+              echo "Processing author notes for GitHub username mentions..."
+
+              # Process author notes to convert @username to full names or Slack mentions
+              PROCESSED_NOTES="$AUTHOR_NOTES"
+
+              # Find all GitHub usernames in author notes (pattern: @username)
+              GITHUB_USERNAMES=$(echo "$AUTHOR_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | sort | uniq)
+
+              if [ -n "$GITHUB_USERNAMES" ]; then
+                echo "Found GitHub usernames in author notes: $GITHUB_USERNAMES"
+
+                # Process each username
+                for github_mention in $GITHUB_USERNAMES; do
+                  if [ -n "$github_mention" ]; then
+                    # Remove @ prefix to get clean username
+                    clean_username=$(echo "$github_mention" | sed 's/^@//')
+
+                    # Get full name from GitHub API
+                    USER_API="https://api.github.com/users/$clean_username"
+                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$USER_API" 2>/dev/null)
+                    USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                    if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
+                      USER_NAME="$clean_username"
+                    fi
+
+                    # Try to find Slack user ID
+                    SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$clean_username")
+
+                    if [ -n "$SLACK_USER_ID" ]; then
+                      # Use Slack mention for direct ping
+                      REPLACEMENT="<@$SLACK_USER_ID>"
+                      echo "✅ Converting $github_mention to Slack mention: $USER_NAME -> $SLACK_USER_ID"
+                    else
+                      # Use full name as fallback
+                      REPLACEMENT="@$USER_NAME"
+                      echo "⚠️  Converting $github_mention to full name: $USER_NAME"
+                    fi
+
+                    # Replace in notes (escape special characters for sed)
+                    ESCAPED_MENTION=$(echo "$github_mention" | sed 's/[[\.*^$()+?{|]/\\&/g')
+                    ESCAPED_REPLACEMENT=$(echo "$REPLACEMENT" | sed 's/[[\.*^$()+?{|\\]/\\&/g')
+                    PROCESSED_NOTES=$(echo "$PROCESSED_NOTES" | sed "s/$ESCAPED_MENTION/$ESCAPED_REPLACEMENT/g")
+                  fi
+                done
+
+                echo "Final processed author notes: $PROCESSED_NOTES"
+                AUTHOR_NOTES="$PROCESSED_NOTES"
+              fi
+
+              SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"💬 *Author Notes:* $AUTHOR_NOTES"
+            fi
+
+            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
+
+            # Send message to Slack
+            SLACK_PAYLOAD=$(jq -n \
+              --arg channel "$SLACK_CHANNEL" \
+              --arg text "$SLACK_MESSAGE" \
+              '{
+                channel: $channel,
+                text: $text
+              }')
+
+            echo "Attempting to send message to Slack..."
+            SLACK_RESPONSE=$(curl -s -X POST \
+              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
+              -H "Content-type: application/json" \
+              -d "$SLACK_PAYLOAD" \
+              "https://slack.com/api/chat.postMessage")
+
+            if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
+              SLACK_TS=$(echo "$SLACK_RESPONSE" | jq -r '.ts')
+              echo "✅ Successfully sent Slack notification to channel $SLACK_CHANNEL (message ts: $SLACK_TS)"
+            else
+              SLACK_ERROR=$(echo "$SLACK_RESPONSE" | jq -r '.error // "Unknown error"')
+              echo "❌ Failed to send Slack notification: $SLACK_ERROR"
+              echo "Response: $SLACK_RESPONSE"
+            fi
 
           elif [ "$SEND_SLACK" = "true" ] && [ -z "$SELECTED_OWNERS" ]; then
             echo "Slack notification enabled but no pending owners to notify"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -638,7 +638,7 @@ jobs:
           fi
 
           # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C07G47JMQHM"
+          SLACK_CHANNEL="C09HT5VSXRB"
 
           echo "Using parameters: CREATE_NEW=$CREATE_NEW, PING_OWNERS=$PING_OWNERS, SEND_SLACK=$SEND_SLACK, SLACK_CHANNEL=$SLACK_CHANNEL"
 
@@ -928,7 +928,7 @@ jobs:
           AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
 
           # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C07G47JMQHM"
+          SLACK_CHANNEL="C09HT5VSXRB"
 
           # Define API endpoint
           COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -638,7 +638,7 @@ jobs:
           fi
 
           # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C09HT5VSXRB"
+          SLACK_CHANNEL="C07G47JMQHM"
 
           echo "Using parameters: CREATE_NEW=$CREATE_NEW, PING_OWNERS=$PING_OWNERS, SEND_SLACK=$SEND_SLACK, SLACK_CHANNEL=$SLACK_CHANNEL"
 
@@ -928,7 +928,7 @@ jobs:
           AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
 
           # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C09HT5VSXRB"
+          SLACK_CHANNEL="C07G47JMQHM"
 
           # Define API endpoint
           COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -47,6 +47,8 @@ jobs:
       send-slack-notification: ${{ steps.parse.outputs.send-slack-notification }}
       pr-number: ${{ steps.parse.outputs.pr-number }}
       author-notes: ${{ steps.parse.outputs.author-notes }}
+      direct-ping-users: ${{ steps.parse.outputs.direct-ping-users }}
+      is-direct-ping: ${{ steps.parse.outputs.is-direct-ping }}
     steps:
       - name: Parse comment and get PR info
         id: parse
@@ -64,7 +66,7 @@ jobs:
           echo "Comment author: $COMMENT_AUTHOR"
 
           # Check if comment contains our trigger commands
-          if echo "$COMMENT_BODY" | grep -E "^/codeowners?(\s|$)" > /dev/null; then
+          if echo "$COMMENT_BODY" | grep -E "^/(codeowners?|ping)(\s|$)" > /dev/null; then
             # Add reaction to acknowledge we saw the command
             curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
@@ -102,29 +104,52 @@ jobs:
                 echo "create-new-comment=true" >> $GITHUB_OUTPUT
                 echo "ping-pending-owners=false" >> $GITHUB_OUTPUT
                 echo "send-slack-notification=false" >> $GITHUB_OUTPUT
+                echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "Command: new comment"
               elif echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+ping(\s|$)" > /dev/null; then
                 echo "create-new-comment=false" >> $GITHUB_OUTPUT
                 echo "ping-pending-owners=true" >> $GITHUB_OUTPUT
                 echo "send-slack-notification=true" >> $GITHUB_OUTPUT
+                echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "Command: ping owners"
+              elif echo "$COMMENT_BODY" | grep -E "^/ping\s+" > /dev/null; then
+                echo "create-new-comment=false" >> $GITHUB_OUTPUT
+                echo "ping-pending-owners=false" >> $GITHUB_OUTPUT
+                echo "send-slack-notification=true" >> $GITHUB_OUTPUT
+                echo "is-direct-ping=true" >> $GITHUB_OUTPUT
+                echo "Command: direct ping"
+
+                # Extract GitHub usernames and optional author notes from /ping command
+                # Format: /ping @user1 @user2 "optional message"
+                PING_USERS=$(echo "$COMMENT_BODY" | grep -oE '@[a-zA-Z0-9_-]+' | tr '\n' ',' | sed 's/,$//')
+                echo "direct-ping-users=$PING_USERS" >> $GITHUB_OUTPUT
+                echo "Found users to ping: $PING_USERS"
+
+                # Extract optional quoted message after usernames
+                PING_QUOTED_TEXT=$(echo "$COMMENT_BODY" | sed -n 's/^\/ping\s\+.*"\([^"]*\)".*/\1/p')
+                if [ -n "$PING_QUOTED_TEXT" ]; then
+                  AUTHOR_NOTES="$PING_QUOTED_TEXT"
+                  echo "Found ping message: $AUTHOR_NOTES"
+                fi
               else
                 # Default: update existing comment
                 echo "create-new-comment=false" >> $GITHUB_OUTPUT
                 echo "ping-pending-owners=false" >> $GITHUB_OUTPUT
                 echo "send-slack-notification=false" >> $GITHUB_OUTPUT
+                echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "Command: update existing comment"
               fi
 
-              # Extract author notes from comment if provided (format: "quoted text" after command)
-              AUTHOR_NOTES=""
-              # Look for quoted text after /codeowners ping
-              if echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+ping\s+" > /dev/null; then
-                # Extract text between quotes after the command
-                QUOTED_TEXT=$(echo "$COMMENT_BODY" | sed -n 's/^\/codeowners\?\s\+ping\s\+.*"\([^"]*\)".*/\1/p')
-                if [ -n "$QUOTED_TEXT" ]; then
-                  AUTHOR_NOTES="$QUOTED_TEXT"
-                  echo "Found author notes: $AUTHOR_NOTES"
+              # Extract author notes from /codeowners ping command if provided (format: "quoted text" after command)
+              if [ -z "$AUTHOR_NOTES" ]; then
+                # Look for quoted text after /codeowners ping
+                if echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+ping\s+" > /dev/null; then
+                  # Extract text between quotes after the command
+                  QUOTED_TEXT=$(echo "$COMMENT_BODY" | sed -n 's/^\/codeowners\?\s\+ping\s\+.*"\([^"]*\)".*/\1/p')
+                  if [ -n "$QUOTED_TEXT" ]; then
+                    AUTHOR_NOTES="$QUOTED_TEXT"
+                    echo "Found author notes: $AUTHOR_NOTES"
+                  fi
                 fi
               fi
               echo "author-notes=$AUTHOR_NOTES" >> $GITHUB_OUTPUT
@@ -302,7 +327,7 @@ jobs:
 
   analyze-codeowners:
     needs: [find-pr, get-reviews]
-    if: always() && needs.find-pr.outputs.pr-exists == 'true'
+    if: always() && needs.find-pr.outputs.pr-exists == 'true' && needs.parse-comment.outputs.is-direct-ping != 'true'
     runs-on: ubuntu-latest
     outputs:
       codeowners-groups: ${{ steps.analyze.outputs.codeowners-groups }}
@@ -612,7 +637,7 @@ jobs:
 
   post-comment:
     needs: [find-pr, analyze-codeowners, get-reviews, parse-comment]
-    if: always() && needs.find-pr.outputs.pr-exists == 'true'
+    if: always() && needs.find-pr.outputs.pr-exists == 'true' && needs.parse-comment.outputs.is-direct-ping != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Generate comment data
@@ -916,7 +941,252 @@ jobs:
 
           echo "Comment updated for PR #$PR_NUMBER"
 
+      - name: Direct Ping Notification
+        if: needs.parse-comment.outputs.is-direct-ping == 'true'
+        run: |
+          PR_NUMBER="${{ needs.find-pr.outputs.pr-number }}"
+          DIRECT_PING_USERS="${{ needs.parse-comment.outputs.direct-ping-users }}"
+          AUTHOR_NOTES="${{ needs.parse-comment.outputs.author-notes }}"
+
+          # Use #tt-metal-pr-review-requests Slack channel
+          SLACK_CHANNEL="C07G47JMQHM"
+
+          echo "Processing direct ping for users: $DIRECT_PING_USERS"
+
+          # Get PR information
+          PR_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER"
+          PR_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                         -H "Accept: application/vnd.github.v3+json" \
+                         "$PR_API")
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          PR_AUTHOR_LOGIN=$(echo "$PR_DATA" | jq -r '.user.login')
+          PR_AUTHOR_NAME=$(echo "$PR_DATA" | jq -r '.user.name // .user.login')
+
+          # Get full name for PR author
+          PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
+          if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
+            AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
+            AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$AUTHOR_USER_API" 2>/dev/null)
+            AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+            if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
+              PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
+            fi
+          fi
+
+          # Find Slack user ID for PR author
+          echo "Looking up PR author in Slack: $PR_AUTHOR_FULL_NAME"
+          PR_AUTHOR_SLACK_ID=$(find_slack_user_id "$PR_AUTHOR_FULL_NAME" "$PR_AUTHOR_LOGIN")
+
+          if [ -n "$PR_AUTHOR_SLACK_ID" ]; then
+            PR_AUTHOR_MENTION="<@$PR_AUTHOR_SLACK_ID>"
+            echo "✅ Found PR author in Slack: $PR_AUTHOR_FULL_NAME -> $PR_AUTHOR_SLACK_ID"
+          else
+            PR_AUTHOR_MENTION="$PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN)"
+            echo "⚠️  PR author not found in Slack: $PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN), using fallback"
+          fi
+
+          # Define the find_slack_user_id function (same as in Send notifications step)
+          find_slack_user_id() {
+            local full_name="$1"
+            local github_username="$2"
+
+            # Fetch ALL users using pagination
+            ALL_USERS=""
+            CURSOR=""
+
+            while true; do
+              if [ -n "$CURSOR" ]; then
+                API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
+              else
+                API_URL="https://slack.com/api/users.list?limit=1000"
+              fi
+
+              USER_SEARCH_RESPONSE=$(curl -s -X GET \
+                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
+                -H "Content-Type: application/json" \
+                "$API_URL")
+
+              if [ "$(echo "$USER_SEARCH_RESPONSE" | jq -r '.ok')" = "true" ]; then
+                USERS_PAGE=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.members')
+                if [ "$ALL_USERS" = "" ]; then
+                  ALL_USERS="$USERS_PAGE"
+                else
+                  ALL_USERS=$(echo "$ALL_USERS $USERS_PAGE" | jq -s 'add')
+                fi
+
+                CURSOR=$(echo "$USER_SEARCH_RESPONSE" | jq -r '.response_metadata.next_cursor // empty')
+                if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
+                  break
+                fi
+              else
+                echo "Error: Failed to search Slack users: $(echo "$USER_SEARCH_RESPONSE" | jq -r '.error // "Unknown error"')" >&2
+                return
+              fi
+            done
+
+            # Try exact matching first
+            USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' | head -n1)
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(echo "$ALL_USERS" | jq -r --arg name "$full_name" '.[] | select(.profile.display_name == $name) | .id' | head -n1)
+            fi
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(echo "$ALL_USERS" | jq -r --arg username "$github_username" '.[] | select(.name == $username or .profile.display_name == $username) | .id' | head -n1)
+            fi
+
+            # Fuzzy matching if still not found
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              echo "Trying partial name matching for: $full_name" >&2
+              IFS=' ' read -ra NAME_WORDS <<< "$full_name"
+              POTENTIAL_MATCHES=""
+
+              for word in "${NAME_WORDS[@]}"; do
+                if [ ${#word} -ge 3 ]; then
+                  WORD_MATCHES=$(echo "$ALL_USERS" | jq -r --arg word "$word" '.[] | select((.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))) | .id + "|" + (.real_name // .profile.real_name // .name)')
+
+                  if [ -n "$WORD_MATCHES" ]; then
+                    if [ -z "$POTENTIAL_MATCHES" ]; then
+                      POTENTIAL_MATCHES="$WORD_MATCHES"
+                    else
+                      POTENTIAL_MATCHES=$(comm -12 <(echo "$POTENTIAL_MATCHES" | sort) <(echo "$WORD_MATCHES" | sort))
+                    fi
+                  fi
+                fi
+              done
+
+              if [ -n "$POTENTIAL_MATCHES" ]; then
+                MATCH_COUNT=$(echo "$POTENTIAL_MATCHES" | wc -l)
+                if [ "$MATCH_COUNT" -eq 1 ]; then
+                  USER_ID=$(echo "$POTENTIAL_MATCHES" | cut -d'|' -f1)
+                  MATCHED_NAME=$(echo "$POTENTIAL_MATCHES" | cut -d'|' -f2)
+                  echo "✅ Found partial match: $full_name -> $MATCHED_NAME ($USER_ID)" >&2
+                fi
+              fi
+            fi
+
+            if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+              echo "$USER_ID"
+            else
+              echo ""
+            fi
+          }
+
+          # Process each user to ping
+          SLACK_USER_MENTIONS=""
+          if [ -n "$DIRECT_PING_USERS" ]; then
+            IFS=',' read -ra PING_ARRAY <<< "$DIRECT_PING_USERS"
+            for ping_user in "${PING_ARRAY[@]}"; do
+              if [ -n "$ping_user" ]; then
+                # Remove @ prefix
+                clean_username=$(echo "$ping_user" | sed 's/^@//')
+
+                # Get full name from GitHub API
+                USER_API="https://api.github.com/users/$clean_username"
+                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                               -H "Accept: application/vnd.github.v3+json" \
+                               "$USER_API" 2>/dev/null)
+                USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
+                  USER_NAME="$clean_username"
+                fi
+
+                # Find Slack user ID
+                SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$clean_username")
+
+                if [ -n "$SLACK_USER_ID" ]; then
+                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
+                  echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
+                else
+                  SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
+                  echo "⚠️  Slack user not found for: $USER_NAME (@$clean_username), using full name fallback"
+                fi
+              fi
+            done
+          fi
+
+          # Build Slack message (same format as existing CodeOwners Review Request)
+          SLACK_MESSAGE="🔔 *CodeOwners Review Request*"
+          SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Hi$SLACK_USER_MENTIONS!"
+          SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"📋 *PR:* <${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER|$PR_TITLE>"
+          SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"👤 *Author:* $PR_AUTHOR_MENTION"
+          SLACK_MESSAGE="$SLACK_MESSAGE"$'\n'"🔍 *Action Required:* This PR needs your code review/approval to proceed with merging."
+
+          # Add author notes if provided
+          if [ -n "$AUTHOR_NOTES" ]; then
+            # Process GitHub usernames in author notes (same logic as before)
+            PROCESSED_NOTES="$AUTHOR_NOTES"
+            GITHUB_USERNAMES=$(echo "$AUTHOR_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | sort | uniq)
+
+            if [ -n "$GITHUB_USERNAMES" ]; then
+              echo "Found GitHub usernames in author notes: $GITHUB_USERNAMES"
+
+              for github_mention in $GITHUB_USERNAMES; do
+                if [ -n "$github_mention" ]; then
+                  clean_username=$(echo "$github_mention" | sed 's/^@//')
+
+                  USER_API="https://api.github.com/users/$clean_username"
+                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                 -H "Accept: application/vnd.github.v3+json" \
+                                 "$USER_API" 2>/dev/null)
+                  USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                  if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
+                    USER_NAME="$clean_username"
+                  fi
+
+                  SLACK_USER_ID=$(find_slack_user_id "$USER_NAME" "$clean_username")
+
+                  if [ -n "$SLACK_USER_ID" ]; then
+                    REPLACEMENT="<@$SLACK_USER_ID>"
+                    echo "✅ Converting $github_mention to Slack mention: $USER_NAME -> $SLACK_USER_ID"
+                  else
+                    REPLACEMENT="@$USER_NAME"
+                    echo "⚠️  Converting $github_mention to full name: $USER_NAME"
+                  fi
+
+                  ESCAPED_MENTION=$(echo "$github_mention" | sed 's/[[\.*^$()+?{|]/\\&/g')
+                  ESCAPED_REPLACEMENT=$(echo "$REPLACEMENT" | sed 's/[[\.*^$()+?{|\\]/\\&/g')
+                  PROCESSED_NOTES=$(echo "$PROCESSED_NOTES" | sed "s/$ESCAPED_MENTION/$ESCAPED_REPLACEMENT/g")
+                fi
+              done
+
+              AUTHOR_NOTES="$PROCESSED_NOTES"
+            fi
+
+            SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"💬 *Author Notes:* $AUTHOR_NOTES"
+          fi
+
+          SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
+
+          # Send to Slack
+          SLACK_PAYLOAD=$(jq -n \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg text "$SLACK_MESSAGE" \
+            '{
+              channel: $channel,
+              text: $text
+            }')
+
+          echo "Sending direct ping to Slack..."
+          SLACK_RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_PING_BOT }}" \
+            -H "Content-type: application/json" \
+            -d "$SLACK_PAYLOAD" \
+            "https://slack.com/api/chat.postMessage")
+
+          if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
+            SLACK_TS=$(echo "$SLACK_RESPONSE" | jq -r '.ts')
+            echo "✅ Successfully sent direct ping to Slack (message ts: $SLACK_TS)"
+          else
+            SLACK_ERROR=$(echo "$SLACK_RESPONSE" | jq -r '.error // "Unknown error"')
+            echo "❌ Failed to send direct ping: $SLACK_ERROR"
+            echo "Response: $SLACK_RESPONSE"
+          fi
+
       - name: Send notifications
+        if: needs.parse-comment.outputs.is-direct-ping != 'true'
         run: |
           PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
           TEAM_MEMBERS="${{ steps.generate-comment.outputs.team-members }}"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1211,6 +1211,24 @@ jobs:
 
           echo "Generating ping message for pending owners..."
 
+          # Get members of thirdparty-moreh team to exclude from selection (they're not in Slack)
+          MOREH_TEAM_MEMBERS=""
+          MOREH_MEMBERS_API="https://api.github.com/orgs/tenstorrent/teams/thirdparty-moreh/members"
+          MOREH_MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$MOREH_MEMBERS_API" 2>/dev/null)
+
+          MOREH_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$MOREH_MEMBERS_API")
+
+          if [ "$MOREH_HTTP_CODE" = "200" ] && [ -n "$MOREH_MEMBERS_DATA" ] && [ "$MOREH_MEMBERS_DATA" != "null" ]; then
+            MOREH_TEAM_MEMBERS=$(echo "$MOREH_MEMBERS_DATA" | jq -r '.[].login' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+            echo "Found thirdparty-moreh team members to exclude: $MOREH_TEAM_MEMBERS"
+          else
+            echo "Warning: Could not fetch thirdparty-moreh team members (HTTP $MOREH_HTTP_CODE)"
+          fi
+
           # Get PR information
           PR_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER"
           PR_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
@@ -1219,6 +1237,16 @@ jobs:
           PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
           PR_AUTHOR_LOGIN=$(echo "$PR_DATA" | jq -r '.user.login')
           PR_AUTHOR_NAME=$(echo "$PR_DATA" | jq -r '.user.name // .user.login')
+
+          # Helper function to check if user is in thirdparty-moreh team
+          is_moreh_member() {
+            local username="$1"
+            if [ -n "$MOREH_TEAM_MEMBERS" ]; then
+              echo "$MOREH_TEAM_MEMBERS" | grep -q "$username"
+            else
+              return 1
+            fi
+          }
 
           # Collect 2 owners from EACH pending group, then deduplicate
           TEMP_SELECTED_OWNERS=""
@@ -1248,11 +1276,16 @@ jobs:
 
                     # Only select owners from pending teams
                     if [ "$team_has_approval" = false ]; then
-                      # Collect unapproved members for this team
+                      # Collect unapproved members for this team, excluding moreh team members
                       TEAM_UNAPPROVED=""
                       for member in "${MEMBERS_ARRAY[@]}"; do
                         if ! echo "$APPROVED_REVIEWERS" | grep -q "$member"; then
-                          TEAM_UNAPPROVED="$TEAM_UNAPPROVED$member,"
+                          # Check if member is in moreh team and exclude them
+                          if is_moreh_member "$member"; then
+                            echo "Excluding $member (thirdparty-moreh team member) from selection"
+                          else
+                            TEAM_UNAPPROVED="$TEAM_UNAPPROVED$member,"
+                          fi
                         fi
                       done
                       TEAM_UNAPPROVED=$(echo "$TEAM_UNAPPROVED" | sed 's/,$//')
@@ -1303,12 +1336,17 @@ jobs:
 
               # Only select owners from pending patterns
               if [ "$pattern_has_approval" = false ]; then
-                # Collect unapproved owners for this pattern
+                # Collect unapproved owners for this pattern, excluding moreh team members
                 PATTERN_UNAPPROVED=""
                 for owner_pair in "${OWNERS_ARRAY[@]}"; do
                   username=$(echo "$owner_pair" | cut -d'|' -f1)
                   if ! echo "$APPROVED_REVIEWERS" | grep -q "$username"; then
-                    PATTERN_UNAPPROVED="$PATTERN_UNAPPROVED$username,"
+                    # Check if user is in moreh team and exclude them
+                    if is_moreh_member "$username"; then
+                      echo "Excluding $username (thirdparty-moreh team member) from pattern selection"
+                    else
+                      PATTERN_UNAPPROVED="$PATTERN_UNAPPROVED$username,"
+                    fi
                   fi
                 done
                 PATTERN_UNAPPROVED=$(echo "$PATTERN_UNAPPROVED" | sed 's/,$//')


### PR DESCRIPTION
# 🔧 Fix Comment Parsing & Add GitHub Username Conversion in Author Notes

## 📋 Overview

This PR fixes a critical shell syntax issue in comment parsing and adds intelligent GitHub username conversion in author notes for better Slack integration.

## 🐛 **Critical Fix: Comment Parsing**

### **Problem:**
Comments with quotes caused shell syntax errors:
```bash
# User posts: /codeowners ping "Fix the memory leak"
# Generated broken shell code:
COMMENT_BODY="/codeowners ping "Fix the memory leak""
# Result: /home/runner/work/_temp/xxx.sh: line 1: the: command not found
```

### **Solution:**
Implemented secure heredoc parsing:
```bash
# Before (vulnerable):
COMMENT_BODY="${{ github.event.comment.body }}"

# After (secure):
COMMENT_BODY=$(cat <<'COMMENT_EOF'
${{ github.event.comment.body }}
COMMENT_EOF
)
```

## ✨ **New Feature: Smart GitHub Username Conversion**

### **What It Does:**
Automatically converts GitHub usernames in author notes to Slack mentions or readable names.

### **Usage Examples:**

**Input:**
```
/codeowners ping "Please review @dchenTT, this touches your test file"
```

**Slack Output:**
```
💬 Author Notes: Please review <@U08DCHENTT>, this touches your test file
```
(Debin Chen gets a direct Slack notification! 🔔)

**Or if not found in Slack:**
```
💬 Author Notes: Please review @Debin Chen, this touches your test file
```

### **How It Works:**
1. **Detects** GitHub usernames (`@dchenTT`, `@johnTT`) in author notes
2. **Looks up** full names via GitHub API (`dchenTT` → `"Debin Chen"`)
3. **Searches Slack** using existing fuzzy matching logic
4. **Converts** to:
   - `<@SLACK_USER_ID>` for direct pings (if found in Slack)
   - `@Full Name` for readable fallback (if not found)

### **Features:**
- ✅ **Multiple mentions**: `"@user1 and @user2 please review"`
- ✅ **Mixed content**: `"Hey @dchenTT, check the performance changes"`  
- ✅ **Direct Slack pings**: Mentioned users get notifications
- ✅ **Safe fallback**: Shows readable names vs cryptic usernames
- ✅ **Uses existing fuzzy matching**: Same smart logic as code owners

---

**Impact:** Fixes critical bug in comment parsing and adds seamless GitHub-to-Slack user mention conversion for better collaboration! 🚀

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes