### PR TITLE
[skip ci] Build TT-Train using system packages for TT-Metalium & TT-NN.

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -156,6 +156,62 @@ jobs:
       distributed: false
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
+  build-tt-train:
+    if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    needs: [ build, find-changed-files ]
+    runs-on: tt-ubuntu-2204-large-stable
+    container:
+      image: harbor.ci.tenstorrent.net/${{ needs.build.outputs.ci-build-docker-image || 'docker-image-unresolved!' }}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build.outputs.packages-artifact-name || 'packages artifact unresolved!' }}
+          path: /work/pkgs/
+      - name: Install packages
+        run: |
+          set -euo pipefail
+
+          apt update
+          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-nn_*.deb ./pkgs/tt-nn-dev_*.deb
+
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v5
+        with:
+          # submodules: recursive
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+          fetch-depth: 500
+          fetch-tags: true # Need tags for `git describe`
+          path: docker-job
+          sparse-checkout: |
+            tt-train
+
+      - name: Submodules
+        run: |
+          set -euo pipefail
+          git submodule update --init --recursive tt-train
+
+      - name: Configure tt-train
+        run: |
+          set -euo pipefail
+
+          cd /work/tt-train
+          mkdir -p .build && cd .build
+          cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ..
+
+      - name: Build tt-train
+        run: |
+          set -euo pipefail
+
+          cd /work/tt-train/.build
+          cmake --build .
+
   metalium-examples:
     needs: [ build, find-changed-files ]
     if: ${{

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -79,14 +79,32 @@ CPMAddPackage(
 
 CPMAddPackage(NAME nlohmann_json GITHUB_REPOSITORY nlohmann/json GIT_TAG v3.11.3 OPTIONS "JSON_BuildTests OFF")
 
-CPMAddPackage(NAME xtl GITHUB_REPOSITORY xtensor-stack/xtl GIT_TAG 0.8.0 OPTIONS "XTL_ENABLE_TESTS OFF")
+CPMAddPackage(
+    NAME xtl
+    GITHUB_REPOSITORY xtensor-stack/xtl
+    GIT_TAG 0.8.0
+    PATCHES
+        xtl.patch
+    OPTIONS
+        "XTL_ENABLE_TESTS OFF"
+)
 
-CPMAddPackage(NAME xtensor GITHUB_REPOSITORY xtensor-stack/xtensor GIT_TAG 0.26.0 OPTIONS "XTENSOR_ENABLE_TESTS OFF")
+CPMAddPackage(
+    NAME xtensor
+    GITHUB_REPOSITORY xtensor-stack/xtensor
+    GIT_TAG 0.26.0
+    PATCHES
+        xtensor.patch
+    OPTIONS
+        "XTENSOR_ENABLE_TESTS OFF"
+)
 
 CPMAddPackage(
     NAME xtensor-blas
     GITHUB_REPOSITORY xtensor-stack/xtensor-blas
     GIT_TAG 0.22.0
+    PATCHES
+        xtensor-blas.patch
     OPTIONS
         "XTENSOR_ENABLE_TESTS OFF"
 )

--- a/tt-train/cmake/xtensor-blas.patch
+++ b/tt-train/cmake/xtensor-blas.patch
@@ -1,0 +1,70 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8886cda..8e1333b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtensor-blas)
+
+ set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+ set(XTENSOR_BLAS_INCLUDE_DIR ${INCLUDE_DIR})
+
+diff --git a/benchmark/CMakeLists.txt b/benchmark/CMakeLists.txt
+index 1b66d74..8aeb775 100644
+--- a/benchmark/CMakeLists.txt
++++ b/benchmark/CMakeLists.txt
+@@ -4,11 +4,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-benchmark)
+
+     find_package(xtensor REQUIRED CONFIG)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 025233f..72fd0e6 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-blas-test)
+
+     enable_testing()
+diff --git a/test/downloadGTest.cmake.in b/test/downloadGTest.cmake.in
+index e06bb06..b315e46 100644
+--- a/test/downloadGTest.cmake.in
++++ b/test/downloadGTest.cmake.in
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ project(googletest-download NONE)
+
+ include(ExternalProject)
+ ExternalProject_Add(googletest
+--
+2.49.0

--- a/tt-train/cmake/xtensor.patch
+++ b/tt-train/cmake/xtensor.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c7ec920..5228c30 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtensor CXX)
+
+ set(XTENSOR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+ # Versionning
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index cc2f928..8e84e39 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-test CXX)
+
+     enable_testing()
+--
+2.49.0

--- a/tt-train/cmake/xtl.patch
+++ b/tt-train/cmake/xtl.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 796dc46..d6ce609 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtl)
+
+ set(XTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+ # Versioning
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index ee6ce9c..ac56750 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ find_package(doctest            REQUIRED)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtl-test)
+--
+2.49.0

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -258,92 +258,96 @@ list(APPEND SOURCES ${METAL_OPS_FILES})
 # Check if TT::Metalium target exists
 # If it does not exist, assume that we are building with tt-train as top level project
 if(NOT TARGET TT::Metalium)
-    if("$ENV{TT_METAL_HOME}" STREQUAL "")
-        message(FATAL_ERROR "TT_METAL_HOME is not set")
-    endif()
+    find_package(TT-NN)
 
-    set(METALIUM_INCLUDE_DIRS
-        # Metalium
-        "$ENV{TT_METAL_HOME}"
-        "$ENV{TT_METAL_HOME}/tt_metal"
-        "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd"
-        "$ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public"
-        "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/wormhole"
-        "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/wormhole/wormhole_b0_defines"
-        "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/blackhole"
-        "$ENV{TT_METAL_HOME}/tt_metal/api/"
-        "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api"
-        "$ENV{TT_METAL_HOME}/tt_metal/hostdevcommon/api"
-        "$ENV{TT_METAL_HOME}/tt_metal/include"
-        "$ENV{TT_METAL_HOME}/tt_stl"
-        # TTNN
-        "$ENV{TT_METAL_HOME}/ttnn"
-        "$ENV{TT_METAL_HOME}/ttnn/api"
-        "$ENV{TT_METAL_HOME}/ttnn/cpp"
-        "$ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated"
-        "${reflect_SOURCE_DIR}"
-    )
+    if(NOT TT-NN_FOUND)
+        if("$ENV{TT_METAL_HOME}" STREQUAL "")
+            message(FATAL_ERROR "TT_METAL_HOME is not set")
+        endif()
 
-    message(STATUS "Metalium not found, attempting to locate")
-
-    # Define the path to look for the library
-    set(METALIUM_LIB_PATH "$ENV{TT_METAL_HOME}/build/lib")
-
-    # Try to find the library
-    find_library(TT_METAL_LIBRARY NAMES "tt_metal" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
-    find_library(TTNNCPP_LIBRARY NAMES "_ttnncpp.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
-    find_library(DEVICE_LIBRARY NAMES "device" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
-    find_library(TT_STL_LIBRARY NAMES "libtt_stl.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
-
-    if(TT_STL_LIBRARY)
-        add_library(Metalium::TT_STL SHARED IMPORTED)
-        set_target_properties(
-            Metalium::TT_STL
-            PROPERTIES
-                IMPORTED_LOCATION
-                    "${TT_STL_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES
-                    "$ENV{TT_METAL_HOME}/tt_stl"
+        set(METALIUM_INCLUDE_DIRS
+            # Metalium
+            "$ENV{TT_METAL_HOME}"
+            "$ENV{TT_METAL_HOME}/tt_metal"
+            "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd"
+            "$ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public"
+            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/wormhole"
+            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/wormhole/wormhole_b0_defines"
+            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/tt-1xx/blackhole"
+            "$ENV{TT_METAL_HOME}/tt_metal/api/"
+            "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api"
+            "$ENV{TT_METAL_HOME}/tt_metal/hostdevcommon/api"
+            "$ENV{TT_METAL_HOME}/tt_metal/include"
+            "$ENV{TT_METAL_HOME}/tt_stl"
+            # TTNN
+            "$ENV{TT_METAL_HOME}/ttnn"
+            "$ENV{TT_METAL_HOME}/ttnn/api"
+            "$ENV{TT_METAL_HOME}/ttnn/cpp"
+            "$ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated"
+            "${reflect_SOURCE_DIR}"
         )
-        message(STATUS "Successfully found libtt_stl.so at ${TT_STL_LIBRARY}")
-    else()
-        message(FATAL_ERROR "libtt_stl.so not found in ${METALIUM_LIB_PATH}")
-    endif()
 
-    if(TT_METAL_LIBRARY)
-        add_library(TT::Metalium SHARED IMPORTED)
-        set_target_properties(
-            TT::Metalium
-            PROPERTIES
-                IMPORTED_LOCATION
-                    "${TT_METAL_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES
-                    "${METALIUM_INCLUDE_DIRS}"
-        )
-        target_link_libraries(
-            TT::Metalium
-            INTERFACE
-                ${DEVICE_LIBRARY}
+        message(STATUS "Metalium not found, attempting to locate")
+
+        # Define the path to look for the library
+        set(METALIUM_LIB_PATH "$ENV{TT_METAL_HOME}/build/lib")
+
+        # Try to find the library
+        find_library(TT_METAL_LIBRARY NAMES "tt_metal" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+        find_library(TTNNCPP_LIBRARY NAMES "_ttnncpp.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+        find_library(DEVICE_LIBRARY NAMES "device" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+        find_library(TT_STL_LIBRARY NAMES "libtt_stl.so" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
+
+        if(TT_STL_LIBRARY)
+            add_library(Metalium::TT_STL SHARED IMPORTED)
+            set_target_properties(
                 Metalium::TT_STL
-                nlohmann_json::nlohmann_json
-        )
-        message(STATUS "Successfully found libtt_metal.so at ${TT_METAL_LIBRARY}")
-    else()
-        message(FATAL_ERROR "libtt_metal.so not found in ${METALIUM_LIB_PATH}")
-    endif()
-    if(TTNNCPP_LIBRARY)
-        add_library(TTNN::TTNN SHARED IMPORTED)
-        set_target_properties(
-            TTNN::TTNN
-            PROPERTIES
-                IMPORTED_LOCATION
-                    "${TTNNCPP_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES
-                    "${METALIUM_INCLUDE_DIRS}"
-        )
-        message(STATUS "Successfully found _ttnncpp.so at ${TTNNCPP_LIBRARY}")
-    else()
-        message(FATAL_ERROR "_ttnncpp.so not found in ${METALIUM_LIB_PATH}")
+                PROPERTIES
+                    IMPORTED_LOCATION
+                        "${TT_STL_LIBRARY}"
+                    INTERFACE_INCLUDE_DIRECTORIES
+                        "$ENV{TT_METAL_HOME}/tt_stl"
+            )
+            message(STATUS "Successfully found libtt_stl.so at ${TT_STL_LIBRARY}")
+        else()
+            message(FATAL_ERROR "libtt_stl.so not found in ${METALIUM_LIB_PATH}")
+        endif()
+
+        if(TT_METAL_LIBRARY)
+            add_library(TT::Metalium SHARED IMPORTED)
+            set_target_properties(
+                TT::Metalium
+                PROPERTIES
+                    IMPORTED_LOCATION
+                        "${TT_METAL_LIBRARY}"
+                    INTERFACE_INCLUDE_DIRECTORIES
+                        "${METALIUM_INCLUDE_DIRS}"
+            )
+            target_link_libraries(
+                TT::Metalium
+                INTERFACE
+                    ${DEVICE_LIBRARY}
+                    Metalium::TT_STL
+                    nlohmann_json::nlohmann_json
+            )
+            message(STATUS "Successfully found libtt_metal.so at ${TT_METAL_LIBRARY}")
+        else()
+            message(FATAL_ERROR "libtt_metal.so not found in ${METALIUM_LIB_PATH}")
+        endif()
+        if(TTNNCPP_LIBRARY)
+            add_library(TTNN::TTNN SHARED IMPORTED)
+            set_target_properties(
+                TTNN::TTNN
+                PROPERTIES
+                    IMPORTED_LOCATION
+                        "${TTNNCPP_LIBRARY}"
+                    INTERFACE_INCLUDE_DIRECTORIES
+                        "${METALIUM_INCLUDE_DIRS}"
+            )
+            message(STATUS "Successfully found _ttnncpp.so at ${TTNNCPP_LIBRARY}")
+        else()
+            message(FATAL_ERROR "_ttnncpp.so not found in ${METALIUM_LIB_PATH}")
+        endif()
     endif()
 else()
     message(STATUS "Metalium targets already exists")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TT-Train's current workflow is to build separately from TT-Metalium & TT-NN.  This is brittle when not using exported configs (provided in packages; not provided in the source tree).  Additionally, CI does not test this flow.  The result is pain for the authors.

### What's changed
* Tell TT-Train to first look for system packages and use them if available
  * This is in parallel to the existing reach-to-many-dirs-because-I-know-secrets approach
  * The parallel path should be considered deprecated now and we'll clean it up after everyone is comfortable with system packages
* Apply the same patches to dependencies that the master repo has
  * These are for old CMake versions that ship by default in Ubuntu 22.04 and 24.04
  * We copy the patches so that a sparse checkout of ONLY TT-Train has everything it needs to build cleanly, as an independent project.
* Added a build of TT-Train that specifically uses the .deb packages in PR Gate to guard against future breakage

### NOTE
This is only testing up to the build phase.  Runtime (including tests) is a future task.