### PR TITLE
extend model_preprocessing with groupnorm params

### DIFF
--- a/ttnn/ttnn/model_preprocessing.py
+++ b/ttnn/ttnn/model_preprocessing.py
@@ -375,6 +375,14 @@ class MaxPool2dArgs(ModuleArgs):
         return super().__repr__()
 
 
+class GroupNormArgs(ModuleArgs):
+    __getattr__ = dict.__getitem__
+    __delattr__ = dict.__delitem__
+
+    def __repr__(self):
+        return super().__repr__()
+
+
 def infer_ttnn_module_args(*, model, run_model, device):
     if run_model is None:
         return None
@@ -442,6 +450,17 @@ def infer_ttnn_module_args(*, model, run_model, device):
                         stride=operation.module.stride,
                         padding=operation.module.padding,
                         dilation=operation.module.dilation,
+                        batch_size=input_shape[0],
+                        input_height=input_shape[-2],
+                        input_width=input_shape[-1],
+                        dtype=ttnn.bfloat16,
+                    )
+                elif isinstance(operation.module, torch.nn.GroupNorm):
+                    ttnn_module_args[module_name] = GroupNormArgs(
+                        num_groups=operation.module.num_groups,
+                        num_channels=operation.module.num_channels,
+                        eps=operation.module.eps,
+                        affine=operation.module.affine,
                         batch_size=input_shape[0],
                         input_height=input_shape[-2],
                         input_width=input_shape[-1],


### PR DESCRIPTION
### Ticket
#29626
### Problem description
Extending infer_ttnn_module_args to pickup groupnorm parameters from torch model

### What's changed
Introducing GroupNormArgs; tested on a separate branch; merging this separately

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18404090320
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes