### PR TITLE
Add APC T3K tests

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -25,7 +25,7 @@ jobs:
         test-group: [
           { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 15, owner_id: UJ45FEC7M}, # Allan Liu
           { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 5, owner_id: U013121KDH9}, #Austin Ho
-          { name: "t3k ttnn ccl tests", arch: wormhole_b0, cmd: run_t3000_ccl_tests, timeout: 5, owner_id: U06LRK6JDGB}, #Saad Jameel
+          { name: "t3k ttnn ccl tests", arch: wormhole_b0, cmd: run_t3000_ccl_tests, timeout: 7, owner_id: U06LRK6JDGB}, #Saad Jameel
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -66,7 +66,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 16
+        timeout-minutes: 17
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -66,7 +66,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
+        timeout-minutes: 16
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -25,6 +25,7 @@ jobs:
         test-group: [
           { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 15, owner_id: UJ45FEC7M}, # Allan Liu
           { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 5, owner_id: U013121KDH9}, #Austin Ho
+          { name: "t3k ttnn ccl tests", arch: wormhole_b0, cmd: run_t3000_ccl_tests, timeout: 5, owner_id: U06LRK6JDGB}, #Saad Jameel
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/tests/nightly/t3000/ccl/test_all_reduce.py
+++ b/tests/nightly/t3000/ccl/test_all_reduce.py
@@ -35,6 +35,19 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import run_all_r
         ([1, 4, 1024, 32]),
         ([2, 4, 2048, 32]),
     ],
+    ids=[
+        "1x1x32x4096",
+        "1x1x32x8192",
+        "1x1x32x1024",
+        "1x1x32x2048",
+        "1x1x4096x32",
+        "1x1x1024x32",
+        "1x1x2048x32",
+        "4x1x32x4096",
+        "8x1x32x1024",
+        "1x4x1024x32",
+        "2x4x2048x32",
+    ],
 )
 @pytest.mark.parametrize(
     "layout",
@@ -48,12 +61,20 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import run_all_r
         ttnn.bfloat16,
         ttnn.bfloat8_b,
     ],
+    ids=[
+        "bfloat16",
+        "bfloat8_b",
+    ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+    ids=[
+        "DRAM",
+        "L1",
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -608,6 +608,11 @@ def test_all_gather_async_sharded_to_sharded(
             ttnn.BufferType.L1,
         ),
     ],
+    ids=[
+        "i2s_shape0",
+        "i2s_shape1",
+        "i2s_shape2",
+    ],
 )
 @pytest.mark.parametrize(
     "enable_trace,num_iters",
@@ -702,6 +707,11 @@ def test_all_gather_async_sharded_to_interleaved(
             ttnn.BufferType.L1,
         ),
     ],
+    ids=[
+        "i2s_shape0",
+        "i2s_shape1",
+        "i2s_shape2",
+    ],
 )
 @pytest.mark.parametrize(
     "enable_trace,num_iters",
@@ -770,7 +780,7 @@ def test_all_gather_async_interleaved_to_sharded(
         ([1, 1, 8, 4096], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
     ids=[
-        "tt_training_test_one",
+        "multiprocess",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -533,7 +533,7 @@ run_t3000_ccl_tests() {
   # composite case
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_training_shapes[wormhole_b0-fabric_linear-random-check-mem_config_input0-mem_config_rs0-tt_training_test_one-mesh_device0-1link]
   # long trace test on dim=1 with ring, currently hanging when run in the suite even though it passes when run in isolation
-  # pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-random-perf-mem_config_input0-mem_config_rs0-scatter_dim_1_test_one-1link-mesh_device0]|
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-random-perf-mem_config_input0-mem_config_rs0-scatter_dim_1_test_one-1link-mesh_device0]
   # long running dim = 3 trace test without barrier and with persistent buffers
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-fabric_ring-no_barrier_with_persistent_buffers-random-perf-mem_config_input0-mem_config_rs0-padded_dim_2_test_one-1link-mesh_device0]
 

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -522,7 +522,7 @@ run_t3000_ccl_tests() {
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_sharded_to_interleaved[wormhole_b0-fabric_linear-check-i2s_shape0-1-layout0-ag_input_dtype0-mesh_device0]
   # 10 iteration trace test with fabric ring
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-perf-mem_config_input0-mem_config_ag0-dit_shape-1link-mesh_device0]
-  # 2D fabric case – not working on main??
+  # 2D fabric case – hanging on main? tracking with issue #30250
   # pytest -n auto tests/nightly/t3000/2d_ccl/test_minimal_all_gather_async.py::test_all_gather_async_training_shapes[wormhole_b0-fabric_2d_dynamic_linear-check-mem_config_input0-mem_config_ag0-tt_training_test_one-mesh_device0-1link]
   # training shapes
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_training_shapes[wormhole_b0-fabric_linear-check-mem_config_input0-mem_config_ag0-tt_training_test_four-mesh_device0-1link]

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -510,6 +510,65 @@ run_t3000_qwen25_vl_unit_tests() {
   echo "LOG_METAL: Unit tests for $qwen25_vl_72b on T3K completed in $duration seconds"
 }
 
+run_t3000_ccl_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_ccl_tests"
+
+  # all gather: 1 ring, 1 line, 1 2d, 1 sharded should be covered
+  # width sharded to interleaved case using linear
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_sharded_to_interleaved[wormhole_b0-fabric_linear-check-i2s_shape0-1-layout0-ag_input_dtype0-mesh_device0]
+  # 10 iteration trace test with fabric ring
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-perf-mem_config_input0-mem_config_ag0-dit_shape-1link-mesh_device0]
+  # 2D fabric case – not working on main??
+  # pytest -n auto tests/nightly/t3000/2d_ccl/test_minimal_all_gather_async.py::test_all_gather_async_training_shapes[wormhole_b0-fabric_2d_dynamic_linear-check-mem_config_input0-mem_config_ag0-tt_training_test_one-mesh_device0-1link]
+  # training shapes
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_training_shapes[wormhole_b0-fabric_linear-check-mem_config_input0-mem_config_ag0-tt_training_test_four-mesh_device0-1link]
+
+  # reduce scatter: 1 ring, 1 line, 1 2d, 1 sharded should be covered
+  # sharded intermediate case with cluster axis 1
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_minimal_async_linear_sharded
+  # composite case
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_training_shapes[wormhole_b0-fabric_linear-random-check-mem_config_input0-mem_config_rs0-tt_training_test_one-mesh_device0-1link]
+  # long trace test on dim=1 with ring, currently hanging when run in the suite even though it passes when run in isolation
+  # pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-random-perf-mem_config_input0-mem_config_rs0-scatter_dim_1_test_one-1link-mesh_device0]|
+  # long running dim = 3 trace test without barrier and with persistent buffers
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-fabric_ring-no_barrier_with_persistent_buffers-random-perf-mem_config_input0-mem_config_rs0-padded_dim_2_test_one-1link-mesh_device0]
+
+  # all reduce: 1 test should be enough
+  # 4 chip test with bfloat8_b
+  pytest -n auto tests/nightly/t3000/ccl/test_all_reduce.py::test_ring_all_reduce_post_commit[wormhole_b0-True-device_params0-math_op0-DRAM-bfloat8_b-layout0-2x4x2048x32-4-1]
+
+  # p2p: 1 test should be enough
+  # trace test with device delay
+  pytest -n auto tests/ttnn/unit_tests/operations/point_to_point/test_point_to_point.py::test_point_to_point_with_device_delay -k tile
+
+  # all broadcast: row major + tile test
+  # both rm and tile test are called here
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py::test_all_broadcast_trace
+
+  # all to all dispatch: 1 test for 2d and 1 for 1d linear should be enough
+  # fabric 1d linear test on cluster axis 0 as other CCL tests aren't testing on this axis
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py::test_all_to_all_dispatch_trace[silicon_arch_name=wormhole_b0-dtype=DataType.BFLOAT16-num_links=MAX_LINKS-dram-dram-s128-hidden_size=7168-select_experts_k=8-experts_per_device=8-batches_per_device=8-cluster_axis_0-2x4_grid-trace_mode=True-fabric_1d_linear]
+  # fabric 2d test on cluster axis 1
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py::test_all_to_all_dispatch_no_trace[silicon_arch_name=wormhole_b0-dram_output-dram_input-dtype=DataType.BFLOAT16-num_links=MAX_LINKS-b1s3-hidden_size=7168-select_experts_k=8-experts_per_device=8-cluster_col-2x4_grid-trace_mode=False-fabric_2d]
+
+  # all to all combine: 1 test for 1d ring and 1 for 2d should be enough
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py::test_all_to_all_combine_no_trace[silicon_arch_name=wormhole_b0-dtype=DataType.BFLOAT16-topology=None-dram-dram-num_iters=2-scheme=random-local_reduce=True-seq=2-hidden_size=7000-select_experts_k=8-experts_per_device=8-batches_per_device=8-fabric_1d_ring_axis_1]
+  # fabric 2d test on cluster axis 0
+  pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_t3000.py::test_all_to_all_combine_no_trace[silicon_arch_name=wormhole_b0-dtype=DataType.BFLOAT16-topology=None-dram-dram-num_iters=2-scheme=random-local_reduce=True-seq=2-hidden_size=7000-select_experts_k=8-experts_per_device=8-batches_per_device=8-fabric_2d_axis_0]
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_ccl_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_tests() {
   # Run ttmetal tests
   run_t3000_ttmetal_tests

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_t3000.py
@@ -525,6 +525,7 @@ def run_all_to_all_dispatch_test(
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_2D},
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
     ],
+    ids=["fabric_2d", "fabric_1d_linear"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [False])
@@ -545,8 +546,12 @@ def run_all_to_all_dispatch_test(
 )
 @pytest.mark.parametrize("num_links", ["MAX_LINKS"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
-@pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
+@pytest.mark.parametrize(
+    "input_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram_input", "l1_input"]
+)
+@pytest.mark.parametrize(
+    "output_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram_output", "l1_output"]
+)
 def test_all_to_all_dispatch_no_trace(
     mesh_device,
     trace_mode,
@@ -610,13 +615,14 @@ def test_all_to_all_dispatch_no_trace(
             "trace_region_size": 500000,
         },
     ],
+    ids=["fabric_2d", "fabric_1d_linear"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]
 )
-@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("cluster_axis", [0, 1], ids=["cluster_axis_0", "cluster_axis_1"])
 @pytest.mark.parametrize("batches_per_device", [8])
 @pytest.mark.parametrize("experts_per_device", [8])
 @pytest.mark.parametrize("select_experts_k", [8])

--- a/tests/ttnn/unit_tests/operations/point_to_point/test_point_to_point.py
+++ b/tests/ttnn/unit_tests/operations/point_to_point/test_point_to_point.py
@@ -113,7 +113,7 @@ def test_point_to_point(mesh_device, shape_coords, layout, dtype):
     "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 500000}], indirect=True
 )
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
-@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["row_major", "tile"])
 @pytest.mark.parametrize("shape_coords", [((1, 1, 1, 16), ((0, 0), (0, 1)))])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_point_to_point_with_device_delay(mesh_device, shape_coords, layout, dtype):


### PR DESCRIPTION
### Ticket
#30051 

### Problem description
We don't have CCL tests in APC, causing repeated regressions.

### What's changed
Add select CCL tests to APC. The total test time is approximately 4.5-5.25 mins but I made the timeout 7 mins just in case.

### Checklist
- [ ] APC: https://github.com/tenstorrent/tt-metal/actions/runs/18360125944
- [ ] T3K frequent: https://github.com/tenstorrent/tt-metal/actions/runs/18360129636
- [ ] T3K nightly: https://github.com/tenstorrent/tt-metal/actions/runs/18360131347