### PR TITLE
[skip ci] Fix wheel build type

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -401,6 +401,7 @@ jobs:
             CCACHE_TEMPDIR=/tmp/ccache
             CCACHE_REMOTE_STORAGE="${{ env.CCACHE_REMOTE_STORAGE }}"
             CIBW_ENABLE_TRACY="${{ env.ENABLE_TRACY_BUILD }}"
+            CIBW_BUILD_TYPE="${{ inputs.build-type }}"
           CIBW_BEFORE_BUILD: "mkdir -p /tmp/ccache && ccache -z && ccache -p"
           CIBW_BEFORE_TEST: ccache -s
           CIBW_TEST_COMMAND: ${{ env.CIBW_TEST_CMD }}

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,9 @@ class CMakeBuild(build_ext):
             ).exists(), "The precompiled option is selected via `TT_FROM_PRECOMPILED` \
             env var. Please place files into `build/lib` and `runtime` folders."
         else:
-            build_dir = source_dir / "build_Release"
+            # Determine desired build type for wheel builds (e.g., Release, Debug, RelWithDebInfo)
+            build_type = os.environ.get("CIBW_BUILD_TYPE", "Release")
+            build_dir = source_dir / f"build_{build_type}"
             # We indirectly set a wheel build for our CMake build by using BUILD_SHARED_LIBS. This does the following things:
             # - Bundles (most) of our libraries into a static library to deal with a potential singleton bug error with tt_cluster (to fix)
             build_script_args = ["--build-static-libs", "--release"]
@@ -238,8 +240,8 @@ class CMakeBuild(build_ext):
                     build_dir,
                     "-G",
                     "Ninja",
-                    "-DCMAKE_BUILD_TYPE=Release",
-                    "-DCMAKE_INSTALL_PREFIX=build_Release",
+                    f"-DCMAKE_BUILD_TYPE={build_type}",
+                    f"-DCMAKE_INSTALL_PREFIX=build_{build_type}",
                     "-DBUILD_SHARED_LIBS=ON",
                     "-DTT_INSTALL=ON",
                     "-DTT_UNITY_BUILDS=ON",


### PR DESCRIPTION
### Ticket
NA

### Problem description
- The `build-type` input is ignored when building the wheel. (The wheel is always built in Release mode).

### What's changed
- Respect input

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18412387541) CI passes
- [ ] [All post commit RelWithDebInfo](https://github.com/tenstorrent/tt-metal/actions/runs/18412391996) CI passes
- [x] New/Existing tests provide coverage for changes