### PR TITLE
[skip ci] Set timeouts for galaxy-apc, t3k-apc, and run-profiler-regression

### DIFF
--- a/.github/workflows/galaxy-apc-fast-tests-impl.yaml
+++ b/.github/workflows/galaxy-apc-fast-tests-impl.yaml
@@ -25,6 +25,10 @@ on:
         default: false
         required: false
         type: boolean
+      timeout:
+        required: false
+        type: number
+        default: 10
 
 jobs:
   galaxy-apc-fast-tests:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 37
       build-artifact-name:
         required: true
         type: string

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      timeout:
+        required: false
+        type: number
+        default: 20
 
 jobs:
   t3000-unit-tests:


### PR DESCRIPTION
### What's changed
Set timeouts for 
galaxy-apc: 10
t3k-apc: 20
run-profiler-regression: 37

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes