### PR TITLE
Fix all gather blackhole bug

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -142,6 +142,7 @@ bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const 
     auto input_tensor_memory_config = input_tensor.memory_config();
     bool input_is_sharded = input_tensor_memory_config.shard_spec().has_value();
     bool output_is_sharded = output_mem_config.shard_spec().has_value();
+    bool input_is_tile = input_tensor.layout() == ttnn::Layout::TILE;
 
     log_trace(tt::LogOp, "[select_version] input_tensor_shape: {}", input_tensor_shape);
     log_trace(tt::LogOp, "[select_version] input_tensor_memory_config: {}", input_tensor_memory_config);
@@ -151,7 +152,7 @@ bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const 
     log_trace(tt::LogOp, "[select_version] output_is_sharded: {}", output_is_sharded);
 
     // Check for minimal sharded case
-    if (input_is_sharded && output_is_sharded) {
+    if (input_is_sharded && output_is_sharded && input_is_tile) {
         uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec()->grid.num_cores();
         uint32_t output_shard_num_cores = output_mem_config.shard_spec()->grid.num_cores();
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/30167

### Problem description
All gather can cause using more cores than are available in Blackhole

### What's changed
The problem is using the llama version of all gather which does not work for Row Major tensors
Fix the all gather path to pick the minimal version instead

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18408422010
- [x] Blackhole multi card unit tests https://github.com/tenstorrent/tt-metal/actions/runs/18408434668
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes