### PR TITLE
#29407: Add subset of tests to run on BH nightly

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -4,6 +4,32 @@ name: "(Blackhole) Blackhole nightly tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_bh_single_card_nightly_demos:
+        description: 'Run Blackhole single card nightly demo tests'
+        required: false
+        type: boolean
+        default: false
+      run_bh_multi_card_nightly_demo_tests:
+        description: 'Run Blackhole multi card nightly demo tests'
+        required: false
+        type: boolean
+        default: false
+      run_bh_nightly_20_cores:
+        description: 'Run Blackhole nightly 20 cores tests'
+        required: false
+        type: boolean
+        default: false
+      run_bh_multi_card_nightly_unit_tests:
+        description: 'Run Blackhole multi card nightly unit tests'
+        required: false
+        type: boolean
+        default: false
+      run_bh_multi_card_nightly_ttnn_stress_tests:
+        description: 'Run Blackhole multi card nightly ttnn stress tests'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
   schedule:
     - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC
@@ -27,6 +53,7 @@ jobs:
       tracy: true
       version: 22.04
   bh-nightly:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_single_card_nightly_demos }}
     needs: build-artifact
     uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
     strategy:
@@ -40,6 +67,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   bh-nightly-20-cores:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_nightly_20_cores }}
     needs: build-artifact
     uses: ./.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
     strategy:
@@ -53,6 +81,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   blackhole-multi-card-demo-tests:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_demo_tests }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -84,6 +113,7 @@ jobs:
       extra-tag: ${{ matrix.test-group.extra-tag }}
       num_devices: ${{ matrix.test-group.num_devices }}
   blackhole-multi-card-unit-tests:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_unit_tests }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -93,6 +123,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   blackhole-multi-card-ttnn-stress-tests:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_ttnn_stress_tests }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/ttnn-stress-tests-impl.yaml


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/29407

### Problem description
BH nightly runs a lot of tests now, but sometimes devs want to only run a specific set of them instead of all.

### What's changed
Add options similar to metal L2 nightly

### Checklist
- [ ] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/18355655565