### PR TITLE
Add more verbose message for 404 on WebServer

### DIFF
--- a/tt_telemetry/server/web_server.cpp
+++ b/tt_telemetry/server/web_server.cpp
@@ -204,15 +204,21 @@ public:
                 }
             } else {
                 // If file not found, serve index.html for SPA routing
-                std::string index_content =
-                    read_file(join_paths(metal_home_, "tt_telemetry/frontend/static/index.html"));
+                std::string full_path = join_paths(metal_home_, "tt_telemetry/frontend/static/index.html");
+                std::string index_content = read_file(full_path);
                 if (!index_content.empty()) {
                     res.set_content(index_content, "text/html");
                 } else {
                     res.status = 404;
-                    res.set_content(
-                        "<html><body><h1>Telemetry Server Running</h1><p>404: File not found</p></body></html>",
-                        "text/html");
+                    std::string error_html = 
+                        "<html><body>"
+                        "<h1>Telemetry Server 404</h1>"
+                        "<p>404: Page not found: " + path + "</p>"
+                        "<p>Local path: " + full_path + "</p>"
+                        "<p>Metal home: " + metal_home_ + "</p>"
+                        "<p>Make sure Metal home (set via either TT_METAL_HOME or --metal-src-dir) points to the tt_metal repository and contains " + full_path + ".</p>"
+                        "</body></html>";
+                    res.set_content(error_html, "text/html");
                 }
             }
         });

--- a/tt_telemetry/server/web_server.cpp
+++ b/tt_telemetry/server/web_server.cpp
@@ -210,13 +210,22 @@ public:
                     res.set_content(index_content, "text/html");
                 } else {
                     res.status = 404;
-                    std::string error_html = 
+                    std::string error_html =
                         "<html><body>"
                         "<h1>Telemetry Server 404</h1>"
-                        "<p>404: Page not found: " + path + "</p>"
-                        "<p>Local path: " + full_path + "</p>"
-                        "<p>Metal home: " + metal_home_ + "</p>"
-                        "<p>Make sure Metal home (set via either TT_METAL_HOME or --metal-src-dir) points to the tt_metal repository and contains " + full_path + ".</p>"
+                        "<p>404: Page not found: " +
+                        path +
+                        "</p>"
+                        "<p>Local path: " +
+                        full_path +
+                        "</p>"
+                        "<p>Metal home: " +
+                        metal_home_ +
+                        "</p>"
+                        "<p>Make sure Metal home (set via either TT_METAL_HOME or --metal-src-dir) points to the "
+                        "tt_metal repository and contains " +
+                        full_path +
+                        ".</p>"
                         "</body></html>";
                     res.set_content(error_html, "text/html");
                 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When running the `tt_telemetry` browser GUI, if the path to which `$TT_METAL_HOME` is set does not point to the `tt_metal` repository, the `WebServer` would have returned an uninformative 404. 

### What's changed
This PR makes the 404 slightly more informative. What could be done as well is to check in the `WebServer` constructor not just whether `$TT_METAL_HOME` is set but also whether it's set correctly. I refrained from doing that for now to keep things simple, as they were.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [X] New/Existing tests provide coverage for changes