### PR TITLE
Showing only essential fields when dumping callstack

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1043,7 +1043,7 @@ def run_debug_script():
         extra_env = {
             "LD_LIBRARY_PATH": None,
         }
-        debug_result = run_process_and_get_result(f"python {debug_script_path} --active-cores", extra_env)
+        debug_result = run_process_and_get_result(f"python {debug_script_path}", extra_env)
 
         logger.info(f"Debug script status: {debug_result.returncode}")
         if debug_result.stdout:

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -43,11 +43,11 @@ class DispatcherCoreData:
 
     # Level 1: Detailed fields
     host_assigned_id: int | None = triage_field("Host Assigned ID", hex_serializer, verbose=1)
-    watcher_previous_kernel_id: int = triage_field("Previous Kernel ID")
-    previous_kernel_name: str | None = triage_field("Previous Kernel Name")
+    watcher_previous_kernel_id: int = triage_field("Previous Kernel ID", verbose=1)
+    previous_kernel_name: str | None = triage_field("Previous Kernel Name", verbose=1)
     kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer, verbose=1)
-    kernel_path: str = triage_field("Kernel Path")
-    firmware_path: str = triage_field("Firmware Path")
+    kernel_path: str = triage_field("Kernel Path", verbose=1)
+    firmware_path: str = triage_field("Firmware Path", verbose=1)
 
     # Level 2: Internal debug fields
     launch_msg_rd_ptr: int = triage_field("RD PTR", verbose=2)

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -33,23 +33,30 @@ script_config = ScriptConfig(
 
 @dataclass
 class DispatcherCoreData:
-    launch_msg_rd_ptr: int = triage_field("RD PTR")
-    kernel_config_base: int = triage_field("Base", hex_serializer)
-    kernel_text_offset: int = triage_field("Offset", hex_serializer)
-    host_assigned_id: int | None = triage_field("Host Assigned ID", hex_serializer)
+    # Level 0: Essential fields (always shown)
     watcher_kernel_id: int = combined_field("kernel_name", "Kernel ID:Name", collection_serializer(":"))
-    watcher_previous_kernel_id: int = combined_field(
-        "previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":")
-    )
-    kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer)
-    firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"))
-    kernel_path: str | None = combined_field()
-    kernel_name: str | None = combined_field()
-    previous_kernel_name: str | None = combined_field()
     subdevice: int = triage_field("Subdevice")
     go_message: str = triage_field("Go Message")
     preload: bool = triage_field("Preload")
     waypoint: str = triage_field("Waypoint")
+
+    # Level 1: Detailed fields
+    host_assigned_id: int | None = triage_field("Host Assigned ID", hex_serializer, verbose=1)
+    watcher_previous_kernel_id: int = combined_field(
+        "previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":"), verbose=1
+    )
+    kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer, verbose=1)
+    firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"), verbose=1)
+
+    # Level 2: Internal debug fields
+    launch_msg_rd_ptr: int = triage_field("RD PTR", verbose=2)
+    kernel_config_base: int = triage_field("Base", hex_serializer, verbose=2)
+    kernel_text_offset: int = triage_field("Offset", hex_serializer, verbose=2)
+
+    # Helper fields (not serialized directly)
+    kernel_path: str | None = combined_field()
+    kernel_name: str | None = combined_field()
+    previous_kernel_name: str | None = combined_field()
 
 
 class DispatcherData:

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -21,7 +21,7 @@ from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.firmware import ELF
 from ttexalens.parse_elf import mem_access
 from ttexalens.context import Context
-from triage import TTTriageError, combined_field, collection_serializer, triage_field, hex_serializer
+from triage import TTTriageError, collection_serializer, triage_field, hex_serializer
 from run_checks import run as get_run_checks
 from run_checks import RunChecks
 
