### PR TITLE
softmax backwards skeleton fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_softmax_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_softmax_backward.py
@@ -51,7 +51,11 @@ def test_bw_softmax(input_shapes, dtype, range, dim, device):
     # Test the fused kernel implementation
     tt_output_tensor_fused = ttnn.softmax_backward(tt_softmax_tensor, grad_tensor, dim=dim)
     pt_output_tensor_fused = ttnn.to_torch(tt_output_tensor_fused)
-    pt_output_tensor_reference = reference_softmax_backward_output(pt_softmax_tensor, grad_data, axis=dim)
+    # pt_output_tensor_reference = reference_softmax_backward_output(pt_softmax_tensor, grad_data, axis=dim)
+
+    # Use multiply operator to compute the reference output for now
+    reference = ttnn.multiply(tt_softmax_tensor, grad_tensor)
+    pt_output_tensor_reference = ttnn.to_torch(reference)
 
     relative_tolerance = 0.01
     absolute_tolerance = 0.1

--- a/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
@@ -4,13 +4,16 @@
 
 #include <dataflow_api.h>
 #include <cstdint>
-#include <tt-metalium/constants.hpp>
 
 void kernel_main() {
     // Compile time args
     constexpr uint32_t src0_cb_id = get_compile_time_arg_val(0);  // softmax_output
     constexpr uint32_t src1_cb_id = get_compile_time_arg_val(1);  // upstream_grad
     constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(2);
+
+    // Set up tensor accessors
+    constexpr auto softmax_output_args = TensorAccessorArgs<3>();
+    constexpr auto upstream_grad_args = TensorAccessorArgs<softmax_output_args.next_compile_time_args_offset()>();
 
     // Runtime args
     uint32_t rt_args_idx = 0;
@@ -19,17 +22,13 @@ void kernel_main() {
     const uint32_t start_tile = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t num_tiles = get_arg_val<uint32_t>(rt_args_idx++);
 
-    // Set up data movement for softmax_output tensor
-    const InterleavedAddrGenFast<true> softmax_output_addrg = {
-        .bank_base_address = softmax_output_addr,
-        .page_size = tt::constants::TILE_HW * sizeof(uint16_t),
-        .data_format = DataFormat::Float16_b};
+    // Get tile sizes
+    const uint32_t src0_tile_size = get_tile_size(src0_cb_id);
+    const uint32_t src1_tile_size = get_tile_size(src1_cb_id);
 
-    // Set up data movement for upstream_grad tensor
-    const InterleavedAddrGenFast<true> upstream_grad_addrg = {
-        .bank_base_address = upstream_grad_addr,
-        .page_size = tt::constants::TILE_HW * sizeof(uint16_t),
-        .data_format = DataFormat::Float16_b};
+    // Create tensor accessors
+    const auto softmax_output_accessor = TensorAccessor(softmax_output_args, softmax_output_addr, src0_tile_size);
+    const auto upstream_grad_accessor = TensorAccessor(upstream_grad_args, upstream_grad_addr, src1_tile_size);
 
     // Process tiles one by one for simplicity
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
@@ -38,14 +37,14 @@ void kernel_main() {
         // Read one tile from softmax_output
         cb_reserve_back(src0_cb_id, 1);
         uint32_t l1_write_addr_src0 = get_write_ptr(src0_cb_id);
-        noc_async_read_tile(current_tile, softmax_output_addrg, l1_write_addr_src0);
+        noc_async_read(softmax_output_accessor.get_noc_addr(current_tile), l1_write_addr_src0, src0_tile_size);
         noc_async_read_barrier();
         cb_push_back(src0_cb_id, 1);
 
         // Read one tile from upstream_grad
         cb_reserve_back(src1_cb_id, 1);
         uint32_t l1_write_addr_src1 = get_write_ptr(src1_cb_id);
-        noc_async_read_tile(current_tile, upstream_grad_addrg, l1_write_addr_src1);
+        noc_async_read(upstream_grad_accessor.get_noc_addr(current_tile), l1_write_addr_src1, src1_tile_size);
         noc_async_read_barrier();
         cb_push_back(src1_cb_id, 1);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_device_operation.cpp
@@ -18,7 +18,7 @@ SoftmaxBackwardDeviceOperation::program_factory_t SoftmaxBackwardDeviceOperation
     // For now, always use the fused kernel implementation
     // In the future, we could add logic to choose between different implementations
     // based on tensor size, device capabilities, etc.
-    return SingleCore{};
+    return MultiCore{};
 }
 
 void SoftmaxBackwardDeviceOperation::validate_on_program_cache_miss(
@@ -45,9 +45,7 @@ void SoftmaxBackwardDeviceOperation::validate_on_program_cache_miss(
 
     // Validate dimension
     const auto rank = softmax_output.logical_shape().rank();
-    TT_ASSERT(
-        attributes.dim == rank - 1 || attributes.dim == static_cast<uint32_t>(-1),
-        "Currently only supporting softmax_backward on last dimension");
+    TT_ASSERT(attributes.dim == rank - 1, "Currently only supporting softmax_backward on last dimension");
 }
 
 void SoftmaxBackwardDeviceOperation::validate_on_program_cache_hit(
@@ -67,7 +65,7 @@ SoftmaxBackwardDeviceOperation::spec_return_value_t SoftmaxBackwardDeviceOperati
     return {
         input_tensor.logical_shape(),
         tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), MemoryConfig{})};
+            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), input_tensor.memory_config())};
 }
 
 SoftmaxBackwardDeviceOperation::tensor_return_value_t SoftmaxBackwardDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_device_operation.hpp
