### PR TITLE
#29197: Append rank suffix to user-provided TT_METAL_CACHE paths

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -105,19 +105,22 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
     Returns:
         Dictionary of environment variables for this rank
     """
-    # Handle TT_METAL_CACHE with rank-specific suffix to ensure multi-process safety.
+    # Handle TT_METAL_CACHE with rank-specific suffix to prevent cache conflicts/collisions between ranks (multi-process safety).
+    hostname = os.uname().nodename
+
     if "TT_METAL_CACHE" in os.environ:
         user_cache_path = os.environ["TT_METAL_CACHE"]
-        cache_path = f"{user_cache_path}_{os.uname().nodename}_rank{binding.rank}"
+        base_path = user_cache_path
         logger.warning(
             f"{TT_RUN_PREFIX} User-provided TT_METAL_CACHE '{user_cache_path}' "
-            f"modified to '{cache_path}' for rank {binding.rank} to ensure multi-process safety"
+            f"will be modified with rank suffix for multi-process safety"
         )
     else:
         # Use default pattern when TT_METAL_CACHE is not set
-        cache_path = DEFAULT_CACHE_DIR_PATTERN.format(
-            home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank
-        )
+        base_path = f"{Path.home()}/.cache"
+
+    # Apply consistent rank suffix pattern to both user-provided and default paths
+    cache_path = f"{base_path}_{hostname}_rank{binding.rank}"
 
     env = {
         "TT_METAL_CACHE": cache_path,

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -105,11 +105,22 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
     Returns:
         Dictionary of environment variables for this rank
     """
+    # Handle TT_METAL_CACHE with rank-specific suffix to ensure multi-process safety.
+    if "TT_METAL_CACHE" in os.environ:
+        user_cache_path = os.environ["TT_METAL_CACHE"]
+        cache_path = f"{user_cache_path}_{os.uname().nodename}_rank{binding.rank}"
+        logger.warning(
+            f"{TT_RUN_PREFIX} User-provided TT_METAL_CACHE '{user_cache_path}' "
+            f"modified to '{cache_path}' for rank {binding.rank} to ensure multi-process safety"
+        )
+    else:
+        # Use default pattern when TT_METAL_CACHE is not set
+        cache_path = DEFAULT_CACHE_DIR_PATTERN.format(
+            home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank
+        )
+
     env = {
-        "TT_METAL_CACHE": os.environ.get(
-            "TT_METAL_CACHE",
-            DEFAULT_CACHE_DIR_PATTERN.format(home=str(Path.home()), hostname=os.uname().nodename, rank=binding.rank),
-        ),  # Need to explicitly configure this because kernel cache is not multi-process safe (#21089)
+        "TT_METAL_CACHE": cache_path,
         "TT_MESH_ID": str(binding.mesh_id),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
         "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", str(Path.home())),


### PR DESCRIPTION
### Ticket
#29197

### Problem description
User-provided `TT_METAL_CACHE` paths are not appended with rank-specific suffixes, causing cache conflicts in multi-process workloads.

### What's changed
- Modified `get_rank_environment()` in `ttrun.py` to append `_{hostname}_rank{N}` suffix to user-provided `TT_METAL_CACHE` paths
- Format matches default pattern for consistency across single and multi-host setups
- Added warning log when modifying user paths for transparency
- Preserves default behavior when `TT_METAL_CACHE` is not set

### CI Runs
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18392398477) CI passes
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18392399659) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes