### PR TITLE
Add all_to_all_async_generic implementation

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -17,6 +17,7 @@ from models.demos.deepseek_v3.tt.rms_norm.rms_norm import RMSNorm
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
 from models.demos.deepseek_v3.utils.config_dataclass import (
     AllGatherAsyncConfig,
+    AllToAllAsyncGenericConfig,
     FromWeightConfig,
     LinearConfig,
     MeshDeviceStub,
@@ -543,16 +544,10 @@ class MLA1D(AbstractModule):
         )
 
         # Q all-to-all
-        wq_a2a_ag_config = AllGatherAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        wq_a2a_config = AllToAllAsyncGenericConfig(
             cluster_axis=1,
-            dim=1,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
-        )
-        wq_a2a_rs_config = ReduceScatterAsyncMinimalConfig(
-            cluster_axis=1,
-            dim=1,
+            in_dim=2,
+            out_dim=1,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -583,16 +578,10 @@ class MLA1D(AbstractModule):
         )
 
         # FlashMLA all-to-all
-        flash_mla_ag_config = AllGatherAsyncConfig(
-            mesh_device=MeshDeviceStub(mesh_shape),
+        flash_mla_a2a_config = AllToAllAsyncGenericConfig(
             cluster_axis=1,
-            dim=1,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=ttnn.Topology.Linear,
-        )
-        flash_mla_rs_config = ReduceScatterAsyncMinimalConfig(
-            cluster_axis=1,
-            dim=1,
+            in_dim=1,
+            out_dim=2,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             topology=ttnn.Topology.Linear,
         )
@@ -632,13 +621,11 @@ class MLA1D(AbstractModule):
             "kv_norm": kv_norm_config,
             "wq_a_rs_decode": wq_a_rs_config,
             "wq_a_ag_decode": wq_a_ag_config,
-            "wq_a2a_ag_decode": wq_a2a_ag_config,
-            "wq_a2a_rs_decode": wq_a2a_rs_config,
+            "wq_a2a_decode": wq_a2a_config,
             "wkv_a_ag_decode": wkv_a_ag_config,
             "wkv_a_r_decode": wkv_a_r_config,
             "wkv_a_rs_decode": wkv_a_rs_config,
-            "flash_mla_ag_decode": flash_mla_ag_config,
-            "flash_mla_rs_decode": flash_mla_rs_config,
+            "flash_mla_a2a_decode": flash_mla_a2a_config,
             "wo_ag_decode": wo_ag_config,
             "mesh_device": mesh_device,
         }
@@ -834,19 +821,7 @@ class MLA1D(AbstractModule):
         # Q ready for FlashMLA
         tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
 
-        # FIXME: All-to-All here!! (tt_q)
-        # The following code does the following:
-        # [1, bsz, num_heads_local, kv_lora_rank + qk_rope_head_dim] -> [1, bsz_local, num_heads, kv_lora_rank + qk_rope_head_dim]
-        # Using the following algorithm: 1. AG on in_dim, 2. Scale by number of devices, 3. RS on out_dim
-        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, num_heads_local, bsz_local, kv_lora_rank + qk_rope_head_dim]
-        tt_q = ttnn.experimental.all_gather_async(
-            tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a2a_ag_decode"])
-        )  # [1, num_heads, bsz_local, kv_lora_rank + qk_rope_head_dim]
-        tt_q = ttnn.permute(tt_q, (0, 2, 1, 3))  # [1, bsz_local, num_heads, kv_lora_rank + qk_rope_head_dim]
-        tt_q = ttnn.experimental.reduce_scatter_minimal_async(
-            tt_q, **ccl.populate_reduce_scatter_runtime_args(cfg["wq_a2a_rs_decode"])
-        )
-        tt_q = tt_q * scale  # Scale the input tensor
+        tt_q = ttnn.experimental.all_to_all_async_generic(tt_q, **cfg["wq_a2a_decode"])
 
         # KVPE Stuff
         tt_kv = ttnn.linear(x, **cfg["wkv_a"])
@@ -917,17 +892,7 @@ class MLA1D(AbstractModule):
         ttnn.deallocate(tt_q)
         attn_out = ttnn.to_memory_config(attn_out, **cfg["flash_mla_out_reshard"])
 
-        # FIXME: All-to-All here!! (attn_out)
-        # TODO: add deallocation of intermediate tensors
-        attn_out = ttnn.experimental.all_gather_async(
-            attn_out, **ccl.populate_all_gather_runtime_args(cfg["flash_mla_ag_decode"])
-        )  # [1, bsz, num_heads, kv_lora_rank]
-        attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, num_heads, bsz, kv_lora_rank]
-        attn_out = ttnn.experimental.reduce_scatter_minimal_async(
-            attn_out, **ccl.populate_reduce_scatter_runtime_args(cfg["flash_mla_rs_decode"])
-        )  # [1, num_heads_local, bsz, kv_lora_rank]
-        attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, bsz, num_heads_local, kv_lora_rank]
-        attn_out = attn_out * scale  # Scale the output tensor
+        attn_out = ttnn.experimental.all_to_all_async_generic(attn_out, **cfg["flash_mla_a2a_decode"])
 
         # wkv_b2
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))  # [1, num_heads_local, bsz, kv_lora_rank]

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -126,6 +126,21 @@ class AllGatherAsyncConfig(OpConfigBase):
 
 
 @dataclass
+class AllToAllAsyncGenericConfig(OpConfigBase):
+    """Common parameters for a ttnn.experimental.all_to_all_async_generic op"""
+
+    in_dim: int | None = None
+    out_dim: int | None = None
+    cluster_axis: int | None = None
+    mesh_device: ttnn._ttnn.multi_device.MeshDevice | None = None
+    topology: ttnn._ttnn.operations.ccl.Topology | None = None
+    persistent_output_tensor: ttnn._ttnn.tensor.Tensor | None = None
+    num_links: int | None = None
+    memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None
+    subdevice_id: ttnn._ttnn.device.SubDeviceId | None = None
+
+
+@dataclass
 class ReduceScatterAsyncMinimalConfig(OpConfigBase):
     """Common parameters for a ttnn.experimental.reduce_scatter_minimal_async op"""
 

--- a/tests/nightly/t3000/ccl/test_all_to_all.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all.py
@@ -288,6 +288,19 @@ def run_all_to_all_impl(
     [
         (
             1,
+            [3, 8, 384, 128],
+            1,
+            2,
+            ttnn.TILE_LAYOUT,
+            ttnn.bfloat16,
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+            2,
+            True,
+            False,
+            False,
+        ),  # Padded, check, no_trace
+        (
+            1,
             [1, 1, 44544, 3072 * 3],
             2,
             3,
@@ -313,7 +326,7 @@ def run_all_to_all_impl(
             False,
         ),  # Post-attn, stress, no_trace
     ],
-    ids=["pre-attn-check-use_trace", "post-attn-stress-no_trace"],
+    ids=["padded", "pre-attn-check-use_trace", "post-attn-stress-no_trace"],
 )
 @pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True

--- a/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+from loguru import logger
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+
+
+def run_with_trace(
+    mesh_device,
+    topology,
+    input_tensor,
+    persistent_output_buffer,
+    in_dim,
+    out_dim,
+    num_links,
+    output_mem_config,
+    num_iter=20,
+    subdevice_id=None,
+    cluster_axis=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_to_all_async_generic(
+        input_tensor,
+        in_dim=in_dim,
+        out_dim=out_dim,
+        persistent_output_buffer=persistent_output_buffer,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=topology,
+        subdevice_id=subdevice_id,
+        cluster_axis=cluster_axis,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_to_all_async_generic(
+            input_tensor,
+            in_dim=in_dim,
+            out_dim=out_dim,
+            persistent_output_buffer=persistent_output_buffer,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=topology,
+            subdevice_id=subdevice_id,
+            cluster_axis=cluster_axis,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_all_to_all_impl(
+    mesh_device,
+    num_devices,
+    logical_shape,
+    in_dim,
+    out_dim,
+    num_links,
+    dtype,
+    layout,
+    topology,
+    num_iters=1,
+    mem_config=None,
+    trace_mode=False,
+    do_check=True,
+    reuse_inputs=False,
+    cluster_axis=None,
+):
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    logger.info(f"Logical shape: {logical_shape}")
+    logger.info(f"in_dim: {in_dim}")
+    logger.info(f"out_dim: {out_dim}")
+
+    ###
+
+    ### Create persistent output buffers
+    logger.info("Creating persistent buffers")
+    output_shape = list(logical_shape)
+    output_shape[out_dim] //= num_devices
+
+    persistent_output_buffers = [
+        ttnn.from_torch(
+            torch.zeros(output_shape),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=dtype,
+            memory_config=mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        for _ in range(num_iters)
+    ]
+
+    logger.info("Done creating persistent buffers")
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters if not reuse_inputs else 1):
+        output_tensor = torch.rand(logical_shape).bfloat16()
+        output_tensor_golden = torch.chunk(output_tensor, num_devices, out_dim)
+
+        if cluster_axis == 0:
+            output_tensor_golden_transposed = []
+            for i in range(len(output_tensor_golden)):
+                col = i // mesh_device.shape[1]
+                row = i % mesh_device.shape[1]
+                index = row * mesh_device.shape[0] + col
+                output_tensor_golden_transposed.append(output_tensor_golden[index])
+            output_tensor_golden = output_tensor_golden_transposed
+
+        output_tensor_goldens_list.append(output_tensor_golden)
+        if cluster_axis == 0:
+            mesh_config = ttnn.MeshMapperConfig(
+                [ttnn.PlacementShard(in_dim), ttnn.PlacementShard(out_dim)], mesh_device.shape
+            )
+        else:
+            mesh_config = ttnn.MeshMapperConfig(
+                [ttnn.PlacementShard(out_dim), ttnn.PlacementShard(in_dim)], mesh_device.shape
+            )
+        input_tensor_mesh = ttnn.from_torch(
+            output_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=dtype,
+            memory_config=mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_config),
+        )
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            topology,
+            input_tensor_mesh_list[0],
+            persistent_output_buffers[0],
+            in_dim,
+            out_dim,
+            num_links,
+            mem_config,
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+            cluster_axis=cluster_axis,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_to_all_async_generic(
+                input_tensor_mesh_list[i if not reuse_inputs else 0],
+                in_dim=in_dim,
+                out_dim=out_dim,
+                num_links=num_links,
+                memory_config=mem_config,
+                topology=topology,
+                subdevice_id=worker_sub_device_id,
+                cluster_axis=cluster_axis,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    if do_check:
+        for tensor_index in range(len(tt_out_tensor_list)):
+            tt_out_tensor = tt_out_tensor_list[tensor_index]
+            output_tensors = output_tensor_goldens_list[tensor_index if not reuse_inputs else 0]
+            tt_output_tensor = ttnn.to_torch(
+                tt_out_tensor, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=out_dim)
+            )
+            output_tensor = torch.cat(output_tensors, dim=out_dim)
+            logger.info(f"Checking output for iteration {tensor_index}")
+            if dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {tensor_index}: {output}")
+                passed = False
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+    if do_check:
+        assert passed, f"FAILED: output mismatch"
+
+
+@pytest.mark.parametrize(
+    "mesh_device, cluster_axis, logical_shape, in_dim, out_dim",
+    [
+        ((1, 8), None, [1, 128, 128, 512], 1, 2),  # test 1-2
+        ((2, 4), 1, [1, 32, 128, 576], 2, 1),  # test 2-1
+        ((2, 4), 1, [3, 1, 256, 768], 2, 3),  # test 2-3
+        ((2, 4), 0, [1, 2, 256, 768], 3, 2),  # test 3-2
+    ],
+    ids=["test1-2:mesh1x8", "test2-1:mesh2x4:1", "test2-3:mesh2x4:1", "test3-2:mesh2x4:0"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
+def test_all_to_all(
+    mesh_device,
+    logical_shape,
+    in_dim,
+    out_dim,
+    function_level_defaults,
+    is_ci_env,
+    cluster_axis,
+):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape,
+        in_dim,
+        out_dim,
+        num_links=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Linear,
+        num_iters=2,
+        mem_config=ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        do_check=True,
+        trace_mode=False,
+        reuse_inputs=False,
+        cluster_axis=cluster_axis,
+    )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -337,6 +337,7 @@ set(CCL_EXPERIMENTAL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/llama_reduce_scatter_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/all_gather_matmul_async_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/matmul_reduce_scatter_async_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -73,6 +73,9 @@ target_sources(
         all_to_all_async/all_to_all_async.cpp
         all_to_all_async/device/all_to_all_program_factory.cpp
         all_to_all_async/device/all_to_all_async_op.cpp
+        all_to_all_async_generic/all_to_all_async_generic.cpp
+        all_to_all_async_generic/device/all_to_all_program_factory.cpp
+        all_to_all_async_generic/device/all_to_all_async_generic_op.cpp
         all_reduce_async/all_reduce_async.cpp
         all_gather_concat_heads_fused/all_gather_concat.cpp
         all_gather_concat_heads_fused/device/all_gather_concat_op.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
@@ -5,6 +5,7 @@
 #include "all_to_all_async.hpp"
 #include <utility>
 #include "ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_op.hpp"
+#include "ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/global_semaphore.hpp"
 
@@ -31,17 +32,35 @@ ttnn::Tensor ExecuteAllToAllAsync::invoke(
             input_tensor, in_dim, out_dim, num_links, memory_config, subdevice_id);
         return persistent_output_buffer;
     } else {
-        return ttnn::operations::experimental::ccl::all_to_all_async(
-            input_tensor,
-            persistent_intermediate_buffer,
-            persistent_output_buffer,
-            in_dim,
-            out_dim,
-            multi_device_global_semaphore,
-            num_links,
-            memory_config,
-            topology,
-            subdevice_id);
+        auto input_shape = input_tensor.logical_shape();
+        auto rank = input_shape.rank();
+        uint32_t num_devices = ttnn::ccl::get_topological_dimension(input_tensor, std::nullopt);
+
+        if (rank == 4 && ((in_dim == 2 && out_dim == 3 && (input_shape[out_dim] / num_devices) % 32 == 0) ||
+                          (in_dim == 3 && out_dim == 2 && input_shape[in_dim] % 32 == 0))) {
+            return ttnn::operations::experimental::ccl::all_to_all_async(
+                input_tensor,
+                persistent_intermediate_buffer,
+                persistent_output_buffer,
+                in_dim,
+                out_dim,
+                multi_device_global_semaphore,
+                num_links,
+                memory_config,
+                topology,
+                subdevice_id);
+        } else {
+            std::optional<ttnn::Tensor> optional_persistent_output_buffer = persistent_output_buffer;
+            return ttnn::operations::experimental::ccl::all_to_all_async_generic(
+                input_tensor,
+                optional_persistent_output_buffer,
+                in_dim,
+                out_dim,
+                num_links,
+                memory_config,
+                topology,
+                subdevice_id);
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_to_all_async_generic.hpp"
+#include <utility>
+#include "ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/global_semaphore.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+ttnn::Tensor ExecuteAllToAllAsyncGeneric::invoke(
+    const ttnn::Tensor& input_tensor,
+    const std::optional<Tensor>& persistent_output_buffer,
+    int32_t in_dim,
+    int32_t out_dim,
+    uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    std::optional<uint32_t> cluster_axis) {
+    return ttnn::operations::experimental::ccl::all_to_all_async_generic(
+        input_tensor,
+        persistent_output_buffer,
+        in_dim,
+        out_dim,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        cluster_axis);
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/global_semaphore.hpp"
+
+namespace ttnn {
+namespace operations::experimental::ccl {
+
+struct ExecuteAllToAllAsyncGeneric {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const std::optional<Tensor>& persistent_output_buffer,
+        int32_t in_dim,
+        int32_t out_dim,
+        uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        std::optional<uint32_t> cluster_axis = std::nullopt);
+};
+
+}  // namespace operations::experimental::ccl
+
+namespace experimental {
+
+constexpr auto all_to_all_async_generic = ttnn::register_operation<
+    "ttnn::experimental::all_to_all_async_generic",
+    ttnn::operations::experimental::ccl::ExecuteAllToAllAsyncGeneric>();
+
+}  // namespace experimental
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_pybind.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_to_all_async_generic_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cpp/ttnn-pybind/decorators.hpp"
+#include "ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/global_semaphore.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+namespace detail {
+
+template <typename ccl_operation_t>
+void bind_all_to_all_async_generic(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t in_dim,
+               const int32_t out_dim,
+               const std::optional<ttnn::Tensor>& persistent_output_buffer,
+               const uint32_t num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::Topology topology,
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+               std::optional<uint32_t> cluster_axis = std::nullopt) -> ttnn::Tensor {
+                return self(
+                    input_tensor,
+                    persistent_output_buffer,
+                    in_dim,
+                    out_dim,
+                    num_links,
+                    memory_config,
+                    topology,
+                    subdevice_id,
+                    cluster_axis);
+            },
+            py::arg("input_tensor"),
+            py::arg("in_dim"),
+            py::arg("out_dim"),
+            py::kw_only(),
+            py::arg("persistent_output_buffer") = std::nullopt,
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring,
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("cluster_axis") = std::nullopt});
+}
+
+}  // namespace detail
+
+void py_bind_all_to_all_async_generic(pybind11::module& module) {
+    detail::bind_all_to_all_async_generic(
+        module,
+        ttnn::experimental::all_to_all_async_generic,
+        R"doc(
+        Performs an asynchronous all-to-all collective communication operation across multiple devices.
+
+        This operation redistributes data between devices by having each device split its input tensor
+        into N chunks (where N is the number of devices) and sending the i-th chunk to device i.
+        The operation uses asynchronous kernels for improved performance.
+
+        Args:
+            input_tensor (ttnn.Tensor): Input tensor to redistribute.
+            in_dim (int): The dimension number to split.
+            out_dim (int): The dimension number to concatenate.
+
+        Keyword Args:
+            persistent_output_buffer (ttnn.Tensor, optional): Buffer where final output will be written.
+            num_links (int, optional): Number of fabric links to use for communication.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for buffers.
+            topology (ttnn.Topology, optional): Network topology to use. Defaults to ttnn.Topology.Ring.
+            subdevice_id (SubDeviceId, optional): Target specific subdevice for the operation.
+            cluster_axis (int, optional): The axis along which to cluster the communication.
+
+        Returns:
+            ttnn.Tensor: Output tensor containing redistributed data.
+
+        Example:
+            >>> # Redistribute data from dim 2 to dim 3 across 4 devices
+            >>> output_buf = ttnn.zeros_like(input_tensor)       # Output buffer
+            >>> result = ttnn.experimental.all_to_all_async_generic(
+            ...     input_tensor,
+            ...     persistent_output_buffer=output_buf,  # Optional buffer
+            ...     in_dim=2,
+            ...     out_dim=3,
+            ...     cluster_axis=1
+            ... )
+        )doc");
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+void py_bind_all_to_all_async_generic(pybind11::module& module);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.cpp
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_to_all_async_generic_op.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/global_semaphore.hpp"
+
+#include "ttnn/tensor/tensor_utils.hpp"
+
+namespace ttnn {
+
+// Implementation of AllToAllAsyncGeneric methods
+
+void AllToAllAsyncGeneric::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    TT_FATAL(
+        input_tensors.size() == 1,
+        "AllToAllAsyncGeneric: Input tensor size must be 1, but is {}",
+        input_tensors.size());
+    const auto& input_tensor = input_tensors[0];
+    const auto& page_size = input_tensor.buffer()->page_size();
+    const auto& input_shape = input_tensor.logical_shape();
+    auto rank = input_shape.rank();
+
+    TT_FATAL(this->in_dim >= 0 && this->in_dim < rank, "in_dim out of range");
+    TT_FATAL(this->out_dim >= 0 && this->out_dim < rank, "out_dim out of range");
+
+    TT_FATAL(page_size % input_tensor.buffer()->alignment() == 0, "AllToAllAsync currently requires aligned pages");
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_to_all_async must be on device");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_to_all_async must be allocated in buffers on device");
+    TT_FATAL(this->num_links == 1, "num_links must be 1, but is {}", this->num_links);
+
+    TT_FATAL(
+        input_shape[this->out_dim] % this->num_devices == 0,
+        "AllToAllAsync: input tensor dimension {} must be divisible by num_devices {}",
+        input_shape[this->out_dim],
+        this->num_devices);
+    TT_FATAL(
+        input_tensor.buffer()->buffer_type() == BufferType::DRAM,
+        "AllToAllAsync: Input tensor must be in DRAM, but is in {}",
+        input_tensor.buffer()->buffer_type());
+    TT_FATAL(input_tensor.layout() == Layout::TILE, "Unsupported input layout {}.", input_tensor.layout());
+
+    const auto& maybe_output_tensor = output_tensors[0];
+    if (maybe_output_tensor.has_value()) {
+        const auto& output_tensor = maybe_output_tensor.value();
+
+        TT_FATAL(
+            output_tensor.storage_type() == StorageType::DEVICE,
+            "Output tensor for all_to_all_async must be on device");
+        TT_FATAL(
+            output_tensor.buffer()->buffer_type() == BufferType::DRAM,
+            "Output tensor for all_to_all_async must be in DRAM, but is in {}",
+            output_tensor.buffer()->buffer_type());
+        TT_FATAL(output_tensor.layout() == Layout::TILE, "Unsupported output layout {}.", output_tensor.layout());
+
+        TT_FATAL(output_tensor.dtype() == input_tensor.dtype(), "Output tensor dtype must match input tensor dtype");
+        TT_FATAL(
+            output_tensor.memory_config() == this->output_mem_config,
+            "Output tensor memory config must match specified output_mem_config");
+
+        const auto& output_shape = output_tensor.logical_shape();
+        auto expected_output_shape = input_tensor.logical_shape();
+        expected_output_shape[this->in_dim] *= this->num_devices;
+        expected_output_shape[this->out_dim] /= this->num_devices;
+        TT_FATAL(
+            output_shape == expected_output_shape,
+            "Output tensor shape {} must match expected output tensor shape {} for AllToAllAsync",
+            output_shape,
+            expected_output_shape);
+    }
+
+    // recreate output shape to cover optional output buffer
+    auto output_shape = input_tensor.logical_shape();
+    output_shape[this->in_dim] *= this->num_devices;
+    output_shape[this->out_dim] /= this->num_devices;
+
+    // Check padding support, currently supported only on height
+    auto last_dim = rank - 1;
+    auto second_last_dim = rank - 2;
+    TT_FATAL(
+        in_dim != second_last_dim || input_shape[in_dim] % 16 == 0,
+        "{} dimension support only 16 padding, so must be dividable by 16. Input tensor shape {} , but has {} padding",
+        in_dim,
+        input_shape,
+        input_shape[in_dim] % 32);
+    TT_FATAL(
+        out_dim != second_last_dim || output_shape[out_dim] % 16 == 0,
+        "{} dimension support only 16 padding, so must be dividable by 16. Output tensor shape {} , but has {} padding",
+        out_dim,
+        output_shape,
+        output_shape[out_dim] % 32);
+    TT_FATAL(
+        in_dim != last_dim || input_shape[in_dim] % 32 == 0,
+        "{} dimension doesnt support padding, so must be dividable by 32. Input tensor shape {} , but has {} padding",
+        in_dim,
+        input_shape,
+        input_shape[in_dim] % 32);
+    TT_FATAL(
+        out_dim != last_dim || output_shape[out_dim] % 32 == 0,
+        "{} dimension doesnt support padding, so must be dividable by 32. Output tensor shape {} , but has {} padding",
+        out_dim,
+        output_shape,
+        output_shape[out_dim] % 32);
+}
+
+std::vector<ttnn::TensorSpec> AllToAllAsyncGeneric::compute_output_specs(
+    const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors[0];
+    auto shape = input_tensor.logical_shape();
+    shape[this->in_dim] *= this->num_devices;
+    shape[this->out_dim] /= this->num_devices;
+    auto tensor_spec = TensorSpec(
+        shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), output_mem_config));
+    return {tensor_spec};
+}
+
+tt::tt_metal::operation::MeshWorkloadWithCallbacks AllToAllAsyncGeneric::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    auto mesh_device = input_tensors[0].device();
+    auto sub_device_id = this->sub_device_id;
+
+    auto subdevice = sub_device_id.has_value() ? *sub_device_id : mesh_device->get_sub_device_ids().at(0);
+    const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice);
+    auto subdevices = {subdevice};
+
+    auto init_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
+    auto final_barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0);
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevices);
+
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(
+                coord, input_tensors, output_tensors, init_barrier_semaphore, final_barrier_semaphore);
+        });
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks AllToAllAsyncGeneric::create_program_at(
+    const MeshCoordinate& coord,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors,
+    const GlobalSemaphore& init_barrier_semaphore,
+    const GlobalSemaphore& final_barrier_semaphore) const {
+    log_debug(tt::LogOp, "DEBUG: create_program_at is called");
+
+    uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(input_tensors[0], coord, cluster_axis);
+
+    const std::optional<MeshCoordinate> forward_coord =
+        ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensors[0], coord, 1, topology, cluster_axis);
+    const std::optional<MeshCoordinate> backward_coord =
+        ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensors[0], coord, -1, topology, cluster_axis);
+
+    TT_FATAL(device_index < this->num_devices, "DEBUG: device_index: {}", device_index);
+
+    return all_to_all_async_generic_program(
+        input_tensors[0],
+        output_tensors.at(0),
+        coord,
+        forward_coord,
+        backward_coord,
+        this->in_dim,
+        this->out_dim,
+        this->num_links,
+        this->num_devices,
+        device_index,
+        this->topology,
+        init_barrier_semaphore,
+        final_barrier_semaphore,
+        this->sub_device_id);
+}
+
+tt::tt_metal::operation::Hash AllToAllAsyncGeneric::compute_program_hash(
+    const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors[0];
+    const auto& input_shape = input_tensor.padded_shape();
+    auto input_memory_layout = input_tensor.layout();
+    auto input_dtype = input_tensor.dtype();
+    const auto& input_memory_config = input_tensor.memory_config();
+
+    return tt::tt_metal::operation::hash_operation<AllToAllAsyncGeneric>(
+        this->in_dim,
+        this->out_dim,
+        this->num_links,
+        this->num_devices,
+        this->output_mem_config,
+        this->topology,
+        input_shape,
+        input_memory_layout,
+        input_dtype,
+        input_memory_config);
+}
+
+std::vector<Tensor> AllToAllAsyncGeneric::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) const {
+    auto tensor_specs = compute_output_specs(input_tensors);
+
+    ttnn::Tensor output_buffer = optional_output_tensors.at(0).has_value()
+                                     ? optional_output_tensors.at(0).value()
+                                     : create_device_tensor(tensor_specs[0], input_tensors.at(0).device());
+
+    return {output_buffer};
+}
+
+namespace operations {
+namespace experimental {
+namespace ccl {
+
+// Top-level API function for AllToAllAsyncGeneric
+Tensor all_to_all_async_generic(
+    const Tensor& input_tensor,
+    const std::optional<Tensor>& persistent_output_buffer,
+    const int32_t in_dim,
+    const int32_t out_dim,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    std::optional<uint32_t> cluster_axis) {
+    uint32_t num_devices = ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+    TT_FATAL(
+        num_devices > 1,
+        "all_to_all_async is a collective operation and requires more than 1 device, but has {}",
+        num_devices);
+
+    std::vector<std::optional<Tensor>> optional_output_tensors = {persistent_output_buffer};
+
+    return tt::tt_metal::operation::run(
+               ttnn::AllToAllAsyncGeneric(
+                   in_dim,
+                   out_dim,
+                   num_links,
+                   num_devices,
+                   memory_config.value_or(input_tensor.memory_config()),
+                   topology,
+                   sub_device_id,
+                   cluster_axis),
+               {input_tensor},
+               {},
+               optional_output_tensors)
+        .at(0);
+}
+
+}  // namespace ccl
+}  // namespace experimental
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.hpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include "ttnn/global_semaphore.hpp"
+
+#include "ttnn/run_operation.hpp"
+
+#include <optional>
+#include <vector>
+
+namespace ttnn {
+
+using ccl::EriscDatamoverBuilder;
+
+struct AllToAllAsyncGeneric {
+    const uint32_t in_dim;
+    const uint32_t out_dim;
+    const uint32_t num_links;
+    const uint32_t num_devices;
+    const MemoryConfig output_mem_config;
+    const ccl::Topology topology;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+    std::optional<uint32_t> cluster_axis;
+
+    AllToAllAsyncGeneric(
+        uint32_t in_dim,
+        uint32_t out_dim,
+        uint32_t num_links,
+        uint32_t num_devices,
+        MemoryConfig output_mem_config,
+        ccl::Topology topology,
+        std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+        std::optional<uint32_t> cluster_axis) :
+        in_dim(in_dim),
+        out_dim(out_dim),
+        num_links(num_links),
+        num_devices(num_devices),
+        output_mem_config(output_mem_config),
+        topology(topology),
+        sub_device_id(sub_device_id),
+        cluster_axis(cluster_axis) {}
+
+    // Add attributes method for reflection
+    auto attributes() const {
+        using tt::stl::reflection::Attribute;
+        std::vector<std::tuple<std::string, Attribute>> attrs;
+
+        attrs.emplace_back("in_dim", in_dim);
+        attrs.emplace_back("out_dim", out_dim);
+        attrs.emplace_back("num_links", num_links);
+        attrs.emplace_back("num_devices", num_devices);
+        attrs.emplace_back("output_mem_config", output_mem_config);
+        attrs.emplace_back("topology", topology);
+        attrs.emplace_back("cluster_axis", cluster_axis);
+
+        return attrs;
+    }
+
+    // Method declarations (implementations will be needed elsewhere)
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
+        const ttnn::MeshCoordinate& coord,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors,
+        const GlobalSemaphore& init_barrier_semaphore,
+        const GlobalSemaphore& final_barrier_semaphore) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<Tensor>>& optional_output_tensors) const;
+};
+
+// Add declaration for the AllToAll program function
+tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_generic_program(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    std::optional<MeshCoordinate> target_device,
+    std::optional<MeshCoordinate> forward_coord,
+    std::optional<MeshCoordinate> backward_coord,
+    uint32_t in_dim,
+    uint32_t out_dim,
+    uint32_t num_links,
+    uint32_t num_devices,
+    uint32_t device_index,
+    ttnn::ccl::Topology topology,
+    const GlobalSemaphore& init_semaphore,
+    const GlobalSemaphore& final_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+
+namespace operations {
+namespace experimental {
+namespace ccl {
+
+// Add declaration for all_to_all_async
+Tensor all_to_all_async_generic(
+    const Tensor& input_tensor,
+    const std::optional<Tensor>& persistent_output_buffer,
+    int32_t in_dim,
+    int32_t out_dim,
+    uint32_t num_links = 1,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    std::optional<uint32_t> cluster_axis = std::nullopt);
+
+}  // namespace ccl
+}  // namespace experimental
+}  // namespace operations
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_program_factory.cpp
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+///
+#include <algorithm>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/fabric.hpp>
+#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_op.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/math.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
+
+#include "ttnn/operations/ccl/common/uops/command_lowering.hpp"
+
+#include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include "ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
+#include <sstream>
+#include <type_traits>
+#include <ranges>
+#include <optional>
+#include <tuple>
+
+using namespace tt::constants;
+
+namespace ttnn {
+
+using namespace ccl;
+ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
+    const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    const auto& shape = input_tensor.padded_shape();
+    ttnn::SmallVector<uint32_t> tiled_shape;
+    tiled_shape.reserve(shape.rank());
+    for (int i = 0; i < shape.rank(); i++) {
+        uint32_t dim = 0;
+        if (i == shape.rank() - 1) {
+            dim = shape[i] / tile_shape[1];
+        } else if (i == shape.rank() - 2) {
+            dim = shape[i] / tile_shape[0];
+        } else {
+            dim = shape[i];
+        }
+        tiled_shape.push_back(dim);
+    }
+    auto res = ttnn::Shape(tiled_shape);
+    return res;
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks all_to_all_async_generic_program(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    std::optional<MeshCoordinate> target_device,
+    std::optional<MeshCoordinate> forward_coord,
+    std::optional<MeshCoordinate> backward_coord,
+    const uint32_t in_dim,
+    const uint32_t out_dim,
+    const uint32_t num_links,
+    const uint32_t num_devices,
+    const uint32_t device_index,
+    ttnn::ccl::Topology topology,
+    const GlobalSemaphore& init_semaphore,
+    const GlobalSemaphore& final_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    tt::tt_metal::Program program{};
+    MeshDevice* device = input_tensor.device();
+
+    std::vector<Tensor> input_tensors = {input_tensor};
+    std::vector<Tensor> output_tensors = {output_tensor};
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
+
+    const size_t num_senders_per_link = 1;
+    uint32_t num_receivers_per_link = 1;
+    auto topology_type = topology == ttnn::ccl::Topology::Ring ? "RING" : "LINEAR";
+
+    const auto [sender_worker_core_range, sender_worker_cores] =
+        choose_worker_cores(num_links, num_senders_per_link, device, sub_device_id);
+
+    // Get OP Config, topology config
+    const auto [total_workers_core_range, total_workers_cores] =
+        choose_worker_cores(num_links, (num_senders_per_link + num_receivers_per_link), device, sub_device_id);
+
+    // Create CB
+    const uint32_t page_size = op_config.get_page_size();
+    const uint32_t packet_size = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+
+    const uint32_t number_pages_per_packet = 2;
+    const uint32_t cb_size = (packet_size / page_size) * page_size * number_pages_per_packet;  // round_down
+    const tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+
+    auto cb_src0_config = tt::tt_metal::CircularBufferConfig(cb_size, {{tt::CB::c_in0, data_format}})
+                              .set_page_size(tt::CB::c_in0, page_size);
+
+    CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+
+    // Create CB for fabric
+    const auto reserved_packet_header_CB_index = tt::CB::c_in4;
+    auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+    const uint32_t num_packet_headers_storable = 4;
+    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_packet_headers_storable * packet_header_size_bytes * 2,
+            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
+            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+    CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+
+    const auto input_shape = get_tiled_shape(input_tensor);
+    uint32_t src_out_dims = 1;
+    uint32_t src_in_dims = 1;
+    for (uint32_t i = 0; i < out_dim; ++i) {
+        src_out_dims *= input_shape[i];
+    }
+
+    for (uint32_t i = out_dim + 1; i < input_shape.size(); ++i) {
+        src_in_dims *= input_shape[i];
+    }
+    const auto output_shape = get_tiled_shape(output_tensor);
+    uint32_t dst_out_dims = 1;
+    uint32_t dst_in_dims = 1;
+    for (uint32_t i = 0; i < in_dim; ++i) {
+        dst_out_dims *= output_shape[i];
+    }
+
+    const uint32_t reader_has_extra_half_tile =
+        out_dim == input_shape.size() - 2 && output_tensor.logical_shape()[out_dim] % 32 == 16;
+    const uint32_t writer_has_extra_half_tile =
+        in_dim == input_shape.size() - 2 && input_tensor.logical_shape()[in_dim] % 32 == 16;
+    for (uint32_t i = in_dim + 1; i < output_shape.size(); ++i) {
+        dst_in_dims *= output_shape[i];
+    }
+
+    auto sender_reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
+    sender_reader_kernel_config.defines.emplace("TOPOLOGY", topology_type);
+    sender_reader_kernel_config.compile_args = {
+        tt::CB::c_in0,                        // cb0_id
+        page_size,                            // tensor0_page_size
+        device_index,                         // device_index
+        num_devices,                          // num_devices
+        src_out_dims,                         // outer_dims_size
+        input_shape[out_dim],                 // split_dim_size
+        src_in_dims,                          // inner_dims_size
+        input_shape[input_shape.size() - 1],  // last_dim_sizes
+        number_pages_per_packet,              // number_pages_per_packet
+        reader_has_extra_half_tile,           // has_reader_tail
+        writer_has_extra_half_tile,           // has_writer_tail
+    };
+
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_kernel_config.compile_args);
+
+    auto sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/"
+        "all_to_all_sender_reader.cpp",
+        sender_worker_core_range,
+        sender_reader_kernel_config);
+
+    auto sender_writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
+    sender_writer_kernel_config.defines.emplace("TOPOLOGY", topology_type);
+    sender_writer_kernel_config.compile_args = {
+        tt::CB::c_in0,               // cb0_id
+        device_index,                // device_index
+        num_devices,                 // num_devices
+        dst_out_dims,                // outer_dims_size
+        output_shape[in_dim],        // concat_dim_size
+        dst_in_dims,                 // inner_dims_size
+        number_pages_per_packet,     // number_pages_per_packet
+        writer_has_extra_half_tile,  // has_writer_tail
+        page_size,                   // intermediate_page_size
+        reserved_packet_header_CB_index,
+    };
+
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_kernel_config.compile_args);
+
+    auto sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/"
+        "all_to_all_sender_writer.cpp",
+        sender_worker_core_range,
+        sender_writer_kernel_config);
+
+    std::vector<uint32_t> sender_reader_rt_args = {input_tensor.buffer()->address()};
+    tt::tt_metal::SetRuntimeArgs(program, sender_reader_kernel_id, sender_worker_core_range, sender_reader_rt_args);
+
+    auto drain_sync_core = device->worker_core_from_logical_core({sender_worker_cores[0]});
+    std::vector<uint32_t> sender_writer_rt_args = {
+        output_tensor.buffer()->address(),
+        init_semaphore.address(),
+        final_semaphore.address(),
+        drain_sync_core.x,
+        drain_sync_core.y};
+    sender_writer_rt_args.push_back(forward_coord.has_value());
+
+    if (forward_coord.has_value()) {
+        const auto sender_device_fabric_node_id = device->get_fabric_node_id(target_device.value());
+        const auto forward_device_fabric_node_id = device->get_fabric_node_id(forward_coord.value());
+        tt::tt_fabric::append_fabric_connection_rt_args(
+            sender_device_fabric_node_id,
+            forward_device_fabric_node_id,
+            0,
+            program,
+            {sender_worker_cores[0]},
+            sender_writer_rt_args);
+    }
+
+    sender_writer_rt_args.push_back(backward_coord.has_value());
+    if (backward_coord.has_value()) {
+        const auto sender_device_fabric_node_id = device->get_fabric_node_id(target_device.value());
+        const auto backward_device_fabric_node_id = device->get_fabric_node_id(backward_coord.value());
+        tt::tt_fabric::append_fabric_connection_rt_args(
+            sender_device_fabric_node_id,
+            backward_device_fabric_node_id,
+            0,
+            program,
+            {sender_worker_cores[0]},
+            sender_writer_rt_args);
+    }
+    tt::tt_metal::SetRuntimeArgs(program, sender_writer_kernel_id, sender_worker_core_range, sender_writer_rt_args);
+
+    auto override_runtime_arguments_callback =
+        [sender_reader_kernel_id, sender_writer_kernel_id, sender_worker_cores, init_semaphore, final_semaphore](
+            const void* operation,
+            tt::tt_metal::Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input = input_tensors[0];
+            const auto& output = output_tensors[0];
+
+            auto& sender_reader_runtime_args = GetRuntimeArgs(program, sender_reader_kernel_id);
+            auto& sender_writer_runtime_args = GetRuntimeArgs(program, sender_writer_kernel_id);
+            for (const auto& core : sender_worker_cores) {
+                auto& worker_sender_reader_runtime_args = sender_reader_runtime_args[core.x][core.y];
+                auto& worker_sender_writer_runtime_args = sender_writer_runtime_args[core.x][core.y];
+                worker_sender_reader_runtime_args[0] = input.buffer()->address();
+                worker_sender_writer_runtime_args[0] = output.buffer()->address();
+                worker_sender_writer_runtime_args[1] = init_semaphore.address();
+                worker_sender_writer_runtime_args[2] = final_semaphore.address();
+            }
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "ckernel.h"
+#include <cstdint>
+
+using address_t = uint32_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
+constexpr uint32_t input_page_size = get_compile_time_arg_val(1);
+constexpr uint32_t current_device_id = get_compile_time_arg_val(2);
+constexpr uint32_t num_devices = get_compile_time_arg_val(3);
+constexpr uint32_t outer_dims_size = get_compile_time_arg_val(4);
+constexpr uint32_t split_dim_size = get_compile_time_arg_val(5);
+constexpr uint32_t inner_dims_size = get_compile_time_arg_val(6);
+constexpr uint32_t last_dim_size = get_compile_time_arg_val(7);
+constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(8);
+constexpr uint32_t has_reader_tail = get_compile_time_arg_val(9);
+constexpr uint32_t has_writer_tail = get_compile_time_arg_val(10);
+
+template <typename AddrGenType>
+void read_data(
+    uint32_t device_id, uint32_t tile_id, uint32_t l1_write_addr, AddrGenType input_addrgen, uint32_t i, bool last) {
+    // half tile output case: add padding to the last tile
+    bool pad_last_half_tile = has_reader_tail && last;
+    if (pad_last_half_tile) {
+        noc_async_read(
+            input_addrgen.get_noc_addr(tile_id, (device_id % 2) * input_page_size / 2),
+            l1_write_addr,
+            input_page_size / 2);
+        uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+        noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
+        return;
+    }
+
+    // half tile output case: all odd devices write with half tile offset
+    bool read_with_half_offset = has_reader_tail && device_id % 2 == 1;
+    if (read_with_half_offset) {
+        noc_async_read(input_addrgen.get_noc_addr(tile_id, input_page_size / 2), l1_write_addr, input_page_size / 2);
+        noc_async_read(
+            input_addrgen.get_noc_addr(tile_id + inner_dims_size, 0),
+            l1_write_addr + input_page_size / 2,
+            input_page_size / 2);
+        return;
+    }
+
+    // half tile input case: odd devices need to read with half tile offset starting from the second tile in block
+    bool read_with_half_offset_for_writer = has_writer_tail && current_device_id % 2 == 1 && i / last_dim_size > 0;
+    if (read_with_half_offset_for_writer) {
+        noc_async_read(
+            input_addrgen.get_noc_addr(tile_id - last_dim_size, input_page_size / 2),
+            l1_write_addr,
+            input_page_size / 2);
+        noc_async_read(
+            input_addrgen.get_noc_addr(tile_id, 0), l1_write_addr + input_page_size / 2, input_page_size / 2);
+        return;
+    }
+
+    noc_async_read_tile(tile_id, input_addrgen, l1_write_addr);
+}
+
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+    size_t arg_idx = 0;
+    address_t input_address = get_arg_val<address_t>(arg_idx++);
+    constexpr auto input_tensor_args = TensorAccessorArgs<11>();
+    auto input_addrgen = TensorAccessor(input_tensor_args, input_address, input_page_size);
+    constexpr uint32_t split_num_half_tiles = split_dim_size * 2 / num_devices;
+#define LINEAR 1
+#define RING 2
+
+#if TOPOLOGY == LINEAR
+    for (uint32_t device_id = 0; device_id < num_devices; ++device_id) {
+#elif TOPOLOGY == RING
+    for (int d = num_devices - 1; d >= 0; --d) {
+        int distance = (d + 1) / 2;
+        int val = (d % 2 == 0) ? distance : -distance;
+        uint32_t device_id = (current_device_id + val) % num_devices;
+#else
+#error "Unsupported Topology Type"
+#endif
+        const uint32_t device_read_offset = (split_num_half_tiles * device_id) / 2;
+        const uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
+        uint64_t block_size = outer_dims_size * split_num_tiles * inner_dims_size;
+
+        auto calculate_tile = [&](int b) {
+            const uint32_t o = b / (split_num_tiles * inner_dims_size);
+            const uint32_t s = (b / inner_dims_size) % split_num_tiles;
+            const uint32_t i = b % inner_dims_size;
+            const uint32_t tile_id =
+                o * inner_dims_size * split_dim_size + device_read_offset * inner_dims_size + s * inner_dims_size + i;
+            return std::tuple{s, i, tile_id};
+        };
+
+        for (uint64_t block_idx = 0; block_idx < block_size; block_idx += number_pages_per_packet) {
+            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_size - block_idx));
+
+            cb_reserve_back(cb0_id, tiles_this_iteration);
+            address_t l1_write_addr = get_write_ptr(cb0_id);
+            for (uint32_t t = 0; t < tiles_this_iteration; ++t) {
+                auto [split_idx, inner_idx, tile_id] = calculate_tile(block_idx + t);
+                read_data(
+                    device_id,
+                    tile_id,
+                    l1_write_addr + t * input_page_size,
+                    input_addrgen,
+                    inner_idx,
+                    split_idx == split_num_tiles - 1);
+            }
+
+            noc_async_read_barrier();
+            cb_push_back(cb0_id, tiles_this_iteration);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "ckernel.h"
+#include <cstdint>
+
+using address_t = uint32_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
+constexpr uint32_t current_device_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_devices = get_compile_time_arg_val(2);
+constexpr uint32_t outer_dims_size = get_compile_time_arg_val(3);
+constexpr uint32_t concat_dim_size = get_compile_time_arg_val(4);
+constexpr uint32_t inner_dims_size = get_compile_time_arg_val(5);
+constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(6);
+constexpr uint32_t has_half_tile = get_compile_time_arg_val(7);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(8);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(9);
+
+template <typename AddrGenType>
+void write_data(
+    bool last,
+    bool local,
+    uint32_t dest_id,
+    AddrGenType addrgen,
+    volatile PACKET_HEADER_TYPE* pkt_hdr,
+    tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
+    size_t l1_read_addr,
+    uint32_t payload_size_bytes,
+    uint32_t offset,
+    uint64_t output_semaphore_noc_addr_in_pkt,
+    uint32_t device_id) {
+    if (last) {
+        if (local) {
+            noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
+            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id, offset), payload_size_bytes);
+            noc_async_write_barrier();
+        } else {
+            perform_atomic_fabric_write(
+                pkt_hdr,
+                dest_id,
+                addrgen,
+                fabric_connection,
+                l1_read_addr,
+                payload_size_bytes,
+                output_semaphore_noc_addr_in_pkt,
+                1,
+                false,
+                offset);
+        }
+    } else {
+        if (local) {
+            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id, offset), payload_size_bytes);
+        } else {
+            tt::tt_fabric::linear::to_noc_unicast_write(payload_size_bytes, pkt_hdr, dest_id, addrgen, offset);
+            perform_payload_send(fabric_connection, l1_read_addr, payload_size_bytes, pkt_hdr);
+        }
+    }
+    noc_async_writes_flushed();
+}
+
+template <typename AddrGenType>
+void write_data(
+    bool last,
+    bool local,
+    uint32_t dest_id0,
+    uint32_t dest_id1,
+    AddrGenType addrgen,
+    volatile PACKET_HEADER_TYPE* pkt_hdr,
+    tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
+    size_t l1_read_addr,
+    uint32_t payload_size_bytes0,
+    uint32_t payload_size_bytes1,
+    uint32_t offset0,
+    uint32_t offset1,
+    uint64_t output_semaphore_noc_addr_in_pkt,
+    uint32_t device_id) {
+    if (last) {
+        if (local) {
+            noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
+            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id0, offset0), payload_size_bytes0);
+            noc_async_write(
+                l1_read_addr + output_page_size, addrgen.get_noc_addr(dest_id1, offset1), payload_size_bytes1);
+            noc_async_write_barrier();
+        } else {
+            tt::tt_fabric::linear::to_noc_unicast_write(payload_size_bytes0, pkt_hdr, dest_id0, addrgen, offset0);
+            perform_payload_send(fabric_connection, l1_read_addr, payload_size_bytes0, pkt_hdr);
+            size_t l1_read_addr_plus_payload = l1_read_addr + output_page_size;
+            noc_async_writes_flushed();
+            perform_atomic_fabric_write(
+                pkt_hdr,
+                dest_id1,
+                addrgen,
+                fabric_connection,
+                l1_read_addr_plus_payload,
+                payload_size_bytes1,
+                output_semaphore_noc_addr_in_pkt,
+                1,
+                false,
+                offset1);
+        }
+    } else {
+        if (local) {
+            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id0, offset0), payload_size_bytes0);
+            noc_async_write(
+                l1_read_addr + output_page_size, addrgen.get_noc_addr(dest_id1, offset1), payload_size_bytes1);
+        } else {
+            constexpr uint32_t half_output_page_size = output_page_size / 2;
+            if (payload_size_bytes0 == half_output_page_size) {
+                tt::data_movement::common::tt_memmove<true, false, false, half_output_page_size>(
+                    l1_read_addr + half_output_page_size, l1_read_addr, half_output_page_size);
+                l1_read_addr = l1_read_addr + half_output_page_size;
+            }
+            auto payload_size = payload_size_bytes0 + payload_size_bytes1;
+
+            auto noc_address0 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(addrgen, dest_id0, offset0);
+            auto noc_address1 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(addrgen, dest_id1, offset1);
+
+            pkt_hdr->to_noc_unicast_scatter_write(
+                NocUnicastScatterCommandHeader(
+                    {{noc_address0, noc_address1}, static_cast<uint16_t>(payload_size_bytes0)}),
+                payload_size);
+            perform_payload_send(fabric_connection, l1_read_addr, payload_size, pkt_hdr);
+        }
+    }
+    noc_async_writes_flushed();
+}
+
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+    size_t arg_idx = 0;
+    address_t output_address = get_arg_val<address_t>(arg_idx++);
+    uint32_t global_init_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t global_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t sender_core_x = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t sender_core_y = get_arg_val<uint32_t>(arg_idx++);
+    constexpr auto output_args = TensorAccessorArgs<10>();
+    auto output_addrgen = TensorAccessor(output_args, output_address, output_page_size);
+
+    // Build fabric connection
+    auto fabric_connection =
+        FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
+            arg_idx);
+    uint64_t init_semaphore_noc_addr_in_pkt =
+        safe_get_noc_addr(sender_core_x, sender_core_y, global_init_semaphore_addr);
+    uint64_t output_semaphore_noc_addr_in_pkt = safe_get_noc_addr(sender_core_x, sender_core_y, global_semaphore_addr);
+
+    volatile tt_l1_ptr uint32_t* global_init_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_init_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* global_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr);
+
+    // packet header cb
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+
+    // pre-populate packet headers
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    fabric_connection.open_finish();
+
+    constexpr bool has_pre_half_tile = has_half_tile && current_device_id % 2 == 1;
+    constexpr bool has_post_half_tile = has_half_tile && current_device_id % 2 == 0;
+
+    constexpr uint32_t concat_num_half_tiles = concat_dim_size * 2 / num_devices;
+    constexpr uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
+    constexpr uint32_t full_block_offset = (concat_num_half_tiles * current_device_id) / 2;
+
+#define LINEAR 1
+#define RING 2
+#if TOPOLOGY == LINEAR
+    if (fabric_connection.has_forward_connection()) {
+        pkt_hdr_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr_forward->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - current_device_id - 1)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
+    }
+
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr_backward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+        pkt_hdr_backward->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(current_device_id)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            packet_header_buffer_addr_backward, sizeof(PACKET_HEADER_TYPE));
+    }
+
+    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
+
+    for (uint32_t device_id = 0; device_id < num_devices; ++device_id) {
+        volatile PACKET_HEADER_TYPE* pkt_hdr;
+        tt::tt_fabric::WorkerToFabricEdmSender& cur_connection = (device_id > current_device_id)
+                                                                     ? fabric_connection.get_forward_connection()
+                                                                     : fabric_connection.get_backward_connection();
+        if (device_id > current_device_id) {
+            pkt_hdr = pkt_hdr_forward;
+            pkt_hdr->to_chip_unicast(device_id - current_device_id);
+        } else {
+            pkt_hdr = pkt_hdr_backward;
+            pkt_hdr->to_chip_unicast(current_device_id - device_id);
+        }
+#elif TOPOLOGY == RING
+    if (fabric_connection.has_forward_connection()) {
+        pkt_hdr_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr_forward->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - 1)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
+    }
+
+    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
+
+    for (int d = num_devices - 1; d >= 0; --d) {
+        int distance = (d + 1) / 2;
+        int val = (d % 2 == 0) ? distance : -distance;
+        uint32_t device_id = (current_device_id + val) % num_devices;
+        volatile PACKET_HEADER_TYPE* pkt_hdr;
+        tt::tt_fabric::WorkerToFabricEdmSender& cur_connection =
+            (val >= 0) ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
+        if (val >= 0) {
+            pkt_hdr = pkt_hdr_forward;
+            pkt_hdr->to_chip_unicast(distance);
+        } else {
+            pkt_hdr = pkt_hdr_backward;
+            pkt_hdr->to_chip_unicast(distance);
+        }
+#else
+#error "Unsupported Topology Type"
+#endif
+
+        uint64_t block_size = outer_dims_size * concat_num_tiles * inner_dims_size;
+        auto calculate_params = [&](int b) {
+            const uint32_t o = b / (concat_num_tiles * inner_dims_size);
+            const uint32_t c = (b / inner_dims_size) % concat_num_tiles;
+            const uint32_t i = b % inner_dims_size;
+            const uint32_t dest_tile_id =
+                o * inner_dims_size * concat_dim_size + (c + full_block_offset) * inner_dims_size + i;
+            bool last = (c == concat_num_tiles - 1) && o == outer_dims_size - 1 && i == inner_dims_size - 1;
+            uint32_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
+                                        ? output_page_size / 2
+                                        : output_page_size;
+            uint32_t offset = (has_pre_half_tile && c == 0) ? (current_device_id % 2) * output_page_size / 2 : 0;
+            return std::tuple{dest_tile_id, last, payload_size, offset};
+        };
+
+        for (uint64_t b = 0; b < block_size; b += number_pages_per_packet) {
+            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_size - b));
+
+            cb_wait_front(cb0_id, tiles_this_iteration);
+            size_t l1_read_addr = get_read_ptr(cb0_id);
+
+            if (tiles_this_iteration == 2) {
+                auto [dest_tile_id0, last0, payload_size0, offset0] = calculate_params(b);
+                auto [dest_tile_id1, last1, payload_size1, offset1] = calculate_params(b + 1);
+
+                write_data(
+                    last1,
+                    device_id == current_device_id,
+                    dest_tile_id0,
+                    dest_tile_id1,
+                    output_addrgen,
+                    pkt_hdr,
+                    cur_connection,
+                    l1_read_addr,
+                    payload_size0,
+                    payload_size1,
+                    offset0,
+                    offset1,
+                    output_semaphore_noc_addr_in_pkt,
+                    device_id);
+            } else {
+                auto [dest_tile_id, last, payload_size, offset] = calculate_params(b);
+
+                write_data(
+                    last,
+                    device_id == current_device_id,
+                    dest_tile_id,
+                    output_addrgen,
+                    pkt_hdr,
+                    cur_connection,
+                    l1_read_addr,
+                    payload_size,
+                    offset,
+                    output_semaphore_noc_addr_in_pkt,
+                    device_id);
+            }
+
+            cb_pop_front(cb0_id, tiles_this_iteration);
+        }
+    }
+
+    fabric_connection.close();
+
+    noc_semaphore_wait(global_semaphore_addr_ptr, num_devices);
+    noc_semaphore_set(global_semaphore_addr_ptr, 0);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_pybind.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/llama_all_gather_matmul_async_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async_pybind.hpp"
+#include "ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/rs_matmul_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async_pybind.hpp"
@@ -32,6 +33,7 @@ void py_module(pybind11::module& module) {
     ccl::py_bind_llama_all_gather_matmul_async(module);
     ccl::py_bind_all_gather_async(module);
     ccl::py_bind_all_to_all_async(module);
+    ccl::py_bind_all_to_all_async_generic(module);
     ccl::py_bind_all_gather_concat(module);
     ccl::py_bind_matmul_reduce_scatter_async(module);
     ccl::py_bind_rs_matmul(module);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -253,17 +253,24 @@ bool use_composite_all_to_all(
     int32_t out_dim,
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
 
     auto input_shape = input_tensor.logical_shape();
+    uint32_t num_devices = ttnn::ccl::get_topological_dimension(input_tensor, std::nullopt);
 
     int32_t rank = input_tensor.logical_shape().rank();
     in_dim = (in_dim < 0) ? rank + in_dim : in_dim;
     out_dim = (out_dim < 0) ? rank + out_dim : out_dim;
 
+    auto last_dim = rank - 1;
+    auto second_last_dim = rank - 2;
+
+    auto output_out_dim = input_shape[out_dim] / num_devices;
     bool is_tiled_and_tile_aligned = input_tensor.layout() == ttnn::Layout::TILE &&
-                                     (input_shape[2] % tile_height == 0 && input_shape[3] % tile_width == 0);
+                                     (in_dim != second_last_dim || input_shape[in_dim] % 16 == 0) &&
+                                     (in_dim != last_dim || input_shape[in_dim] % tile_width == 0) &&
+                                     (out_dim != second_last_dim || output_out_dim % 16 == 0) &&
+                                     (out_dim != last_dim || output_out_dim % tile_width == 0);
 
     // the current native implementation works for very specific cases
     bool use_native =
@@ -272,7 +279,7 @@ bool use_composite_all_to_all(
          input_tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED &&
          (!memory_config.has_value() ||
           memory_config.value().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED) &&
-         (in_dim == 2 || in_dim == 3) && (out_dim == 2 || out_dim == 3) && is_tiled_and_tile_aligned);
+         is_tiled_and_tile_aligned);
 
     return !use_native;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -14,6 +14,7 @@
 
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25129

### Problem description
The all_to_all_async operation had limited parameter support that was insufficient for the Deepseek3 model. 
Only certain in_dim/out_dim parameters were supported (missing support for in_dim/out_dim 1 and 2). 
Sub-tile support was not available.

### What's changed
Created a generic implementation that supports any in_dim/out_dim for tiled tensors.
Added support for sub-tile padding
Compared to all_to_all_async, all_to_all_async_generic supports cluster_axis and doesn't require the user to create semaphores and output buffers (which can still be passed as optional arguments)

### Checklist
- [x] [Galaxy Deepseek tests](https://github.com/tenstorrent/tt-metal/actions/runs/18917795158)
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes