### PR TITLE
remove bfloat8 ddr test

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
@@ -29,7 +29,7 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_n
     ids=[
         "float_16",
         "uint_32",
-        #"bfloat_8",
+        # "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -134,11 +134,7 @@ def test_ccl_ddr_smoke_test(
         ttnn.uint32,
         ttnn.bfloat8_b,
     ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat8"
-    ],
+    ids=["float_16", "uint_32", "bfloat8"],
 )
 @pytest.mark.parametrize(
     "mem_config_input, mem_config_ag",

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
@@ -24,12 +24,12 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.nightly.test_all_gather_n
     [
         ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
+        # ttnn.bfloat8_b, #issue #30353
     ],
     ids=[
         "float_16",
         "uint_32",
-        "bfloat_8",
+        #"bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -132,10 +132,12 @@ def test_ccl_ddr_smoke_test(
     [
         ttnn.bfloat16,
         ttnn.uint32,
+        ttnn.bfloat8_b,
     ],
     ids=[
         "float_16",
         "uint_32",
+        "bfloat8"
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
@@ -132,12 +132,10 @@ def test_ccl_ddr_smoke_test(
     [
         ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
         "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Removing the bfloat 8 ddr test

On IRD the test passes but in CI it is seeing failures. We are investigating if it is firmware related or something else, however removing the test to unblock sys-eng and investigating on the software side

container smoke test https://github.com/tenstorrent/tt-metal/actions/runs/18389750023

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes