### PR TITLE
Fix build error for Lite Fabric

### DIFF
--- a/tt_metal/lite_fabric/build.cpp
+++ b/tt_metal/lite_fabric/build.cpp
@@ -83,6 +83,7 @@ int CompileFabricLite(
         root_dir / "tt_metal/hw/inc/ethernet",
         root_dir / "tt_metal/hostdevcommon/api",
         root_dir / "tt_metal/hw/inc/debug",
+        root_dir / "tt_metal/hw/inc/tt-1xx/",
         root_dir / "tt_metal/hw/inc/tt-1xx/blackhole",
         root_dir / "tt_metal/hw/inc/tt-1xx/blackhole/blackhole_defines",
         root_dir / "tt_metal/hw/inc/tt-1xx/blackhole/noc",


### PR DESCRIPTION

### Problem description
Some header files were moved which led to missing file

### What's changed
Added the correct path to the include paths

### Checklist
- verified locally the failing test