### PR TITLE
MM Activation - Force Accurate GELU

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -157,9 +157,12 @@ ttnn::Tensor bound_matmul(
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
+
+        // Gelu must have approximation disabled for model accuracy. Other activations are run as-is.
         auto activation = (op_type == UnaryOpType::GELU)
                               ? ttnn::operations::unary::EltwiseUnaryWithParam{op_type, static_cast<float>(false)}
                               : ttnn::operations::unary::EltwiseUnaryWithParam{op_type};
+
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
             output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);
     }

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -157,11 +157,11 @@ ttnn::Tensor bound_matmul(
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
+        auto activation = (op_type == UnaryOpType::GELU)
+                              ? ttnn::operations::unary::EltwiseUnaryWithParam{op_type, static_cast<float>(false)}
+                              : ttnn::operations::unary::EltwiseUnaryWithParam{op_type};
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
-            output_tensor,
-            {ttnn::operations::unary::EltwiseUnaryWithParam{op_type, {static_cast<float>(false)}}},
-            parameters.output_mem_config,
-            optional_output_tensor);
+            output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);
     }
 
     return output_tensor;

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -159,7 +159,7 @@ ttnn::Tensor bound_matmul(
         const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
             output_tensor,
-            {ttnn::operations::unary::EltwiseUnaryWithParam{op_type}},
+            {ttnn::operations::unary::EltwiseUnaryWithParam{op_type, {static_cast<float>(false)}}},
             parameters.output_mem_config,
             optional_output_tensor);
     }


### PR DESCRIPTION
### Problem description
With https://github.com/tenstorrent/tt-metal/commit/8cd5ef11ba50187dc45874e90c98b43c5b9b0213, matmul activations were changed to invoke the underlying unary op activation instead of manually specifying a `ttnn::[activation]` call.

For GELU, the default that got called in this new case was the non-approx version, while certain models were relying on an accurate GELU.

### What's changed
Changed the unfused activation implementation to force a non-approx argument upon GELU.

We may be able to revisit this, cleaning out this hardcoding and adding approx + non approx support after the [PR](https://github.com/tenstorrent/tt-metal/pull/29322) adding gelu_approx is merged.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18346074552)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18346042358)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18347584813) 
- [x] Frequent Models/TTNN tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18346025296)
