### PR TITLE
The return of ttnn.all_gather

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -354,6 +354,7 @@ set(CCL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/mesh_partition/mesh_partition_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/barrier/barrier_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_gather/all_gather_${PY_BINDING}.cpp
 )
 
 set(DEBUG_TTNN_SRCS_PYBIND

--- a/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/ccl/CMakeLists.txt
@@ -64,6 +64,9 @@ target_sources(
         common/host/ccl_command_stream_builders.cpp
         common/host/moe_utils.cpp
         # Ops
+        all_gather/all_gather.cpp
+        all_gather/device/all_gather_device_operation.cpp
+        all_gather/device/all_gather_program_factory.cpp
         all_to_all_combine/all_to_all_combine.cpp
         all_to_all_combine/device/all_to_all_combine_device_operation.cpp
         all_to_all_combine/device/all_to_all_combine_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/common/queue_id.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include "all_gather.hpp"
+#include "device/all_gather_device_operation.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/fabric.hpp>
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
+
+namespace ttnn::operations::ccl {
+
+ttnn::Tensor ExecuteAllGather::invoke(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    std::optional<uint32_t> num_links,
+    std::optional<tt::tt_fabric::Topology> topology) {
+    auto mesh_device = input_tensor.device();
+    uint32_t normalized_dim = input_tensor.logical_shape().get_normalized_index(dim);
+    tt::tt_fabric::Topology topology_ = topology.value_or(
+        ::ttnn::ccl::get_usable_topology(input_tensor, tt::tt_fabric::get_fabric_topology(), cluster_axis));
+    auto memory_config_ = memory_config.value_or(input_tensor.memory_config());
+    uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, cluster_axis));
+
+    if (composite_common::use_composite_all_gather(input_tensor, dim, memory_config)) {
+        return composite_common::composite_all_gather(
+            input_tensor, dim, num_links_, memory_config_, subdevice_id, cluster_axis);
+    }
+
+    return ttnn::prim::all_gather(
+        input_tensor,
+        normalized_dim,
+        cluster_axis,
+        subdevice_id,
+        memory_config_,
+        optional_output_tensor,
+        num_links_,
+        topology_);
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+
+namespace ttnn {
+namespace operations::ccl {
+
+struct ExecuteAllGather {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        int32_t dim,
+        std::optional<uint32_t> cluster_axis = std::nullopt,
+        const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
+        std::optional<uint32_t> num_links = std::nullopt,
+        std::optional<tt::tt_fabric::Topology> topology = std::nullopt);
+};
+
+}  // namespace operations::ccl
+
+constexpr auto all_gather = ttnn::register_operation<"ttnn::all_gather", ttnn::operations::ccl::ExecuteAllGather>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -20,7 +20,7 @@ void py_bind_all_gather(py::module& module) {
     auto doc =
         R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor
 
-            All-gather operation across devices along a selected dimension and optional cluster axis. If cluster axis is specified then we gather across the cluster axis. All-gather is a collective operation that gathers data from all devices into a new output tensor, concatenated along the specified `dim`. When cluster_axis is specified, each of the non-cluster_axis dimensions are performing independent all-gathers along the devices on the cluster axis.
+            All-gather operation across devices along a selected dimension and optional cluster axis. If cluster axis is specified then we gather across the cluster axis. All-gather is a collective operation that gathers data from all devices into a new output tensor, concatenated along the specified `dim`. When cluster_axis is specified, each of the non-cluster_axis dimensions are performing independent all-gathers along the devices on the cluster axis. When the layout is row-major or we have tile padding on the gather dim, we use the composite all-gather implementation.
 
             Args:
                 input_tensor (ttnn.Tensor): Input tensor to be gathered.

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -20,7 +20,7 @@ void py_bind_all_gather(py::module& module) {
     auto doc =
         R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor
 
-            All-gather operation across devices along a selected dimension and optional cluster axis.
+            All-gather operation across devices along a selected dimension and optional cluster axis. If cluster axis is specified then we gather across the cluster axis. All-gather is a collective operation that gathers data from all devices into a new output tensor, concatenated along the specified `dim`. When cluster_axis is specified, each of the non-cluster_axis dimensions are performing independent all-gathers along the devices on the cluster axis.
 
             Args:
                 input_tensor (ttnn.Tensor): Input tensor to be gathered.
@@ -34,7 +34,7 @@ void py_bind_all_gather(py::module& module) {
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
 
            Returns:
-               ttnn.Tensor: The gathered tensor.
+               ttnn.Tensor: The gathered tensor, with output_shape = input_shape for all the unspecified dimensions, and output_shape[dim] = input_shape[dim] * num_devices, where num_devices is the number of devices along the `cluster_axis` if specified, else the total number of devices along the mesh.
 
             Example:
                 >>> full_tensor = torch.randn([1, 1, 32, 256], dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -27,14 +27,29 @@ void py_bind_all_gather(py::module& module) {
                 dim (int): Dimension along which to gather.
 
             Keyword Args:
-                cluster_axis (int, optional): The cluster axis to gather across. Defaults to `None`.
+                cluster_axis (int, optional): The axis on the mesh device to gather across. Defaults to `None`.
                 topology (ttnn.Topology, optional): Fabric topology. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
 
            Returns:
-               ttnn.Tensor: The gathered tensor.)doc";
+               ttnn.Tensor: The gathered tensor.
+
+            Example:
+                >>> full_tensor = torch.randn([1, 1, 32, 256], dtype=torch.bfloat16)
+                >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+                >>> ttnn_tensor = ttnn.from_torch(
+                                full_tensor,
+                                dtype=input_dtype,
+                                device=mesh_device,
+                                layout=layout,
+                                memory_config=mem_config,
+                                mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(1, 8), dims=(-1, -2)))
+                >>> output = ttnn.all_gather(ttnn_tensor, dim=0)
+                >>> print(output.shape)
+                [8, 1, 32, 256]
+                )doc";
 
     using OperationType = decltype(ttnn::all_gather);
     ttnn::bind_registered_operation(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -20,7 +20,7 @@ void py_bind_all_gather(py::module& module) {
     auto doc =
         R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor
 
-            All-gather operation across devices along a selected dimension and optional cluster axis. If cluster axis is specified then we gather across the cluster axis. All-gather is a collective operation that gathers data from all devices into a new output tensor, concatenated along the specified `dim`. When cluster_axis is specified, each of the non-cluster_axis dimensions are performing independent all-gathers along the devices on the cluster axis. When the layout is row-major or we have tile padding on the gather dim, we use the composite all-gather implementation.
+            All-gather operation across devices along a selected dimension and optional cluster axis. If cluster axis is specified then we gather across the cluster axis. All-gather is a collective operation that gathers data from all devices into a new output tensor, concatenated along the specified `dim`. When cluster_axis is specified, each of the non-cluster_axis dimensions are performing independent all-gathers along the devices on the cluster axis. When the layout is row-major or we have tile padding on the gather dim, we use the composite all-gather implementation that falls back to all-broadcast.
 
             Args:
                 input_tensor (ttnn.Tensor): Input tensor to be gathered.

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -28,7 +28,7 @@ void py_bind_all_gather(py::module& module) {
 
             Keyword Args:
                 cluster_axis (int, optional): The cluster axis to gather across. Defaults to `None`.
-                topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
+                topology (ttnn.Topology, optional): Fabric topology. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::ccl {
 
 void py_bind_all_gather(py::module& module) {
     auto doc =
-        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None, queue_id: int = 0) -> ttnn.Tensor
+        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None) -> ttnn.Tensor
 
             All-gather operation across devices along a selected dimension and optional cluster axis.
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_gather_pybind.hpp"
+
+#include <cstdint>
+#include <optional>
+
+#include <pybind11/pybind11.h>
+
+#include "ttnn-pybind/decorators.hpp"
+#include "all_gather.hpp"
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+
+namespace ttnn::operations::ccl {
+
+void py_bind_all_gather(py::module& module) {
+    auto doc =
+        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, cluster_axis: Optional[int] = None, topology: ttnn.Topology = ttnn.Topology.Linear, output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None, queue_id: int = 0) -> ttnn.Tensor
+
+            All-gather operation across devices along a selected dimension and optional cluster axis.
+
+            Args:
+                input_tensor (ttnn.Tensor): Input tensor to be gathered.
+                dim (int): Dimension along which to gather.
+
+            Keyword Args:
+                cluster_axis (int, optional): The cluster axis to gather across. Defaults to `None`.
+                topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
+                output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
+                memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
+                subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
+                queue_id (int, optional): Command queue id. Defaults to 0.
+
+           Returns:
+               ttnn.Tensor: The gathered tensor.)doc";
+
+    using OperationType = decltype(ttnn::all_gather);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::all_gather,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               int32_t dim,
+               const std::optional<uint32_t> cluster_axis,
+               const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               std::optional<ttnn::Tensor>& optional_output_tensor,
+               const std::optional<uint32_t> num_links,
+               const std::optional<tt::tt_fabric::Topology> topology) {
+                return self(
+                    input_tensor,
+                    dim,
+                    cluster_axis,
+                    subdevice_id,
+                    memory_config,
+                    optional_output_tensor,
+                    num_links,
+                    topology);
+            },
+            py::arg("input_tensor").noconvert(),
+            py::arg("dim"),
+            py::kw_only(),
+            py::arg("cluster_axis") = std::nullopt,
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("num_links") = std::nullopt,
+            py::arg("topology") = std::nullopt,
+        });
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -32,7 +32,6 @@ void py_bind_all_gather(py::module& module) {
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
-                queue_id (int, optional): Command queue id. Defaults to 0.
 
            Returns:
                ttnn.Tensor: The gathered tensor.)doc";

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::ccl {
+namespace py = pybind11;
+void py_bind_all_gather(pybind11::module& module);
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -134,6 +134,7 @@ ttsl::hash::hash_t AllGatherDeviceOperation::compute_program_hash(
         operation_attributes.cluster_axis,
         operation_attributes.memory_config,
         subdevice_core_range_set,
+        operation_attributes.topology,
         input_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -69,7 +69,7 @@ void AllGatherDeviceOperation::validate_on_program_cache_hit(
             "Output tensor shape {} does not match computed output spec shape {}",
             output_tensor.logical_shape(),
             output_spec.logical_shape());
-        auto optional_output_tensor_spec = output_tensor.tensor_spec();
+        const auto& optional_output_tensor_spec = output_tensor.tensor_spec();
         // everything but memory config must match
         TT_FATAL(
             optional_output_tensor_spec.page_config() == output_spec.page_config(),

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <utility>
+
+#include "all_gather_device_operation.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::ccl {
+
+AllGatherDeviceOperation::program_factory_t AllGatherDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return AllGatherProgram{};
+}
+
+void AllGatherDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_hit(operation_attributes, tensor_args);
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    auto input_tensor = tensor_args.input_tensor;
+
+    // Basic validations
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in buffer on device!");
+    TT_FATAL(input_tensor.logical_shape().rank() > 2, "AllGather requires tensor of rank 3 or greater");
+
+    uint32_t target_ring_size = ::ttnn::ccl::get_topological_dimension(input_tensor, operation_attributes.cluster_axis);
+    TT_FATAL(target_ring_size > 1, "all_gather op will only work for num_devices > 1, but has {}", target_ring_size);
+
+    TT_FATAL(
+        operation_attributes.num_links > 0,
+        "num_links should be more than 0 but has {}",
+        operation_attributes.num_links);
+    TT_FATAL(
+        operation_attributes.num_links <= input_tensor.device()->compute_with_storage_grid_size().y,
+        "Worker cores used by links are parallelized over rows");
+
+    // Page alignment check
+    auto page_size = input_tensor.buffer()->page_size();
+    TT_FATAL(page_size % input_tensor.buffer()->alignment() == 0, "All Gather currently requires aligned pages");
+
+    // Memory layout validations
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Unsupported input tensor memory layout {}.",
+        input_tensor.memory_config().memory_layout());
+
+    // Don't support input DRAM block sharding
+    if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+        TT_FATAL(
+            input_tensor.memory_config().buffer_type() == BufferType::L1, "We don't support input DRAM block sharding");
+    }
+
+    if (tensor_args.optional_output_tensor) {
+        auto output_tensor = tensor_args.optional_output_tensor.value();
+        TT_FATAL(
+            output_tensor.shape() == output_specs.logical_shape(),
+            "Output tensor shape {} does not match computed output spec shape {}",
+            output_tensor.shape(),
+            output_specs.at(0).logical_shape());
+        auto optional_output_tensor_spec = output_tensor.tensor_spec();
+        // everything but memory config must match
+        TT_FATAL(
+            optional_output_tensor_spec.page_config() == output_spec.page_config(),
+            "Output tensor page config {} does not match computed output spec page config {}",
+            optional_output_tensor_spec.page_config(),
+            output_spec.page_config());
+        TT_FATAL(
+            optional_output_tensor_spec.layout() == output_spec.layout(),
+            "Output tensor layout {} does not match computed output spec layout {}",
+            optional_output_tensor_spec.layout(),
+            output_spec.layout());
+        TT_FATAL(
+            optional_output_tensor_spec.dtype() == output_spec.dtype(),
+            "Output tensor dtype {} does not match computed output spec dtype {}",
+            optional_output_tensor_spec.dtype(),
+            output_spec.dtype());
+        TT_FATAL(
+            optional_output_tensor_spec.physical_shape() == output_spec.physical_shape(),
+            "Output tensor physical shape {} does not match computed output spec physical shape {}",
+            optional_output_tensor_spec.physical_shape(),
+            output_spec.physical_shape());
+        TT_FATAL(
+            optional_output_tensor_spec.tile() == output_spec.tile(),
+            "Output tensor tile {} does not match computed output spec tile {}",
+            optional_output_tensor_spec.tile(),
+            output_spec.tile());
+    }
+}
+
+void AllGatherDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        auto output_specs = compute_output_specs(operation_attributes, tensor_args);
+        TT_FATAL(
+            tensor_args.optional_output_tensor.value().tensor_spec() == output_specs.at(0),
+            "Output tensor spec {} does not match computed output spec {}",
+            tensor_args.optional_output_tensor.value().tensor_spec(),
+            output_specs.at(0));
+    }
+}
+
+AllGatherDeviceOperation::spec_return_value_t AllGatherDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto output_shape = input_tensor.logical_shape();
+    uint32_t target_ring_size = ::ttnn::ccl::get_topological_dimension(input_tensor, operation_attributes.cluster_axis);
+    output_shape[operation_attributes.dim] *= target_ring_size;
+
+    auto mem_config = operation_attributes.memory_config;
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), mem_config));
+}
+
+AllGatherDeviceOperation::tensor_return_value_t AllGatherDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto output_specs = compute_output_specs(operation_attributes, tensor_args);
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
+    return create_device_tensor(output_specs, tensor_args.input_tensor.device());
+}
+
+ttsl::hash::hash_t AllGatherDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto input_tensor = tensor_args.input_tensor;
+    auto subdevice_id = operation_attributes.subdevice_id;
+    auto mesh_device = input_tensor.device();
+    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    return tt::tt_metal::operation::hash_operation<AllGatherDeviceOperation>(
+        operation_attributes.dim,
+        operation_attributes.num_links,
+        operation_attributes.cluster_axis,
+        operation_attributes.memory_config,
+        subdevice_core_range_set,
+        input_tensor);
+}
+
+std::tuple<AllGatherDeviceOperation::operation_attributes_t, AllGatherDeviceOperation::tensor_args_t>
+AllGatherDeviceOperation::invoke(
+    const ttnn::Tensor& input_tensor,
+    uint32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology) {
+    return {
+        operation_attributes_t{
+            .memory_config = memory_config,
+            .dim = dim,
+            .cluster_axis = cluster_axis,
+            .subdevice_id = subdevice_id,
+            .topology = topology,
+            .num_links = num_links},
+        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor}};
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
@@ -37,7 +37,7 @@ struct AllGatherDeviceOperation {
         std::optional<Tensor> optional_output_tensor;
     };
 
-    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using spec_return_value_t = ttnn::TensorSpec;
     using tensor_return_value_t = ttnn::Tensor;
 
     struct AllGatherProgram {

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include <optional>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/fabric_edm_types.hpp>
+#include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+
+namespace ttnn::operations::ccl {
+
+// Re-export AllGatherProgramArtifacts from experimental
+using AllGatherProgramArtifacts = ttnn::AllGatherProgramArtifacts;
+
+struct AllGatherDeviceOperation {
+    struct operation_attributes_t {
+        const MemoryConfig memory_config;
+        uint32_t dim;
+        const std::optional<uint32_t> cluster_axis;
+        const std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
+        const tt::tt_fabric::Topology topology;
+        const uint32_t num_links;
+    };
+
+    struct tensor_args_t {
+        const Tensor input_tensor;
+        std::optional<Tensor> optional_output_tensor;
+    };
+
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = ttnn::Tensor;
+
+    struct AllGatherProgram {
+        struct shared_variables_t {
+            std::vector<tt::tt_metal::GlobalSemaphore> multidevice_semaphores;
+            tt::tt_metal::GlobalSemaphore barrier_semaphore;
+            ttnn::operations::ccl::AllGatherProgramArtifacts program_artifacts;
+        };
+        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coordinate,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const std::vector<tt::tt_metal::GlobalSemaphore>& multidevice_semaphores,
+            const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<AllGatherProgram>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const ttnn::Tensor& input_tensor,
+        uint32_t dim,
+        std::optional<uint32_t> cluster_axis,
+        const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+        const ttnn::MemoryConfig& memory_config,
+        const std::optional<ttnn::Tensor>& optional_output_tensor,
+        uint32_t num_links,
+        tt::tt_fabric::Topology topology);
+};
+
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+constexpr auto all_gather =
+    ttnn::register_operation<"ttnn::prim::all_gather", ttnn::operations::ccl::AllGatherDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_gather_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <unordered_map>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/device_pool.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/fabric.hpp>
+#include <tt-metalium/mesh_graph.hpp>
+#include <tt-metalium/hal.hpp>
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+
+namespace ttnn::operations::ccl {
+
+AllGatherDeviceOperation::AllGatherProgram::cached_mesh_workload_t
+AllGatherDeviceOperation::AllGatherProgram::create_mesh_workload(
+    const operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    auto mesh_device = tensor_args.input_tensor.device();
+    auto sd_id = operation_attributes.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+
+    // Create semaphores internally (internalized global semaphores)
+    // 2 semaphores used for within op synchronizations (forward and backward links)
+    std::vector<tt::tt_metal::GlobalSemaphore> multidevice_semaphores = {
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0),
+        ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0),
+    };
+
+    // 1 barrier semaphore used to ensure that all the buffers are allocated
+    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {sd_id};
+    auto barrier_semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device, subdevice_core_range_set, 0);
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevice_ids);
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto cached_program = create_at(
+            operation_attributes,
+            coord,
+            tensor_args,
+            tensor_return_value,
+            tensor_coords,
+            multidevice_semaphores,
+            barrier_semaphore);
+        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+    }
+
+    return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
+}
+
+ttnn::device_operation::CachedProgram<AllGatherDeviceOperation::AllGatherProgram::shared_variables_t>
+AllGatherDeviceOperation::AllGatherProgram::create_at(
+    const operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinate& mesh_coordinate,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<tt::tt_metal::GlobalSemaphore>& multidevice_semaphores,
+    const tt::tt_metal::GlobalSemaphore& barrier_semaphore) {
+    tt::tt_metal::Program program{};
+
+    // Get mesh and axis related information
+    auto mesh_device = tensor_args.input_tensor.device();
+    uint32_t target_ring_size =
+        ::ttnn::ccl::get_topological_dimension(tensor_args.input_tensor, operation_attributes.cluster_axis);
+
+    log_debug(tt::LogOp, "Getting forward neighbor for {}", mesh_coordinate);
+    const std::optional<MeshCoordinate> forward_coordinate = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        tensor_args.input_tensor, mesh_coordinate, 1, operation_attributes.topology, operation_attributes.cluster_axis);
+
+    log_debug(tt::LogOp, "Getting backward neighbor for {}", mesh_coordinate);
+    const std::optional<MeshCoordinate> backward_coordinate = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+        tensor_args.input_tensor,
+        mesh_coordinate,
+        -1,
+        operation_attributes.topology,
+        operation_attributes.cluster_axis);
+    TT_FATAL(
+        forward_coordinate.has_value() || backward_coordinate.has_value(),
+        "DEBUG: forward_coord or backward_coord is null");
+
+    log_debug(tt::LogOp, "Getting device index for {}", mesh_coordinate);
+    uint32_t device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+        tensor_args.input_tensor, mesh_coordinate, operation_attributes.cluster_axis);
+    log_debug(tt::LogOp, "Device index for {} is {}", mesh_coordinate, device_index);
+
+    // Get core and subdevice related information
+    auto sd_id = operation_attributes.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    auto bbox = subdevice_core_range_set.bounding_box();
+    auto first_coord = bbox.start_coord;
+
+    std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> no_fuse = std::nullopt;
+
+    // Build the program artifacts using the shared builder function
+    auto all_gather_program_artifacts = build_all_gather_async_minimal_default_program_artifacts(
+        program,
+        tensor_args.input_tensor,
+        mesh_coordinate,
+        forward_coordinate,
+        backward_coordinate,
+        tensor_return_value.at(0),
+        operation_attributes.dim,
+        operation_attributes.num_links,
+        target_ring_size,
+        device_index,
+        operation_attributes.topology,
+        multidevice_semaphores,
+        barrier_semaphore,
+        false,  // using_persistent_buffers - false since we don't have optional output tensor in this version
+        operation_attributes.subdevice_id,
+        no_fuse,       // never fusing with this
+        std::nullopt,  // use chunks per sync decision making tree
+        std::nullopt,  // use num workers per link decision making tree
+        std::nullopt,  // use num buffers per channel decision making tree
+        first_coord,   // first core in the subdevice is our offset as we don't use this version for fusions
+        false);        // reverse_order = false
+
+    return {
+        std::move(program),
+        {.multidevice_semaphores = multidevice_semaphores,
+         .barrier_semaphore = barrier_semaphore,
+         .program_artifacts = all_gather_program_artifacts}};
+}
+
+void AllGatherDeviceOperation::AllGatherProgram::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    // Update runtime arguments using the shared function
+    for (auto& [range, program] : cached_workload.workload.get_programs()) {
+        const auto& coord = range.start_coord();
+        TT_FATAL(
+            coord == range.end_coord(),
+            "Expected single coordinate per program but got range of {} to {}",
+            coord,
+            range.end_coord());
+        const auto& shared_variables = cached_workload.shared_variables.at(range);
+
+        all_gather_async_minimal_default_helper_override_runtime_arguments(
+            program,
+            shared_variables.program_artifacts.reader_kernel_ids,
+            shared_variables.program_artifacts.writer_kernel_ids,
+            shared_variables.program_artifacts.all_cores,
+            operation_attributes.num_links,
+            shared_variables.program_artifacts.num_directions_per_link,
+            shared_variables.program_artifacts.num_workers_per_direction,
+            shared_variables.program_artifacts.num_mux_cores_per_direction_per_link,
+            shared_variables.program_artifacts.num_cores_per_link,
+            shared_variables.barrier_semaphore,
+            shared_variables.multidevice_semaphores,
+            tensor_args.input_tensor,
+            tensor_return_value);
+    }
+}
+
+}  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -111,7 +111,7 @@ AllGatherDeviceOperation::AllGatherProgram::create_at(
         mesh_coordinate,
         forward_coordinate,
         backward_coordinate,
-        tensor_return_value.at(0),
+        tensor_return_value,
         operation_attributes.dim,
         operation_attributes.num_links,
         target_ring_size,
@@ -119,7 +119,7 @@ AllGatherDeviceOperation::AllGatherProgram::create_at(
         operation_attributes.topology,
         multidevice_semaphores,
         barrier_semaphore,
-        false,  // using_persistent_buffers - false since we don't have optional output tensor in this version
+        false,  // using_persistent_buffers - false since we always barrier in this version
         operation_attributes.subdevice_id,
         no_fuse,       // never fusing with this
         std::nullopt,  // use chunks per sync decision making tree

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/operations/ccl/mesh_partition/mesh_partition_pybind.hpp"
 #include "ttnn/operations/ccl/barrier/barrier_pybind.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather_pybind.hpp"
 #include "ttnn/operations/ccl/all_to_all_combine/all_to_all_combine_pybind.hpp"
 #include "ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.hpp"
 #include "ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp"
@@ -28,6 +29,7 @@ void py_module(py::module& module) {
     ccl::py_bind_common(module);
     ccl::py_bind_mesh_partition(module);
     ccl::py_bind_barrier(module);
+    ccl::py_bind_all_gather(module);
     ccl::py_bind_all_to_all_combine(module);
     ccl::py_bind_all_to_all_dispatch(module);
     ccl::py_bind_reduce_scatter(module);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
@@ -28,11 +28,10 @@ void py_bind_reduce_scatter(py::module& module) {
 
             Keyword Args:
                 cluster_axis (int, optional): The cluster axis to reduce across. Defaults to `None`.
-                topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
+                topology (ttnn.Topology, optional): Fabric topology. Defaults to `None`.
                 output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
                 memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
                 subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
-                queue_id (int, optional): Command queue id. Defaults to 0.
 
            Returns:
                ttnn.Tensor: The reduced and scattered tensor.)doc";
@@ -70,7 +69,7 @@ void py_bind_reduce_scatter(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("num_links") = std::nullopt,
-            py::arg("topology") = tt::tt_fabric::Topology::Linear,
+            py::arg("topology") = std::nullopt,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -125,6 +125,56 @@ struct AllGatherAsync {
     AllGatherAsyncVersion select_version(const Tensor& input_tensor) const;
 };
 
+struct AllGatherProgramArtifacts {
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    std::vector<tt::tt_metal::CoreCoord> all_cores;
+    uint32_t num_directions_per_link;
+    uint32_t num_workers_per_direction;
+    uint32_t num_mux_cores_per_direction_per_link;
+    uint32_t num_cores_per_link;
+};
+
+// Builder function that creates kernels and returns artifacts
+AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifacts(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const MeshCoordinate& sender_device_coord,
+    const std::optional<MeshCoordinate>& forward_coord,
+    const std::optional<MeshCoordinate>& backward_coord,
+    Tensor& output_tensor,
+    uint32_t dim,
+    uint32_t num_links,
+    uint32_t ring_size,
+    uint32_t ring_index,
+    ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphore,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
+    bool using_persistent_buffers,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_direction_opt,
+    std::optional<uint32_t> num_buffers_per_channel,
+    CoreCoord core_grid_offset,
+    bool reverse_order = false);
+
+// Runtime argument override function
+void all_gather_async_minimal_default_helper_override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    const std::vector<tt::tt_metal::CoreCoord>& all_cores,
+    uint32_t num_links,
+    uint32_t num_directions_per_link,
+    uint32_t num_workers_per_direction,
+    uint32_t num_mux_cores_per_direction_per_link,
+    uint32_t num_cores_per_link,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
+    const std::vector<GlobalSemaphore>& semaphore,
+    const Tensor& input,
+    const Tensor& output);
+
 // All Gather Variants
 tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -157,7 +157,7 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     std::optional<uint32_t> num_workers_per_direction_opt,
     std::optional<uint32_t> num_buffers_per_channel,
     CoreCoord core_grid_offset,
-    bool reverse_order = false);
+    bool reverse_order);
 
 // Runtime argument override function
 void all_gather_async_minimal_default_helper_override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -131,6 +131,88 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(num_workers_per_direction);
 }
 
+struct AllGatherProgramArtifacts {
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    std::vector<tt::tt_metal::CoreCoord> all_cores;
+    uint32_t num_directions_per_link;
+    uint32_t num_workers_per_direction;
+    uint32_t num_mux_cores_per_direction_per_link;
+    uint32_t num_cores_per_link;
+};
+
+AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifacts(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const MeshCoordinate& sender_device_coord,
+    const std::optional<MeshCoordinate>& forward_coord,
+    const std::optional<MeshCoordinate>& backward_coord,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphore,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
+    bool using_persistent_buffers,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_direction_opt,
+    std::optional<uint32_t> num_buffers_per_channel,
+    const CoreCoord core_grid_offset,
+    const bool reverse_order);
+
+void all_gather_async_minimal_default_helper_override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    const std::vector<tt::tt_metal::CoreCoord>& all_cores,
+    uint32_t num_links,
+    uint32_t num_directions_per_link,
+    uint32_t num_workers_per_direction,
+    uint32_t num_mux_cores_per_direction_per_link,
+    uint32_t num_cores_per_link,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
+    const std::vector<GlobalSemaphore>& semaphore,
+    const Tensor& input,
+    const Tensor& output) {
+    // Update runtime arguments for all worker cores
+    uint32_t core_idx = 0;
+    for (uint32_t link = 0; link < num_links; link++) {
+        for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
+            for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
+                uint32_t mux_core_offset = (link * num_cores_per_link) +
+                                           (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
+                tt::tt_metal::CoreCoord core =
+                    all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_ids[core_idx]);
+                auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
+
+                auto out_ready_semaphore = semaphore.at(dir);
+
+                // sender reader
+                auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
+                worker_reader_sender_runtime_args[0] = input.buffer()->address();
+                worker_reader_sender_runtime_args[1] = output.buffer()->address();
+                worker_reader_sender_runtime_args[13] = out_ready_semaphore.address();
+
+                // sender writer
+                auto& worker_writer_sender_runtime_args = writer_runtime_args[core.x][core.y];
+                worker_writer_sender_runtime_args[0] = output.buffer()->address();
+                worker_writer_sender_runtime_args[14] = out_ready_semaphore.address();
+
+                if (barrier_semaphore.has_value()) {
+                    worker_writer_sender_runtime_args[18] = barrier_semaphore.value().address();
+                }
+
+                core_idx++;
+            }
+        }
+    }
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default(
     const Tensor& input_tensor,
     const MeshCoordinate& sender_device_coord,
@@ -176,7 +258,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default(
         reverse_order);
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_helper(
+AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifacts(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     const MeshCoordinate& sender_device_coord,
@@ -662,6 +744,72 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
         }
     }
 
+    // Return the program artifacts
+    return {
+        reader_kernel_ids,
+        writer_kernel_ids,
+        all_cores,
+        num_directions_per_link,
+        num_workers_per_direction,
+        num_mux_cores_per_direction_per_link,
+        num_cores_per_link};
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_helper(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const MeshCoordinate& sender_device_coord,
+    const std::optional<MeshCoordinate>& forward_coord,
+    const std::optional<MeshCoordinate>& backward_coord,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphore,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
+    bool using_persistent_buffers,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_direction_opt,
+    std::optional<uint32_t> num_buffers_per_channel,
+    const CoreCoord core_grid_offset,
+    const bool reverse_order) {
+    // Call the builder to create the program and get artifacts
+    auto
+        [reader_kernel_ids,
+         writer_kernel_ids,
+         all_cores,
+         num_directions_per_link,
+         num_workers_per_direction,
+         num_mux_cores_per_direction_per_link,
+         num_cores_per_link] =
+            build_all_gather_async_minimal_default_program_artifacts(
+                program,
+                input_tensor,
+                sender_device_coord,
+                forward_coord,
+                backward_coord,
+                output_tensor,
+                dim,
+                num_links,
+                ring_size,
+                ring_index,
+                topology,
+                semaphore,
+                barrier_semaphore,
+                using_persistent_buffers,
+                sub_device_id,
+                fused_op_signaler,
+                chunks_per_sync,
+                num_workers_per_direction_opt,
+                num_buffers_per_channel,
+                core_grid_offset,
+                reverse_order);
+
+    // Create the callback using the artifacts returned by the builder
     auto override_runtime_arguments_callback =
         [reader_kernel_ids,
          writer_kernel_ids,
@@ -680,38 +828,22 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_default_h
             const auto& output = output_tensors[0];
 
             auto barrier_semaphore = static_cast<const ttnn::AllGatherAsync*>(operation)->barrier_semaphore;
-            // update senders
-            uint32_t core_idx = 0;
-            for (uint32_t link = 0; link < num_links; link++) {
-                for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
-                    for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
-                        uint32_t mux_core_offset =
-                            (link * num_cores_per_link) +
-                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
-                        CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
-                        auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_ids[core_idx]);
-                        auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
+            auto semaphore = static_cast<const ttnn::AllGatherAsync*>(operation)->semaphore;
 
-                        auto out_ready_semaphore =
-                            static_cast<const ttnn::AllGatherAsync*>(operation)->semaphore.at(dir);
-                        // sender reader
-                        auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
-                        worker_reader_sender_runtime_args[0] = input.buffer()->address();
-                        worker_reader_sender_runtime_args[1] = output.buffer()->address();
-                        worker_reader_sender_runtime_args[13] = out_ready_semaphore.address();
-                        // sender writer
-                        auto& worker_writer_sender_runtime_args = writer_runtime_args[core.x][core.y];
-                        worker_writer_sender_runtime_args[0] = output.buffer()->address();
-                        worker_writer_sender_runtime_args[14] = out_ready_semaphore.address();
-
-                        if (barrier_semaphore.has_value()) {
-                            worker_writer_sender_runtime_args[18] = barrier_semaphore.value().address();
-                        }
-
-                        core_idx++;
-                    }
-                }
-            }
+            all_gather_async_minimal_default_helper_override_runtime_arguments(
+                program,
+                reader_kernel_ids,
+                writer_kernel_ids,
+                all_cores,
+                num_links,
+                num_directions_per_link,
+                num_workers_per_direction,
+                num_mux_cores_per_direction_per_link,
+                num_cores_per_link,
+                barrier_semaphore,
+                semaphore,
+                input,
+                output);
         };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -131,16 +131,6 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(num_workers_per_direction);
 }
 
