### PR TITLE
#29640: Improve sigmoid_accurate accuracy using exp21f

### DIFF
--- a/models/experimental/efficientnetb0/tt/efficientnetb0.py
+++ b/models/experimental/efficientnetb0/tt/efficientnetb0.py
@@ -215,9 +215,9 @@ class MBConvBlock:
     def __call__(self, x):
         if not self.is_depthwise_first:
             x = self._expand_conv(x)
-            x = x * ttnn.sigmoid_accurate(x)
+            x = x * ttnn.sigmoid_accurate(x, True)
         x = self._depthwise_conv(x)
-        x = x * ttnn.sigmoid_accurate(x)
+        x = x * ttnn.sigmoid_accurate(x, True)
         mul1 = x
 
         if x.is_sharded():
@@ -228,10 +228,10 @@ class MBConvBlock:
 
         x = self._se_reduce(x)
 
-        x = x * ttnn.sigmoid_accurate(x)
+        x = x * ttnn.sigmoid_accurate(x, True)
         x = self._se_expand(x)
 
-        x = ttnn.sigmoid_accurate(x)
+        x = ttnn.sigmoid_accurate(x, True)
         mul1_interleaved = mul1
         if mul1.is_sharded():
             mul1_interleaved = ttnn.sharded_to_interleaved(mul1, ttnn.L1_MEMORY_CONFIG)
@@ -475,7 +475,7 @@ class Efficientnetb0:
 
         x = self._conv_head(x)
 
-        x = x * ttnn.sigmoid_accurate(x)
+        x = x * ttnn.sigmoid_accurate(x, True)
 
         x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
         x = ttnn.global_avg_pool2d(x)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def test_sigmoid_accurate_arange(device):
+    # Generate all possible bit patterns for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # Mask NaN
+    mask = torch.isnan(input_tensor)
+    input_tensor[mask] = 1.0
+
+    # Exp Working range - Overflow from 88.5(inf), Underflow till -87(<0)
+    low = -87.0
+    high = 88.5
+    # masking to working range
+    mask = (input_tensor >= low) & (input_tensor <= high)
+    input_tensor = input_tensor[mask]
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.sigmoid_accurate)
+    golden = golden_function(input_tensor, device=device)
+    tt_result = ttnn.sigmoid_accurate(tt_in, approximate_mode=False)
+    result = ttnn.to_torch(tt_result)
+    assert_with_ulp(golden, result, 3, allow_nonfinite=True)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
@@ -34,6 +34,6 @@ def test_sigmoid_accurate_arange(device):
 
     golden_function = ttnn.get_golden_function(ttnn.sigmoid_accurate)
     golden = golden_function(input_tensor, device=device)
