### PR TITLE
[skip ci] Fix bug in notebooks to python conversion script that prevents commit in specific cases

### DIFF
--- a/scripts/convert_notebooks_to_python.py
+++ b/scripts/convert_notebooks_to_python.py
@@ -79,6 +79,11 @@ def filter_modified_files(files: list[Path]) -> list[Path]:
     Filter files that have changed since last commit
     """
 
+    # If input is empty list, then `git diff --name-only` will list unstaged files
+    # which is not what we want.
+    if not files:
+        return []
+
     # Make sure that untracked files are also added to the index
     # Otherwise, `git diff` will not show them
     subprocess.run(["git", "add", "--intent-to-add"] + [str(f) for f in files], check=True)


### PR DESCRIPTION
### Ticket
#28374

### Problem description

`convert_notebook_to_python.py` converts Jupyter notebooks into matching python files and adds python files if they have changed. 

In this script, `filter_modified_files(files)` checks if python files from tutorials have changed since last commit.
To do that, it uses: `git diff --name-only <files>`. 

Problem: if `files` is empty (notebooks have been updated, but matching python script did not) then previous command adds unrelated unstaged files, and fails if it's a sub-module (i.e. re-commiting will not work either, it's a loop). 

### What's changed
`filter_modified_files(files)` checks if input is empty and returns and empty list if that's the case, thus fixing the bug. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes