### PR TITLE
Fix kernel path resolution

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -47,43 +47,53 @@ namespace {
 // If the path doesn't exist as a absolute/relative path, then it must be relative to
 // TT_METAL_HOME/TT_METAL_KERNEL_PATH.
 //
-std::vector<fs::path> source_search_paths(const fs::path& given_file_name) {
-    std::vector<fs::path> paths = {given_file_name};
+fs::path resolve_path(const fs::path& given_file_name) {
+    // Priority 0: Absolute path
+    if (given_file_name.is_absolute()) {
+        return given_file_name;
+    }
 
-    TT_ASSERT(
-        fs::exists(given_file_name) || (!fs::path(given_file_name).is_absolute()),
-        "Kernel source path {} must be relative to TT_METAL_HOME/TT_METAL_KERNEL_PATH or be an absolute path to a "
-        "valid file",
-        given_file_name);
+    // Priority 1: Current working directory
+    {
+        auto current_working_dir_search_path = fs::current_path() / given_file_name;
+        if (fs::exists(current_working_dir_search_path)) {
+            return current_working_dir_search_path;
+        }
+    }
 
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
-    if (rtoptions.is_root_dir_specified()) {
-        auto root_dir_search_path = fs::path(rtoptions.get_root_dir()) / given_file_name;
-        paths.push_back(root_dir_search_path);
-    }
 
+    // Priority 2: Kernel directory
     if (rtoptions.is_kernel_dir_specified()) {
-        auto kernel_dir_search_path = fs::path(rtoptions.get_kernel_dir()) / given_file_name;
-        paths.push_back(kernel_dir_search_path);
+        auto kernel_dir_search_path = fs::absolute(fs::path(rtoptions.get_kernel_dir()) / given_file_name);
+        if (fs::exists(kernel_dir_search_path)) {
+            return kernel_dir_search_path;
+        }
     }
 
-    auto system_kernel_dir_search_path = fs::path(rtoptions.get_system_kernel_dir()) / given_file_name;
-    paths.push_back(system_kernel_dir_search_path);
+    // Priority 3: Root directory
+    if (rtoptions.is_root_dir_specified()) {
+        auto root_dir_search_path = fs::absolute(fs::path(rtoptions.get_root_dir()) / given_file_name);
+        if (fs::exists(root_dir_search_path)) {
+            return root_dir_search_path;
+        }
+    }
 
-    return paths;
+    // Priority 4: System kernel directory
+    auto system_kernel_dir_search_path = fs::absolute(fs::path(rtoptions.get_system_kernel_dir()) / given_file_name);
+    if (fs::exists(system_kernel_dir_search_path)) {
+        return system_kernel_dir_search_path;
+    }
+
+    // Not found
+    TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", given_file_name);
 }
 }  // namespace
 
 KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
     source_(source), source_type_(source_type) {
     if (source_type == FILE_PATH) {
-        auto search_paths = source_search_paths(source);
-        auto itr = std::ranges::find_if(search_paths, [](const auto& path) { return fs::exists(path); });
-        if (itr == search_paths.end()) {
-            log_critical(LogMetal, "Kernel file searched in {}!", source, fmt::join(search_paths, ", "));
-            TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", source);
-        }
-        path_ = *itr;
+        path_ = resolve_path(source);
     }
 };
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -42,11 +42,13 @@ namespace tt_metal {
 namespace fs = std::filesystem;
 
 namespace {
-// Kernel path searching:
+// Kernel path resolve:
 //
-// If the path doesn't exist as a absolute/relative path, then it must be relative to
-// TT_METAL_HOME/TT_METAL_KERNEL_PATH.
-//
+// If the path is not an absolute path, then it must be resolved relative to:
+// 1. CWD
+// 2. TT_METAL_KERNEL_PATH
+// 3. TT_METAL_HOME / SetRootDir (API)
+// 4. System Kernel Directory
 fs::path resolve_path(const fs::path& given_file_name) {
     // Priority 0: Absolute path
     if (given_file_name.is_absolute()) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/unreachable.hpp>
 #include "build.hpp"
 #include "hlk_desc.hpp"
 #include "jit_build_options.hpp"
@@ -49,20 +50,14 @@ void gen_kernel_cpp(const string& src, const string& dst_name) {
     gen_kernel_cpp(src, dst_name, empty_prolog);
 }
 
-string get_kernel_source_to_include(const KernelSource& kernel_src, const std::string& root_dir) {
+string get_kernel_source_to_include(const KernelSource& kernel_src) {
     switch (kernel_src.source_type_) {
         case KernelSource::FILE_PATH: {
-            std::filesystem::path p(kernel_src.path_);
-            if (!p.is_absolute()) {
-                p = std::filesystem::path(root_dir) / p;
-            }
-            return "#include \"" + fs::absolute(p).string() + "\"\n";
+            return "#include \"" + kernel_src.path_.string() + "\"\n";
         }
         case KernelSource::SOURCE_CODE: return kernel_src.source_;
-        default: {
-            TT_THROW("Unsupported kernel source type!");
-        }
     }
+    ttsl::unreachable();
 }
 
 }  // namespace
@@ -75,7 +70,7 @@ void jit_build_genfiles_kernel_include(
     string out_dir = env.get_out_kernel_root_path() + settings.get_full_kernel_name() + "/";
     string kernel_header = out_dir + "kernel_includes.hpp";
 
-    const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src, env.get_root_path());
+    const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
 
     gen_kernel_cpp(kernel_src_to_include, kernel_header);
 }
@@ -96,7 +91,7 @@ void jit_build_genfiles_triscs_src(
     string pack_cpp = pack_base + ".cpp";
     string pack_llk_args_h = pack_base + "_llk_args.h";
 
-    const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src, env.get_root_path());
+    const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
 
     vector<string> unpack_prolog;
     unpack_prolog.push_back("#define TRISC_UNPACK\n");

--- a/tt_metal/programming_examples/tests/CMakeLists.txt
+++ b/tt_metal/programming_examples/tests/CMakeLists.txt
@@ -16,4 +16,8 @@ target_link_libraries(
         protobuf::libprotobuf
 )
 
+add_executable(out_of_tree_test)
+target_sources(out_of_tree_test PRIVATE out_of_tree_test.cpp)
+target_link_libraries(out_of_tree_test PUBLIC TT::Metalium)
+
 # Any other integration tests should be added here

--- a/tt_metal/programming_examples/tests/out_of_tree_test.cpp
+++ b/tt_metal/programming_examples/tests/out_of_tree_test.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
 #include <fstream>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>

--- a/tt_metal/programming_examples/tests/out_of_tree_test.cpp
+++ b/tt_metal/programming_examples/tests/out_of_tree_test.cpp
@@ -1,0 +1,68 @@
+#include <fstream>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include "tt-metalium/kernel_types.hpp"
+#include "tt_stl/assert.hpp"
+
+using namespace tt::tt_metal;
+
+constexpr std::string_view null_kernel_dm =
+    R"(
+void kernel_main() {
+}
+)";
+
+constexpr std::string_view null_kernel_compute =
+    R"(
+#include "compute_kernel_api.h"
+namespace NAMESPACE {
+void MAIN {
+}
+}
+)";
+
+int main() {
+    // Emulate we are executing and using kerrnels outside of TT_METAL_HOME
+    chdir("/tmp");
+
+    constexpr int device_id = 0;
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    Program program = CreateProgram();
+
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    // Generate the kernels
+    {
+        std::ofstream null_kernel_compute_out("null_kernel_compute.cpp");
+        std::ofstream null_kernel_dm_out("null_kernel_dm.cpp");
+        TT_ASSERT(null_kernel_compute_out.is_open(), "Failed to open file for writing");
+        TT_ASSERT(null_kernel_dm_out.is_open(), "Failed to open file for writing");
+        null_kernel_compute_out << null_kernel_compute;
+        null_kernel_dm_out << null_kernel_dm;
+    }
+
+    constexpr CoreCoord core = {0, 0};
+
+    CreateKernel(
+        program,
+        "./null_kernel_dm.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(program, "./null_kernel_compute.cpp", core, ComputeConfig{});
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+    distributed::Finish(cq);
+
+    // Close the device
+    if (!mesh_device->close()) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tt_metal/programming_examples/tests/out_of_tree_test.cpp
+++ b/tt_metal/programming_examples/tests/out_of_tree_test.cpp
@@ -23,7 +23,7 @@ void MAIN {
 )";
 
 int main() {
-    // Emulate we are executing and using kerrnels outside of TT_METAL_HOME
+    // Emulate we are executing and using kernels outside of TT_METAL_HOME
     chdir("/tmp");
 
     constexpr int device_id = 0;

--- a/tt_stl/tt_stl/unreachable.hpp
+++ b/tt_stl/tt_stl/unreachable.hpp
@@ -22,8 +22,6 @@ using std::unreachable;
 
 #else
 
-// Choose a helpful debug behavior and an optimizing release behavior.
-// Define TTSL_UNREACHABLE_DEBUG_ABORT to force abort in all builds if desired.
 [[noreturn]] inline void unreachable() noexcept {
 #if defined(__GNUC__) || defined(__clang__)
     __builtin_unreachable();

--- a/tt_stl/tt_stl/unreachable.hpp
+++ b/tt_stl/tt_stl/unreachable.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Try to surface feature-test macros as early as possible
+#if defined(__has_include)
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+#include <utility>  // ensures __cpp_lib_unreachable is visible on some libcs
+
+// We may use abort() in debug-fallbacks
+#include <cstdlib>
+
+namespace ttsl {
+
+// Prefer the C++23 library facility when available
+#if defined(__cpp_lib_unreachable)
+using std::unreachable;
+
+#else
+
+// Choose a helpful debug behavior and an optimizing release behavior.
+// Define TTSL_UNREACHABLE_DEBUG_ABORT to force abort in all builds if desired.
+[[noreturn]] inline void unreachable() noexcept {
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_unreachable();
+#elif defined(_MSC_VER)
+    __assume(false);
+#else
+    // Portable fallback: still ensure no return
+    std::abort();
+#endif
+}
+
+#endif  // !defined(__cpp_lib_unreachable)
+
+}  // namespace ttsl


### PR DESCRIPTION
### Ticket
NA

### Problem description
- I broke something
- Marty complained
- Trouble with finding kernels

The following documented behavior was not observed by our code base:
```
The path to the kernel source file can either be
Relative to the TT_METAL_KERNEL_PATH environment variable (or TT_METAL_HOME if the former is not set), or
Absolute path to the file, or
Relative to the current working directory
```

### What's changed
- Rewrite path resolution logic to match documentation
- Added test from @marty1885 
- Added ttsl::unreachable to make things cleaner

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18385465576) CI passes
- [x] New/Existing tests provide coverage for changes