### PR TITLE
Added stability test for yolov8s_world

### DIFF
--- a/models/demos/yolov8s_world/tests/test_stability.py
+++ b/models/demos/yolov8s_world/tests/test_stability.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import pytest
+import torch
+from loguru import logger
+from tqdm import tqdm
+
+import ttnn
+from models.common.utility_functions import run_for_wormhole_b0
+from models.demos.yolov8s_world.common import YOLOV8SWORLD_L1_SMALL_SIZE
+from models.demos.yolov8s_world.runner.performant_runner import YOLOv8sWorldPerformantRunner
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": YOLOV8SWORLD_L1_SMALL_SIZE, "trace_region_size": 6434816, "num_command_queues": 2}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype",
+    ((1, ttnn.bfloat16, ttnn.bfloat16),),
+)
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        (640, 640),
+    ],
+)
+@pytest.mark.parametrize("test_duration", [5])
+@pytest.mark.parametrize("pcc_check_interval", [5])
+def test_yolov8s_world_stability(
+    device,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    resolution,
+    test_duration,
+    pcc_check_interval,
+):
+    performant_runner = YOLOv8sWorldPerformantRunner(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        resolution=resolution,
+        model_location_generator=None,
+    )
+
+    logger.info(f"Running stability test for YOLOv8s_world with resolution: {resolution} and batch size: {batch_size}")
+
+    pcc_iter = 0
+    check_pcc = False
+    start_time = time.time()
+
+    with tqdm(total=test_duration, desc="Executing on device", unit="sec", mininterval=1) as pbar:
+        while True:
+            elapsed_time = round(time.time() - start_time, 1)
+            pbar.update(min(elapsed_time, test_duration) - pbar.n)
+
+            if elapsed_time >= test_duration:
+                break
+
+            if elapsed_time >= pcc_iter * pcc_check_interval:
+                check_pcc = True
+                pcc_iter += 1
+
+            torch_input_tensor = torch.randn((1, 3, *resolution), dtype=torch.float32)
+            _ = performant_runner.run(torch_input_tensor, check_pcc=check_pcc)
+            check_pcc = False
+
+    performant_runner.release()


### PR DESCRIPTION
### Problem description
The stability test can help with regression testing for model

Fix #1: Missing Event Initialization
Problem: AttributeError: 'YOLOv8sWorldPerformantRunner' object has no attribute 'op_event'
Root Cause: _capture_yolov8s_world_trace_2cqs() method was never called
Solution: Added self._capture_yolov8s_world_trace_2cqs() call in __init__ method
Impact: Fixed initialization of op_event, write_event, and trace capture setup

Fix #2: Tuple Handling in Validation
Problem: AttributeError: 'tuple' object has no attribute 'shape'
Root Cause: YOLOv8s_world returns a tuple (main_tensor, [additional_tensors]), but assert_with_pcc expected tensors
Solution: Modified _validate method to extract and convert the first tuple element:
```
result_output_tensor = ttnn.to_torch(result_output_tensor[0])
assert_with_pcc(torch_output_tensor[0], result_output_tensor, 0.99)
```