### PR TITLE
[UMD] Switch configure_tlb to use CoreCoord

### DIFF
--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -165,7 +165,10 @@ void configure_static_tlbs(
         uint64_t peer_dram_offset = dram_channel_0_peer2peer_region_start;
         for (uint32_t tlb_id = dynamic_tlb_base_index; tlb_id < dynamic_tlb_base_index + dynamic_tlb_count; tlb_id++) {
             device_driver.configure_tlb(
-                mmio_device_id, CoreCoord(dram_channel_0_x, dram_channel_0_y), tlb_id, peer_dram_offset);
+                mmio_device_id,
+                tt::umd::CoreCoord(dram_channel_0_x, dram_channel_0_y, CoreType::DRAM, CoordSystem::NOC0),
+                tlb_id,
+                peer_dram_offset);
             // Align address space of 16MB TLB to 16MB boundary
             peer_dram_offset += dynamic_tlb_16m_size;
         }
@@ -173,7 +176,8 @@ void configure_static_tlbs(
         // Setup static 4GB tlbs for DRAM cores
         uint32_t dram_addr = 0;
         for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
-            tt_xy_pair dram_core = blackhole::ddr_to_noc0(dram_channel);
+            tt::umd::CoreCoord dram_core =
+                tt::umd::CoreCoord(blackhole::ddr_to_noc0(dram_channel), CoreType::DRAM, CoordSystem::NOC0);
             auto tlb_index = tt::umd::blackhole::TLB_COUNT_2M + dram_channel;
             device_driver.configure_tlb(mmio_device_id, dram_core, tlb_index, dram_addr, TLB_DATA::Posted);
         }


### PR DESCRIPTION
### Ticket
This is preventing UMD bump.

### Problem description
This change in UMD https://github.com/tenstorrent/tt-umd/pull/1329 changed the entry point of configure_tlb to expect TRANSLATED instead of VIRTUAL coords.
This api should've been removed a while back.

### What's changed
- Changed configure_tlb call to the one with CoreCoord instead of tt_xy_pair
- Update UMD to include removal of VIRTUAL coords

### Checklist
All runs on brosko/fix_virt_test :
- [ ] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323234072
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323236916
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323240192
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/18323243691
- [ ] (Single-card) Demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323247192
- [ ] (Galaxy) Quick : https://github.com/tenstorrent/tt-metal/actions/runs/18323251408
- [ ] Galaxy demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323254569
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323258370
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/18323260981