### PR TITLE
set rt args for all cores even if no op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1633,7 +1633,6 @@ operation::ProgramWithCallbacks pad_tile_multicore(
             num_pages_per_core = num_pages_per_core_group_2;
         } else {
             num_pages_per_core = 0;  // no-op
-            continue;
         }
 
         all_runtime_args = {


### PR DESCRIPTION
### Ticket
[Link to CI Failure](https://github.com/tenstorrent/tt-metal/actions/runs/18332567283/job/52293721728)

### Problem description
Not setting rt args meant sometimes in PC override_runtime_args was trying to access rt indices that didn't exist.

### What's changed
Always set rt args, even on no op, will still be a no op.

### Checklist
- [ ] [Fixes Deepseek Galaxy CI](https://github.com/tenstorrent/tt-metal/actions/runs/18353763846)
- [ ] [Post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/18382598865)