### PR TITLE
#0: [skip ci] Fix test report upload path in models-post-commit.yaml

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -76,5 +76,4 @@ jobs:
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
-          path: generated/test_reports/
           prefix: "test_reports_"


### PR DESCRIPTION
### Ticket
None

### Problem description
@arshahTT noticed APC model tests didn't have test case info in superset
Workflow is looking for test reports in the wrong path

### What's changed
Fix path to test reports (use [default](https://github.com/tenstorrent/tt-metal/blob/main/.github/actions/upload-artifact-with-job-uuid/action.yml#L8))

### Checklist
- [ ] New/Existing tests provide coverage for changes