@@ -21,30 +21,6 @@ struct SoftmaxBackwardDeviceOperation {
     using spec_return_value_t = softmax_backward::spec_return_value_t;
     using tensor_return_value_t = softmax_backward::tensor_return_value_t;
 
-    // Note spec_return_value_t and tensor_return_value_t should follow the same pattern
-    // i.e. if spec_return_value_t is a std::vector<std::optional<ttnn::TensorSpec>> then tensor_return_value_t should
-    // be std::vector<std::optional<Tensor>>
-    struct SingleCore {
-        using shared_variables_t = SoftmaxBackwardProgramFactory::shared_variables_t;
-        using cached_program_t = SoftmaxBackwardProgramFactory::cached_program_t;
-
-        static cached_program_t create(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value) {
-            return SoftmaxBackwardProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-        }
-
-        static void override_runtime_arguments(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value) {
-            SoftmaxBackwardProgramFactory::override_runtime_arguments(
-                cached_program, operation_attributes, tensor_args, tensor_return_value);
-        }
-    };
-
     struct MultiCore {
         using shared_variables_t = SoftmaxBackwardProgramFactory::shared_variables_t;
         using cached_program_t = SoftmaxBackwardProgramFactory::cached_program_t;
@@ -66,7 +42,7 @@ struct SoftmaxBackwardDeviceOperation {
         }
     };
 
-    using program_factory_t = std::variant<SingleCore, MultiCore>;
+    using program_factory_t = std::variant<MultiCore>;
 
     // Mandatory methods
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -43,9 +43,7 @@ SoftmaxBackwardProgramFactory::cached_program_t SoftmaxBackwardProgramFactory::c
 
     // For simplicity, we'll implement for the last dimension (most common case)
     // This can be extended to support other dimensions
-    TT_ASSERT(
-        dim == rank - 1 || dim == static_cast<uint32_t>(-1),
-        "Currently only supporting softmax_backward on last dimension");
+    TT_ASSERT(dim == rank - 1, "Currently only supporting softmax_backward on last dimension");
 
     const auto height = shape[-2];
     const auto width = shape[-1];
@@ -153,12 +151,11 @@ SoftmaxBackwardProgramFactory::cached_program_t SoftmaxBackwardProgramFactory::c
         CoreCoord core = {core_idx / num_cores_y, core_idx % num_cores_y};
 
         uint32_t start_tile = core_idx * tiles_per_core;
-        uint32_t end_tile = std::min(start_tile + tiles_per_core, num_rows);
-        uint32_t num_tiles_this_core = end_tile - start_tile;
-
-        if (num_tiles_this_core == 0) {
+        if (start_tile >= num_rows) {
             continue;
         }
+        uint32_t end_tile = std::min(start_tile + tiles_per_core, num_rows);
+        uint32_t num_tiles_this_core = end_tile - start_tile;
 
         // Reader runtime args
         SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/normalization/softmax_backward/softmax_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax_backward/softmax_backward_pybind.cpp
@@ -76,9 +76,14 @@ void bind_normalization_softmax_backward_operation(py::module& module) {
             [](const OperationType& self,
                const ttnn::Tensor& softmax_output_tensor,
                const ttnn::Tensor& grad_tensor,
-               const uint32_t dim) -> ttnn::Tensor {
+               int32_t dim) -> ttnn::Tensor {
+                // Convert negative dimension to positive (Python convention: -1 means last dimension)
+                const auto rank = softmax_output_tensor.logical_shape().rank();
+                uint32_t normalized_dim = dim < 0 ? static_cast<uint32_t>(dim + rank) : static_cast<uint32_t>(dim);
                 return self(
-                    softmax_output_tensor, grad_tensor, dim /*, memory_config, compute_kernel_config, numeric_stable*/);
+                    softmax_output_tensor,
+                    grad_tensor,
+                    normalized_dim /*, memory_config, compute_kernel_config, numeric_stable*/);
             },
             py::arg("softmax_output_tensor").noconvert(),
             py::arg("grad_tensor").noconvert(),


### PR DESCRIPTION
### Ticket
N/A

### What's changed
Fix fused softmax backward skeleton that computes eltwise multiply
- Wrong storage type in InterleavedAddrgen in writer (L1 instead of DRAM). Replaced InterleavedAddrgen with TensorAccessor to avoid this pitfall
- Wrongly used init for binary op and for mul_tiles
- Missing tile registers syncronization in compute
- Fix underflow in computation of num_tiles_per_core
- Fix negative dim case (underflow)
- Some other small fixes that could result in an error later

Still fails for non-trivial shapes @vtsilytskyiTT this is up to you to debug
@vtsilytskyiTT please ping me if you have some questions