-struct AllGatherProgramArtifacts {
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
-    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
-    std::vector<tt::tt_metal::CoreCoord> all_cores;
-    uint32_t num_directions_per_link;
-    uint32_t num_workers_per_direction;
-    uint32_t num_mux_cores_per_direction_per_link;
-    uint32_t num_cores_per_link;
-};
-
 AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifacts(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -131,29 +131,6 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(num_workers_per_direction);
 }
 
-AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifacts(
-    tt::tt_metal::Program& program,
-    const Tensor& input_tensor,
-    const MeshCoordinate& sender_device_coord,
-    const std::optional<MeshCoordinate>& forward_coord,
-    const std::optional<MeshCoordinate>& backward_coord,
-    Tensor& output_tensor,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    ccl::Topology topology,
-    const std::vector<GlobalSemaphore>& semaphore,
-    const std::optional<GlobalSemaphore>& barrier_semaphore,
-    bool using_persistent_buffers,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-    std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
-    std::optional<uint32_t> chunks_per_sync,
-    std::optional<uint32_t> num_workers_per_direction_opt,
-    std::optional<uint32_t> num_buffers_per_channel,
-    const CoreCoord core_grid_offset,
-    const bool reverse_order);
-
 void all_gather_async_minimal_default_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
@@ -180,7 +157,7 @@ void all_gather_async_minimal_default_helper_override_runtime_arguments(
                 auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_ids[core_idx]);
                 auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
 
-                auto out_ready_semaphore = semaphore.at(dir);
+                const auto& out_ready_semaphore = semaphore.at(dir);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];


### PR DESCRIPTION
### Ticket
#26456 
#26952 
#30348

### Problem description
`ttnn.all_gather` exposed op internals like semaphores and required persistent buffers. As well, it contained hard coded implementations that we often accidentally demux-ed too. This is required for us to proceed with #30348 as we would otherwise need an API to compose a parent mesh global semaphore from submeshes.

### What's changed
Add back ttnn.all_gather with semaphores removed, automatic topology and link count deduction, and hyperparameters unexposed. We still have the freedom to pass all of these in but they're no longer required.

### Checklist
- APC: https://github.com/tenstorrent/tt-metal/actions/runs/18420171850
- T3K: https://github.com/tenstorrent/tt-metal/actions/runs/18420182231