### PR TITLE
Use TT_ASSERT instead of assert in runtime args validation

### DIFF
--- a/tt_metal/api/tt-metalium/runtime_args_data.hpp
+++ b/tt_metal/api/tt-metalium/runtime_args_data.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <utility>
 
-#include <ttsl/assert.hpp>
+#include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal {
 // RuntimeArgsData provides an indirection to the runtime args

--- a/tt_metal/api/tt-metalium/runtime_args_data.hpp
+++ b/tt_metal/api/tt-metalium/runtime_args_data.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <utility>
 
-#include <tt-metalium/assert.hpp>
+#include <ttsl/assert.hpp>
 
 namespace tt::tt_metal {
 // RuntimeArgsData provides an indirection to the runtime args

--- a/tt_metal/api/tt-metalium/runtime_args_data.hpp
+++ b/tt_metal/api/tt-metalium/runtime_args_data.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <utility>
 
+#include <tt-metalium/assert.hpp>
+
 namespace tt::tt_metal {
 // RuntimeArgsData provides an indirection to the runtime args
 // Prior to generating the cq cmds for the device, this points into a vector within the kernel

--- a/tt_metal/api/tt-metalium/runtime_args_data.hpp
+++ b/tt_metal/api/tt-metalium/runtime_args_data.hpp
@@ -31,12 +31,12 @@ struct RuntimeArgsData {
     }
 
     std::uint32_t& operator[](std::size_t index) noexcept {
-        assert(in_bounds(index));
+        TT_ASSERT(in_bounds(index));
         return this->rt_args_data[index];
     }
 
     const std::uint32_t& operator[](std::size_t index) const noexcept {
-        assert(in_bounds(index));
+        TT_ASSERT(in_bounds(index));
         return this->rt_args_data[index];
     }
 


### PR DESCRIPTION

### Ticket
Link to Github Issue

### Problem description
Currently we use a regular assert when accessing an incorrect index into runtime args. In a python model, this only outputs an error message and can be hard to debug.

### What's changed
TT_ASSERT throws a runtime error with a backtrace, which can help when debugging the cause of the assertion, so use it instead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes