### PR TITLE
Modify Llama70B-Glx initialization to be compatible with DP factor received from vLLM V1

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -10,6 +10,8 @@ from models.demos.llama3_70b_galaxy.tt.llama_model import TtTransformer
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations, TtModelArgs
 from models.tt_transformers.tt.generator import create_submeshes
 
+import vllm.envs as envs
+
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransformer, tt_cache_path):
     submesh_devices = [model.mesh_device]
@@ -49,6 +51,14 @@ def initialize_vllm_text_transformer(
     dtype=ttnn.bfloat8_b,
     optimizations=LlamaOptimizations.performance,
 ):
+    if envs.VLLM_USE_V1:
+        # tt_data_parallel is the total number of DP kv caches, so need to divide by the DP factor of attention.
+        dp_attention_factor = mesh_device.shape[1]
+        assert (
+            tt_data_parallel % dp_attention_factor == 0
+        ), f"Total DP ({tt_data_parallel}) must be divisible by dp_attention_factor ({dp_attention_factor})"
+        tt_data_parallel = tt_data_parallel // dp_attention_factor
+
     submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
     # Load model args, weights
     model_args = []

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -350,7 +350,9 @@ class TtTransformer(LightweightModule):
         """
         B = tokens.shape[0]
         # assert current_pos.shape[0] == B, "Batch size mismatch"
-        assert B == self.args.max_batch_size, f"Batch size must be equal to max_batch_size {self.args.max_batch_size}"
+        assert (
+            B == self.args.max_batch_size
+        ), f"Batch size {B} must be equal to max_batch_size {self.args.max_batch_size}"
 
         # Necessary padding to be full tile sized when on device
         tokens = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens)), "constant", 0)

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -234,7 +234,9 @@ class Transformer(LightweightModule):
         """
         B = tokens.shape[0]
         assert current_pos.shape[0] == B, "Batch size mismatch"
-        assert B == self.args.max_batch_size, "Batch size must be equal to max_batch_size"
+        assert (
+            B == self.args.max_batch_size
+        ), f"Batch size {B} must be equal to max_batch_size {self.args.max_batch_size}"
 
         # Necessary padding to be full tile sized when on device
         tokens = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens)), "constant", 0)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/112

### Problem description
N/A

### What's changed
- Made the necessary modification for full DP attention support in V1. When running with V1, `tt_data_parallel` will contain the total DP factor (including DP attention), so it needs to be divided by the model's DP attention factor prior to model initialization to retain previous behaviour.
- TT-Transformers does not require such a modification since it doesn't do DP attention for an individual submesh.
- This PR must be paired with https://github.com/tenstorrent/vllm/pull/203 for full DP attention support in V1.
- Improved assertion messages for batch_size == max_batch_size in decode.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

All post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/18395717836
vLLM nightly tests: https://github.com/tenstorrent/tt-metal/actions/runs/18395810211