-    tt_result = ttnn.sigmoid_accurate(tt_in, approximate_mode=False)
+    tt_result = ttnn.sigmoid_accurate(tt_in, fast_and_approximate_mode=False)
     result = ttnn.to_torch(tt_result)
     assert_with_ulp(golden, result, 3, allow_nonfinite=True)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -240,13 +240,13 @@ template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::FILL>::inv
 
 Tensor Sigmoid_accurate::invoke(
     const Tensor& input,
-    bool approximate_mode,
+    bool fast_and_approximate_mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
         input,
         {UnaryWithParam(UnaryOpType::NEG),
-         UnaryWithParam(UnaryOpType::EXP, approximate_mode ? 1.0f : 0.0f),
+         UnaryWithParam(UnaryOpType::EXP, fast_and_approximate_mode ? 1.0f : 0.0f),
          UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
          UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -240,12 +240,13 @@ template Tensor ExecuteUnaryWithVariantFloatIntParameter<UnaryOpType::FILL>::inv
 
 Tensor Sigmoid_accurate::invoke(
     const Tensor& input,
+    bool approximate_mode,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
         input,
         {UnaryWithParam(UnaryOpType::NEG),
-         UnaryWithParam(UnaryOpType::EXP, 1.0f),
+         UnaryWithParam(UnaryOpType::EXP, approximate_mode ? 1.0f : 0.0f),
          UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
          UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -78,6 +78,7 @@ struct LogSigmoid {
 struct Sigmoid_accurate {
     static Tensor invoke(
         const Tensor& input,
+        bool approximate_mode = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -78,7 +78,7 @@ struct LogSigmoid {
 struct Sigmoid_accurate {
     static Tensor invoke(
         const Tensor& input,
-        bool approximate_mode = false,
+        bool fast_and_approximate_mode = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1078,7 +1078,7 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            approximate_mode (bool, optional): Enables accurate version of exponential operation. Defaults to `False`.
+            fast_and_approximate_mode (bool, optional): Enables accurate version of exponential operation. Defaults to `False`.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
@@ -1118,13 +1118,13 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
-               bool approximate_mode,
+               bool fast_and_approximate_mode,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
-                return self(input_tensor, approximate_mode, memory_config, output_tensor);
+                return self(input_tensor, fast_and_approximate_mode, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
-            py::arg("approximate_mode") = false,
+            py::arg("fast_and_approximate_mode") = false,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1078,7 +1078,7 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            fast_and_approximate_mode (bool, optional): Enables accurate version of exponential operation. Defaults to `False`.
+            fast_and_approximate_mode (bool, optional): Enables fast and approximate mode for exponential operation. When False, uses the accurate version of exponential algorithm. Defaults to `False`.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
@@ -1106,7 +1106,7 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
             >>> output = {1}(tensor)
 
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> output = {1}(tensor, False)
+            >>> output = {1}(tensor, fast_and_approximate_mode = False)
         )doc",
         ttnn::sigmoid_accurate.base_name(),
         ttnn::sigmoid_accurate.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1069,8 +1069,8 @@ void bind_tanh_like(py::module& module, const unary_operation_t& operation) {
 
 template <typename unary_operation_t>
 void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operation) {
-                        auto doc = fmt::format(
-                            R"doc(
+    auto doc = fmt::format(
+        R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::
@@ -1078,6 +1078,7 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
+            approximate_mode (bool, optional): Enables accurate version of exponential operation. Defaults to `False`.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
@@ -1103,25 +1104,30 @@ void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operatio
         Example:
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor)
-        )doc",
-                            ttnn::sigmoid_accurate.base_name(),
-                            ttnn::sigmoid_accurate.python_fully_qualified_name());
 
-                        bind_registered_operation(
-                            module,
-                            ttnn::sigmoid_accurate,
-                            doc,
-                            ttnn::pybind_overload_t{
-                                [](const unary_operation_t& self,
-                                   const Tensor& input_tensor,
-                                   const std::optional<MemoryConfig>& memory_config,
-                                   const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
-                                    return self(input_tensor, memory_config, output_tensor);
-                                },
-                                py::arg("input_tensor"),
-                                py::kw_only(),
-                                py::arg("memory_config") = std::nullopt,
-                                py::arg("output_tensor") = std::nullopt});
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor, False)
+        )doc",
+        ttnn::sigmoid_accurate.base_name(),
+        ttnn::sigmoid_accurate.python_fully_qualified_name());
+
+    bind_registered_operation(
+        module,
+        ttnn::sigmoid_accurate,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const Tensor& input_tensor,
+               bool approximate_mode,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, approximate_mode, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("approximate_mode") = false,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
 }
 
 template <typename unary_operation_t>


### PR DESCRIPTION
### Ticket
[#29640](https://github.com/tenstorrent/tt-metal/issues/29640)

### Problem description
Improving accuracy of `sigmoid_accurate` using improved version of exp(21f algorithm)[[PR](https://github.com/tenstorrent/tt-metal/pull/28486)]. But this caused `efficientnetb0` to be [fail](https://github.com/tenstorrent/tt-metal/actions/runs/18026122548) on Device perf regressions CI.

### What's changed
Introducing `approximate_mode` parameter to sigmoid_accurate. Default is set to `false` (approximate_mode is set to `true` in the failing test file)

- Added test for this as well
- Device perf results : [link](https://github.com/tenstorrent/tt-metal/actions/runs/18381002452) - PASSED

<img width="864" height="674" alt="Screenshot 2025-10-15 at 7 35 02 AM" src="https://github.com/user-attachments/assets/66f6a4f0-851d-446a-9e8d-018de1251ff6" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18393963923) 
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/18393974366)
- [x] [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/18393976956)
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18393982857)
- [ ] [(APC) Select and Run Post-Commit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/18393981274) - Passes as in main
- [ ] [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/18393979980) - Test passes as in main except for [t3000-model-perf-tests / t3k LLM falcon40b model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/18393979980/job/52587437440#logs) - Checked with model owner and perf targets will be updated on merge
- [x] New/Existing tests provide coverage for changes