@@ -34,7 +34,8 @@ script_config = ScriptConfig(
 @dataclass
 class DispatcherCoreData:
     # Level 0: Essential fields (always shown)
-    watcher_kernel_id: int = combined_field("kernel_name", "Kernel ID:Name", collection_serializer(":"))
+    watcher_kernel_id: int = triage_field("Kernel ID")
+    kernel_name: str | None = triage_field("Kernel Name")
     subdevice: int = triage_field("Subdevice")
     go_message: str = triage_field("Go Message")
     preload: bool = triage_field("Preload")
@@ -42,21 +43,16 @@ class DispatcherCoreData:
 
     # Level 1: Detailed fields
     host_assigned_id: int | None = triage_field("Host Assigned ID", hex_serializer, verbose=1)
-    watcher_previous_kernel_id: int = combined_field(
-        "previous_kernel_name", "Previous Kernel ID:Name", collection_serializer(":"), verbose=1
-    )
+    watcher_previous_kernel_id: int = triage_field("Previous Kernel ID")
+    previous_kernel_name: str | None = triage_field("Previous Kernel Name")
     kernel_offset: int | None = triage_field("Kernel Offset", hex_serializer, verbose=1)
-    firmware_path: str = combined_field("kernel_path", "Firmware / Kernel Path", collection_serializer("\n"), verbose=1)
+    kernel_path: str = triage_field("Kernel Path")
+    firmware_path: str = triage_field("Firmware Path")
 
     # Level 2: Internal debug fields
     launch_msg_rd_ptr: int = triage_field("RD PTR", verbose=2)
     kernel_config_base: int = triage_field("Base", hex_serializer, verbose=2)
     kernel_text_offset: int = triage_field("Offset", hex_serializer, verbose=2)
-
-    # Helper fields (not serialized directly)
-    kernel_path: str | None = combined_field()
-    kernel_name: str | None = combined_field()
-    previous_kernel_name: str | None = combined_field()
 
 
 class DispatcherData:

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -234,7 +234,7 @@ def _format_callstack(callstack: list[CallstackEntry], color: bool = False) -> l
     frame_number_width = len(str(len(callstack) - 1))
     result = []
     cwd = Path.cwd()
-    
+
     # Set color codes based on color flag
     pc_color = BLUE if color else ""
     func_color = ORANGE if color else ""
@@ -268,23 +268,27 @@ def _format_callstack(callstack: list[CallstackEntry], color: bool = False) -> l
         result.append(line)
     return result
 
+
 def format_callstack_with_message(callstack_with_message: KernelCallstackWithMessage, color: bool = False) -> str:
     """Return string representation of the callstack with optional error message. Adding empty line at the beginning for prettier look."""
     empty_line = ""  # For prettier look
-    
+
     # Set color codes based on color flag
     error_color = RED if color else ""
     reset = RST if color else ""
-    
+
     if callstack_with_message.message is not None:
         return "\n".join(
-            [f"{error_color}{callstack_with_message.message}{reset}"] + _format_callstack(callstack_with_message.callstack, color)
+            [f"{error_color}{callstack_with_message.message}{reset}"]
+            + _format_callstack(callstack_with_message.callstack, color)
         )
     else:
         return "\n".join([empty_line] + _format_callstack(callstack_with_message.callstack, color))
 
+
 def _make_dump_callstacks_data_class(color: bool):
     """Factory function to create DumpCallstacksData class with color-aware serializer."""
+
     @dataclass
     class DumpCallstacksData:
         """Callstack data showing essential fields: Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, and Callstack."""
@@ -298,11 +302,13 @@ def _make_dump_callstacks_data_class(color: bool):
         kernel_callstack_with_message: KernelCallstackWithMessage = triage_field(
             "Kernel Callstack", partial(format_callstack_with_message, color=color)
         )
+
     return DumpCallstacksData
 
 
 def _make_dump_callstacks_data_verbose_class(color: bool):
     """Factory function to create DumpCallstacksDataVerbose class with color-aware serializer."""
+
     @dataclass
     class DumpCallstacksDataVerbose:
         """Verbose callstack data showing all dispatcher fields."""
@@ -312,6 +318,7 @@ def _make_dump_callstacks_data_verbose_class(color: bool):
         kernel_callstack_with_message: KernelCallstackWithMessage = triage_field(
             "Kernel Callstack", partial(format_callstack_with_message, color=color)
         )
+
     return DumpCallstacksDataVerbose
 
 
@@ -330,7 +337,7 @@ def dump_callstacks(
     # Get the appropriate dataclass with color-aware serializer
     DumpCallstacksData = _make_dump_callstacks_data_class(color)
     DumpCallstacksDataVerbose = _make_dump_callstacks_data_verbose_class(color)
-    
+
     result = None
 
     try:

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -251,7 +251,7 @@ def _format_callstack(callstack: list[CallstackEntry]) -> list[str]:
             except ValueError:
                 # Path is not relative to cwd, keep as is
                 display_path = frame.file
-            
+
             line += f"at {GREEN}{display_path}{RST}"
             if frame.line is not None:
                 line += f" {GREEN}{frame.line}{RST}"
@@ -273,6 +273,7 @@ def format_callstack_with_message(callstack_with_message: KernelCallstackWithMes
 @dataclass
 class DumpCallstacksData:
     """Callstack data showing essential fields: Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, and Callstack."""
+
     kernel_id_name: str = triage_field("Kernel ID:Name")
     go_message: str = triage_field("Go Message")
     subdevice: int = triage_field("Subdevice")
@@ -287,6 +288,7 @@ class DumpCallstacksData:
 @dataclass
 class DumpCallstacksDataVerbose:
     """Verbose callstack data showing all dispatcher fields."""
+
     dispatcher_core_data: DispatcherCoreData = recurse_field()
     pc: int | None = triage_field("PC", hex_serializer)
     kernel_callstack_with_message: KernelCallstackWithMessage = triage_field(

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -150,30 +150,8 @@ def collection_serializer(separator: str):
 def triage_field(serialized_name: str | None = None, serializer: Callable[[Any], str] | None = None, verbose: int = 0):
     if serializer is None:
         serializer = default_serializer
-    return field(metadata={"recurse": False, "serialized_name": serialized_name, "serializer": serializer, "verbose": verbose})
-
-
-def combined_field(
-    additional_fields: str | list[str] | None = None, serialized_name: str | None = None, serializer=None, verbose: int = 0
-):
-    if additional_fields is None and serialized_name is None and serializer is None:
-        return field(metadata={"recurse": False, "dont_serialize": True})
-    assert (
-        additional_fields is not None and serialized_name is not None
-    ), "additional_fields and serialized_name must be provided."
-    if serializer is None:
-        serializer = default_serializer
-    # TODO: If serializer accepts single value, it should be wrapped around method that converts arguments to list and passes them to serializer
-    if not isinstance(additional_fields, list):
-        additional_fields = [additional_fields]
     return field(
-        metadata={
-            "recurse": False,
-            "additional_fields": additional_fields,
-            "serialized_name": serialized_name,
-            "serializer": serializer,
-            "verbose": verbose,
-        }
+        metadata={"recurse": False, "serialized_name": serialized_name, "serializer": serializer, "verbose": verbose}
     )
 
 

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -38,29 +38,47 @@ If a check is critical (such as a missing ELF file), the script should raise a `
 
 #### dump_callstacks output modes
 
-By default, `dump_callstacks` shows only essential fields:
-- Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, and Callstack
+By default, `dump_callstacks`:
+- Shows only essential fields: Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, and Callstack
 - **Automatically filters out DONE cores** to reduce noise
 
-To see all fields including DONE cores and verbose dispatcher data (RD PTR, Base, Offset, and full firmware/kernel paths), use:
+You can control the output with two independent flags:
+
+**Show more columns** using `-v` (can be repeated):
 ```bash
-./tools/tt-triage.py --run=dump_callstacks --show-details
+# Level 1: Add detailed fields (Firmware/Kernel Path, Host Assigned ID, Kernel Offset)
+./tools/tt-triage.py --run=dump_callstacks -v
+
+# Level 2: Add internal debug fields (RD PTR, Base, Offset)
+./tools/tt-triage.py --run=dump_callstacks -vv
+```
+
+**Show all cores** (including DONE cores):
+```bash
+./tools/tt-triage.py --run=dump_callstacks --all-cores
+```
+
+**Combine both** for full details:
+```bash
+./tools/tt-triage.py --run=dump_callstacks --all-cores -vv
 ```
 
 This keeps the default output clean while allowing detailed inspection when needed.
 
 To enable rich visualization, a checker script should return data as a tagged `@dataclass` or a list of tagged `@dataclass` objects of the same type. Visualization in `tt-triage` is achieved by serializing data fields in a way that describes how they should appear in the output. You control this by using tagging methods and their arguments to specify how each field should be serialized and thus visualized:
-- `triage_field(serialized_name, serializer)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). This controls how the field appears in the visualization.
-- `combined_field(additional_fields, serialized_name, serializer)` – The field will be serialized together with `additional_fields` under `serialized_name` using `serializer`. If none of the parameters are provided, visualization will be ignored, as it will be visualized with a different field. Example:
+- `triage_field(serialized_name, serializer, verbose=0)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). The `verbose` parameter controls at which verbosity level the field is shown (0=always, 1=with `-v`, 2=with `-vv`). This controls how the field appears in the visualization.
+- `combined_field(additional_fields, serialized_name, serializer, verbose=0)` – The field will be serialized together with `additional_fields` under `serialized_name` using `serializer`. If none of the parameters are provided, visualization will be ignored, as it will be visualized with a different field. The `verbose` parameter controls visibility level. Example:
   ```python
   @dataclass
   class Chip:
-    # This field will trigger visualization
+    # This field will trigger visualization (always shown)
     id: int = combined_field("arch", "ID:Arch", collection_serializer(":"))
     # This will be ignored by visualization
     arch: str = combined_field()
+    # This field only shows with -v or higher
+    detailed_info: str = triage_field("Detailed Info", verbose=1)
   ```
-- `recurse_field()` – This will cause expansion of a field that is tagged as a `@dataclass`, so its internal fields are visualized as part of the parent.
+- `recurse_field(verbose=0)` – This will cause expansion of a field that is tagged as a `@dataclass`, so its internal fields are visualized as part of the parent. The `verbose` parameter controls the minimum verbosity level for this recursion.
   ```python
   @dataclass
   class ChipCheck:
@@ -68,6 +86,8 @@ To enable rich visualization, a checker script should return data as a tagged `@
     check: str = triage_field("Check")
     # Field that will be expanded and visualized as its internal fields (see previous example)
     chip: Chip = recurse_field()
+    # Advanced data only shown with -vv
+    debug_data: DebugInfo = recurse_field(verbose=2)
   ```
 
 By carefully specifying these serialization options, you control how your data will be visualized in the `tt-triage` output.

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -67,17 +67,6 @@ This keeps the default output clean while allowing detailed inspection when need
 
 To enable rich visualization, a checker script should return data as a tagged `@dataclass` or a list of tagged `@dataclass` objects of the same type. Visualization in `tt-triage` is achieved by serializing data fields in a way that describes how they should appear in the output. You control this by using tagging methods and their arguments to specify how each field should be serialized and thus visualized:
 - `triage_field(serialized_name, serializer, verbose=0)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). The `verbose` parameter controls at which verbosity level the field is shown (0=always, 1=with `-v`, 2=with `-vv`). This controls how the field appears in the visualization.
-- `combined_field(additional_fields, serialized_name, serializer, verbose=0)` – The field will be serialized together with `additional_fields` under `serialized_name` using `serializer`. If none of the parameters are provided, visualization will be ignored, as it will be visualized with a different field. The `verbose` parameter controls visibility level. Example:
-  ```python
-  @dataclass
-  class Chip:
-    # This field will trigger visualization (always shown)
-    id: int = combined_field("arch", "ID:Arch", collection_serializer(":"))
-    # This will be ignored by visualization
-    arch: str = combined_field()
-    # This field only shows with -v or higher
-    detailed_info: str = triage_field("Detailed Info", verbose=1)
-  ```
 - `recurse_field(verbose=0)` – This will cause expansion of a field that is tagged as a `@dataclass`, so its internal fields are visualized as part of the parent. The `verbose` parameter controls the minimum verbosity level for this recursion.
   ```python
   @dataclass
@@ -98,14 +87,14 @@ Below is a representative example showing how to define data classes for visuali
 
 ```python
 from dataclasses import dataclass
-from triage import triage_field, combined_field, recurse_field, collection_serializer
+from triage import triage_field, recurse_field, collection_serializer
 
 @dataclass
 class Chip:
     # This field will be visualized as "ID:Arch" with value "id:arch"
-    id: int = combined_field("arch", "ID:Arch", collection_serializer(":"))
+    id: int = triage_field("Id")
     # This field is only used for combination above, not visualized separately
-    arch: str = combined_field()
+    arch: str = triage_field("Arch")
 
 @dataclass
 class ChipCheck:
@@ -127,12 +116,12 @@ When this data is returned from your script, `tt-triage` will visualize it as a 
 
 For example, the output might look like:
 ```
-╭───────────┬─────────╮
-│  Check    │ ID:Arch │
-├───────────┼─────────┤
-│ Power OK  │  1:A0   │
-│ Temp High │  2:B1   │
-╰───────────┴─────────╯
+╭───────────┬────┬──────╮
+│  Check    │ Id │ Arch │
+├───────────┼────┼──────┤
+│ Power OK  │  1 │  A0  │
+│ Temp High │  2 │  B1  │
+╰───────────┴────┴──────╯
 ```
 
 ## Script configuration

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -36,6 +36,19 @@ If a check is critical (such as a missing ELF file), the script should raise a `
 
 `tt-triage` will try to visualize data returned by scripts, so it is important to describe the data accordingly. For example, see `dump_callstacks` — `tt-triage` would generate a table with all callstacks.
 
+#### dump_callstacks output modes
+
+By default, `dump_callstacks` shows only essential fields:
+- Kernel ID:Name, Go Message, Subdevice, Preload, Waypoint, PC, and Callstack
+- **Automatically filters out DONE cores** to reduce noise
+
+To see all fields including DONE cores and verbose dispatcher data (RD PTR, Base, Offset, and full firmware/kernel paths), use:
+```bash
+./tools/tt-triage.py --run=dump_callstacks --show-details
+```
+
+This keeps the default output clean while allowing detailed inspection when needed.
+
 To enable rich visualization, a checker script should return data as a tagged `@dataclass` or a list of tagged `@dataclass` objects of the same type. Visualization in `tt-triage` is achieved by serializing data fields in a way that describes how they should appear in the output. You control this by using tagging methods and their arguments to specify how each field should be serialized and thus visualized:
 - `triage_field(serialized_name, serializer)` – The field will be serialized (and visualized) as `serialized_name` (or the original field name if not provided) using the specified `serializer` (or `default_serializer`). This controls how the field appears in the visualization.
 - `combined_field(additional_fields, serialized_name, serializer)` – The field will be serialized together with `additional_fields` under `serialized_name` using `serializer`. If none of the parameters are provided, visualization will be ignored, as it will be visualized with a different field. Example:

--- a/tools/triage/utils.py
+++ b/tools/triage/utils.py
@@ -5,15 +5,6 @@
 import os
 import sys
 
-# Colors for terminal output
-RST = "\033[0m"
-BLUE = "\033[34m"  # For good values
-RED = "\033[31m"  # For bad values
-GREEN = "\033[32m"  # For instructions
-GREY = "\033[37m"  # For general information
-ORANGE = "\033[33m"  # For warnings
-VERBOSE_CLR = "\033[94m"  # For verbose output
-
 
 def should_use_color() -> bool:
     """
@@ -33,6 +24,19 @@ def should_use_color() -> bool:
 
     # Check if output is going to a terminal
     return sys.stdout.isatty()
+
+
+# Cache the result of should_use_color
+_USE_COLOR = should_use_color()
+
+# Colors for terminal output
+RST = "\033[0m" if _USE_COLOR else ""
+BLUE = "\033[34m" if _USE_COLOR else ""  # For good values
+RED = "\033[31m" if _USE_COLOR else ""  # For bad values
+GREEN = "\033[32m" if _USE_COLOR else ""  # For instructions
+GREY = "\033[37m" if _USE_COLOR else ""  # For general information
+ORANGE = "\033[33m" if _USE_COLOR else ""  # For warnings
+VERBOSE_CLR = "\033[94m" if _USE_COLOR else ""  # For verbose output
 
 
 # Tabulate format for displaying tables

--- a/tools/triage/utils.py
+++ b/tools/triage/utils.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 # Colors for terminal output
 RST = "\033[0m"
 BLUE = "\033[34m"  # For good values
@@ -10,6 +13,26 @@ GREEN = "\033[32m"  # For instructions
 GREY = "\033[37m"  # For general information
 ORANGE = "\033[33m"  # For warnings
 VERBOSE_CLR = "\033[94m"  # For verbose output
+
+
+def should_use_color() -> bool:
+    """
+    Determine if color output should be enabled based on environment.
+
+    Returns:
+        bool: True if colors should be used, False otherwise.
+
+    Checks:
+        - TT_TRIAGE_COLOR environment variable (0 = disabled, other values = enabled)
+        - Whether stdout is connected to a TTY (terminal)
+    """
+    # Respect TT_TRIAGE_COLOR environment variable
+    color_env = os.environ.get("TT_TRIAGE_COLOR")
+    if color_env is not None:
+        return color_env != "0"
+
+    # Check if output is going to a terminal
+    return sys.stdout.isatty()
 
 
 # Tabulate format for displaying tables


### PR DESCRIPTION
### Problem description
Enhance dump_callstacks: add essential fields, fix alignment, improve paths

### What's changed
- Show relative paths (./) in callstacks when running from project root
- Fix callstack column alignment and add assertions to prevent regressions
- Add Go Message, Subdevice, Preload, Waypoint to default output
- Remove duplicate location/risc columns and --active-cores option
- Make colored call stack output optional instead of default
- Update documentation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes


