### PR TITLE
Push device performance data to Superset

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -355,6 +355,20 @@ jobs:
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME CHECK
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
+      - name: Save environment data
+        if: ${{ !cancelled() }}
+        run: python3 /work/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+
+      - name: Upload benchmark data
+        if: ${{ !cancelled() }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
+
       - name: Check device perf report exists
         id: check-device-perf-report
         if: ${{ !cancelled() }}

--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -138,7 +138,7 @@ class BenchmarkData:
         profiler_name: str = None,
         input_sequence_length: int = None,
         output_sequence_length: int = None,
-        image_dimension: int = None,
+        image_dimension: str = None,
         perf_analysis: bool = None,
         training: bool = None,
     ):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28129

### Problem description
Currently, we are not recording device performance data in Superset. We want to see device performance on main over time for all models.

### What's changed
- `prep_device_perf_report()` saves a pickled PartialBenchmark dataclass alongside the current CSV file with the same device performance data.
- "Save environment data" and "Upload benchmark data" steps are added to `perf-device-models` CI workflow.

The changes prioritize keeping the signatures and usage of functions in `models/perf/device_perf_utils.py` intact. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
  All relevant steps, including the newly introduced ones pass. The jobs that failed did so on performance checks. 
  - https://github.com/tenstorrent/tt-metal/actions/runs/18561256802/