### PR TITLE
BHPC: [skip ci] Set label for scheduled P100 nightly runs

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -77,8 +77,8 @@ jobs:
           # Check if this is a scheduled P100-only run at 7:00 UTC (daily)
           if [[ "${{ github.event_name }}" = "schedule" && "${{ github.event.schedule }}" = "0 7 * * *" ]]; then
             matrix='["P100"]'
-            civ2_matrix='["P100"]'
-            civ2_viommu_matrix='["P100"]'
+            civ2_matrix='["P100a"]'
+            civ2_viommu_matrix='["P100a-viommu"]'
           elif [ "${{ inputs.enable-llmbox-tests }}" = "true" ]; then
             if [[ "$runner_label" != *"BH-LLMBox"* ]]; then
               echo "::warning::LLMBox tests are enabled but runner-label does not contain BH-LLMBox. Current value: $runner_label"


### PR DESCRIPTION
### What's changed
Update the P100 label for scheduled nightly runs

### Checklist
- [ ] Blackhole Post commit CI run: https://github.com/tenstorrent/tt-metal/actions/runs/18348965016