### PR TITLE
ERISC0 Stability Updates

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -341,11 +341,6 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocReadNoSend) {
         auto device = mesh_device->get_devices()[0];
         for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
-                if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                    tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                    log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                    continue;
-                }
                 const auto ethernet_config = tt_metal::EthernetConfig{
                     .noc = static_cast<NOC>(erisc_idx), .processor = static_cast<DataMovementProcessor>(erisc_idx)};
                 ASSERT_TRUE(unit_tests::erisc::kernels::reader_kernel_no_send(
@@ -388,11 +383,6 @@ TEST_F(UnitMeshCQSingleCardProgramFixture, ActiveEthKernelsNocWriteNoReceive) {
         auto device = mesh_device->get_devices()[0];
         for (const auto& eth_core : device->get_active_ethernet_cores(true)) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
-                if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                    tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                    log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                    continue;
-                }
                 const auto ethernet_config = tt_metal::EthernetConfig{
                     .noc = static_cast<tt_metal::NOC>(erisc_idx),
                     .processor = static_cast<DataMovementProcessor>(erisc_idx)};

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -579,11 +579,6 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                 const auto num_eriscs = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
                     HalProgrammableCoreType::ACTIVE_ETH);
                 for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {
-                    if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                        tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                        log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                        continue;
-                    }
                     const auto processor = static_cast<DataMovementProcessor>(erisc_idx);
                     log_info(
                         tt::LogTest,
@@ -673,11 +668,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
                 }
 
                 for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
-                    if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                        tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                        log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                        continue;
-                    }
                     const auto processor = static_cast<DataMovementProcessor>(erisc_idx);
                     log_info(
                         tt::LogTest,
@@ -754,11 +744,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                 }
 
                 for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
-                    if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                        tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                        log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                        continue;
-                    }
                     const auto processor = static_cast<DataMovementProcessor>(erisc_idx);
                     log_info(
                         tt::LogTest,

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -956,11 +956,6 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomEthPacketSizeDirectSendTests)
             const auto num_eriscs =
                 MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
             for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {
-                if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                    tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                    log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                    continue;
-                }
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
                     static_cast<MeshDispatchFixture*>(this),
                     send_chip,
