### PR TITLE
AI fixed noc alignment in where kernel.

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/kernels/dataflow/elemwise_reader_kernel.cpp
@@ -14,8 +14,8 @@ void kernel_main() {
     constexpr auto c_args = make_compile_time_struct_from_args<CompileTimeReaderKernelArgs>();
 
     constexpr auto condition_args = TensorAccessorArgs<3>();
-    constexpr auto true_args = TensorAccessorArgs<condition_args.next_compile_time_args_offset()>();
-    constexpr auto false_args = TensorAccessorArgs<true_args.next_compile_time_args_offset()>();
+    constexpr auto true_args = TensorAccessorArgs<4>();
+    constexpr auto false_args = TensorAccessorArgs<5>();
 
     const auto condition_tensor =
         TensorAccessor(condition_args, args.condition_tensor_base_addr, get_tile_size(c_args.condition_cb));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27392?reload=1?reload=1)

### Problem description
TT-sim caught noc alignment issue on where op.

### What's changed
Fix the compile time arg index.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
