### PR TITLE
Hack To Make MPWI Work with Kernel Sizes < 9

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -185,6 +185,11 @@ void MAIN {
                     tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
                     tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
 
+                    // the max_reduce_with_indices LLK function only supports kernel_size=9, pending
+                    // https://github.com/tenstorrent/tt-metal/issues/28141 but, since for return_indices the in_cb is
+                    // oversized (equal to 1 tile), and since this CB is filled with padding values in the beginning of
+                    // the data movement kernel, it is possible to still use max_reduce_with_indices with kernel sizes
+                    // smaller than 9 as the excess sticks are just filled with padding values
                     constexpr uint32_t max_mpwi_kernel_size = 9;
                     max_reduce_with_indices<max_mpwi_kernel_size>(data_dst_idx, index_dst_idx);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -185,7 +185,8 @@ void MAIN {
                     tilize_block_no_pack(curr_in_cb_id, topk_output_tiles, data_dst_idx, topk_cb_tile_idx);
                     tilize_uninit_with_dt_no_pack(curr_in_cb_id, curr_in_idx_cb_id);
 
-                    max_reduce_with_indices<window_size_hw>(data_dst_idx, index_dst_idx);
+                    constexpr uint32_t max_mpwi_kernel_size = 9;
+                    max_reduce_with_indices<max_mpwi_kernel_size>(data_dst_idx, index_dst_idx);
 
                     cb_pop_front(curr_in_idx_cb_id, 1);
                 } else {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -63,7 +63,7 @@ void validate_pool2d(
             std::numeric_limits<uint16_t>::max());
         auto kernel_h = sliding_window_config.window_hw.first;
         auto kernel_w = sliding_window_config.window_hw.second;
-        TT_FATAL(kernel_h * kernel_w == 9, "only kernel sizes equal to 9 are supported, got {}x{}", kernel_h, kernel_w);
+        TT_FATAL(kernel_h * kernel_w <= 9, "only kernel sizes equal to 9 are supported, got {}x{}", kernel_h, kernel_w);
 
         TT_FATAL(output_layout == Layout::ROW_MAJOR, "Only ROW_MAJOR supported when return_indices is true");
     }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -63,7 +63,11 @@ void validate_pool2d(
             std::numeric_limits<uint16_t>::max());
         auto kernel_h = sliding_window_config.window_hw.first;
         auto kernel_w = sliding_window_config.window_hw.second;
-        TT_FATAL(kernel_h * kernel_w <= 9, "only kernel sizes equal to 9 are supported, got {}x{}", kernel_h, kernel_w);
+        TT_FATAL(
+            kernel_h * kernel_w <= 9,
+            "only kernel sizes less than or equal to 9 are supported, got {}x{}",
+            kernel_h,
+            kernel_w);
 
         TT_FATAL(output_layout == Layout::ROW_MAJOR, "Only ROW_MAJOR supported when return_indices is true");
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We need MPWI support for kernel sizes = 2x2.

### What's changed
A long term general solution for arbitrary kernel sizes will take some time, but with padding it is possible for the current LLK functions (which only support kernel_size=9) to work for kernel sizes <= 9, including the desired 2x2 configurations.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390272249
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390278567
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390292282
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390294844
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390282929
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390288604
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/18390297059
- [x] New/Existing tests provide coverage for changes - will be tested by upcoming sweep test PR