@@ -1001,11 +996,6 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                     continue;
                 }
                 for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {
-                    if (this->arch_ == ARCH::BLACKHOLE && erisc_idx == 0 &&
-                        tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                        log_info(tt::LogTest, "Skipping Blackhole test for erisc_idx {}", erisc_idx);
-                        continue;
-                    }
                     const auto processor = static_cast<DataMovementProcessor>(erisc_idx);
                     ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
                         static_cast<MeshDispatchFixture*>(this),

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -190,8 +190,14 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
 
 namespace {
 bool requires_forced_assignment_to_noc1() {
+    // When creating a kernel on erisc0 and 2 erisc mode is disabled, the physical processor is erisc1 while erisc0 is
+    // running base firmware. As base firmware may occassionally use noc0 force fabric on "erisc0" to use noc1
+    //
+    // When 2 erisc mode is enabled on the runtime, erisc index == noc index is enforced hence the condition
+    // !get_enable_2_erisc_mode() below.
+    //
     return tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE &&
-           get_num_riscv_cores() == 1;
+           get_num_riscv_cores() == 1 && !tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode();
 }
 }  // anonymous namespace
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -191,7 +191,7 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
 namespace {
 bool requires_forced_assignment_to_noc1() {
     // When creating a kernel on erisc0 and 2 erisc mode is disabled, the physical processor is erisc1 while erisc0 is
-    // running base firmware. As base firmware may occassionally use noc0 force fabric on "erisc0" to use noc1
+    // running base firmware. As base firmware may occasionally use noc0 force fabric on "erisc0" to use noc1
     //
     // When 2 erisc mode is enabled on the runtime, erisc index == noc index is enforced hence the condition
     // !get_enable_2_erisc_mode() below.

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -495,10 +495,6 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
             ct_args.push_back(router_channels_mask);
 
             auto proc = static_cast<tt::tt_metal::DataMovementProcessor>(risc_id);
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                // Force fabric to run on erisc1
-                proc = tt::tt_metal::DataMovementProcessor::RISCV_1;
-            }
 
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto kernel = tt::tt_metal::CreateKernel(

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -169,7 +169,7 @@ extern "C" __attribute__((naked)) void enter_reset(void) {
         "sw gp, 13 * 4( sp )\n"
 
         // Copy contents of local memory to L1, because local memory is cleared on reset. There is a register that in
-        // theory can be set to prevent resetting the core from clearing L1, but the hardware doesn't support it.
+        // theory can be set to prevent resetting the core from clearing local memory, but the hardware doesn't support it.
         "li   t0, " STRINGIFY(MEM_LOCAL_BASE) "\n\t"   // src
         "li   t1, " STRINGIFY(MEM_ERISC_L1_TEMP_STORAGE) "\n\t"   // dst (256 KiB)
         "li   t2, 2048\n\t"         // 8 KiB / 4B = 2048 words

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -104,6 +104,91 @@ inline void initialize_local_memory() {
     l1_to_local_mem_copy(__ldm_data_start, data_image, ldm_data_size);
 }
 
+#define STR(x) #x
+#define STRINGIFY(s) STR(s)
+#define MEM_ERISC_HALT_STACK_MAILBOX_ADDRESS (MEM_AERISC_MAILBOX_BASE + 4)
+#define MEM_ERISC_L1_TEMP_STORAGE (0x00040000)
+
+extern "C" __attribute__((naked, used)) void resume_from_reset() {
+    __asm__ volatile(
+        // Restore contents of local memory from L1
+	    ".option push\n"
+        ".option norelax\n"
+        "li   t0, " STRINGIFY(MEM_ERISC_L1_TEMP_STORAGE) "\n\t" // src
+        "li   t1, " STRINGIFY(MEM_LOCAL_BASE) "\n\t"   // dst
+        "li   t2, 2048\n\t"
+        "0:\n\t"
+        "lw   t3, 0(t0)\n\t"
+        "sw   t3, 0(t1)\n\t"
+        "addi t0, t0, 4\n\t"
+        "addi t1, t1, 4\n\t"
+        "addi t2, t2, -1\n\t"
+        "bnez t2, 0b\n\t"
+        "lw  sp, " STRINGIFY(MEM_ERISC_HALT_STACK_MAILBOX_ADDRESS) "( zero )\n"
+        // Restore contents of callee-saved registers from the stack.
+        "lw  ra, 0 * 4( sp )\n"
+        "lw  s0, 1 * 4( sp )\n"
+        "lw  s1, 2 * 4( sp )\n"
+        "lw  s2, 3 * 4( sp )\n"
+        "lw  s3, 4 * 4( sp )\n"
+        "lw  s4, 5 * 4( sp )\n"
+        "lw  s5, 6 * 4( sp )\n"
+        "lw  s6, 7 * 4( sp )\n"
+        "lw  s7, 8 * 4( sp )\n"
+        "lw  s8, 9 * 4( sp )\n"
+        "lw  s9, 10 * 4( sp )\n"
+        "lw  s10, 11 * 4( sp )\n"
+        "lw  s11, 12 * 4( sp )\n"
+        "lw gp, 13 * 4( sp )\n"
+        ".option pop\n"
+        "addi sp, sp, (16 * 4)\n"
+        "ret\n"
+    );
+}
+
+// After running the base firmware, some core state (for erisc0) seems broken, so jumps into the kernel may occasionally
+// hang. Resetting the core fixes the issue. We need to save all the GPR and local memory to L1, because local memory is
+// cleared on reset. ERISC1 is responsible for triggering the reset, which willl start execution in resume_from_reset.
+extern "C" __attribute__((naked)) void enter_reset(void) {
+    __asm__ volatile(
+        // Save contents to stack
+        "addi sp, sp, -(16 * 4)\n"
+        "sw ra, 0 * 4( sp )\n"
+        "sw s0, 1 * 4( sp )\n"
+        "sw s1, 2 * 4( sp )\n"
+        "sw s2, 3 * 4( sp )\n"
+        "sw s3, 4 * 4( sp )\n"
+        "sw s4, 5 * 4( sp )\n"
+        "sw s5, 6 * 4( sp )\n"
+        "sw s6, 7 * 4( sp )\n"
+        "sw s7, 8 * 4( sp )\n"
+        "sw s8, 9 * 4( sp )\n"
+        "sw s9, 10 * 4( sp )\n"
+        "sw s10, 11 * 4( sp )\n"
+        "sw s11, 12 * 4( sp )\n"
+        "sw gp, 13 * 4( sp )\n"
+
+        // Copy contents of local memory to L1, because local memory is cleared on reset. There is a register that in
+        // theory can be set to prevent resetting the core from clearing L1, but the hardware doesn't support it.
+        "li   t0, " STRINGIFY(MEM_LOCAL_BASE) "\n\t"   // src
+        "li   t1, " STRINGIFY(MEM_ERISC_L1_TEMP_STORAGE) "\n\t"   // dst (256 KiB)
+        "li   t2, 2048\n\t"         // 8 KiB / 4B = 2048 words
+        "0:\n\t"
+        "lw   t3, 0(t0)\n\t"
+        "sw   t3, 0(t1)\n\t"
+        "addi t0, t0, 4\n\t"
+        "addi t1, t1, 4\n\t"
+        "addi t2, t2, -1\n\t"
+        "bnez t2, 0b\n\t"
+
+        // Store stack pointer to allow restoring after reset.
+        "sw sp, " STRINGIFY(MEM_ERISC_HALT_STACK_MAILBOX_ADDRESS) "( zero )\n"
+        // Infinite loop to prevent the core from continuing execution.
+        "done_loop:\n"
+        "j done_loop\n"
+    );
+}
+
 int __attribute__((noinline)) main(void) {
     WAYPOINT("I");
     configure_csr();
@@ -134,6 +219,9 @@ int __attribute__((noinline)) main(void) {
 
 #if defined(ENABLE_2_ERISC_MODE)
     deassert_all_reset();
+
+    WRITE_REG(AERISC_RESET_PC, (uint32_t)(void*)resume_from_reset);
+    enter_reset();
 #endif
     wait_subordinate_eriscs();
     flag_disable[0] = 1;

--- a/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
@@ -104,6 +104,23 @@ int main() {
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
     risc_init();
     signal_subordinate_erisc_completion();
+#if defined(ENABLE_2_ERISC_MODE)
+    if (k_ProgrammableCoreType == ProgrammableCoreType::ACTIVE_ETH) {
+        while (true) {
+            // Wait for ERISC0 to signal that it has saved its state to L1
+            if (mailboxes->ncrisc_halt.stack_save != 0) {
+                // Trigger a soft reset of ERISC0
+                static constexpr uint32_t TENSIX_SOFT_RESET_ADDR = 0xFFB121B0;
+                WRITE_REG(TENSIX_SOFT_RESET_ADDR, 1 << 11);
+                riscv_wait(100);
+                WRITE_REG(TENSIX_SOFT_RESET_ADDR, 0);
+
+                break;
+            }
+            invalidate_l1_cache();
+        }
+    }
+#endif
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/inc/tt-1xx/risc_common.h
+++ b/tt_metal/hw/inc/tt-1xx/risc_common.h
@@ -220,8 +220,10 @@ inline void riscv_wait(uint32_t cycles) {
 // Flush i$ on ethernet riscs
 inline __attribute__((always_inline)) void flush_erisc_icache() {
 #ifdef ARCH_BLACKHOLE
-#pragma GCC unroll 2048
-    for (int i = 0; i < 2048; i++) {
+    // 2K is enough to touch all entries but after running base firmware there seems to be some
+    // state in the i$ which is sticking and adding 1K more nops resolves it.
+#pragma GCC unroll 3072
+    for (int i = 0; i < 3072; i++) {
         __asm__ volatile("nop");
     }
 #else

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -156,7 +156,7 @@ void JitBuildEnv::init(
     string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
-        common_flags += "-g ";
+        common_flags += "-g -fstack-usage ";
     }
 
     this->cflags_ = common_flags;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -170,6 +170,15 @@ public:
               params.processor_class == HalProcessorClassType::COMPUTE)) {
             cflags += "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
         }
+        // Unlike other core types, the stack on erisc0 is not dynamic because it's setup by base firmware.
+        // Trigger an error for kernels which may exceed the static stack usage to prevent difficult to debug issues
+        // 1536 B = stack size taken from the base firmware
+        // 72 B = Approx. stack usage at the time the kernel is launched
+        // 1536 B - 64 B = 1464 B free for kernel
+        if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH && params.processor_id == 0 &&
+            blackhole::is_2_erisc_mode()) {
+            cflags += "-Werror=stack-usage=1464 ";
+        }
         return cflags;
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25427
https://github.com/tenstorrent/tt-metal/issues/29233

### Problem description
- ERISC0 is in a non deterministic bad state when metal firmware is being called from base firmware.
- Running Fabric on ERISC0 hangs on 8xP150
  - It was overflowing the stack by about 200 B
  - This issue is not present on 2xP150 because less objects are created

### What's changed
- Add save/restore reset code to active_erisc init to clean up the bad state
- Update the build flags to trigger an error if the static stack usage by the kernel exceeds the maximum on ERISC0
- Enable additional ERISC0+ERISC1 tests
- Allow Fabric to run on ERISC0 again
- Based on testing, increased the number of nops in flush i$ cache to 3K

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18420662449
Blackhole PC
https://github.com/tenstorrent/tt-metal/actions/runs/18487874520
Blackhole Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/18476322274
Blackhole Demo
https://github.com/tenstorrent/tt-metal/actions/runs/18476323373