### PR TITLE
Fix `self.model_name is '.'` bug

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1550,7 +1550,7 @@ class ModelArgs:
             self.multiple_of = text_config["multiple_of"]
             self.hidden_dim = calculate_hidden_dim(self.dim, self.ffn_dim_multiplier, self.multiple_of)
 
-        if "_name_or_path" in config:
+        if "_name_or_path" in config and config["_name_or_path"]:
             if is_hf:
                 normalized_path = os.path.normpath(config["_name_or_path"])
                 # For HF paths, they might end with `<model_name>/snapshots/<snapshot_id>/`


### PR DESCRIPTION
### Ticket
#30224

### Problem description
Quote from issue:
> Recent runs (e.g. https://github.com/tenstorrent/tt-metal/actions/runs/18329742023/job/52202847774#step:14:172) are failing with AssertionError: The model specified in vLLM (Qwen/Qwen2.5-VL-72B-Instruct) does not match the model name (.) with model weights (Qwen/Qwen2.5-VL-72B-Instruct).

The root cause of this is mismatched `transformers` version -- tt-metal depends on 4.53.0 while vLLM is rocking 4.57.0 now and Qwen2.5-VL configuration in 4.57.0 added a key value pair `{"_name_or_path": ""}`. Though essentially meaning the same thing as 4.53.0 (where there is no key "_name_or_path"), this added key-value pair sends `model_config.py` down an unwanted execution path, which ends up overwriting `model_name` with empty string that normalized to ".".

### What's changed
We can solve this problem with a simple conditional check on the value of `config["_name_or_path"]` to treat an empty string the same way as absent key.

### Checklist
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
  - https://github.com/tenstorrent/tt-metal/actions/runs/18359583525 --> failures unrelated to this PR
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
  - https://github.com/tenstorrent/tt-metal/actions/runs/18359610835  --> failures unrelated to this PR