### PR TITLE
Apply common subexpression elimination to some configuration strings

### DIFF
--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -6,6 +6,7 @@
 #include <enchantum/enchantum.hpp>
 #include <numeric>
 #include <string>
+#include <string_view>
 
 #include "dev_mem_map.h"  // MEM_LOCAL_BASE
 #include "hal_types.hpp"
@@ -166,45 +167,30 @@ public:
 
     std::string linker_script(const Params& params) const override {
         const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        const std::string_view path = "runtime/hw/toolchain/wormhole";
+        std::string_view fork = params.is_fw ? "firmware" : "kernel";
         switch (params.core_type) {
             case HalProgrammableCoreType::TENSIX:
                 switch (params.processor_class) {
-                    case HalProcessorClassType::DM: {
-                        return fmt::format(
-                            "runtime/hw/toolchain/wormhole/{}_{}risc.ld",
-                            params.is_fw ? "firmware" : "kernel",
-                            params.processor_id == 0 ? "b" : "nc");
-                    }
+                    case HalProcessorClassType::DM:
+                        return fmt::format("{}/{}_{}risc.ld", path, fork, params.processor_id == 0 ? "b" : "nc");
                     case HalProcessorClassType::COMPUTE:
-                        return fmt::format(
-                            "runtime/hw/toolchain/wormhole/{}_trisc{}.ld",
-                            params.is_fw ? "firmware" : "kernel",
-                            params.processor_id);
+                        return fmt::format("{}/{}_trisc{}.ld", path, fork, params.processor_id);
                 }
                 break;
             case HalProgrammableCoreType::ACTIVE_ETH:
                 if (params.is_fw) {
-                    return rtoptions.get_erisc_iram_enabled() ? "runtime/hw/toolchain/wormhole/erisc-b0-app_iram.ld"
-                                                              : "runtime/hw/toolchain/wormhole/erisc-b0-app.ld";
-                } else {
-                    return rtoptions.get_erisc_iram_enabled() ? "runtime/hw/toolchain/wormhole/erisc-b0-kernel_iram.ld"
-                                                              : "runtime/hw/toolchain/wormhole/erisc-b0-kernel.ld";
+                    // Firmware is named 'app' in this case.
+                    fork = "app";
                 }
-                break;
+                return fmt::format(
+                    "{}/erisc-b0-{}{}.ld", path, fork, rtoptions.get_erisc_iram_enabled() ? "_iram" : "");
             case HalProgrammableCoreType::IDLE_ETH:
-                switch (params.processor_id) {
-                    case 0:
-                        return params.is_fw ? "runtime/hw/toolchain/wormhole/firmware_ierisc.ld"
-                                            : "runtime/hw/toolchain/wormhole/kernel_ierisc.ld";
-                    case 1:
-                        return params.is_fw ? "runtime/hw/toolchain/wormhole/firmware_subordinate_ierisc.ld"
-                                            : "runtime/hw/toolchain/wormhole/kernel_subordinate_ierisc.ld";
-                    default: TT_THROW("Invalid processor id {}", params.processor_id);
+                if (params.processor_id < 2) {
+                    return fmt::format("{}/{}_{}ierisc.ld", path, fork, params.processor_id ? "subordinate_" : "");
                 }
                 break;
-            default:
-                TT_THROW(
-                    "Unsupported programmable core type {} to query lflags", enchantum::to_string(params.core_type));
+            default: break;
         }
         TT_THROW(
             "Invalid processor id {} of processor class {} in programmable core type {}",


### PR DESCRIPTION
### Ticket
NA

### Problem description
I noticed considerable duplication of strings and associated construction when working on some adjacent code. It made me sad.

### What's changed
Apply manual common subsexpression elimination and avoid specifying the same thing multiple times.

### Checklist
- [YES ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes