### PR TITLE
Leave space for padding in cmddat_q when sizing max size prefetch com…

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -192,7 +192,8 @@ void init(int argc, char** argv) {
         test_args::get_command_option_uint32(input_args, "-hp", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
     prefetch_q_entries_g = test_args::get_command_option_uint32(input_args, "-hq", DEFAULT_PREFETCH_Q_ENTRIES);
     cmddat_q_size_g = test_args::get_command_option_uint32(input_args, "-cs", DEFAULT_CMDDAT_Q_SIZE);
-    max_prefetch_command_size_g = cmddat_q_size_g / 2;  // note: half this for best perf
+    max_prefetch_command_size_g =
+        cmddat_q_size_g / 2 - (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1);  // note: half this for best perf
     scratch_db_size_g = test_args::get_command_option_uint32(input_args, "-ss", DEFAULT_SCRATCH_DB_SIZE);
     use_coherent_data_g = test_args::has_command_option(input_args, "-c");
     readback_every_iteration_g = !test_args::has_command_option(input_args, "-rb");
@@ -377,9 +378,10 @@ void add_prefetcher_cmd_to_hostq(
     uint32_t new_size = (cmds.size() - prior_end) * sizeof(uint32_t);
     TT_FATAL(
         new_size <= max_prefetch_command_size_g,
-        "Generated prefetcher command {} exceeds max command size {}",
+        "Generated prefetcher command {} exceeds max command size {} (padding size {} B)",
         new_size,
-        max_prefetch_command_size_g);
+        max_prefetch_command_size_g,
+        pad_size_bytes);
     TT_FATAL((new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
     sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
 }
@@ -1190,7 +1192,7 @@ void gen_rnd_test(
                     gen_rnd_debug_cmd(prefetch_cmds, cmd_sizes, device_data);
                 }
                 break;
-            default: TT_THROW("Invalid prefetch cmd {} in gen_rnd_test", cmd);
+            default: gen_rnd_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         }
     }
 }


### PR DESCRIPTION
…mand

### Ticket
No issue

### Problem description
Recent addition of CQDispatchCmdLarge type has necessitated adjusting some sizes pertaining to the test_prefetcher (maybe test_dispatcher in theory, although no issues reported there). Our pre-commit checks were run with _release_ build, which disabled all the asserts. Nightly runs with _debug_ will catch more - this PR will have the fixes to them.

### What's changed
Adjusted some sizes to not cause overflow


### Testing performed
Wormhole:
https://github.com/tenstorrent/tt-metal/actions/runs/18352987079/job/52279647004
https://github.com/tenstorrent/tt-metal/actions/runs/18352987079/job/52279646958
Blackhole:
https://github.com/tenstorrent/tt-metal/actions/runs/18353833187
https://github.com/tenstorrent/tt-metal/actions/runs/18353800629
No other tests would be impacted as change is limited to the test file impacting the above tests only.
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes