### PR TITLE
[skip ci] Decrease timeout for models-unit-test in APC

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 28
+        default: 30
       docker-image:
         required: true
         type: string

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 28
       docker-image:
         required: true
         type: string


### PR DESCRIPTION
### What's changed
Decrease timeout  for models-unit-test to limit APC runtime.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes