### PR TITLE
[tt-train] Add reduction type None to CrossEntropyLoss

### DIFF
--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -33,6 +33,12 @@ autograd::TensorPtr mse_loss(
 
 autograd::TensorPtr cross_entropy_loss(
     const autograd::TensorPtr& prediction, const autograd::TensorPtr& target, ReduceType reduce) {
+    if (reduce != ReduceType::NONE && reduce != ReduceType::MEAN) {
+        throw std::logic_error(fmt::format(
+            "Unsupported cross entropy reduction type, only NONE and MEAN are supported. Got: {}",
+            enchantum::to_string(reduce)));
+    }
+
     auto prediction_shape = prediction->get_shape();
     auto target_shape = target->get_shape();
 

--- a/tt-train/sources/ttml/ops/losses.hpp
+++ b/tt-train/sources/ttml/ops/losses.hpp
@@ -8,7 +8,7 @@
 
 namespace ttml::ops {
 
-enum ReduceType : uint8_t { MEAN = 0, SUM = 1 };
+enum ReduceType : uint8_t { NONE = 0, MEAN = 1, SUM = 2 };
 
 autograd::TensorPtr mse_loss(
     const autograd::TensorPtr& prediction, const autograd::TensorPtr& target, ReduceType reduce = ReduceType::MEAN);

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -108,7 +108,8 @@ autograd::TensorPtr log_softmax_moreh(const autograd::TensorPtr& tensor, int dim
 
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
     auto shape = ttnn::Shape({1, 1, 1, 1});
-    autograd::TensorPtr out = autograd::create_tensor(core::from_vector({0.F}, shape, &autograd::ctx().get_device()));
+    auto out =
+        autograd::create_tensor(core::empty(shape, &autograd::ctx().get_device(), tensor->get_value().memory_config()));
     ttnn::moreh_mean(
         tensor->get_value(),
         std::nullopt,

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -321,7 +321,7 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
 TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
     using namespace ttml;
 
-    const uint32_t N = 1U, C = 1U, H = 91U, W = 187U;
+    const uint32_t N = 5U, C = 1U, H = 91U, W = 187U;
     const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
@@ -359,8 +359,6 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
 
     auto result_none_after_mean_xtensor = core::to_xtensor(result_none_with_mean_after->get_value());
     auto result_mean_xtensor = core::to_xtensor(result_mean->get_value());
-
-    // print all shapes
 
     assert((result_none_after_mean_xtensor.shape() == result_mean_xtensor.shape()));
     EXPECT_TRUE(xt::allclose(result_none_after_mean_xtensor, result_mean_xtensor, 3e-2F, 1e-2F));

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -18,6 +18,8 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ops/losses.hpp"
+#include "ops/unary_ops.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 class CrossEntropyBackwardTest : public ::testing::Test {
@@ -314,4 +316,58 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+}
+
+TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
+    using namespace ttml;
+
+    const uint32_t N = 1U, C = 1U, H = 91U, W = 187U;
+    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+
+    std::random_device rd;
+    std::mt19937 gen(42);
+    xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
+    auto& rng = ttml::autograd::ctx().get_generator();
+    uint32_t seed = rng();
+    ttml::core::parallel_generate(
+        std::span{input_tensor.data(), input_tensor.size()},
+        []() { return std::uniform_real_distribution<float>(-10.0F, 10.0F); },
+        seed);
+    xt::xarray<uint32_t> target_tensor = xt::zeros<uint32_t>({N, H});
+    xt::xarray<float> grad_tensor = xt::ones<float>({1U, 1U, 1U, 1U});
+
+    std::uniform_int_distribution<uint32_t> class_dist(0, W - 1);
+    for (uint32_t n = 0; n < N; ++n) {
+        for (uint32_t h = 0; h < H; ++h) {
+            uint32_t true_class = class_dist(gen);
+            target_tensor(n, h) = true_class;
+        }
+    }
+
+    auto input = ttml::autograd::create_tensor(core::from_xtensor(input_tensor, &autograd::ctx().get_device()));
+    auto target = ttml::autograd::create_tensor(core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(
+        target_tensor, &autograd::ctx().get_device(), ttnn::Layout::ROW_MAJOR));
+
+    auto result_none = ttml::ops::cross_entropy_loss(input, target, ttml::ops::ReduceType::NONE);
+    auto result_none_with_mean_after = ttml::ops::mean(result_none);
+    auto result_mean = ttml::ops::cross_entropy_loss(input, target, ttml::ops::ReduceType::MEAN);
+
+    result_mean->backward();
+    result_none_with_mean_after->backward();
+
+    auto result_mean_grad = core::to_xtensor(result_mean->get_grad());
+    auto result_none_with_mean_after_grad = core::to_xtensor(result_none_with_mean_after->get_grad());
+
+    auto result_none_after_mean_xtensor = core::to_xtensor(result_none_with_mean_after->get_value());
+    auto result_mean_xtensor = core::to_xtensor(result_mean->get_value());
+
+    // print all shapes
+    std::cout << "Result_none_shape: " << result_none->get_shape() << std::endl;
+    std::cout << "Result_mean_shape: " << result_mean->get_shape() << std::endl;
+    std::cout << "Result_none_with_mean_after_shape: " << result_none_with_mean_after->get_shape() << std::endl;
+
+    assert((result_none_after_mean_xtensor.shape() == result_mean_xtensor.shape()));
+    EXPECT_TRUE(xt::allclose(result_none_after_mean_xtensor, result_mean_xtensor, 3e-2F, 1e-2F));
+    assert((result_none_with_mean_after_grad.shape() == result_mean_grad.shape()));
+    EXPECT_TRUE(xt::allclose(result_none_with_mean_after_grad, result_mean_grad, 3e-2F, 1e-2F));
 }

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -334,7 +334,6 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
         []() { return std::uniform_real_distribution<float>(-10.0F, 10.0F); },
         seed);
     xt::xarray<uint32_t> target_tensor = xt::zeros<uint32_t>({N, H});
-    xt::xarray<float> grad_tensor = xt::ones<float>({1U, 1U, 1U, 1U});
 
     std::uniform_int_distribution<uint32_t> class_dist(0, W - 1);
     for (uint32_t n = 0; n < N; ++n) {

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -361,9 +361,6 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
     auto result_mean_xtensor = core::to_xtensor(result_mean->get_value());
 
     // print all shapes
-    std::cout << "Result_none_shape: " << result_none->get_shape() << std::endl;
-    std::cout << "Result_mean_shape: " << result_mean->get_shape() << std::endl;
-    std::cout << "Result_none_with_mean_after_shape: " << result_none_with_mean_after->get_shape() << std::endl;
 
     assert((result_none_after_mean_xtensor.shape() == result_mean_xtensor.shape()));
     EXPECT_TRUE(xt::allclose(result_none_after_mean_xtensor, result_mean_xtensor, 3e-2F, 1e-2F));


### PR DESCRIPTION
### Problem description
This will help our fine-tune demo. 

### What's changed
* Add reduction type None to CrossEntropyLoss
* Add test for None vs Mean reduction type 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18389368067) CI passes
- [x] New/Existing tests provide coverage for changes