### PR TITLE
Matmul Activations - Generalise Unfused Activation for all Unary Ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -140,7 +140,7 @@ def test_linear_with_core_grid(
 @pytest.mark.parametrize("m_size", [32, 64])
 @pytest.mark.parametrize("k_size", [1024])
 @pytest.mark.parametrize("n_size", [1024])
-@pytest.mark.parametrize("activation", [None, "relu", "silu"])
+@pytest.mark.parametrize("activation", [None, "relu", "silu", "gelu", "relu6"])
 def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     device, batch_size, m_size, k_size, n_size, activation
 ):
@@ -151,8 +151,12 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     torch_output_tensor = torch_input_tensor_a @ torch_input_tensor_b
     if activation == "relu":
         torch_output_tensor = torch.relu(torch_output_tensor)
+    elif activation == "relu6":
+        torch_output_tensor = torch.nn.functional.relu6(torch_output_tensor)
     elif activation == "silu":
         torch_output_tensor = torch.nn.functional.silu(torch_output_tensor)
+    elif activation == "gelu":
+        torch_output_tensor = torch.nn.functional.gelu(torch_output_tensor)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -157,15 +157,11 @@ ttnn::Tensor bound_matmul(
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
-        if (op_type == UnaryOpType::RELU) {
-            output_tensor = ttnn::relu(output_tensor, parameters.output_mem_config, optional_output_tensor);
-        } else if (op_type == UnaryOpType::GELU) {
-            output_tensor = ttnn::gelu(output_tensor, false, parameters.output_mem_config, optional_output_tensor);
-        } else if (op_type == UnaryOpType::SILU) {
-            output_tensor = ttnn::silu(output_tensor, parameters.output_mem_config, optional_output_tensor);
-        } else {
-            TT_THROW("ttnn.matmul: Unsupported activation function");
-        }
+        output_tensor = ttnn::operations::unary::Unary_chain::invoke(
+            output_tensor,
+            {ttnn::operations::unary::EltwiseUnaryWithParam{op_type}},
+            parameters.output_mem_config,
+            optional_output_tensor);
     }
 
     return output_tensor;


### PR DESCRIPTION
## Ticket
#29886 

### Problem description
When using the matmul activation parameter (i.e. not the fused_activation parameter of matmul program configs), bound_matmul only explicitly supported relu, gelu, and silu. Other activations, such as relu6, resulted in an error.

### What's changed
Changed the activation functionality so it invokes the implementation associated with the Unary op, rather than manually specifying a call to ttnn:[activation]. 

Added relu6 to the linear unit tests, demonstrating the expanded activation functionality. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18318667616)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18318673570)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes