### PR TITLE
Add CODEOWNERS entries for inspector files in debug directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ tt_metal/impl/allocator/ @abhullar-tt @tt-aho @tenstorrent/metalium-codeowners-l
 tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT @cfjchu @omilyutin-tt @TT-BrianLiu @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/context/ @jbaumanTT @aliuTT @cfjchu @omilyutin-tt @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/data_format/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @fvranicTT @tenstorrent/metalium-codeowners-large-changes
-tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @tt-vjovanovic @tenstorrent/metalium-codeowners-large-changes
+tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu @omilyutin-tt @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/dispatch/ @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/event @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-codeowners-large-changes
@@ -318,6 +318,11 @@ models/**/requirements*.txt @tenstorrent/metalium-developers-infra @tenstorrent/
 
 # tracy
 tools/tracy/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-codeowners-large-changes
+
+# inspector
+tt_metal/impl/debug/inspector.cpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
+tt_metal/impl/debug/inspector.hpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
+tt_metal/impl/debug/inspector @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
 
 # tt-triage
 tools/tt-triage.py @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,7 @@ tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT @cfjchu @omilyutin-tt @TT-BrianLi
 tt_metal/impl/context/ @jbaumanTT @aliuTT @cfjchu @omilyutin-tt @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/data_format/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @fvranicTT @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @tenstorrent/metalium-codeowners-large-changes
+tt_metal/impl/debug/inspector/ @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu @omilyutin-tt @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/dispatch/ @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/event @jbaumanTT @nhuang-tt @mpiseTT @tt-asaigal @tt-aho @tenstorrent/metalium-codeowners-large-changes
@@ -318,11 +319,6 @@ models/**/requirements*.txt @tenstorrent/metalium-developers-infra @tenstorrent/
 
 # tracy
 tools/tracy/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-codeowners-large-changes
-
-# inspector
-tt_metal/impl/debug/inspector.cpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
-tt_metal/impl/debug/inspector.hpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
-tt_metal/impl/debug/inspector/ @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
 
 # tt-triage
 tools/tt-triage.py @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,7 +322,7 @@ tools/tracy/ @mo-tenstorrent @sagarwalTT @tenstorrent/metalium-codeowners-large-
 # inspector
 tt_metal/impl/debug/inspector.cpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
 tt_metal/impl/debug/inspector.hpp @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
-tt_metal/impl/debug/inspector @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
+tt_metal/impl/debug/inspector/ @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes
 
 # tt-triage
 tools/tt-triage.py @tt-vjovanovic @adjordjevic-TT @miacim @tenstorrent/metalium-codeowners-large-changes

--- a/docs/source/tt-metalium/tools/inspector.rst
+++ b/docs/source/tt-metalium/tools/inspector.rst
@@ -54,7 +54,7 @@ Example changes in your Metal host runtime code:
 
 .. code-block:: cpp
 
-   #include "tt_metal/impl/debug/inspector.hpp"
+   #include "tt_metal/impl/debug/inspector/inspector.hpp"
    #include "impl/debug/inspector/rpc_server_generated.hpp"
 
    // In your initialization code

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -51,7 +51,7 @@
 #include <env_lib.hpp>
 
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
-#include "tt_metal/impl/debug/inspector.hpp"
+#include "tt_metal/impl/debug/inspector/inspector.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 #include "dispatch/launch_message_ring_buffer_state.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -36,7 +36,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
-#include "tt_metal/impl/debug/inspector.hpp"
+#include "tt_metal/impl/debug/inspector/inspector.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -59,8 +59,8 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/relay_mux.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/util/dispatch_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/inspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/rpc_server_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/noc_logging.cpp

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -16,7 +16,7 @@
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
-#include "tt_metal/impl/debug/inspector.hpp"
+#include "tt_metal/impl/debug/inspector/inspector.hpp"
 #include "tt_metal/impl/debug/inspector/data.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -27,9 +27,7 @@ inspector::Data* get_inspector_data() {
 }
 }  // namespace
 
-bool Inspector::is_enabled() {
-    return tt::tt_metal::MetalContext::instance().rtoptions().get_inspector_enabled();
-}
+bool Inspector::is_enabled() { return tt::tt_metal::MetalContext::instance().rtoptions().get_inspector_enabled(); }
 
 std::unique_ptr<inspector::Data> Inspector::initialize() {
     if (!is_enabled()) {
@@ -40,8 +38,7 @@ std::unique_ptr<inspector::Data> Inspector::initialize() {
         auto* data = new inspector::Data();
 
         return std::unique_ptr<inspector::Data>(data);
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to initialize Inspector: {}", e.what());
         throw;
     }
@@ -54,14 +51,12 @@ void Inspector::serialize_rpc() {
     try {
         auto* data = get_inspector_data();
         data->serialize_rpc();
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to serialize RPC: {}", e.what());
     }
 }
 
-void Inspector::program_created(
-    const detail::ProgramImpl* program) noexcept {
+void Inspector::program_created(const detail::ProgramImpl* program) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -69,17 +64,15 @@ void Inspector::program_created(
         auto* data = get_inspector_data();
         std::lock_guard<std::mutex> lock(data->programs_mutex);
         auto& program_data = data->programs_data[program->get_id()];
-        program_data.program=program->weak_from_this();
-        program_data.program_id=program->get_id();
+        program_data.program = program->weak_from_this();
+        program_data.program_id = program->get_id();
         data->logger.log_program_created(program_data);
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to log program created: {}", e.what());
     }
 }
 
-void Inspector::program_destroyed(
-    const detail::ProgramImpl* program) noexcept {
+void Inspector::program_destroyed(const detail::ProgramImpl* program) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -92,16 +85,13 @@ void Inspector::program_destroyed(
             data->kernel_id_to_program_id.erase(kernel_id);
         }
         data->programs_data.erase(program->get_id());
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to log program destroyed: {}", e.what());
     }
 }
 
 void Inspector::program_compile_started(
-    const detail::ProgramImpl* program,
-    const IDevice* device,
-    uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -111,16 +101,13 @@ void Inspector::program_compile_started(
         auto& program_data = data->programs_data[program->get_id()];
         program_data.compile_started_timestamp = std::chrono::high_resolution_clock::now();
         data->logger.log_program_compile_started(program_data);
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to log program destroyed: {}", e.what());
     }
 }
 
 void Inspector::program_compile_already_exists(
-    const detail::ProgramImpl* program,
-    const IDevice* device,
-    uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -160,9 +147,7 @@ void Inspector::program_kernel_compile_finished(
 }
 
 void Inspector::program_compile_finished(
-    const detail::ProgramImpl* program,
-    const IDevice* device,
-    uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -178,9 +163,7 @@ void Inspector::program_compile_finished(
 }
 
 void Inspector::program_set_binary_status(
-    const detail::ProgramImpl* program,
-    std::size_t device_id,
-    ProgramBinaryStatus status) noexcept {
+    const detail::ProgramImpl* program, std::size_t device_id, ProgramBinaryStatus status) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -190,15 +173,13 @@ void Inspector::program_set_binary_status(
         auto& program_data = data->programs_data[program->get_id()];
         program_data.binary_status_per_device[device_id] = status;
         data->logger.log_program_binary_status_change(program_data, device_id, status);
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
         TT_INSPECTOR_LOG("Failed to log program binary status change: {}", e.what());
     }
 }
 
 void Inspector::mesh_device_created(
-    const distributed::MeshDevice* mesh_device,
-    std::optional<int> parent_mesh_id) noexcept {
+    const distributed::MeshDevice* mesh_device, std::optional<int> parent_mesh_id) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -215,8 +196,7 @@ void Inspector::mesh_device_created(
     }
 }
 
-void Inspector::mesh_device_destroyed(
-    const distributed::MeshDevice* mesh_device) noexcept {
+void Inspector::mesh_device_destroyed(const distributed::MeshDevice* mesh_device) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -231,8 +211,7 @@ void Inspector::mesh_device_destroyed(
     }
 }
 
-void Inspector::mesh_device_initialized(
-    const distributed::MeshDevice* mesh_device) noexcept {
+void Inspector::mesh_device_initialized(const distributed::MeshDevice* mesh_device) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -247,8 +226,7 @@ void Inspector::mesh_device_initialized(
     }
 }
 
-void Inspector::mesh_workload_created(
-    const distributed::MeshWorkloadImpl* mesh_workload) noexcept {
+void Inspector::mesh_workload_created(const distributed::MeshWorkloadImpl* mesh_workload) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -264,8 +242,7 @@ void Inspector::mesh_workload_created(
     }
 }
 
-void Inspector::mesh_workload_destroyed(
-    const distributed::MeshWorkloadImpl* mesh_workload) noexcept {
+void Inspector::mesh_workload_destroyed(const distributed::MeshWorkloadImpl* mesh_workload) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -298,9 +275,7 @@ void Inspector::mesh_workload_add_program(
 }
 
 void Inspector::mesh_workload_set_program_binary_status(
-    const distributed::MeshWorkloadImpl* mesh_workload,
-    std::size_t mesh_id,
-    ProgramBinaryStatus status) noexcept {
+    const distributed::MeshWorkloadImpl* mesh_workload, std::size_t mesh_id, ProgramBinaryStatus status) noexcept {
     if (!is_enabled()) {
         return;
     }

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -13,12 +13,12 @@ namespace tt::tt_metal {
 namespace distributed {
 class MeshDevice;
 class MeshWorkloadImpl;
-}
+}  // namespace distributed
 
 namespace inspector {
 class Data;
 class RpcServer;  // NOLINT(cppcoreguidelines-virtual-class-destructor)
-}
+}  // namespace inspector
 
 class Inspector {
 public:
@@ -27,55 +27,37 @@ public:
     static std::unique_ptr<inspector::Data> initialize();
     static void serialize_rpc();
 
-    static void program_created(
-        const detail::ProgramImpl* program) noexcept;
-    static void program_destroyed(
-        const detail::ProgramImpl* program) noexcept;
+    static void program_created(const detail::ProgramImpl* program) noexcept;
+    static void program_destroyed(const detail::ProgramImpl* program) noexcept;
     static void program_set_binary_status(
-        const detail::ProgramImpl* program,
-        std::size_t device_id,
-        ProgramBinaryStatus status) noexcept;
+        const detail::ProgramImpl* program, std::size_t device_id, ProgramBinaryStatus status) noexcept;
     static void program_compile_started(
-        const detail::ProgramImpl* program,
-        const IDevice* device,
-        uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
     static void program_compile_already_exists(
-        const detail::ProgramImpl* program,
-        const IDevice* device,
-        uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
     static void program_kernel_compile_finished(
         const detail::ProgramImpl* program,
         const IDevice* device,
         const std::shared_ptr<Kernel>& kernel,
         const tt::tt_metal::JitBuildOptions& build_options) noexcept;
     static void program_compile_finished(
-        const detail::ProgramImpl* program,
-        const IDevice* device,
-        uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
 
     static void mesh_device_created(
-        const distributed::MeshDevice* mesh_device,
-        std::optional<int> parent_mesh_id) noexcept;
-    static void mesh_device_destroyed(
-        const distributed::MeshDevice* mesh_device) noexcept;
-    static void mesh_device_initialized(
-        const distributed::MeshDevice* mesh_device) noexcept;
+        const distributed::MeshDevice* mesh_device, std::optional<int> parent_mesh_id) noexcept;
+    static void mesh_device_destroyed(const distributed::MeshDevice* mesh_device) noexcept;
+    static void mesh_device_initialized(const distributed::MeshDevice* mesh_device) noexcept;
 
-    static void mesh_workload_created(
-        const distributed::MeshWorkloadImpl* mesh_workload) noexcept;
-    static void mesh_workload_destroyed(
-        const distributed::MeshWorkloadImpl* mesh_workload) noexcept;
+    static void mesh_workload_created(const distributed::MeshWorkloadImpl* mesh_workload) noexcept;
+    static void mesh_workload_destroyed(const distributed::MeshWorkloadImpl* mesh_workload) noexcept;
     static void mesh_workload_add_program(
         const distributed::MeshWorkloadImpl* mesh_workload,
         const distributed::MeshCoordinateRange& device_range,
         std::size_t program_id) noexcept;
     static void mesh_workload_set_program_binary_status(
-        const distributed::MeshWorkloadImpl* mesh_workload,
-        std::size_t mesh_id,
-        ProgramBinaryStatus status) noexcept;
+        const distributed::MeshWorkloadImpl* mesh_workload, std::size_t mesh_id, ProgramBinaryStatus status) noexcept;
 
     static inspector::RpcServer& get_rpc_server();
-
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -66,7 +66,7 @@
 #include "tile.hpp"
 #include "tt_memory.h"
 #include "tt_metal/detail/kernel_cache.hpp"
-#include "tt_metal/impl/debug/inspector.hpp"
+#include "tt_metal/impl/debug/inspector/inspector.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"


### PR DESCRIPTION
Updating Inspector code owners.
Also moving `inspector.hpp` and `inspector.cpp` inside `inspector` directory per request...