### PR TITLE
fix hang and pcc issues with activation reuse on resnet p150

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -5105,16 +5105,21 @@ def test_conv2d_1kX1k(
         slice_config=slice_config,
     )
 
-# CB pointer update regression test
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, core_range_set, shard_shape, enable_weights_double_buffer",
     (
-        # ResNet50 first conv parameters - batch_size=32, input_shape={32; 115; 115; 16}
-        (32, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, HS, {"act_block_h": 49 * 32}),
+        # CB pointer update regression test
+        (32, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, HS, {"act_block_h": 49 * 32},
+         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 8)), ttnn.CoreRange(ttnn.CoreCoord(0, 9), ttnn.CoreCoord(10, 9))],
+         (3328, 16), False),
+        # Weights double buffer regression test
+        (32, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 5 * 32},
+         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 8)), ttnn.CoreRange(ttnn.CoreCoord(0, 9), ttnn.CoreCoord(8, 9))],
+         (800, 64), True),
     ),
 )
-def test_resnet50_first_conv_p150(
+def test_resnet50_conv_p150(
     device,
     torch_tensor_map,
     batch_size,
@@ -5130,21 +5135,19 @@ def test_resnet50_first_conv_p150(
     pad_w,
     shard_layout,
     config_override,
+    core_range_set,
+    shard_shape,
+    enable_weights_double_buffer,
 ):
     # Test runs on Blackhole P150
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) != (13, 10):
         pytest.skip("Test is only supported on Blackhole P150")
 
-    input_core_range_set = ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 8)),
-            ttnn.CoreRange(ttnn.CoreCoord(0, 9), ttnn.CoreCoord(10, 9)),
-        }
-    )
+    input_core_range_set = ttnn.CoreRangeSet(set(core_range_set))
     memory_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.BufferType.L1,
-        ttnn.ShardSpec(input_core_range_set, (3328, 16), ttnn.ShardOrientation.ROW_MAJOR)
+        ttnn.ShardSpec(input_core_range_set, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     )
 
     run_conv(
@@ -5169,10 +5172,11 @@ def test_resnet50_first_conv_p150(
         output_layout=ttnn.TILE_LAYOUT,
         deallocate_activation=True,
         enable_act_double_buffer=False,
-        enable_weights_double_buffer=False,
+        enable_weights_double_buffer=enable_weights_double_buffer,
         activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
         input_dtype=ttnn.bfloat16,
         sharded_cfg=memory_config,
+        packer_l1_acc=True,
         enable_activation_reuse=True,
     )
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -662,7 +662,7 @@ Result conv2d_L1(
     if (conv_config.enable_activation_reuse) {
         if (conv_config.enable_act_double_buffer) {
             conv_config.enable_act_double_buffer = false;
-            log_warning(
+            log_debug(
                 tt::LogOp,
                 "Activation double buffering is currently not supported when activation reuse optimization is enabled, "
                 "disabling double buffering.");
@@ -670,7 +670,7 @@ Result conv2d_L1(
 
         if (conv_config.enable_weights_double_buffer) {
             conv_config.enable_weights_double_buffer = false;
-            log_warning(
+            log_debug(
                 tt::LogOp,
                 "Weights are already fully buffered when activation reuse optimization is enabled, disabling weights "
                 "double buffering.");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -667,6 +667,14 @@ Result conv2d_L1(
                 "Activation double buffering is currently not supported when activation reuse optimization is enabled, "
                 "disabling double buffering.");
         }
+
+        if (conv_config.enable_weights_double_buffer) {
+            conv_config.enable_weights_double_buffer = false;
+            log_warning(
+                tt::LogOp,
+                "Weights are already fully buffered when activation reuse optimization is enabled, disabling weights "
+                "double buffering.");
+        }
     }
     auto [output_height, output_width] =
         calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -188,11 +188,13 @@ std::vector<CBInfo> get_cb_info(
             (is_1d_depthwise_conv ? block_config.act_block_h_ntiles : block_config.act_block_w_ntiles);
         if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
             // If activation reuse is enabled, we already have full inner dim
-            const bool enable_fully_buffered_weights = num_blocks_act_h > 1 && !conv_config.enable_activation_reuse;
-            if (enable_fully_buffered_weights) {
-                weight_block_num_tiles *= kernel_size[0];
-            } else if (conv_config.enable_weights_double_buffer) {
-                weight_block_num_tiles *= 2;
+            if (!conv_config.enable_activation_reuse) {
+                const bool enable_fully_buffered_weights = num_blocks_act_h > 1;
+                if (enable_fully_buffered_weights) {
+                    weight_block_num_tiles *= kernel_size[0];
+                } else if (conv_config.enable_weights_double_buffer) {
+                    weight_block_num_tiles *= 2;
+                }
             }
         } else if (conv_config.enable_weights_double_buffer) {
             weight_block_num_tiles *= 2;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -147,8 +147,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
     }
 
     // Put all cores with non-meaningful work to the set
-    uint32_t start_idx =
-        all_input_cores.size() - config.num_cores_with_non_meaningful_work - (config.has_partial_core ? 1 : 0);
+    uint32_t start_idx = all_input_cores.size() - config.num_cores_with_non_meaningful_work;
     for (uint32_t i = start_idx; i < all_input_cores.size(); i++) {
         config.cores_with_non_meaningful_work.insert(all_input_cores[i]);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -28,7 +28,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
-    uint32_t core_index = get_arg_val<uint32_t>(0);
+    uint32_t runtime_arg_idx = 0;
+    uint32_t core_index = get_arg_val<uint32_t>(runtime_arg_idx++);
     load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(core_index);
 
 #ifdef ACTIVATION_REUSE
@@ -41,7 +42,7 @@ void kernel_main() {
     constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(36) == 1;
     constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(37) == 1;
 
-    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(0);
+    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(runtime_arg_idx++);
 #endif
 
 


### PR DESCRIPTION
### Ticket
#30065

### Problem description
Conv that was added to the unit tests was hanging.

### What's changed
- Hang was happening due to the bug with calculating how many cores do non-meaningful work. We pre-calculate how many last cores process input data that is 'padding' to fit the sharding scheme. There are N last cores that do only non-meaningful work, and there is 1 or 0 cores that do one part of the valid input and one part of 'padding'. This is called the 'partial core'. In the config we calculate number of cores with non-meaningful work and this number includes this partial core if it exists. When calculating starting index of the cores with non-meaningful work I mistakenly thought that the count includes only cores with only non-meaningful work. 

- While debugging the hang I discovered there was a regression in how we read the runtime argument in activation reader in https://github.com/tenstorrent/tt-metal/commit/999bb7c9596b268f9f76644d3f8eb27d18278059.
- After the hang was resolved, the test had PCC issues. This was due to weights double buffering feature - if we have activation reuse enabled, there is no need to double buffer weights as we keep full inner dim.

### Checklist

- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/18401295188
- [x] Nightly L2: https://github.com/tenstorrent/tt-metal/actions/runs/18374998139
- [x] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/18401184508