### PR TITLE
#0: [skip ci] Add test_suite_bh_pcie_didt_tests back to BH upstream containers

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -243,12 +243,14 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_loudbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_p300"]="
 test_suite_bh_umd_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests
 test_suite_bh_multi_pcie_metal_unit_tests
+test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Failing didt tests fixed in https://github.com/tenstorrent/tt-metal/pull/30104 need to be added back to containers that were not running the tests.

### What's changed
Add test_suite_bh_pcie_didt_tests to loudbox and p300 upstream tests

### Checklist
- [ ] Upstream tests https://github.com/tenstorrent/tt-metal/actions/runs/18383527090