### PR TITLE
Sparse Matmul: Fix page size for sparsity tensor

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -512,6 +512,7 @@ on:
           - matmul.short.matmul_user_program_config_mcast_1d
           - matmul.short.matmul_user_program_config_mcast_2d
           - matmul.sparse.sparse_matmul
+          - matmul.sparse.batched_sparse_matmul
           - max_pool2d.full.max_pool2d_large_dims
           - max_pool2d.full.max_pool2d_params
           - max_pool2d.short.max_pool2d_short_sweep

--- a/tests/sweep_framework/sweeps/matmul/sparse/batched_sparse_matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/sparse/batched_sparse_matmul.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+
+from loguru import logger
+import pytest
+import random
+import torch
+import math
+import ttnn
+
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
+from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
+
+TIMEOUT = 50
+
+# Parameters provided to the test vector generator are defined here.
+parameters = {
+    "gpt_traces": {
+        "m": list(1 << x for x in range(5, 16)),
+        "kn": [(360, 2880)],
+        "num_experts": [(1, 32), (1, 128)],
+        "tile_h": [32],
+        "tile_w": [32],
+        "in1_dtype": [ttnn.bfloat4_b],
+        "core_grid": [(5, 6)],
+    },
+}
+
+
+def run_sparse_matmul(device, m, kn, num_experts, tile_h, tile_w, in1_dtype, core_grid) -> list:
+    k, n = kn
+    b, s = num_experts
+    in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
+    in1 = torch.randn((b, s, k, n), dtype=torch.bfloat16)
+
+    sparsity_shape = (1, 1, b, s)
+    sparsity = torch.rand(sparsity_shape)
+
+    # Mark some as 0 to test the sparsity
+    sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
+    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
+    sparsity.view(-1)[zero_indices] = 0.0
+
+    sparsity = sparsity.to(dtype=torch.bfloat16)
+
+    nnz = int((sparsity != 0).sum().item())
+    logger.info(f"nnz: {nnz}")
+
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    sparsity_t = ttnn.from_torch(
+        sparsity,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    core_x, core_y = core_grid
+    output_tile = ttnn.Tile([tile_h, tile_w])
+
+    start_time = start_measuring_time()
+    output_t = ttnn.sparse_matmul(
+        in0_t,
+        in1_t,
+        sparsity=sparsity_t,
+        nnz=nnz,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_tile=output_tile,
+        is_input_a_sparse=True,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // 32,
+            per_core_N=int(math.ceil(n / 32)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
+    )
+    output_tensor = ttnn.to_torch(output_t)
+    e2e_perf = stop_measuring_time(start_time)
+
+    # Compute matmul using torch for each batch and concatenate the results
+    for b_idx, s_idx in itertools.product(range(b), range(s)):
+        if sparsity[0, 0, b_idx, s_idx] == 0.0:
+            continue
+        in0_batch = in0[b_idx, s_idx, :, :]
+        in1_batch = in1[b_idx, s_idx, :, :]
+        pt_out = torch.matmul(in0_batch, in1_batch)
+        ttnn_out = output_tensor[b_idx, s_idx, :, :]
+        # We only check the first non-zero entry for PCC
+        return get_run_return(pt_out, ttnn_out, 0.99, [in0_t, in1_t, sparsity_t], e2e_perf)
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
+def test_sparse_matmul(device, m, kn, num_experts, tile_h, tile_w, in1_dtype, core_grid):
+    (result, msg), e2e_perf = run_sparse_matmul(device, m, kn, num_experts, tile_h, tile_w, in1_dtype, core_grid)
+    assert result, msg
+    logger.info(f"e2e_perf: {e2e_perf}")
+
+
+def run(
+    m,
+    kn,
+    num_experts,
+    tile_h,
+    tile_w,
+    in1_dtype,
+    core_grid,
+    *,
+    device,
+) -> list:
+    return run_sparse_matmul(device, m, kn, num_experts, tile_h, tile_w, in1_dtype, core_grid)

--- a/tests/sweep_framework/sweeps/matmul/sparse/sparse_matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/sparse/sparse_matmul.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
-import os
-from typing import Optional, Tuple
 
 from loguru import logger
 import pytest
@@ -13,8 +11,7 @@ import torch
 import math
 import ttnn
 
-from models.common.utility_functions import comp_pcc
-from tests.ttnn.utils_for_testing import assert_with_pcc, start_measuring_time, stop_measuring_time
+from tests.ttnn.utils_for_testing import start_measuring_time, stop_measuring_time
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.sweep_framework.sweep_utils.roofline_utils import get_run_return
 
@@ -22,20 +19,39 @@ TIMEOUT = 50
 
 # Parameters provided to the test vector generator are defined here.
 parameters = {
-    "moe_traces": {
-        "mkn": [(128, 7168, 2048), (128, 2048, 7168)],
+    "moe_traces1": {
+        "mkn": [(128, 7168, 2048)],
         "num_experts": [8],
-        "num_tokens": [(1, 1), (1, 4), (1, 32)],
-        "tile_h": [32, 16],
-        "tile_w": [32, 16],
+        "num_batches": [(1, 1), (1, 4), (1, 32)],
+        "tile_h": [32],
+        "tile_w": [32],
         "in1_dtype": [ttnn.bfloat8_b],
+        "core_grid": [(8, 8)],
+    },
+    "moe_traces2": {
+        "mkn": [(128, 2048, 7168)],
+        "num_experts": [8],
+        "num_batches": [(1, 1), (1, 4), (1, 32)],
+        "tile_h": [32],
+        "tile_w": [32],
+        "in1_dtype": [ttnn.bfloat8_b],
+        "core_grid": [(7, 8)],
+    },
+    "gpt_traces": {
+        "mkn": [(32, 2880, 360)],
+        "num_experts": [32, 128],
+        "num_batches": [(1, 1 << x) for x in range(0, 13)],
+        "tile_h": [32],
+        "tile_w": [32],
+        "in1_dtype": [ttnn.bfloat4_b],
+        "core_grid": [(3, 4)],
     },
 }
 
 
-def run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype) -> list:
+def run_sparse_matmul(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid) -> list:
     m, k, n = mkn
-    b, s = num_tokens
+    b, s = num_batches
     in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
     in1 = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
 
@@ -48,10 +64,9 @@ def run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 
-    sparsity = sparsity.to(dtype=torch.float32)
+    sparsity = sparsity.to(dtype=torch.bfloat16)
 
     nnz = int((sparsity != 0).sum().item())
-
     logger.info(f"nnz: {nnz}")
 
     in0_t = ttnn.from_torch(
@@ -74,13 +89,14 @@ def run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_
 
     sparsity_t = ttnn.from_torch(
         sparsity,
-        dtype=ttnn.float32,
+        dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
     output_tile = ttnn.Tile([tile_h, tile_w])
+    core_x, core_y = core_grid
 
     start_time = start_measuring_time()
     output_t = ttnn.sparse_matmul(
@@ -90,6 +106,19 @@ def run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_
         nnz=nnz,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // 32,
+            per_core_N=int(math.ceil(n / 32)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
     )
     output_tensor = ttnn.to_torch(output_t)
     e2e_perf = stop_measuring_time(start_time)
@@ -103,12 +132,14 @@ def run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_
         pt_out = torch.matmul(in0_batch, in1_batch)
         ttnn_out = output_tensor[b_idx, s_idx, 0, e_idx, :, :]
         # We only check the first non-zero entry for PCC
-        return get_run_return(pt_out, ttnn_out, 0.999, [in0_t, in1_t, sparsity_t], e2e_perf)
+        return get_run_return(pt_out, ttnn_out, 0.99, [in0_t, in1_t, sparsity_t], e2e_perf)
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
-def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
-    (result, msg), e2e_perf = run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype)
+def test_sparse_matmul(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid):
+    (result, msg), e2e_perf = run_sparse_matmul(
+        device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid
+    )
     assert result, msg
     logger.info(f"e2e_perf: {e2e_perf}")
 
@@ -116,11 +147,12 @@ def test_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1
 def run(
     mkn,
     num_experts,
-    num_tokens,
+    num_batches,
     tile_h,
     tile_w,
     in1_dtype,
+    core_grid,
     *,
     device,
 ) -> list:
-    return run_sparse_matmul(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype)
+    return run_sparse_matmul(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid)

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -15,7 +15,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
-@pytest.mark.parametrize("num_experts", [8])
+@pytest.mark.parametrize("num_experts", [8, 32])
 @pytest.mark.parametrize("num_tokens", [(1, 4)])
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
             // This means we have unstructured sparsity.
             // The compute kernel needs to be made aware whether this batch is valid or not.
             // We do this by passing the value to the compute kernel via nnz_cb_id.
-            // But first, lets wait for the sparisty data to be multicast to us.
+            // But first, lets wait for the sparsity data to be multicast to us.
             // Set in0 semaphore value to INVALID
             noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
             // Atomic increment source core counter

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -341,4 +341,9 @@ void kernel_main() {
         }
     }
     noc_async_write_barrier();
+    if constexpr (batchB > 0) {
+        cb_push_back(cb_id_sparsity, 1);
+        cb_wait_front(cb_id_sparsity, 1);
+        cb_pop_front(cb_id_sparsity, 1);
+    }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -341,6 +341,7 @@ void kernel_main() {
         }
     }
     noc_async_write_barrier();
+    // For completeness, we empty the sparsity CB if it was reserved earlier
     if constexpr (batchB > 0) {
         cb_push_back(cb_id_sparsity, 1);
         cb_wait_front(cb_id_sparsity, 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -3249,10 +3249,10 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         (std::uint32_t)Mt * Kt,  // MtKt
         (std::uint32_t)B_A,      // batchA
         // sparsity args
-        (std::uint32_t)B_B,                               // batchB
-        (std::uint32_t)B_B * (uint32_t)sizeof(uint32_t),  // sparsity_pagesize
-        (std::uint32_t)!is_input_a_sparse,                // bcast_A
-        (std::uint32_t)!nnz.has_value(),                  // get_batch_from_reader
+        (std::uint32_t)B_B,                                     // batchB
+        (std::uint32_t)sparsity.buffer()->aligned_page_size(),  // sparsity_pagesize
+        (std::uint32_t)!is_input_a_sparse,                      // bcast_A
+        (std::uint32_t)!nnz.has_value(),                        // get_batch_from_reader
         // fuse op args
         (std::uint32_t)false,  // fuse_op
     };
@@ -3284,8 +3284,8 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         (std::uint32_t)B_A,      // batchA
         (std::uint32_t)true,     // bcast_B
         // sparsity args
-        (std::uint32_t)B_B,                               // batchB
-        (std::uint32_t)B_B * (uint32_t)sizeof(uint32_t),  // sparsity_pagesize
+        (std::uint32_t)B_B,                                     // batchB
+        (std::uint32_t)sparsity.buffer()->aligned_page_size(),  // sparsity_pagesize
 
         // WRITER
         // out tensor args
@@ -3509,12 +3509,14 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     uint32_t sparsity_cb_index0 = tt::CBIndex::c_6;
     uint32_t sparsity_cb_index1 = tt::CBIndex::c_7;
 
-    uint32_t sparsity_cb_size = B_B * sizeof(uint32_t);
+    uint32_t sparsity_cb_size = sparsity.buffer()->aligned_page_size();
     tt_metal::CircularBufferConfig sparsity_cb_config0 =
-        tt_metal::CircularBufferConfig(sparsity_cb_size, {{sparsity_cb_index0, tt::DataFormat::Float32}})
+        tt_metal::CircularBufferConfig(
+            sparsity_cb_size, {{sparsity_cb_index0, tt::tt_metal::datatype_to_dataformat_converter(sparsity.dtype())}})
             .set_page_size(sparsity_cb_index0, sparsity_cb_size);
     tt_metal::CircularBufferConfig sparsity_cb_config1 =
-        tt_metal::CircularBufferConfig(sparsity_cb_size, {{sparsity_cb_index1, tt::DataFormat::Float32}})
+        tt_metal::CircularBufferConfig(
+            sparsity_cb_size, {{sparsity_cb_index1, tt::tt_metal::datatype_to_dataformat_converter(sparsity.dtype())}})
             .set_page_size(sparsity_cb_index1, sparsity_cb_size);
 
     tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config0);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -3189,6 +3189,19 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
+    // There should not be any cores without work in the receiver grid. If a grid is
+    // not rectangular, then there will be some cores without work in the receiver grid.
+    // For example, if there are 12 blocks of work, it should be put into a 3x4 grid.
+    // If its laid out in row major with 8 cores in first row and 4 cores in second row,
+    // then there will be 4 cores without work in the receiver grid, causing a hang.
+    // We check for this below and error out.
+    TT_FATAL(
+        num_cores_with_work == in0_mcast_receiver_num_cores,
+        "num_cores_with_work ({}) must be equal to in0_mcast_receiver_num_cores ({}), please adjust the core grid to "
+        "make it rectangular.",
+        num_cores_with_work,
+        in0_mcast_receiver_num_cores);
+
     CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid;
     CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid;
     CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29946

### Problem description
Since page size for sparsity tensor was tied to the tensor being float32, the page sizes were incorrect. This led to hangs when the tensor had more than 64B page size.

### What's changed
1. Made the fixes to tie the page size to the sparsity tensor's size and dtype directly in the factory.
2. Added sweeps for the failing cases to the GPT OSS sweep folder.
3. Added unit test to cover the scenario

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18392145657
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18392164304
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes