### PR TITLE
[skip ci] Increase timeout of falcon_causallm to unblock

### DIFF
--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -74,7 +74,7 @@ def test_falcon_causal_lm(
         shard_dim = 0
 
     # This is way too long... but hopefully after github-ci-infra#1016 we can try lowering this again
-    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True, ci_v2_timeout_in_s=1200)
+    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
 
     configuration = transformers.FalconConfig.from_pretrained(model_location_or_version)
     configuration.num_hidden_layers = num_layers


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/30247

### Problem description
Run-profiler-regression is failing on APC
https://github.com/tenstorrent/tt-metal/actions/runs/18353438459/job/52279995528#step:5:571

### What's changed
Increase timeout of falcon_causallm to unblock temporarily

### Checklist
- [ ] All post commit CI run: https://github.com/tenstorrent/tt-metal/actions/runs/18359140918