### PR TITLE
 #30011: Reduce input_channels_alignment requirement of Conv2D DRAM 

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -245,8 +245,8 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
     layer_pcc_thresholds = {
         "res2": 0.998,
         "res3": 0.997,
-        "res4": 0.997,
-        "res5": 0.995,
+        "res4": 0.9965,
+        "res5": 0.9945,
     }
 
     for layer_name in ["res2", "res3", "res4", "res5"]:

--- a/models/experimental/stable_diffusion_xl_refiner/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/test_common.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Refiner-specific constants
-SDXL_REFINER_L1_SMALL_SIZE = 14272
+SDXL_REFINER_L1_SMALL_SIZE = 15040

--- a/models/experimental/stable_diffusion_xl_refiner/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/test_common.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Refiner-specific constants
-SDXL_REFINER_L1_SMALL_SIZE = 15040
+SDXL_REFINER_L1_SMALL_SIZE = 15552

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
@@ -554,7 +554,9 @@ def test_conv2d_localrun(device, input_spec):
 
 # fmt: off
 failing_parameters = [
-# [batch_size, output_channels, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, groups, dilation_h, dilation_w, bias, [input_layout, input_memory_config, input_datatype], [weight_layout, weight_memory_config, weight_datatype], [output_layout, output_memory_config, output_datatype]]
+    # [batch_size, output_channels, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, groups, dilation_h, dilation_w, bias, [input_layout, input_memory_config, input_datatype], [weight_layout, weight_memory_config, weight_datatype], [output_layout, output_memory_config, output_datatype]]
+    # Will be fixed in https://github.com/tenstorrent/tt-metal/pull/30446
+    [1, 320, 320, 80, 80, 3, 3, 16, 16, 0, 0, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
 
 ]
 # fmt: on

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -839,7 +839,7 @@ def test_conv_dram(
         input_layout=input_layout,
         output_layout=input_layout,
         packer_l1_acc=packer_l1_acc,
-        run_twice=False,
+        run_twice=True,
         fast_compare=True,
         throttle_level=throttle,
         use_dram_slicing=True,
@@ -3464,35 +3464,35 @@ def test_conv2d_sdxl_refiner(
         # VAE
         # Decoder
         # kernel 3x3
-        # (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  8,   32, 3),
-        # (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 16,   32, 0),
-        # (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 16,  512, 0),
-        # (1, 256, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  4,  512, 0),
-        # (1, 512, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False,                      None,  1,  512, 0),
-        # (1, 512, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  256, 0),
-        # (1, 512, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  512, 0),
-        # (1, 512, 512,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  256, 0),
-        # # output_channels 3,
-        # (1, 128,   3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
+        (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  8,   32, 3),
+        (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 16,   32, 0),
+        (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 16,  512, 0),
+        (1, 256, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  4,  512, 0),
+        (1, 512, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False,                      None,  1,  512, 0),
+        (1, 512, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  256, 0),
+        (1, 512, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  512, 0),
+        (1, 512, 512,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  256, 0),
+        # output_channels 3,
+        (1, 128,   3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
         # input_channels 4,
         (1,   4, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False,                      None, 1,     0, 0),
 
         # Encoder
 
         # kernel 3x3
-        # (1, 128, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  4,    64, 0),
-        # (1, 256, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  1024, 0),
+        (1, 128, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  4,    64, 0),
+        (1, 256, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  1024, 0),
 
         # input_channels 3,
         (1,   3, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   1024, 0),
 
         # input_channels 8,
-        # (1, 512,   8, 128,   128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 2,     0,  0),
+        (1, 512,   8, 128,   128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 2,     0,  0),
 
-        # # stride 2x2
-        # (1, 128,   128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
-        # (1, 256,   256,  512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 4,   1024, 0),
-        # (1, 512,   512,  256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 2,   512, 0),
+        # stride 2x2
+        (1, 128,   128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
+        (1, 256,   256,  512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 4,   1024, 0),
+        (1, 512,   512,  256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 2,   512, 0),
     ),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 27 * 1024}], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3464,35 +3464,35 @@ def test_conv2d_sdxl_refiner(
         # VAE
         # Decoder
         # kernel 3x3
-        (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  8,   32, 3),
-        (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 16,   32, 0),
-        (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 16,  512, 0),
-        (1, 256, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  4,  512, 0),
-        (1, 512, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False,                      None,  1,  512, 0),
-        (1, 512, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  256, 0),
-        (1, 512, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  512, 0),
-        (1, 512, 512,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  256, 0),
-        # output_channels 3,
-        (1, 128,   3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
+        # (1, 128, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  8,   32, 3),
+        # (1, 256, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 16,   32, 0),
+        # (1, 256, 256, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 16,  512, 0),
+        # (1, 256, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  4,  512, 0),
+        # (1, 512, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False,                      None,  1,  512, 0),
+        # (1, 512, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  256, 0),
+        # (1, 512, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  512, 0),
+        # (1, 512, 512,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  8,  256, 0),
+        # # output_channels 3,
+        # (1, 128,   3, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
         # input_channels 4,
         (1,   4, 512,  128,  128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False,                      None, 1,     0, 0),
 
         # Encoder
 
         # kernel 3x3
-        (1, 128, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  4,    64, 0),
-        (1, 256, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  1024, 0),
+        # (1, 128, 256,  512,  512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth,  4,    64, 0),
+        # (1, 256, 512,  256,  256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth,  2,  1024, 0),
 
         # input_channels 3,
         (1,   3, 128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   1024, 0),
 
         # input_channels 8,
-        (1, 512,   8, 128,   128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 2,     0,  0),
+        # (1, 512,   8, 128,   128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 2,     0,  0),
 
-        # stride 2x2
-        (1, 128,   128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
-        (1, 256,   256,  512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 4,   1024, 0),
-        (1, 512,   512,  256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 2,   512, 0),
+        # # stride 2x2
+        # (1, 128,   128, 1024, 1024, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), HS, False, ttnn.Conv2dDRAMSliceWidth, 8,   256, 0),
+        # (1, 256,   256,  512, 512, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 4,   1024, 0),
+        # (1, 512,   512,  256, 256, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (0, 1, 0, 1), (1, 1), BS, False, ttnn.Conv2dDRAMSliceWidth, 2,   512, 0),
     ),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 27 * 1024}], indirect=True)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -323,7 +323,7 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
 @pytest.mark.parametrize("slice_dim", [1, 2])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("pad_value", [8, 32])
+@pytest.mark.parametrize("pad_value", [32])
 def test_slice_block_sharded_for_conv2d(
     device, dims, slice_dim, slice_size, core_x, core_y, layout, input_dtype, pad_value
 ):

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -323,15 +323,13 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
 @pytest.mark.parametrize("slice_dim", [1, 2])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("pad_value", [32])
+@pytest.mark.parametrize("pad_value", [8, 32])
 def test_slice_block_sharded_for_conv2d(
     device, dims, slice_dim, slice_size, core_x, core_y, layout, input_dtype, pad_value
 ):
     if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is not supported in row major layout")
 
-    if pad_value == 8 and layout == ttnn.TILE_LAYOUT:
-        pytest.skip("pad_value of 8 is not supported in tile layout & block sharding")
     orientation = ttnn.ShardOrientation.COL_MAJOR
     core_grid = device.core_grid
     if core_grid.x < core_x or core_grid.y < core_y:

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -311,14 +311,14 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
 @pytest.mark.parametrize(
     "dims, slice_size, core_y, core_x",
     [
-        # [[2, 64, 64, 256], 32, 4, 4],
-        # [[2, 64, 64, 512], 16, 4, 4],
-        # [[2, 16, 16, 1024], 4, 4, 4],
-        # [[2, 128, 128, 256], 32, 8, 4],
-        # [[2, 128, 128, 63], 32, 8, 2],
-        # [[2, 128, 128, 528], 96, 8, 6],
-        # [[2, 128, 128, 96], 96, 8, 3],
-        [[2, 1024, 1024, 256], 33, 10, 11]
+        [[2, 64, 64, 256], 32, 4, 4],
+        [[2, 64, 64, 512], 16, 4, 4],
+        [[2, 16, 16, 1024], 4, 4, 4],
+        [[2, 128, 128, 256], 32, 8, 4],
+        [[2, 128, 128, 63], 32, 8, 2],
+        [[2, 128, 128, 528], 96, 8, 6],
+        [[2, 128, 128, 96], 96, 8, 3],
+        [[2, 1024, 1024, 256], 33, 10, 11],
     ],
 )
 @pytest.mark.parametrize("slice_dim", [1, 2])
@@ -330,6 +330,8 @@ def test_slice_block_sharded_for_conv2d(
 ):
     if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is not supported in row major layout")
+    if round_up(dims[-1], pad_value) / pad_value < core_x:
+        pytest.skip("Skipping test with dim %s where all cores %d are not used in block sharding" % (dims, core_x))
 
     orientation = ttnn.ShardOrientation.ROW_MAJOR
     core_grid = device.core_grid
@@ -343,7 +345,6 @@ def test_slice_block_sharded_for_conv2d(
     torch.manual_seed(2005)
     torch_dtype = torch.float32 if input_dtype == ttnn.float32 else torch.bfloat16
     torch_input = torch.randint(-10, 10, dims).to(dtype=torch_dtype)
-    torch_input = torch.tensor(range(0, dims[3])).reshape(1, 1, 1, dims[3]).broadcast_to(dims).to(dtype=torch_dtype)
     num_slices = dims[slice_dim] // slice_size
     ttnn_input = ttnn.from_torch(
         torch_input, device=device, layout=layout, dtype=input_dtype, memory_config=ttnn.DRAM_MEMORY_CONFIG
@@ -375,6 +376,7 @@ def test_slice_block_sharded_for_conv2d(
         )
         this_ttnn_output = ttnn.padded_slice(ttnn_input, begins, ends, strides, memory_config=memory_config)
         output = this_ttnn_output.cpu().to_torch_with_padded_shape()
+        this_torch_output = this_torch_output[:, :, :, : output.shape[-1]]
         output = torch.reshape(output, this_torch_output.shape)
         assert torch.allclose(this_torch_output, output, atol=1e-2, rtol=1e-2)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -319,7 +319,7 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
         [[2, 128, 128, 528], 96, 8, 6],
         [[2, 128, 128, 96], 96, 8, 3],
         [[2, 1024, 1024, 256], 33, 10, 11],
-        [[1, 128, 256, 256], 127, 4, 5],
+        [[1, 64, 128, 256], 65, 4, 5],
     ],
 )
 @pytest.mark.parametrize("slice_dim", [1, 2])

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -342,6 +342,7 @@ def test_slice_block_sharded_for_conv2d(
     torch.manual_seed(2005)
     torch_dtype = torch.float32 if input_dtype == ttnn.float32 else torch.bfloat16
     torch_input = torch.randint(-10, 10, dims).to(dtype=torch_dtype)
+    torch_input = torch.tensor(range(0, dims[3])).reshape(1, 1, 1, dims[3]).broadcast_to(dims).to(dtype=torch_dtype)
     num_slices = dims[slice_dim] // slice_size
     ttnn_input = ttnn.from_torch(
         torch_input, device=device, layout=layout, dtype=input_dtype, memory_config=ttnn.DRAM_MEMORY_CONFIG
@@ -389,7 +390,8 @@ def test_slice_block_sharded_for_conv2d(
 @pytest.mark.parametrize("slice_dim", [1, 2])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
-def test_slice_width_sharded_for_conv2d(device, dims, slice_dim, slice_size, cores, layout, input_dtype):
+@pytest.mark.parametrize("pad_value", [8, 32])
+def test_slice_width_sharded_for_conv2d(device, dims, slice_dim, slice_size, cores, layout, input_dtype, pad_value):
     if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is not supported in row major layout")
 
@@ -414,7 +416,7 @@ def test_slice_width_sharded_for_conv2d(device, dims, slice_dim, slice_size, cor
     parallel_config = ttnn.SlidingWindowParallelConfig(
         grid=core_range, shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED, shard_orientation=orientation
     )
-    padded_channels = round_up(dims[-1], 32)
+    padded_channels = round_up(dims[-1], pad_value * cores)
     padded_torch_input = torch.nn.functional.pad(torch_input, (0, padded_channels - dims[-1]))
     torch.set_printoptions(sci_mode=False, precision=2)
     for i in range(num_slices):
@@ -424,7 +426,12 @@ def test_slice_width_sharded_for_conv2d(device, dims, slice_dim, slice_size, cor
         ends[slice_dim] = (i + 1) * slice_size
         this_torch_output = padded_torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2]]
         output_shape = this_torch_output.shape
-        output_shape = [1, 1, output_shape[0] * output_shape[1] * output_shape[2], round_up(output_shape[3], 32)]
+        output_shape = [
+            1,
+            1,
+            output_shape[0] * output_shape[1] * output_shape[2],
+            round_up(output_shape[3], pad_value * cores),
+        ]
 
         memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
             output_shape, parallel_config, 1

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -319,6 +319,7 @@ def test_slice_height_sharded_for_conv2d(device, dims, slice_dim, slice_size, co
         [[2, 128, 128, 528], 96, 8, 6],
         [[2, 128, 128, 96], 96, 8, 3],
         [[2, 1024, 1024, 256], 33, 10, 11],
+        [[1, 128, 256, 256], 127, 4, 5],
     ],
 )
 @pytest.mark.parametrize("slice_dim", [1, 2])
@@ -345,6 +346,7 @@ def test_slice_block_sharded_for_conv2d(
     torch.manual_seed(2005)
     torch_dtype = torch.float32 if input_dtype == ttnn.float32 else torch.bfloat16
     torch_input = torch.randint(-10, 10, dims).to(dtype=torch_dtype)
+    torch_input = torch.tensor(range(dims[-1]), dtype=torch_dtype).reshape(1, 1, 1, dims[-1]).broadcast_to(dims)
     num_slices = dims[slice_dim] // slice_size
     ttnn_input = ttnn.from_torch(
         torch_input, device=device, layout=layout, dtype=input_dtype, memory_config=ttnn.DRAM_MEMORY_CONFIG

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -363,9 +363,6 @@ Result conv2d_DRAM(
         ttnn::Tensor output_tensor;
         std::tie(output_tensor, std::ignore, std::ignore, weight_tensor_on_device, bias_tensor_on_device) = conv2d_L1(
             input_tensor_on_device,
-            // TODO: Add check to ensure that the shard_layout and memory_config are the same as the last slice to
-            // re-use the weights tensor.
-            // TODO: Add caching mechanism for multiple weights tensors, depending on the memory configs.
             weight_tensor,
             device,
             in_channels,
@@ -585,9 +582,6 @@ Result conv2d_DRAM(
         std::tie(sliced_output_tensor, std::ignore, std::ignore, weight_tensor_on_device, bias_tensor_on_device) =
             conv2d_L1(
                 sliced_input_tensor,
-                // TODO: Add check to ensure that the shard_layout and memory_config are the same as the last slice to
-                // re-use the weights tensor.
-                // TODO: Add caching mechanism for multiple weights tensors, depending on the memory configs.
                 first_run ? weight_tensor : weight_tensor_on_device,
                 device,
                 in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -240,11 +240,7 @@ Result conv2d_DRAM(
     std::optional<ttnn::Tensor> bias_tensor_on_device;
     if (mm_conv) {
         const uint32_t input_channels_alignment = get_input_channels_alignment(
-            tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
-            input_tensor.layout(),
-            BufferType::DRAM,
-            mm_conv,
-            std::nullopt);
+            tt::tt_metal::TensorMemoryLayout::INTERLEAVED, input_tensor.layout(), true, mm_conv, std::nullopt);
         // Configure weight and bias preparation parameters
         Conv2dWeightsBiasPrepConfig params(
             input_channels_alignment,
@@ -749,7 +745,7 @@ Result conv2d_L1(
     const uint32_t input_channels_alignment = get_input_channels_alignment(
         input_tensor_post_tm.memory_config().memory_layout(),
         input_tensor_post_tm.layout(),
-        input_tensor_post_tm.memory_config().buffer_type(),
+        false,
         mm_conv,
         input_tensor_post_tm.memory_config());
     const uint32_t in_channels_padded = tt::round_up(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -360,8 +360,7 @@ Result conv2d_DRAM(
             output_sliced_dim);
     }
     if (dram_slice_config.num_slices == 1) {
-        ttnn::Tensor output_tensor;
-        std::tie(output_tensor, std::ignore, std::ignore, weight_tensor_on_device, bias_tensor_on_device) = conv2d_L1(
+        return conv2d_L1(
             input_tensor_on_device,
             weight_tensor,
             device,
@@ -380,7 +379,6 @@ Result conv2d_DRAM(
             conv_config,
             compute_config_,
             DRAM_MEMORY_CONFIG);
-        return {output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
     }
     const auto unflattened_input_shape = ttnn::Shape{batch_size, input_height, input_width, in_channels};
     input_tensor_on_device = ttnn::reshape(input_tensor_on_device, unflattened_input_shape, unflattened_input_shape);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -625,7 +625,6 @@ Result conv2d_DRAM(
         first_run = false;
         output_slice_dim_start += output_slice_size;
         slice_index++;
-        // return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
     }
 
     if (conv_config.deallocate_activation) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -33,7 +33,7 @@ uint32_t find_closest_largest_divisor_with_num_padding(uint32_t num1, uint32_t n
 uint32_t get_input_channels_alignment(
     TensorMemoryLayout input_tensor_memory_layout,
     Layout input_tensor_layout,
-    BufferType input_tensor_buffer_type,
+    bool sliced_op,
     bool is_mm_conv,
     const std::optional<MemoryConfig>& input_memory_config);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1009,7 +1009,7 @@ static Conv2dBlockConfig get_opt_block_config(
     const uint32_t in_channels_alignment = get_input_channels_alignment(
         conv_config.shard_layout.value(),
         input_layout,
-        input_memory_config.buffer_type(),
+        input_memory_config.buffer_type() == BufferType::DRAM,
         mm_conv,
         input_memory_config);
 
@@ -1171,11 +1171,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
                 .mm_conv = mm_conv},
             device);
         const uint32_t input_channels_alignment = get_input_channels_alignment(
-            TensorMemoryLayout::INTERLEAVED,
-            input_layout,
-            is_dram_conv ? BufferType::DRAM : BufferType::L1,
-            mm_conv,
-            input_memory_config);
+            TensorMemoryLayout::INTERLEAVED, input_layout, is_dram_conv, mm_conv, input_memory_config);
         if (mm_conv) {
             return Conv2dWeightsBiasPrepConfig(
                 input_channels_alignment,
@@ -1256,11 +1252,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     }
 
     uint32_t input_channels_alignment = get_input_channels_alignment(
-        conv_config.shard_layout.value(),
-        input_layout,
-        is_dram_conv ? BufferType::DRAM : BufferType::L1,
-        mm_conv,
-        input_memory_config);
+        conv_config.shard_layout.value(), input_layout, is_dram_conv, mm_conv, input_memory_config);
 
     ParallelConfig parallel_config;
     if (input_memory_config.shard_spec().has_value() && !conv_config.reshard_if_not_optimal) {
@@ -1324,11 +1316,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
             has_bias);
 
         input_channels_alignment = get_input_channels_alignment(
-            conv_config.shard_layout.value(),
-            input_layout,
-            BufferType::L1,
-            mm_conv,
-            input_tensor_sharded_memory_config);
+            conv_config.shard_layout.value(), input_layout, false, mm_conv, input_tensor_sharded_memory_config);
     }
 
     ParallelConfig output_parallel_config = determine_output_parallel_config(

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -191,7 +191,7 @@ Result conv_transpose2d(
     const uint32_t input_channels_alignment = get_input_channels_alignment(
         input_tensor_post_tm.memory_config().memory_layout(),
         input_tensor.layout(),
-        input_tensor.memory_config().buffer_type(),
+        false,
         mm_conv,
         input_tensor_post_tm.memory_config());
     uint32_t in_channels_padded = tt::round_up(

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
 
     uint32_t src_stick_id = start_id;
     uint32_t sticks_read = 0;
-#define DEBUG
+
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", padded_stick_size: " << padded_stick_size
            << ", unpadded_stick_size: " << unpadded_stick_size << ", stick_size_offset: " << stick_size_offset

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -53,10 +53,18 @@ void kernel_main() {
     while (tiles_read < num_tiles_per_core) {
         cb_reserve_back(cb_id_in0, num_tiles_per_barrier);
         uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
-
+#ifdef DEBUG
+        DPRINT << "Src Buffer L1 Addr: " << src_buffer_l1_addr << ENDL();
+        DPRINT << "Tiles read " << tiles_read << ", Num tiles pushed: " << num_tiles_pushed << ENDL();
+#endif
         for (uint32_t i = 0; i < num_tiles_per_barrier and tiles_read < num_tiles_per_core; ++i) {
             tiles_read++;
             if (id_per_dim[0] >= (num_unpadded_sticks[0] - extra_tiles_per_row)) {
+#ifdef DEBUG
+                DPRINT << "Skipping read for src_stick_id: " << src_stick_id << ", id_per_dim: " << id_per_dim[0] << ","
+                       << id_per_dim[1] << "," << id_per_dim[2] << "," << id_per_dim[3]
+                       << ", tiles_read: " << tiles_read << ENDL();
+#endif
                 src_buffer_l1_addr += tile_size;
                 src_stick_id++;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -28,11 +28,10 @@ void kernel_main() {
     uint32_t src_stick_id = start_id;
     uint32_t tiles_read = 0;
     const uint32_t tile_size = get_tile_size(cb_id_in0);
-    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_args = TensorAccessorArgs<1>();
     const auto s0 = TensorAccessor(src_args, src_addr, tile_size);
     const uint32_t extra_tiles_per_row = num_tiles_per_row - num_tiles_per_row_this_core;
 
-#define DEBUG
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", num_dims: " << num_dims << ", start_id: " << start_id
            << ", num_tiles_per_core: " << num_tiles_per_core << ", num_tiles_per_barrier: " << num_tiles_per_barrier
@@ -58,9 +57,6 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_tiles_per_barrier and tiles_read < num_tiles_per_core; ++i) {
             tiles_read++;
             if (id_per_dim[0] >= (num_unpadded_sticks[0] - extra_tiles_per_row)) {
-                DPRINT << "SKIP READ src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr
-                       << "id " << id_per_dim[0] << "," << id_per_dim[1] << "," << id_per_dim[2] << "," << id_per_dim[3]
-                       << ENDL();
                 src_buffer_l1_addr += tile_size;
                 src_stick_id++;
 
@@ -89,6 +85,5 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, num_tiles_per_barrier);
         num_tiles_pushed += num_tiles_per_barrier;
-        DPRINT << "num_tiles_pushed: " << num_tiles_pushed << ENDL();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_tiled_interleaved_start_id.cpp
@@ -3,17 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
+    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(0);
+
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t num_dims = get_arg_val<uint32_t>(1);
     const uint32_t start_id = get_arg_val<uint32_t>(2);
     const uint32_t num_tiles_per_core = get_arg_val<uint32_t>(3);
     const uint32_t num_tiles_per_barrier = get_arg_val<uint32_t>(4);
-    const uint32_t num_unpadded_sticks_addr = get_arg_addr(5);
+    const uint32_t num_tiles_per_row_this_core = get_arg_val<uint32_t>(5);
+    const uint32_t num_unpadded_sticks_addr = get_arg_addr(6);
 
     tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(num_unpadded_sticks_addr);
     volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
@@ -26,7 +30,9 @@ void kernel_main() {
     const uint32_t tile_size = get_tile_size(cb_id_in0);
     constexpr auto src_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(src_args, src_addr, tile_size);
+    const uint32_t extra_tiles_per_row = num_tiles_per_row - num_tiles_per_row_this_core;
 
+#define DEBUG
 #ifdef DEBUG
     DPRINT << "src_addr: " << src_addr << ", num_dims: " << num_dims << ", start_id: " << start_id
            << ", num_tiles_per_core: " << num_tiles_per_core << ", num_tiles_per_barrier: " << num_tiles_per_barrier
@@ -39,24 +45,37 @@ void kernel_main() {
            << num_unpadded_sticks[2] << " " << num_unpadded_sticks[3] << " " << ENDL();
     DPRINT << "num_padded_sticks: " << num_padded_sticks[0] << " " << num_padded_sticks[1] << " "
            << num_padded_sticks[2] << " " << num_padded_sticks[3] << " " << ENDL();
+    DPRINT << "num_tiles_per_row_this_core: " << num_tiles_per_row_this_core
+           << " extra_tiles_per_row: " << extra_tiles_per_row << ENDL();
 #endif
     const uint32_t base_src_buffer_l1_addr = get_write_ptr(cb_id_in0);
     const uint64_t base_noc_addr = get_noc_addr(0, s0);
-
+    uint32_t num_tiles_pushed = 0;
     while (tiles_read < num_tiles_per_core) {
         cb_reserve_back(cb_id_in0, num_tiles_per_barrier);
         uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
 
         for (uint32_t i = 0; i < num_tiles_per_barrier and tiles_read < num_tiles_per_core; ++i) {
             tiles_read++;
-            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            noc_async_read(src_noc_addr, src_buffer_l1_addr, tile_size);
-            src_buffer_l1_addr += tile_size;
-            src_stick_id++;
+            if (id_per_dim[0] >= (num_unpadded_sticks[0] - extra_tiles_per_row)) {
+                DPRINT << "SKIP READ src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr
+                       << "id " << id_per_dim[0] << "," << id_per_dim[1] << "," << id_per_dim[2] << "," << id_per_dim[3]
+                       << ENDL();
+                src_buffer_l1_addr += tile_size;
+                src_stick_id++;
+
+            } else {
+                uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+                noc_async_read(src_noc_addr, src_buffer_l1_addr, tile_size);
 #ifdef DEBUG
-            DPRINT << "src_stick_id: " << src_stick_id << ", src_noc_addr: " << src_noc_addr
-                   << ", src_buffer_l1_addr: " << src_buffer_l1_addr << ", tiles_read: " << tiles_read << ENDL();
+                DPRINT << "src_stick_id: " << src_stick_id << ", src_buffer_l1_addr: " << src_buffer_l1_addr
+                       << ", tiles_read: " << tiles_read << "id " << id_per_dim[0] << "," << id_per_dim[1] << ","
+                       << id_per_dim[2] << "," << id_per_dim[3] << ENDL();
 #endif
+                src_buffer_l1_addr += tile_size;
+                src_stick_id++;
+            }
+
             for (uint32_t j = 0; j < num_dims; j++) {
                 id_per_dim[j]++;
                 if (id_per_dim[j] == num_unpadded_sticks[j]) {
@@ -69,5 +88,7 @@ void kernel_main() {
         }
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, num_tiles_per_barrier);
+        num_tiles_pushed += num_tiles_per_barrier;
+        DPRINT << "num_tiles_pushed: " << num_tiles_pushed << ENDL();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -18,7 +18,6 @@ uint32_t round_down(uint32_t value, uint32_t multiple) {
     return value;
 }
 
-#define DEBUG
 void kernel_main() {
     const uint32_t total_num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t num_tiles_per_read = get_arg_val<uint32_t>(1);

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -113,7 +113,6 @@ void kernel_main() {
                 current_noc_read_addr += block_row_size;
                 current_write_addr += output_row_size_bytes;
             }
-            noc_async_read_barrier();
         } else {
             noc_async_read(noc_read_addr, write_addr, read_rows_size * block_row_size);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -110,10 +110,10 @@ void kernel_main() {
             uint32_t current_write_addr = write_addr;
             for (uint32_t row = 0; row < read_rows_size; row++) {
                 noc_async_read(current_noc_read_addr, current_write_addr, output_row_size_bytes);
-                noc_async_read_barrier();
                 current_noc_read_addr += block_row_size;
                 current_write_addr += output_row_size_bytes;
             }
+            noc_async_read_barrier();
         } else {
             noc_async_read(noc_read_addr, write_addr, read_rows_size * block_row_size);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -126,6 +126,16 @@ void kernel_main() {
         }
         uint32_t pad_write_addr = write_addr + output_row_size_bytes - padded_channels_bytes;
         if (padded_channels_elems > 0) {
+#ifdef DEBUG
+            volatile tt_l1_ptr uint16_t* pad_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                pad_addr + output_row_size_bytes - padded_channels_bytes);
+            DPRINT << "Pad Data = ";
+            for (uint32_t i = 0; i < padded_channels_elems; ++i) {
+                DPRINT << pad_ptr[i] << " ";
+            }
+            DPRINT << ENDL();
+            DPRINT << "Pad Write Addr : " << pad_write_addr << ENDL();
+#endif
             for (uint32_t row_index = 0; row_index < read_rows_size; row_index++) {
                 noc_async_read(pad_noc_addr, pad_write_addr, padded_channels_elems * output_elem_size);
                 pad_write_addr += output_row_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -17,7 +17,6 @@ uint32_t round_down(uint32_t value, uint32_t multiple) {
     }
     return value;
 }
-// #define DEBUG
 void kernel_main() {
     constexpr uint32_t cb_untilized_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_out_id = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/writer_unary_sharded_padded_tiled.cpp
@@ -17,6 +17,7 @@ uint32_t round_down(uint32_t value, uint32_t multiple) {
     }
     return value;
 }
+// #define DEBUG
 void kernel_main() {
     constexpr uint32_t cb_untilized_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_out_id = get_compile_time_arg_val(1);
@@ -96,17 +97,16 @@ void kernel_main() {
                << ", Width Tile Start in Input: " << width_tile_start_in_input
                << ", Read Start Offset: " << read_start_offset << ", Read Rows Size: " << read_rows_size << "Remaining "
                << rows_remaining << ENDL();
-        DPRINT << "output row size bytes " << output_row_size_bytes << ENDL();
-        DPRINT << "misalignment " << misalignment << ENDL();
-        DPRINT << "Output Coord: " << output_coord[0] << ", " << output_coord[1] << ", " << output_coord[2] << ", "
-               << output_coord[3] << ENDL();
+
+        DPRINT << "Tiles Read " << tiles_read << " Output Coord: " << output_coord[0] << ", " << output_coord[1] << ", "
+               << output_coord[2] << ", " << output_coord[3] << ENDL();
         DPRINT << "Write Addr Offset " << write_addr - base_write_addr << ENDL();
 #endif
         cb_wait_front(cb_untilized_id, num_tiles_per_read);
         uint64_t noc_read_addr = get_noc_addr(get_read_ptr(cb_untilized_id));
 
         noc_read_addr += read_start_offset * block_row_size;
-        if (is_non_aligned) {
+        if constexpr (is_non_aligned) {
             uint64_t current_noc_read_addr = noc_read_addr;
             uint32_t current_write_addr = write_addr;
             for (uint32_t row = 0; row < read_rows_size; row++) {

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -118,7 +118,7 @@ get_padded_slice_runtime_args_rm_sharded_output(
     auto dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                     ? hal::get_dram_alignment()
                                     : hal::get_l1_alignment();
-    // auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
     uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
     uint32_t misalignment = begins_bytes % src_buffer_alignment;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -289,7 +289,7 @@ static operation::ProgramWithCallbacks padded_slice_rm_multi_core(
                 .set_page_size(temp_pad_cb_index, output_row_size_bytes);
         tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_temp_pad_config);
     } else {
-        non_aligned_temp_cb_index = temp_pad_cb_index;  // Use the unused temp pad index so that CBs are continous.
+        non_aligned_temp_cb_index = temp_pad_cb_index;  // Use the unused temp pad index so that CBs are continuous.
     }
     if (is_non_aligned) {
         tt::tt_metal::create_cb(

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -782,7 +782,7 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
         program,
         total_cores,
         input_single_tile_size,
-        cb_buffer_size * num_tiles_per_channel,
+        cb_buffer_size * max_num_tiles_per_row,
         input_cb_data_format);
 
     tt::tt_metal::create_cb(
@@ -790,7 +790,7 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
         program,
         total_cores,
         output_single_tile_size,
-        cb_buffer_size * num_tiles_per_channel,
+        cb_buffer_size * max_num_tiles_per_row,
         output_cb_data_format);
 
     log_debug(
@@ -815,13 +815,12 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
         output_row_size_bytes,
         1,  // We need only a single row to hold the padding, and reuse it.
         output_cb_data_format);
-
     log_debug(
         tt::LogOp,
-        "num_tiles_height_per_core: {}, max_num_tiles_per_row: {}",
+        "num_tiles_height_per_core: {}, num_tiles_per_channel: {}, max_num_tiles_per_row: {}",
         num_tiles_height_per_core,
+        num_tiles_per_channel,
         max_num_tiles_per_row);
-
     std::vector<uint32_t> compute_args = {
         cb_input_index,         // src0_cb_index
         cb_untilized_index,     // untilized_cb_index

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_program_factory.cpp
@@ -808,9 +808,9 @@ static operation::ProgramWithCallbacks padded_slice_tile_multi_core(
 
     log_debug(
         tt::LogOp,
-        "num_tiles_height_per_core: {}, num_tiles_per_channel: {}",
+        "num_tiles_height_per_core: {}, max_num_tiles_per_row: {}",
         num_tiles_height_per_core,
-        num_tiles_per_channel);
+        max_num_tiles_per_row);
 
     std::vector<uint32_t> compute_args = {
         cb_input_index,         // src0_cb_index

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -15,11 +15,20 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t out_cb_id0 = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id1 = get_compile_time_arg_val(2);
-    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
     constexpr uint32_t block_size = get_compile_time_arg_val(4);  // number of tiles along height that make up a block
 
     const uint32_t total_blocks = get_arg_val<uint32_t>(0);
 
+#ifdef RUNTIME_TILES_PER_ROW
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);  // number of tiles along width of shard
+
+    bool use_pack_untilize = false;
+
+    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
+    untilize_init(src_cb_id);
+    const uint32_t tiles_per_block = block_size * tiles_per_row;
+#else
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
     compute_kernel_hw_startup(src_cb_id, out_cb_id0);
@@ -28,23 +37,27 @@ void MAIN {
     } else {
         untilize_init(src_cb_id);
     }
-
     constexpr uint32_t tiles_per_block = block_size * tiles_per_row;
+#endif
+
     for (uint32_t block_idx = 0; block_idx < total_blocks; block_idx++) {
         const uint32_t out_cb_id = (block_idx % NUM_RISCV_DATA_MOVEMENT_CORES == 0) ? out_cb_id0 : out_cb_id1;
 
         cb_wait_front(src_cb_id, tiles_per_block);
         cb_reserve_back(out_cb_id, tiles_per_block);
+#if RUNTIME_TILES_PER_ROW
+        untilize_block(src_cb_id, block_size * tiles_per_row, out_cb_id);
+#else
         if constexpr (use_pack_untilize) {
             pack_untilize_block<tiles_per_row>(src_cb_id, block_size, out_cb_id);
         } else {
             untilize_block(src_cb_id, block_size * tiles_per_row, out_cb_id);
         }
+#endif
         cb_push_back(out_cb_id, tiles_per_block);
         cb_pop_front(src_cb_id, tiles_per_block);
     }
-
-    if constexpr (use_pack_untilize) {
+    if (use_pack_untilize) {
         pack_untilize_uninit(out_cb_id0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -18,20 +18,19 @@ void MAIN {
     constexpr uint32_t block_size = get_compile_time_arg_val(4);  // number of tiles along height that make up a block
 
     const uint32_t total_blocks = get_arg_val<uint32_t>(0);
+    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
 
 #ifdef RUNTIME_TILES_PER_ROW
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);  // number of tiles along width of shard
 
-    bool use_pack_untilize = false;
+    constexpr bool use_pack_untilize = false;
 
-    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
     untilize_init(src_cb_id);
     const uint32_t tiles_per_block = block_size * tiles_per_row;
 #else
     constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
-    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
     if constexpr (use_pack_untilize) {
         pack_untilize_init<tiles_per_row>(src_cb_id, out_cb_id0);
     } else {
@@ -57,7 +56,7 @@ void MAIN {
         cb_push_back(out_cb_id, tiles_per_block);
         cb_pop_front(src_cb_id, tiles_per_block);
     }
-    if (use_pack_untilize) {
+    if constexpr (use_pack_untilize) {
         pack_untilize_uninit(out_cb_id0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -15,47 +15,35 @@ void MAIN {
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t out_cb_id0 = get_compile_time_arg_val(1);
     constexpr uint32_t out_cb_id1 = get_compile_time_arg_val(2);
+    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
     constexpr uint32_t block_size = get_compile_time_arg_val(4);  // number of tiles along height that make up a block
 
     const uint32_t total_blocks = get_arg_val<uint32_t>(0);
-    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
 
-#ifdef RUNTIME_TILES_PER_ROW
-    const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);  // number of tiles along width of shard
-
-    constexpr bool use_pack_untilize = false;
-
-    untilize_init(src_cb_id);
-    const uint32_t tiles_per_block = block_size * tiles_per_row;
-#else
-    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
+    compute_kernel_hw_startup(src_cb_id, out_cb_id0);
     if constexpr (use_pack_untilize) {
         pack_untilize_init<tiles_per_row>(src_cb_id, out_cb_id0);
     } else {
         untilize_init(src_cb_id);
     }
-    constexpr uint32_t tiles_per_block = block_size * tiles_per_row;
-#endif
 
+    constexpr uint32_t tiles_per_block = block_size * tiles_per_row;
     for (uint32_t block_idx = 0; block_idx < total_blocks; block_idx++) {
         const uint32_t out_cb_id = (block_idx % NUM_RISCV_DATA_MOVEMENT_CORES == 0) ? out_cb_id0 : out_cb_id1;
 
         cb_wait_front(src_cb_id, tiles_per_block);
         cb_reserve_back(out_cb_id, tiles_per_block);
-#if RUNTIME_TILES_PER_ROW
-        untilize_block(src_cb_id, block_size * tiles_per_row, out_cb_id);
-#else
         if constexpr (use_pack_untilize) {
             pack_untilize_block<tiles_per_row>(src_cb_id, block_size, out_cb_id);
         } else {
             untilize_block(src_cb_id, block_size * tiles_per_row, out_cb_id);
         }
-#endif
         cb_push_back(out_cb_id, tiles_per_block);
         cb_pop_front(src_cb_id, tiles_per_block);
     }
+
     if constexpr (use_pack_untilize) {
         pack_untilize_uninit(out_cb_id0);
     }


### PR DESCRIPTION
### Ticket
#30011

### Problem description
Input channels alignment is set to DRAM Alignment in Conv2D DRAM. This causes layers with small input channels (like 3) to be significantly padded. 

### What's changed
Reduced the input channels alignment requirement to L1 alignment from DRAM alignment.
This is enabled by copying the data to a temp CB in L1 and then doing the final copy to the L1.

Updated the conv2d get_input_channels_alignment function to match this new behaviour.

Also, call conv2d_L1 directly when num_slices is 1. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18755731494)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18715197928)
- [x] Frequent Models [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18769705202)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/18770934623) (if applicable)
- [x] Blackhole Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18769912413)
- [x] Nightly L2 passes [all](https://github.com/tenstorrent/tt-metal/actions/runs/18755740774)  [SDXL](https://github.com/tenstorrent/tt-metal/actions/runs/18765934415)
- [x] New/Existing tests provide coverage for changes