### PR TITLE
[skip ci] Fix t3k Choose Your Own pipeline syntax

### DIFF
--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -129,6 +129,8 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      topology: config-t3000
+      test-script: ./tests/scripts/t3000/run_t3000_profiler_tests.sh
     if: ${{ inputs.t3000-profiler }}
   t3000-perplexity-tests:
     needs: build-artifact


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/pull/29916 made it so that profiler tests require topo and script input. Forgot to make the corresponding change to T3k select workflow which calls profiler tests.

Testing:
Confirmed the pipeline starts up correctly. https://github.com/tenstorrent/tt-metal/actions/runs/18321948738