### PR TITLE
Add program_hash to `program_descriptor`

### DIFF
--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -132,6 +132,7 @@ struct ProgramDescriptor {
     KernelDescriptors kernels;
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
+    std::optional<tt::stl::hash::hash_t> program_hash;
 
     uint32_t add_semaphore(CoreRangeSet core_ranges, uint32_t initial_value, CoreType core_type = CoreType::WORKER);
 };

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -51,7 +51,7 @@ struct CBFormatDescriptor {
 };
 
 struct CBDescriptor {
-    using FormatDescriptors = tt::stl::SmallVector<CBFormatDescriptor, 1>;
+    using FormatDescriptors = ttsl::SmallVector<CBFormatDescriptor, 1>;
 
     uint32_t total_size = 0;
     CoreRangeSet core_ranges;
@@ -125,14 +125,14 @@ struct KernelDescriptor {
 };
 
 struct ProgramDescriptor {
-    using KernelDescriptors = tt::stl::SmallVector<KernelDescriptor, 3>;
-    using SemaphoreDescriptors = tt::stl::SmallVector<SemaphoreDescriptor, 3>;
-    using CBDescriptors = tt::stl::SmallVector<CBDescriptor, 5>;
+    using KernelDescriptors = ttsl::SmallVector<KernelDescriptor, 3>;
+    using SemaphoreDescriptors = ttsl::SmallVector<SemaphoreDescriptor, 3>;
+    using CBDescriptors = ttsl::SmallVector<CBDescriptor, 5>;
 
     KernelDescriptors kernels;
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
-    std::optional<tt::stl::hash::hash_t> custom_program_hash;
+    std::optional<ttsl::hash::hash_t> custom_program_hash;
 
     uint32_t add_semaphore(CoreRangeSet core_ranges, uint32_t initial_value, CoreType core_type = CoreType::WORKER);
 };

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -132,7 +132,7 @@ struct ProgramDescriptor {
     KernelDescriptors kernels;
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
-    std::optional<tt::stl::hash::hash_t> program_hash;
+    std::optional<tt::stl::hash::hash_t> custom_program_hash;
 
     uint32_t add_semaphore(CoreRangeSet core_ranges, uint32_t initial_value, CoreType core_type = CoreType::WORKER);
 };

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -64,6 +64,15 @@ struct GenericOpDeviceOperation {
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const std::vector<Tensor>& io_tensors, const operation_attributes_t& operation_attributes);
 
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+        if (operation_attributes.program_hash) {
+            return *operation_attributes.program_hash;
+        } else {
+            return tt::stl::hash::hash_objects_with_default_seed(
+                tt::stl::hash::type_hash<GenericOpDeviceOperation>, operation_attributes, tensor_args);
+        }
+    }
     // static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };  // struct GenericOpDeviceOperation
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -64,14 +64,15 @@ struct GenericOpDeviceOperation {
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const std::vector<Tensor>& io_tensors, const operation_attributes_t& operation_attributes);
 
+    // Note: will either compute a program hash, or simply return user provided custom program hash
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-        if (operation_attributes.program_hash) {
-            return *operation_attributes.program_hash;
-        } else {
-            return tt::stl::hash::hash_objects_with_default_seed(
-                tt::stl::hash::type_hash<GenericOpDeviceOperation>, operation_attributes, tensor_args);
+        if (operation_attributes.custom_program_hash) {
+            return *operation_attributes.custom_program_hash;
         }
+
+        return tt::stl::hash::hash_objects_with_default_seed(
+            tt::stl::hash::type_hash<GenericOpDeviceOperation>, operation_attributes, tensor_args);
     }
 };  // struct GenericOpDeviceOperation
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -73,7 +73,6 @@ struct GenericOpDeviceOperation {
                 tt::stl::hash::type_hash<GenericOpDeviceOperation>, operation_attributes, tensor_args);
         }
     }
-    // static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };  // struct GenericOpDeviceOperation
 
 }  // namespace ttnn::operations::generic


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Direct consumer: ttnn.jit. We can calculate a program hash in MLIR [runtime](https://github.com/tenstorrent/tt-mlir/pull/5300/files#diff-8e5f810c3a3ad363e239b406370a2edefde6fec51146994574b4efe7756f0c84), and can re-use said hash in ttnn. No need to do another hash calculation.

### What's changed
- added optional `program_hash` field to `program_descriptor`
- if set, use `program_hash` in `compute_program_hash` for generic op, else default to ttnn hash calculation.


### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/18566240961
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/18566246089
- [ ] ~[Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)~
- [ ] ~[Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)~
- [ ] ~(For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).~
- [ ] ~[Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)~
- [ ] ~[Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work~
- [ ] ~(For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)~
- [ ] ~(For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)~