### PR TITLE
#30348: APIs to work with unit-mesh tensors

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -174,6 +174,7 @@ target_sources(
         tensor/test_tensor_nd_sharding.cpp
         tensor/test_tensor_serialization.cpp
         tensor/test_tensor_sharding.cpp
+        tensor/test_unit_mesh_utils.cpp
         tensor/test_vector_conversion.cpp
         tensor/test_xtensor_adapter.cpp
         tensor/test_xtensor_conversion.cpp

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <memory>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/memory_config/memory_config.hpp"
+#include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+namespace ttnn::experimental::unit_mesh {
+namespace {
+
+using ::testing::SizeIs;
+using ::tt::tt_metal::distributed::MeshShape;
+
+using UnitMeshUtilsTest = ::tt::tt_metal::MeshDevice2x4Fixture;
+
+TEST_F(UnitMeshUtilsTest, AggregateAndDisaggregate) {
+    auto unit_meshes = mesh_device_->create_submeshes(MeshShape(1, 1));
+    ASSERT_THAT(unit_meshes, SizeIs(mesh_device_->shape().mesh_size()));
+
+    // Create a tensor spec for testing
+    auto shape = ttnn::Shape(std::array<uint32_t, 2>{32, 32});
+    auto dtype = tt::tt_metal::DataType::BFLOAT16;
+    auto layout = tt::tt_metal::Layout::TILE;
+
+    // Create tensors on each unit mesh at the same address, assuming deterministic lock-step allocation.
+    std::vector<Tensor> unit_tensors;
+    unit_tensors.reserve(unit_meshes.size());
+
+    for (const auto& unit_mesh : unit_meshes) {
+        auto tensor = create_device_tensor(
+            tt::tt_metal::TensorSpec(
+                shape,
+                tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(layout), tt::tt_metal::MemoryConfig())),
+            unit_mesh.get());
+        unit_tensors.push_back(tensor);
+    }
+
+    // Verify all tensors are at the same address
+    auto reference_address = unit_tensors[0].mesh_buffer()->address();
+    for (size_t i = 1; i < unit_tensors.size(); i++) {
+        EXPECT_EQ(unit_tensors[i].mesh_buffer()->address(), reference_address);
+    }
+
+    // Test aggregate
+    auto aggregated_tensor = aggregate(unit_tensors);
+
+    EXPECT_EQ(aggregated_tensor.device(), mesh_device_.get());
+    EXPECT_EQ(aggregated_tensor.logical_shape(), shape);
+    EXPECT_EQ(aggregated_tensor.dtype(), dtype);
+    EXPECT_EQ(aggregated_tensor.layout(), layout);
+    EXPECT_EQ(aggregated_tensor.mesh_buffer()->address(), reference_address);
+
+    // Test disaggregate
+    auto disaggregated_tensors = disaggregate(aggregated_tensor);
+
+    ASSERT_THAT(disaggregated_tensors, SizeIs(unit_meshes.size()));
+
+    for (size_t i = 0; i < disaggregated_tensors.size(); i++) {
+        const auto& tensor = disaggregated_tensors[i];
+
+        EXPECT_NE(tensor.device(), nullptr);
+        EXPECT_EQ(tensor.device()->shape().mesh_size(), 1);
+        EXPECT_EQ(tensor.logical_shape(), shape);
+        EXPECT_EQ(tensor.dtype(), dtype);
+        EXPECT_EQ(tensor.layout(), layout);
+        EXPECT_EQ(tensor.mesh_buffer()->address(), reference_address);
+    }
+}
+
+TEST_F(UnitMeshUtilsTest, AggregateEmptyVector) {
+    std::vector<Tensor> empty_tensors;
+    EXPECT_ANY_THROW(aggregate(empty_tensors));
+}
+
+TEST_F(UnitMeshUtilsTest, AggregateMismatchedTensorSpecs) {
+    auto unit_meshes = mesh_device_->create_submeshes(MeshShape(1, 1));
+    ASSERT_GE(unit_meshes.size(), 2);
+
+    auto shape1 = ttnn::Shape(std::array<uint32_t, 2>{32, 32});
+    auto shape2 = ttnn::Shape(std::array<uint32_t, 2>{64, 64});
+
+    auto tensor1 = create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            shape1,
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                tt::tt_metal::MemoryConfig())),
+        unit_meshes[0].get());
+    auto tensor2 = create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            shape2,
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                tt::tt_metal::MemoryConfig())),
+        unit_meshes[1].get());
+
+    std::vector<Tensor> tensors = {tensor1, tensor2};
+    EXPECT_ANY_THROW(aggregate(tensors));
+}
+
+TEST_F(UnitMeshUtilsTest, AggregateWrongNumberOfTensors) {
+    auto unit_meshes = mesh_device_->create_submeshes(MeshShape(1, 1));
+    ASSERT_GE(unit_meshes.size(), 2);
+
+    auto shape = ttnn::Shape(std::array<uint32_t, 2>{32, 32});
+
+    auto tensor = create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                tt::tt_metal::MemoryConfig())),
+        unit_meshes[0].get());
+
+    std::vector<Tensor> tensors = {tensor};
+    EXPECT_ANY_THROW(aggregate(tensors));
+}
+
+TEST_F(UnitMeshUtilsTest, DisaggregateWithoutSubmeshes) {
+    // Create a tensor on the parent mesh directly (no submeshes created yet)
+    auto shape = ttnn::Shape(std::array<uint32_t, 2>{32, 32});
+
+    auto tensor = create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                tt::tt_metal::MemoryConfig())),
+        mesh_device_.get());
+
+    // Should throw because no submeshes exist
+    EXPECT_ANY_THROW(disaggregate(tensor));
+}
+
+}  // namespace
+}  // namespace ttnn::experimental::unit_mesh

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -296,6 +296,7 @@ public:
     std::string to_string() const;
     bool is_parent_mesh() const;
 
+    const std::shared_ptr<MeshDevice>& get_parent_mesh() const;
     std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
 
     std::shared_ptr<MeshDevice> create_submesh(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -624,6 +624,7 @@ chip_id_t MeshDevice::build_id() const { return reference_device()->id(); }
 
 bool MeshDevice::is_parent_mesh() const { return parent_mesh_ == nullptr; }
 
+const std::shared_ptr<MeshDevice>& MeshDevice::get_parent_mesh() const { return parent_mesh_; }
 std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const {
     std::vector<std::shared_ptr<MeshDevice>> result;
     result.reserve(submeshes_.size());

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -94,6 +94,7 @@ target_sources(
         core/tensor/tensor_spec.cpp
         core/tensor/tensor_utils.cpp
         core/tensor/types.cpp
+        core/tensor/unit_mesh/unit_mesh_utils.cpp
         core/tensor/xtensor/partition.cpp
 )
 target_include_directories(

--- a/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
+++ b/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::unit_mesh {
+
+// Aggregates tensors from unit meshes (1x1 submeshes) into a single tensor on the parent mesh.
+//
+// All input tensors must be allocated on unit meshes that share the same parent mesh, have identical
+// TensorSpecs, and their mesh buffers must be at the same address. The number of input tensors must
+// match the parent mesh size.
+//
+// Returns a tensor distributed across the parent mesh.
+Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors);
+
+// Disaggregates a tensor from a parent mesh into individual tensors on unit meshes (1x1 submeshes).
+//
+// The input tensor must be allocated on a mesh device that has submeshes; the number of submeshes must match the
+// parent mesh size, and each submesh must be a unit mesh (1x1).
+//
+// Returns a vector of tensors, one per submesh, all sharing the same buffer address.
+std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor);
+
+}  // namespace ttnn::experimental::unit_mesh

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
+
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/distributed/tensor_topology.hpp"
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace ttnn::experimental::unit_mesh {
+
+Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
+    TT_FATAL(!tensors.empty(), "Cannot aggregate empty tensor vector");
+
+    // Validate all tensors are allocated on the unit meshes.
+    std::vector<tt::tt_metal::distributed::MeshDevice*> devices;
+    devices.reserve(tensors.size());
+    for (const auto& tensor : tensors) {
+        auto* device = tensor.device();
+        TT_FATAL(device != nullptr, "All tensors must be on device");
+
+        const auto& shape = device->shape();
+        TT_FATAL(shape.mesh_size() == 1, "Expected unit mesh (1x1), but got mesh of size {}", shape.mesh_size());
+
+        devices.push_back(device);
+    }
+
+    // Validate all devices have the same parent mesh.
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> parent_mesh = tensors[0].device()->get_parent_mesh();
+    TT_FATAL(parent_mesh != nullptr, "First device must have a parent mesh");
+    TT_FATAL(parent_mesh->shape().mesh_size() == tensors.size(), "Input tensors must span the entire parent mesh");
+
+    for (size_t i = 1; i < devices.size(); i++) {
+        TT_FATAL(
+            devices[i]->get_parent_mesh().get() == parent_mesh.get(),
+            "All tensors must belong to the same parent mesh");
+    }
+
+    // Validate all tensor specs and mesh buffer addresses are the same.
+    const auto& reference_spec = tensors[0].tensor_spec();
+    auto reference_address = tensors[0].mesh_buffer()->address();
+    for (size_t i = 1; i < tensors.size(); i++) {
+        TT_FATAL(tensors[i].tensor_spec() == reference_spec, "All tensors must have the same TensorSpec");
+        TT_FATAL(
+            tensors[i].mesh_buffer()->address() == reference_address, "All mesh buffers must be at the same address");
+    }
+
+    // Create a new mesh tensor for parent mesh.
+    const auto& reference_buffer = tensors[0].mesh_buffer();
+    auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        reference_buffer->global_config(),
+        reference_buffer->device_local_config(),
+        parent_mesh.get(),
+        reference_address);
+
+    std::vector<tt::tt_metal::distributed::MeshCoordinate> coords;
+    coords.reserve(parent_mesh->shape().mesh_size());
+    for (const auto& coord : tt::tt_metal::distributed::MeshCoordinateRange(parent_mesh->shape())) {
+        coords.push_back(coord);
+    }
+
+    tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer), std::move(coords));
+
+    return Tensor(
+        std::move(device_storage),
+        reference_spec,
+        tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+            tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0));
+}
+
+std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor) {
+    using namespace tt::tt_metal;
+
+    // Validate the tensor is allocated on mesh device, that is parent mesh of unit meshes.
+    auto* mesh_device = tensor.device();
+    TT_FATAL(mesh_device != nullptr, "Tensor must be allocated on a mesh device");
+    const auto submeshes = mesh_device->get_submeshes();
+    TT_FATAL(
+        submeshes.size() == mesh_device->shape().mesh_size(),
+        "Number of submeshes ({}) must match mesh size ({})",
+        submeshes.size(),
+        mesh_device->shape().mesh_size());
+    for (const auto& submesh : submeshes) {
+        const auto& submesh_shape = submesh->shape();
+        TT_FATAL(
+            submesh_shape.mesh_size() == 1,
+            "All submeshes must be a unit mesh (1x1), but got mesh of size {}",
+            submesh_shape.mesh_size());
+    }
+
+    const auto& input_mesh_buffer = tensor.mesh_buffer();
+    const auto input_address = input_mesh_buffer->address();
+    const auto& reference_spec = tensor.tensor_spec();
+
+    // For all unit meshes, create individual mesh buffers with the same address.
+    std::vector<Tensor> result;
+    result.reserve(submeshes.size());
+    for (const auto& submesh : submeshes) {
+        auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+            input_mesh_buffer->global_config(), input_mesh_buffer->device_local_config(), submesh.get(), input_address);
+
+        DeviceStorage device_storage(
+            std::move(mesh_buffer), std::vector<distributed::MeshCoordinate>{distributed::MeshCoordinate(0, 0)});
+
+        result.push_back(Tensor(std::move(device_storage), reference_spec, TensorTopology{}));
+    }
+
+    return result;
+}
+
+}  // namespace ttnn::experimental::unit_mesh

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -49,6 +49,7 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     }
 
     // Create a new mesh tensor for parent mesh.
+    // TODO: #30348 - synchronize the state of parent mesh allocator with all of submeshes.
     const auto& reference_buffer = tensors[0].mesh_buffer();
     auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         reference_buffer->global_config(),


### PR DESCRIPTION
### Ticket
#30348

### Problem description
APIs for aggregating/disaggregating unit-mesh tensors to/from mesh tensor allocated on the parent mesh.

### What's changed
See #30348 for details.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18414971177)
- [x] New/Existing tests provide coverage for changes