### PR TITLE
Disable gp relaxations on erisc0

### DIFF
--- a/tt_metal/hw/inc/tt-1xx/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/eth_fw_api.h
@@ -219,11 +219,11 @@ struct boot_results_t {
 #include "tt_metal/hw/inc/ethernet/tt_eth_api.h"
 #include "dev_msgs.h"
 
-uint64_t get_next_link_status_check_timestamp() {
+FORCE_INLINE uint64_t get_next_link_status_check_timestamp() {
     return *reinterpret_cast<volatile tt_l1_ptr uint64_t*>(GET_MAILBOX_ADDRESS_DEV(link_status_check_timestamp));
 }
 
-void update_next_link_status_check_timestamp() {
+FORCE_INLINE void update_next_link_status_check_timestamp() {
 #if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
     uint64_t timestamp = eth_read_wall_clock() + (ETH_CLOCK_CYCLE_1MS * ETH_UPDATE_LINK_STATUS_INTERVAL_MS);
     *reinterpret_cast<volatile tt_l1_ptr uint64_t*>(GET_MAILBOX_ADDRESS_DEV(link_status_check_timestamp)) = timestamp;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -170,6 +170,10 @@ public:
               params.processor_class == HalProcessorClassType::COMPUTE)) {
             cflags += "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
         }
+        if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH && blackhole::is_2_erisc_mode()) {
+            // Cannot use the gp as it's used by the base firmware
+            cflags += "-mno-relax ";
+        }
         return cflags;
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25427

### Problem description
- The gp is unusable on erisc0 by Metal as it was setup to point to the base firmware data

### What's changed
- Add mno-relax to the erisc0 build flags

### Checklist
BH APC
https://github.com/tenstorrent/tt-metal/actions/runs/18385722090
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18385719491
BH Multi Card
https://github.com/tenstorrent/tt-metal/actions/runs/18385716407