### PR TITLE
[skip ci] Add ticket issue to already commented out Galaxy CCL Nightly test

### DIFF
--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          #{ name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: U05ACKAJTHS}, # Naif Tarafdar
+          #{ name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: U05ACKAJTHS}, # Naif Tarafdar #See issue #29578
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           {


### PR DESCRIPTION
### Ticket
#29578 

### Problem description
Already commented out, due to https://github.com/tenstorrent/tt-metal/issues/29741

### What's changed
Test was already commented out, now it has the correlated issue ticket added to it for visibility purposes