### PR TITLE
#30347: Add tt-run distributed process launcher documentation

### DIFF
--- a/tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md
+++ b/tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md
@@ -189,9 +189,9 @@ For more examples, please see `tests/tt_metal/distributed/multiprocess/run_visib
 **Core Abstraction: Rank Bindings**
 
 The central concept in `tt-run` is the **rank binding**, which maps each MPI rank to:
-- A mesh identifier (`mesh_id`) — which logical mesh this rank belongs to
-- A mesh host rank (`mesh_host_rank`) — position within a multi-host mesh (for SPMD Big-Mesh)
-- Environment overrides — global and rank-specific environment variables
+- A mesh identifier (`mesh_id`) - which logical mesh this rank belongs to
+- A mesh host rank (`mesh_host_rank`) - position within a multi-host mesh (for SPMD Big-Mesh)
+- Environment overrides - global and rank-specific environment variables
 
 **Mesh Graph Descriptors (MGD 2.0)**
 

--- a/tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md
+++ b/tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md
@@ -1,6 +1,6 @@
 # Programming Mesh of Devices with TT-NN
 
-Author: Joseph Chu
+Authors: Scale-Out Team
 
 ## Contents
 
@@ -164,6 +164,164 @@ TT_VISIBLE_DEVICES="0,1" ./your_cpp_program
 
 
 For more examples, please see `tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh`.
+
+### 2.4 Distributed Process Launch with tt-run
+
+#### 2.4.1 Overview and Design Philosophy
+
+`tt-run` is a distributed process launcher for TT-Metal/TTNN workloads supporting both **single-host multi-process** and **multi-host distributed** configurations. It provides a declarative YAML-based interface to orchestrate MPI-based distributed execution, abstracting the complexity of environment management, device partitioning, and mesh topology configuration.
+
+**Design Patterns Supported**
+
+`tt-run` enables two primary distributed execution patterns:
+
+1. **SPMD "Big-Mesh" Pattern**: Multiple MPI ranks coordinate to present a single, unified logical mesh spanning multiple hosts. Each rank manages a local sub-mesh while executing identical program code. This pattern is ideal for:
+   - Tensor Parallelism (TP) across large meshes
+   - Data Parallelism (DP) with uniform data distribution
+   - Hybrid TP+DP workloads that scale uniformly across the mesh
+   - Described in detail: [TT-Distributed: Multi-Host Runtime](../../tech_reports/TT-Distributed/MultiHostMeshRuntime.md)
+
+2. **Multi-Mesh Pattern**: Different MPI ranks manage independent meshes, potentially running different workload stages. This pattern supports:
+   - Pipeline Parallelism where each rank handles different model layers
+   - Multi-model inference where independent models run on separate meshes
+   - Heterogeneous workloads requiring different mesh configurations per stage
+
+**Core Abstraction: Rank Bindings**
+
+The central concept in `tt-run` is the **rank binding**, which maps each MPI rank to:
+- A mesh identifier (`mesh_id`) — which logical mesh this rank belongs to
+- A mesh host rank (`mesh_host_rank`) — position within a multi-host mesh (for SPMD Big-Mesh)
+- Environment overrides — global and rank-specific environment variables
+
+**Mesh Graph Descriptors (MGD 2.0)**
+
+The Mesh Graph Descriptor defines the topology of the distributed system, including host topology for multi-host meshes and inter-mesh connections for multi-mesh scenarios.
+
+MGD 2.0 uses Protobuf text format (`.textproto` extension). For detailed schema documentation and examples, see: [`tt_metal/fabric/MGD_README.md`](../../tt_metal/fabric/MGD_README.md)
+
+**Automatic Environment Isolation**
+
+To ensure safe multi-process execution, `tt-run` automatically manages per-rank environments:
+- **TT_METAL_CACHE**: Unique cache directory per rank (default: `~/.cache/{hostname}_rank{N}`) prevents kernel compilation conflicts
+- **TT_VISIBLE_DEVICES**: Controls PCIe device visibility per rank (see [Section 2.3](#23-controlling-device-visibility)). By default, all devices are visible.
+- **TT_MESH_GRAPH_DESC_PATH**: Path to topology descriptor
+- **TT_MESH_ID** & **TT_MESH_HOST_RANK**: Mesh identification for runtime coordination
+
+#### 2.4.2 Configuration and Usage
+
+**Basic Configuration Example**
+
+```yaml
+rank_bindings:
+  - rank: 0
+    mesh_id: 0                 # Mesh identifier
+    mesh_host_rank: 0          # Position within multi-host mesh
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1"  # Devices visible to this rank
+
+  - rank: 1
+    mesh_id: 0
+    mesh_host_rank: 1
+    env_overrides:
+      TT_VISIBLE_DEVICES: "2,3"
+
+mesh_graph_desc_path: "mesh_descriptor.textproto"  # MGD 2.0 topology definition
+
+global_env:                    # Environment variables for all ranks
+  TT_METAL_LOGGER_LEVEL: "INFO"
+```
+
+**Command-Line Invocation**
+
+```bash
+tt-run --rank-binding config.yaml [--mpi-args "<mpi_args>"] <program> [args...]
+```
+
+Common options:
+- `--dry-run`: Preview generated MPI command without execution
+- `--verbose`: Enable detailed logging
+- `--mpi-args`: Pass additional MPI arguments (rankfiles, network options, etc.)
+
+#### 2.4.3 Usage Patterns
+
+**Pattern 1: SPMD Big-Mesh**
+
+Multiple ranks collaborate to form a single logical mesh spanning hosts. All ranks share the same `mesh_id` but have different `mesh_host_rank` values.
+
+```yaml
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {TT_VISIBLE_DEVICES: "0,1"}
+  - rank: 1
+    mesh_id: 0
+    mesh_host_rank: 1
+    env_overrides: {TT_VISIBLE_DEVICES: "2,3"}
+
+mesh_graph_desc_path: "dual_host_mesh.textproto"  # Multi-host topology
+```
+
+**Pattern 2: Multi-Mesh (Independent Meshes)**
+
+Each rank manages an independent mesh, enabling pipeline parallelism or multi-model scenarios. Ranks have different `mesh_id` values.
+
+```yaml
+rank_bindings:
+  - rank: 0
+    mesh_id: 0      # First pipeline stage
+    env_overrides: {TT_VISIBLE_DEVICES: "0"}
+  - rank: 1
+    mesh_id: 1      # Second pipeline stage
+    env_overrides: {TT_VISIBLE_DEVICES: "1"}
+
+mesh_graph_desc_path: "multi_mesh.textproto"
+```
+
+**Pattern 3: Single-Host Emulation**
+
+Emulate multi-host workloads on a single host by partitioning devices across processes:
+
+```yaml
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1"}}
+  - {rank: 1, mesh_id: 0, mesh_host_rank: 1, env_overrides: {TT_VISIBLE_DEVICES: "2,3"}}
+mesh_graph_desc_path: "emulated_dual_host.textproto"
+```
+
+**Pattern 4: Multi-Host Cluster Deployment**
+
+For multi-host clusters, combine rank bindings with MPI rankfiles to specify physical host assignments:
+
+```bash
+# Rankfile specifies physical host assignment
+# rank 0=host1 slot=0
+# rank 1=host2 slot=0
+
+tt-run --rank-binding config.yaml \
+       --mpi-args "--rankfile hosts.txt --mca btl tcp" \
+       python distributed_workload.py
+```
+
+
+**Example Files and Tests**
+
+Configuration examples:
+- `tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml` - Single-host multi-process configuration
+- `tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto` - T3000 mesh topology (MGD 2.0)
+- `tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.textproto` - Galaxy mesh topology (MGD 2.0)
+
+Test scripts demonstrating `tt-run` usage:
+- `tests/scripts/run_t3000_unit_tests.sh` - T3000 multi-process test launcher
+- `tests/scripts/run_dual_galaxy_tests.sh` - Multi-host Galaxy test launcher
+- `tests/tt_metal/distributed/multiprocess/run_visible_devices_mp_tests.sh` - Device visibility examples
+
+**Related Documentation**
+
+- Section 2.3: [Controlling Device Visibility](#23-controlling-device-visibility) - for `TT_VISIBLE_DEVICES` details
+- Section 2.1: [System Topology](#21-system-topology) - for understanding mesh configurations
+- [`tt_metal/fabric/MGD_README.md`](../../tt_metal/fabric/MGD_README.md) - MGD 2.0 schema and examples
+- [TT-Distributed: Multi-Host Runtime](../../tech_reports/TT-Distributed/MultiHostMeshRuntime.md) - SPMD architecture details
 
 ## 3. Distributing Tensor to MeshDevice
 

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -323,6 +323,13 @@ def main(
             filename: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_dual_host_cluster_desc_rank_1.yaml"
 
     See examples/ttrun/ for example configuration files.
+
+    \b
+    Documentation:
+        For comprehensive usage guide, design patterns (SPMD Big-Mesh and Multi-Mesh),
+        and integration with MGD 2.0, see:
+        tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md
+        Section 2.4: Distributed Process Launch with tt-run
     """
     program = ctx.args
     try:


### PR DESCRIPTION
### Ticket
#30347

### Problem description
Users lack comprehensive documentation for `tt-run`, the distributed process launcher for TT-Metal/TTNN workloads supporting single-host and multi-host configurations.

### What's changed
- Added Section 2.4 to Programming Mesh of Devices documentation covering `tt-run` distributed process launcher
- Documented two execution patterns: SPMD Big-Mesh for unified meshes and Multi-Mesh for pipeline parallelism
- Explained core abstractions including rank bindings, MGD 2.0 integration, and automatic environment isolation
- Provided four usage patterns with YAML configuration examples
- Added references to example config files in `tests/tt_metal/distributed/config/` and test scripts
- Cross-referenced MultiHostMeshRuntime.md and MGD_README.md for detailed technical documentation

### CI Runs
- [ ] [All post commit](APC_JOB_URL) CI passes
- [ ] [T3000 unit tests](T3000_JOB_URL) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes