### PR TITLE
Change log level from warning to debug

### DIFF
--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -280,7 +280,7 @@ int GraphProcessor::add_tensor(const Tensor& t) {
         storage);
     std::int64_t tensor_id;
     if (not t.tensor_id.has_value()) {
-        log_warning(
+        log_debug(
             tt::LogAlways,
             "Tensor doesn't have tensor_id, generating new one. Ideally this should not happen. Please set tensor_id "
             "for this tensor ahead of time.");


### PR DESCRIPTION
tt-forge CI is overflowed with a warning log from `ttnn/core/graph/graph_processor.cpp`:

`2025-10-08 07:37:15.746 | warning  |          Always | Tensor doesn't have tensor_id, generating new one. Ideally this should not happen. Please set tensor_id for this tensor ahead of time. (graph_processor.cpp:286)`

To avoid unnecessary logging, log level is changed from 'warning' to 'debug'.