### PR TITLE
Generalize `ttnn.convert_to_hwc` to support arbitrary channel counts

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -184,7 +184,6 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
     input_shard_shape = (C, padded_sharded_dim)
     input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
-
     input_tensor = ttnn.Tensor(
         input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
     )
@@ -194,6 +193,7 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
     ):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
 
+    # Create an output shard that is not padded up to nearest aligned width
     output_shard_shape = (padded_sharded_dim, C)
     output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)

--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -7,9 +7,12 @@ import ttnn
 import torch
 
 from tests.ttnn.utils_for_testing import assert_equal
+from tests.ttnn.unit_tests.operations.test_utils import round_up
+
+CHANNEL_TEST_CASES = [1, 3, 8, 12, 15, 32]
 
 
-@pytest.mark.parametrize("C", [8, 16])
+@pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
 @pytest.mark.parametrize("provide_memory_config", [True, False])
 @pytest.mark.parametrize(
     "HW, core_grid, padded_sharded_dim",
@@ -62,7 +65,7 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_me
     )
 
     if provide_memory_config:
-        output_shard_shape = (padded_sharded_dim, C)
+        output_shard_shape = (padded_sharded_dim, round_up(C, 8))
         output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec
@@ -73,11 +76,13 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_me
 
     actual = ttnn.to_torch(actual)
 
-    passed, message = assert_equal(expected, actual)
+    passed, message = assert_equal(
+        expected, actual[:, :, :, : expected.shape[-1]]
+    )  # slice off padding that is applied when C % 8 != 0
     assert passed, message
 
 
-@pytest.mark.parametrize("C", [8, 16])
+@pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
 @pytest.mark.parametrize(
     "HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim",
     (
@@ -151,7 +156,7 @@ def test_convert_to_hwc_dram(
     input_shard_spec = ttnn.ShardSpec(input_core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
 
-    output_shard_shape = (output_padded_sharded_dim, C)
+    output_shard_shape = (output_padded_sharded_dim, round_up(C, 8))
     output_shard_spec = ttnn.ShardSpec(output_core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
@@ -162,7 +167,9 @@ def test_convert_to_hwc_dram(
     actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
     actual = ttnn.to_torch(actual)
 
-    passed, message = assert_equal(expected, actual)
+    passed, message = assert_equal(
+        expected, actual[:, :, :, : expected.shape[-1]]
+    )  # slice off padding that is applied when C % 8 != 0
     assert passed, message
 
 

--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -174,7 +174,7 @@ def test_convert_to_hwc_dram(
 
 
 def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
-    C = 8
+    C = 4
     HW = 32
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
     padded_sharded_dim = 32
@@ -193,3 +193,10 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
         RuntimeError, match="When input tensor is in DRAM, output memory_config must be explicitly specified"
     ):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
+
+    output_shard_shape = (padded_sharded_dim, C)
+    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    with pytest.raises(RuntimeError):
+        ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16, memory_config=output_mem_config)

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "convert_to_hwc.hpp"
-
 #include "device/convert_to_hwc_op.hpp"
 
 namespace ttnn::operations::experimental::cnn {
@@ -16,14 +15,21 @@ static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Ten
         input_memory_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
         "Input tensor must be width sharded");
 
-    const auto& input_shape = input_tensor.logical_shape();
-    const auto C = input_shape[-2];
-
+    // const auto& input_shape = input_tensor.logical_shape();
     const auto& input_shard_spec = input_memory_config.shard_spec().value();
+    const auto input_shard_height = input_shard_spec.shape[0];
     const auto input_shard_width = input_shard_spec.shape[1];
-    const auto output_shard_height = input_shard_width;  // HW dimension per core stays the same
 
-    const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, C};
+    const auto output_shard_height = input_shard_width;                   // HW dimension per core stays the same
+    const auto output_shard_width = tt::round_up(input_shard_height, 8);  // deduce rounding from element size
+
+    const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, output_shard_width};
+    log_info(
+        tt::LogType::LogAlways,
+        "input_shard_shape={}, output_shard_shape={}",
+        input_shard_spec.shape,
+        output_shard_shape);
+
     auto output_shard_spec =
         tt::tt_metal::ShardSpec(input_shard_spec.grid, output_shard_shape, input_shard_spec.orientation);
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -17,12 +17,13 @@ static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Ten
         "Input tensor must be width sharded");
 
     const auto& input_shard_spec = input_memory_config.shard_spec().value();
-    const auto input_shard_height = input_shard_spec.shape[0];
-    const auto input_shard_width = input_shard_spec.shape[1];
+    const int input_shard_height = input_shard_spec.shape[0];
+    const int input_shard_width = input_shard_spec.shape[1];
 
-    const auto output_shard_height = input_shard_width;  // HW dimension per core stays the same
-    const auto alignment_elements = detail::compute_alignment_requirement_in_elements(input_tensor);
-    const auto output_shard_width = tt::round_up(input_shard_height, alignment_elements);
+    const int output_shard_height = input_shard_width;  // HW dimension per core stays the same
+    const int alignment_elements = detail::compute_alignment_requirement_in_elements(input_tensor);
+    TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
+    const int output_shard_width = tt::round_up(input_shard_height, alignment_elements);
 
     const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, output_shard_width};
 
@@ -54,6 +55,7 @@ ttnn::Tensor ExecuteConvertToHWC::invoke(
         }
     }
     const auto alignment_elements = detail::compute_alignment_requirement_in_elements(a);
+    TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
     TT_FATAL(
         output_memory_config.shard_spec()->shape[1] % alignment_elements == 0,
         "Output shard width must be rounded up to next multiple of {} to satisfy alignment constraints (width was {})",

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -24,11 +24,6 @@ static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Ten
     const auto output_shard_width = tt::round_up(input_shard_height, 8);  // deduce rounding from element size
 
     const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, output_shard_width};
-    log_info(
-        tt::LogType::LogAlways,
-        "input_shard_shape={}, output_shard_shape={}",
-        input_shard_spec.shape,
-        output_shard_shape);
 
     auto output_shard_spec =
         tt::tt_metal::ShardSpec(input_shard_spec.grid, output_shard_shape, input_shard_spec.orientation);
@@ -59,7 +54,7 @@ ttnn::Tensor ExecuteConvertToHWC::invoke(
     }
     TT_FATAL(
         output_memory_config.shard_spec()->shape[1] % 8 == 0,
-        "Output shard width must be rounded up to next multiple of 8 to satisfy alignment constrains (width was {})",
+        "Output shard width must be rounded up to next multiple of 8 to satisfy alignment constraints (width was {})",
         output_memory_config.shard_spec()->shape[1]);
 
     auto program = ConvertToHWC{output_memory_config, dtype.value_or(a.dtype())};

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -23,10 +23,14 @@ void bind_convert_to_hwc(py::module& module) {
     The input tensor is expected to be in row-major layout and width-sharded in L1 or DRAM.
     The output is a row-major height-sharded tensor.
 
+    When C is not a multiple of 8, the output shard width is automatically padded up
+    to the next multiple of 8 to satisfy alignment constraints.
+
     Args:
         input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
                                                      Required only for DRAM inputs. If omitted for L1 inputs, the output memory_config is automatically inferred.
+                                                     The output shard width will be rounded up to the next multiple of 8 for alignment.
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -23,14 +23,14 @@ void bind_convert_to_hwc(py::module& module) {
     The input tensor is expected to be in row-major layout and width-sharded in L1 or DRAM.
     The output is a row-major height-sharded tensor.
 
-    When C is not a multiple of 8, the output shard width is automatically padded up
-    to the next multiple of 8 to satisfy alignment constraints.
+    When C is not a multiple of the device alignment requirement, the output shard width is automatically padded up
+    to the next multiple of the alignment requirement to satisfy alignment constraints.
 
     Args:
         input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
                                                      Required only for DRAM inputs. If omitted for L1 inputs, the output memory_config is automatically inferred.
-                                                     The output shard width will be rounded up to the next multiple of 8 for alignment.
+                                                     The output shard width will be rounded up to the next multiple of the alignment requirement for proper memory alignment.
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "convert_to_hwc_op.hpp"
-
 #include "convert_to_hwc_program_factory.hpp"
 
 #include <tt-metalium/constants.hpp>
+#include <cmath>
 
 namespace ttnn::operations::experimental::cnn {
 
@@ -37,11 +37,15 @@ void ConvertToHWC::validate(const std::vector<Tensor>& input_tensors) const {
 
 std::vector<ttnn::TensorSpec> ConvertToHWC::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& shape = input_tensors.at(0).logical_shape();
-    const auto B = shape[0];
-    const auto C = shape[2];
-    const auto HW = shape[3];
+    const int B = shape[0];
+    const int C = shape[2];
+    const int HW = shape[3];
+
+    // Output needs to be multiple of 8 since this is what conv expects (also to guarantee aligned copies)
+    const auto output_channels = tt::round_up(C, 8);  // TODO: Get this from the dtype
+
     return {TensorSpec(
-        Shape({B, 1, HW, C}),
+        Shape({B, 1, HW, output_channels}),
         tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), memory_config))};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -42,7 +42,8 @@ std::vector<ttnn::TensorSpec> ConvertToHWC::compute_output_specs(const std::vect
     const int HW = shape[3];
 
     // Output needs to be multiple of 8 since this is what conv expects (also to guarantee aligned copies)
-    const auto output_channels = tt::round_up(C, 8);  // TODO: Get this from the dtype
+    // Alignment requirement is 16 bytes, which equals 8 elements for bfloat16 (2 bytes each)
+    const auto output_channels = tt::round_up(C, 8);
 
     return {TensorSpec(
         Shape({B, 1, HW, output_channels}),

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -41,9 +41,9 @@ std::vector<ttnn::TensorSpec> ConvertToHWC::compute_output_specs(const std::vect
     const int C = shape[2];
     const int HW = shape[3];
 
-    // Output needs to be multiple of 8 since this is what conv expects (also to guarantee aligned copies)
-    // Alignment requirement is 16 bytes, which equals 8 elements for bfloat16 (2 bytes each)
-    const auto output_channels = tt::round_up(C, 8);
+    // Output needs to be multiple of alignment requirement to guarantee aligned copies
+    const auto alignment_elements = detail::compute_alignment_requirement_in_elements(input_tensors.at(0));
+    const auto output_channels = tt::round_up(C, alignment_elements);
 
     return {TensorSpec(
         Shape({B, 1, HW, output_channels}),

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -14,11 +14,9 @@ namespace ttnn::operations::experimental::cnn::detail {
 
 using namespace tt::constants;
 
-// Helper function to compute alignment requirement based on L1 alignment and element size
 uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor) {
     const uint32_t element_size_bytes = input_tensor.element_size();
     const uint32_t l1_alignment_bytes = tt::tt_metal::hal::get_l1_alignment();
-    // Calculate alignment requirement in number of elements
     return l1_alignment_bytes / element_size_bytes;
 }
 
@@ -44,6 +42,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
         "Shard width must be multiple of tile width (was {})",
         l1_input_shard_width);
     const auto alignment_elements = compute_alignment_requirement_in_elements(output);
+    TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
     TT_FATAL(
         output_shard_width % alignment_elements == 0,
         "Output shard width must be multiple of {} to satisfy alignment constraints (was {})",

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -36,7 +36,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
         l1_input_shard_width);
     TT_FATAL(
         output_shard_width % 8 == 0,
-        "Output shard height must be multiple of 8 to satisfy alignment constrains (was {})",
+        "Output shard width must be multiple of 8 to satisfy alignment constraints (was {})",
         output_shard_width);
 
     const auto create_circular_buffer = [&program, &l1_input_core_grid](

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -19,17 +19,27 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
     // If we are pulling from DRAM we infer the shard shape by using the output shard spec
     const bool is_input_in_dram = a.buffer()->core_type() == CoreType::DRAM;
 
-    const uint32_t input_shard_height = is_input_in_dram ? a.logical_shape()[-2] : a.shard_spec()->shape[0];
-    const uint32_t input_shard_width = is_input_in_dram ? output.shard_spec()->shape[0] : a.shard_spec()->shape[1];
-    const CoreRangeSet input_core_grid = is_input_in_dram ? output.shard_spec()->grid : a.shard_spec()->grid;
-    const std::vector<CoreCoord> input_cores = corerange_to_cores(
-        input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    const uint32_t output_shard_height = output.shard_spec()->shape[0];
+    const uint32_t output_shard_width = output.shard_spec()->shape[1];
 
-    TT_FATAL(input_shard_height <= TILE_HEIGHT, "Shard height must be 32 or smaller");
-    // TT_FATAL(input_shard_height % 8 == 0, "Shard height must be mutliple of 8");
-    TT_FATAL(input_shard_width % TILE_WIDTH == 0, "Shard width must be multiple of tile width");
+    const uint32_t l1_input_shard_height = is_input_in_dram ? a.logical_shape()[-2] : a.shard_spec()->shape[0];
+    const uint32_t l1_input_shard_width = is_input_in_dram ? output_shard_height : a.shard_spec()->shape[1];
+    const CoreRangeSet l1_input_core_grid = is_input_in_dram ? output.shard_spec()->grid : a.shard_spec()->grid;
+    const std::vector<CoreCoord> l1_input_cores = corerange_to_cores(
+        l1_input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
-    const auto create_circular_buffer = [&program, &input_core_grid](
+    TT_FATAL(
+        l1_input_shard_height <= TILE_HEIGHT, "Shard height must be 32 or smaller (was {})", l1_input_shard_height);
+    TT_FATAL(
+        l1_input_shard_width % TILE_WIDTH == 0,
+        "Shard width must be multiple of tile width (was {})",
+        l1_input_shard_width);
+    TT_FATAL(
+        output_shard_width % 8 == 0,
+        "Output shard height must be multiple of 8 to satisfy alignment constrains (was {})",
+        output_shard_width);
+
+    const auto create_circular_buffer = [&program, &l1_input_core_grid](
                                             uint32_t index,
                                             uint32_t total_size,
                                             uint32_t page_size,
@@ -39,7 +49,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
         if (buffer != nullptr) {
             config = config.set_globally_allocated_address(*buffer);
         }
-        return tt::tt_metal::CreateCircularBuffer(program, input_core_grid, config);
+        return tt::tt_metal::CreateCircularBuffer(program, l1_input_core_grid, config);
     };
 
     const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
@@ -48,17 +58,17 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
     const uint32_t cb_in_id = tt::CBIndex::c_0;
     const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     const uint32_t input_element_size = tt::datum_size(input_format);
-    const uint32_t cb_in_page_size = input_shard_width * input_element_size;
-    const uint32_t cb_in_total_size = input_shard_height * cb_in_page_size;
+    const uint32_t cb_in_page_size = l1_input_shard_width * input_element_size;
+    const uint32_t cb_in_total_size = l1_input_shard_height * cb_in_page_size;
     const auto cb_in = create_circular_buffer(
         cb_in_id, cb_in_total_size, cb_in_page_size, input_format, is_input_in_dram ? nullptr : a.buffer());
 
     const uint32_t cb_in_tiled_id = tt::CBIndex::c_1;
-    const uint32_t cb_in_tiled_total_size = tt::div_up(input_shard_width, TILE_WIDTH) * intermediary_tile_size;
+    const uint32_t cb_in_tiled_total_size = tt::div_up(l1_input_shard_width, TILE_WIDTH) * intermediary_tile_size;
     const uint32_t cb_in_tiled_page_size = intermediary_tile_size;
     create_circular_buffer(cb_in_tiled_id, cb_in_tiled_total_size, cb_in_tiled_page_size, intermediary_format);
 
-    const uint32_t cb_in_transpose_total_size = tt::div_up(input_shard_width, TILE_WIDTH) * intermediary_tile_size;
+    const uint32_t cb_in_transpose_total_size = tt::div_up(l1_input_shard_width, TILE_WIDTH) * intermediary_tile_size;
     const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
 
     const uint32_t cb_in_transpose_id0 = tt::CBIndex::c_2;
@@ -72,17 +82,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
     const uint32_t cb_out_id = tt::CBIndex::c_4;
     const tt::DataFormat output_format = input_format;
     const uint32_t cb_out_total_size = cb_in_total_size;  // same size as input
-    const uint32_t cb_out_page_size = input_shard_height * input_element_size;
+    const uint32_t cb_out_page_size = l1_input_shard_height * input_element_size;
     const auto cb_out =
         create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
 
-    const uint32_t total_tiles_per_core = tt::div_up(input_shard_width, TILE_HEIGHT);
+    const uint32_t total_tiles_per_core = tt::div_up(l1_input_shard_width, TILE_HEIGHT);
     const uint32_t total_tiles_writer0 = tt::div_up(total_tiles_per_core, 2);
     const uint32_t total_tiles_writer1 = total_tiles_per_core - total_tiles_writer0;
     uint32_t output_stride_sticks = TILE_WIDTH;  // needed to stride output address when doing split writers
-
-    const uint32_t output_shard_height = output.shard_spec()->shape[0];
-    const uint32_t output_shard_width = output.shard_spec()->shape[1];
 
     const auto dram_input_cores = corerange_to_cores(
         a.shard_spec()->grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
@@ -91,9 +98,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
     const auto remote_buffer_type = a.buffer()->buffer_type();
     const auto [runtime_args_for_each_core, _, dram_write_stride_bytes, dram_read_stride_bytes] =
         data_movement::detail::compute_width_sharding_reshard_segments(
-            {input_shard_height, input_shard_width},
+            {l1_input_shard_height, l1_input_shard_width},
             a.shard_spec()->shape,  // dram shard shape
-            input_cores,
+            l1_input_cores,
             dram_input_cores,
             remote_buffer_type,
             remote_core_type,
@@ -101,8 +108,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
             2);
 
     // Split DRAM read across each kernel along tensor height since this is the best way to split work evenly
-    const uint32_t total_num_sticks_kernel_0 = input_shard_height / 2;
-    const uint32_t total_num_sticks_kernel_1 = input_shard_height - total_num_sticks_kernel_0;
+    const uint32_t total_num_sticks_kernel_0 = l1_input_shard_height / 2;
+    const uint32_t total_num_sticks_kernel_1 = l1_input_shard_height - total_num_sticks_kernel_0;
 
     std::vector<uint32_t> writer_compile_time_args0 = {
         cb_in_id,
@@ -142,25 +149,25 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
         cb_in_transpose_id0,
         cb_in_transpose_id1,
         total_tiles_per_core,
-        input_shard_height,
+        l1_input_shard_height,
         is_input_in_dram};
 
     auto writer_kernel_id0 = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
-        input_core_grid,
+        l1_input_core_grid,
         tt::tt_metal::ReaderDataMovementConfig(writer_compile_time_args0));
 
     auto writer_kernel_id1 = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
-        input_core_grid,
+        l1_input_core_grid,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args1));
 
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp",
-        input_core_grid,
+        l1_input_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = false,
@@ -170,7 +177,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
     auto set_runtime_args = [cb_in,
                              cb_out,
                              is_input_in_dram,
-                             input_cores,
+                             l1_input_cores,
                              runtime_args_for_each_core,
                              writer_kernel_id0,
                              writer_kernel_id1,
@@ -181,7 +188,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
                              dram_write_stride_bytes](
                                 tt::tt_metal::Program& program, const Tensor& a, const Tensor& output) {
         if (is_input_in_dram) {
-            for (uint32_t core_idx = 0; core_idx < input_cores.size(); core_idx++) {
+            for (uint32_t core_idx = 0; core_idx < l1_input_cores.size(); core_idx++) {
                 const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
                 std::vector<uint32_t> runtime_args_0 = {remote_address, args_for_all_segments.size()};
                 std::vector<uint32_t> runtime_args_1 = {remote_address, args_for_all_segments.size()};
@@ -201,8 +208,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Te
                         args.write_size, adjusted_read_offset, args.bank_id, adjusted_write_offset};
                     runtime_args_1.insert(runtime_args_1.end(), segment_kernel_1.begin(), segment_kernel_1.end());
                 }
-                SetRuntimeArgs(program, writer_kernel_id0, input_cores[core_idx], runtime_args_0);
-                SetRuntimeArgs(program, writer_kernel_id1, input_cores[core_idx], runtime_args_1);
+                SetRuntimeArgs(program, writer_kernel_id0, l1_input_cores[core_idx], runtime_args_0);
+                SetRuntimeArgs(program, writer_kernel_id1, l1_input_cores[core_idx], runtime_args_1);
             }
         } else {
             tt::tt_metal::Buffer* a_buffer = a.buffer();

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -8,6 +8,9 @@
 
 namespace ttnn::operations::experimental::cnn::detail {
 
+// Helper function to compute alignment requirement based on L1 alignment and element size
+uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor);
+
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Tensor& a, Tensor& output);
 
 }  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -8,7 +8,6 @@
 
 namespace ttnn::operations::experimental::cnn::detail {
 
-// Helper function to compute alignment requirement based on L1 alignment and element size
 uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor);
 
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Tensor& a, Tensor& output);


### PR DESCRIPTION
### Summary
This PR changes `ttnn.convert_to_hwc` to support tensors with any number of channels (C), including cases where C is not a multiple of 8. 

Previously, the operation was limited to channel counts that were multiples of 8. The implementation now automatically handles alignment requirements by padding the output shard width to the next multiple of 8 when necessary, ensuring compatibility with downstream sliding window operations.

### What's Changed
  - Extended channel support: Operation now works with any channel count up to 32
  - Automatic padding: When C % 8 != 0, output shard width is automatically rounded up to satisfy 16-byte alignment and downstream sliding window op constraints

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18298112606
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18313383331 (pipeline broken on main at the moment, tested locally for now)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18298118558