### PR TITLE
Added workaround for Qwen2.5-VL reshape hang fix

### DIFF
--- a/models/demos/qwen25_vl/tt/patch_merger.py
+++ b/models/demos/qwen25_vl/tt/patch_merger.py
@@ -61,7 +61,11 @@ class PatchMerger(LightweightModule):
         x = self.norm(x)
 
         # Reshape to merge spatial dimensions
+        # bug in ttnn.reshape tilized causing hangs https://github.com/tenstorrent/tt-metal/issues/29932
+        # using workaround of converting to row major first
+        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
         x = ttnn.reshape(x, (x.shape[0], x.shape[1], -1, self.mlp_size))
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
 
         # First linear + GELU
         x = ttnn.linear(


### PR DESCRIPTION
### Ticket
#30234 

### Problem description
After noticing hangs for the Qwen2.5-VL models on tt-inference-server, I was able to narrow down the op causing the issue to a ttnn.reshape bug in the tilized mode (read https://github.com/tenstorrent/tt-metal/issues/29932 for more info).  Implementing a workaround for this which converts to row major before reshaping resolves the bug.

### What's changed
Temporarily convert to ROW_MAJOR format before reshaping

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes