### PR TITLE
[GRIDSAMPLE] Adding allclose check for gridsample nightly tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -308,6 +308,12 @@ def test_grid_sample_near_uniform_grid(device, input_shape, grid_shape, use_prec
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(pcc_message)
 
+    atol, rtol = 1.0, 1e-1
+    allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
+
 
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize("batch_output_channels", [True, False])
@@ -366,6 +372,20 @@ def test_grid_sample_batch_output_channels_flag(
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
     logger.info(pcc_message)
 
+    # Test allclose with tolerances based on grid type and precomputed grid usage
+    if use_precomputed_grid:
+        atol, rtol = 1.0, 1e-1  # Precomputed grid has slightly lower accuracy
+    else:
+        if grid_dtype == ttnn.float32:
+            atol, rtol = 0.02, 1e-2
+        else:  # bfloat16
+            atol, rtol = 1.0, 1e-1
+
+    allclose_passed = torch.allclose(torch_expected_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
+
 
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
 @pytest.mark.parametrize("grid_dtype", [ttnn.bfloat16, ttnn.float32])
@@ -420,6 +440,21 @@ def test_grid_sample_sharded(device, input_shape, grid_shape, use_precomputed_gr
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     pcc_passed, pcc_message = assert_with_pcc(torch_output_nhwc, ttnn_output_torch, pcc=0.99)
+    logger.info(pcc_message)
+
+    # Test allclose with tolerances based on grid type and precomputed grid usage
+    if use_precomputed_grid:
+        atol, rtol = 1.0, 1e-1  # Precomputed grid has slightly lower accuracy
+    else:
+        if grid_dtype == ttnn.float32:
+            atol, rtol = 0.02, 1e-2
+        else:  # bfloat16
+            atol, rtol = 1.0, 1e-1
+
+    allclose_passed = torch.allclose(torch_output_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"
 
 
 @pytest.mark.parametrize("use_precomputed_grid", [True, False])
@@ -490,3 +525,18 @@ def test_grid_sample_sharded_batched(
         torch_output_nhwc, batch_size, grid_h, grid_w, channels, grid_batching_factor, batch_output_channels
     )
     pcc_passed, pcc_message = assert_with_pcc(torch_expected_nhwc, ttnn_output_torch, pcc=0.99)
+    logger.info(pcc_message)
+
+    # Test allclose with tolerances based on grid type and precomputed grid usage
+    if use_precomputed_grid:
+        atol, rtol = 1.0, 1e-1  # Precomputed grid has slightly lower accuracy
+    else:
+        if grid_dtype == ttnn.float32:
+            atol, rtol = 0.02, 1e-2
+        else:  # bfloat16
+            atol, rtol = 1.0, 1e-1
+
+    allclose_passed = torch.allclose(torch_expected_nhwc, ttnn_output_torch, atol=atol, rtol=rtol)
+
+    assert pcc_passed, f"Test failed with PCC below threshold"
+    assert allclose_passed, f"Test failed allclose comparison (atol={atol}, rtol={rtol})"

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_grid_sample.py
@@ -36,7 +36,7 @@ def validate_grid_sample_output(
 
     # Determine allclose tolerances based on grid type and precomputed grid usage
     if use_precomputed_grid:
-        atol, rtol = 1.0, 1e-1  # Precomputed grid has slightly lower accuracy
+        atol, rtol = 0.02, 2e-2  # Precomputed grid has slightly lower accuracy
     else:
         if grid_dtype == ttnn.float32:
             atol, rtol = 0.02, 1e-2


### PR DESCRIPTION
### Problem description
The pcc check for the gridsample tests is not enough to catch regression. There is a need for more thorough element-wise check which is all close. This already exists in some unit tests but needs to be added in all nightly tests as well.

### What's changed
Added all close check to the gridsample nightly batch of tests with the same absolute and relative tolerances as already existing all close check in unit tests

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18491815738) 
- [x] [Nightly tt-metal L2 tests ](https://github.com/tenstorrent/tt-metal/actions/runs/18491786287)