### PR TITLE
Make CCL docstrings match implementation

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
@@ -28,7 +28,7 @@ void py_bind_reduce_scatter(py::module& module) {
 
             Keyword Args:
                 cluster_axis (int, optional): The cluster axis to reduce across. Defaults to `None`.
-                topology (ttnn.Topology, optional): Fabric topology. Defaults to current mesh topology.
+                topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_broadcast_async/all_broadcast_async_pybind.cpp
@@ -63,7 +63,7 @@ void py_bind_all_broadcast_async(pybind11::module& module) {
         Keyword Args:
             num_links (int, optional): Number of links to use for the all-broadcast operation. Defaults to `1`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
 
         Returns:
             std::vector<ttnn.Tensor>: a vector of tensors from all the devices.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -195,7 +195,7 @@ void py_bind_all_gather_async(pybind11::module& module) {
         Keyword Args:
             num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring` for overloads without `cluster_axis`; the cluster-axis overload requires an explicit value.
 
         Returns:
             ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
@@ -87,7 +87,7 @@ void py_bind_all_gather_concat(pybind11::module& module) {
             num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
             num_heads (int): Number of heads for NLP concat heads
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
         Returns:
             ttnn.Tensor: the output tensor.
         )doc");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/all_gather_matmul_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/all_gather_matmul_async_pybind.cpp
@@ -121,6 +121,7 @@ void py_bind_all_gather_matmul_async(pybind11::module& module) {
         Keyword Args:
             * :attr:`bias` (ttnn.Tensor): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.
+            * :attr:`topology` (ttnn.Topology): Communication topology for the all-gather. Defaults to `ttnn.Topology.Ring`.
             * :attr:`memory_config_ag` (Optional[ttnn.MemoryConfig]): Memory configuration for the All Gather operation.
             * :attr:`memory_config_mm` (Optional[ttnn.MemoryConfig]): Memory configuration for the Matmul operation.
             * :attr:`transpose_a` (bool)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
@@ -163,7 +163,7 @@ void py_bind_all_reduce_async(pybind11::module& module) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             num_links (int, optional): Number of links to use for the all_reduce_async operation. Defaults to `None`, which indicates to the operation that it should choose. Note that this value will be ignored if there are fewer links available than requested.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
 
         Returns:
             ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/llama_all_gather_matmul_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/llama_all_gather_matmul_async_pybind.cpp
@@ -95,7 +95,7 @@ void py_bind_llama_all_gather_matmul_async(pybind11::module& module) {
             dim (int): Dimension to perform All-Gather operation.
             cluster_axis (int): Provided a MeshTensor, the axis corresponding to MeshDevice to perform the line-all-gather-replicate operation on.
             mesh_device (MeshDevice): Device mesh to perform the line-all-gather-replicate operation on.
-            topology (ttnn.Topology): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
+            topology (ttnn.Topology): The topology configuration to run the operation in. Valid options are Ring and Linear; callers must provide the desired value.
             multi_device_global_semaphore (ttnn.GlobalSemaphore): The global semaphore to use for the operation.
 
         Mesh Tensor Programming Guide : https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_pybind.cpp
@@ -36,6 +36,8 @@ void py_bind_llama_reduce_scatter(py::module& module) {
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                topology (ttnn.Topology, optional): Communication topology to use. Defaults to `ttnn.Topology.Linear`.
+                use_noc1_only (bool, optional): Force NOC1-only transport. Defaults to `False`.
 
            Returns:
                ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_pybind.cpp
@@ -22,6 +22,7 @@ void py_bind_llama_rs_create_heads(py::module& module) {
                 subdevice_id (ttnn.SubDeviceId): the subdevice id.
                 cluster_axis (number): the cluster axis.
                 mesh_device (ttnn.MeshDevice): the mesh device.
+                topology (ttnn.Topology): Communication topology for the reduce-scatter stage.
                 num_links (number, optional): the number of links. Defaults to `3`.
 
             Keyword Args:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.cpp
@@ -32,6 +32,7 @@ void py_bind_rs_matmul(pybind11::module& module) {
 
         Keyword Args:
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.
+            * :attr:`topology` (ttnn.Topology): Communication topology for the reduce-scatter stage. Defaults to `ttnn.Topology.Linear`.
             * :attr:`memory_config_ag` (Optional[ttnn.MemoryConfig]): Memory configuration for the All Gather operation.
             * :attr:`memory_config_mm` (Optional[ttnn.MemoryConfig]): Memory configuration for the Matmul operation.
             * :attr:`transpose_a` (bool)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async_pybind.cpp
@@ -118,6 +118,7 @@ void py_bind_matmul_reduce_scatter_async(pybind11::module& module) {
         Keyword Args:
             * :attr:`bias` (ttnn.Tensor): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.
+            * :attr:`topology` (ttnn.Topology): Communication topology for the reduce-scatter phase. Defaults to `ttnn.Topology.Ring`.
             * :attr:`memory_config_rs` (Optional[ttnn.MemoryConfig]): Memory configuration for the Reduce Scatter operation.
             * :attr:`memory_config_mm` (Optional[ttnn.MemoryConfig]): Memory configuration for the Matmul operation.
             * :attr:`transpose_a` (bool)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async_pybind.cpp
@@ -63,7 +63,7 @@ void py_bind_neighbor_pad_async(pybind11::module& module) {
         Keyword Args:
             num_links (int, optional): Number of links to use for the neighbor_pad operation. Defaults to `1`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
 
         Returns:
             ttnn.Tensor: the padded output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
@@ -122,7 +122,7 @@ void py_bind_reduce_scatter_async(pybind11::module& module) {
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             num_links (int, optional): Number of links to use for the reduce_scatter operation. Defaults to `None`, which indicates to the operation that it should choose. Note that this value will be ignored if there are fewer links available than requested.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
 
         Returns:
             ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/ring_attention_all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/ring_attention_all_gather_async_pybind.cpp
@@ -81,7 +81,7 @@ void py_bind_ring_attention_all_gather_async(pybind11::module& module) {
         Keyword Args:
             num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
-            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            topology (ttnn.Topology): The topology configuration to run the operation in. Valid options are Ring and Linear; callers must supply the desired value.
 
         Returns:
             ttnn.Tensor: the output tensor.


### PR DESCRIPTION
### Ticket
#30107

### Problem description
While reviewing the CCL bindings we found multiple operations whose docstrings still mentioned a Ring default even though the pybind layer hardcoded Linear. A few of the llama helper ops also expose an argument without documenting it, and the newest ring-attention/all-gather bindings require callers to pass a topology even though the docs implied an implicit default.

### What's changed
Update the docstrings in the relevant files so the user-facing documentation now matches the binding behavior.
No runtime behavior changed; this is strictly a documentation sync so users are not misled about which topology is selected by default.