### PR TITLE
Misc changes to GSD and Cluster Validation

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -105,6 +105,8 @@ public:
     // Constructor with just hostnames (no physical location info)
     CablingGenerator(const std::string& cluster_descriptor_path, const std::vector<std::string>& hostnames);
 
+    CablingGenerator() = default;
+
     // Getters for all data
     const std::vector<Host>& get_deployment_hosts() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -62,9 +62,9 @@ InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
     }
 
     if (test_args::has_command_option(args_vec, "--cabling-descriptor-path")) {
-        TT_FATAL(
-            test_args::has_command_option(args_vec, "--deployment-descriptor-path"),
-            "Deployment Descriptor Path is required when Cabling Descriptor Path is provided.");
+        // TT_FATAL(
+        //     test_args::has_command_option(args_vec, "--deployment-descriptor-path"),
+        //     "Deployment Descriptor Path is required when Cabling Descriptor Path is provided.");
         input_args.cabling_descriptor_path = test_args::get_command_option(args_vec, "--cabling-descriptor-path");
     }
     if (test_args::has_command_option(args_vec, "--deployment-descriptor-path")) {
@@ -119,16 +119,22 @@ InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
     return input_args;
 }
 
-std::string get_factory_system_descriptor_path(const InputArgs& input_args) {
+std::string get_factory_system_descriptor_path(const InputArgs& input_args, const std::vector<std::string>& hostnames) {
     std::string fsd_path;
     if (input_args.cabling_descriptor_path.has_value()) {
         const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
         log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
-        tt::scaleout_tools::CablingGenerator cabling_generator(
-            input_args.cabling_descriptor_path.value(), input_args.deployment_descriptor_path.value());
+        CablingGenerator cabling_generator;
         std::string filename =
-            "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
-        fsd_path = input_args.output_path / filename;
+                "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
+            fsd_path = input_args.output_path / filename;
+        if (not input_args.deployment_descriptor_path.has_value()) {
+            TT_FATAL(hostnames.size() == 1, "Expected exactly one host in the cluster when no deployment descriptor is provided");
+            cabling_generator = tt::scaleout_tools::CablingGenerator(input_args.cabling_descriptor_path.value(), hostnames);
+        } else {
+            cabling_generator = tt::scaleout_tools::CablingGenerator(
+                input_args.cabling_descriptor_path.value(), input_args.deployment_descriptor_path.value());
+        }
         cabling_generator.emit_factory_system_descriptor(fsd_path);
     } else {
         fsd_path = input_args.fsd_path.value();
@@ -190,7 +196,7 @@ AsicTopology validate_connectivity(const InputArgs& input_args, PhysicalSystemDe
     physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
     log_output_rank0("Validating Factory System Descriptor (Golden Representation) against Global System Descriptor");
     bool log_output = *distributed_context.rank() == 0;
-    const auto fsd_path = get_factory_system_descriptor_path(input_args);
+    const auto fsd_path = get_factory_system_descriptor_path(input_args, physical_system_descriptor.get_all_hostnames());
     auto missing_physical_connections = tt::scaleout_tools::validate_fsd_against_gsd(
         fsd_path, gsd_yaml_path, true, input_args.fail_on_warning, log_output);
     log_output_rank0("Factory System Descriptor (Golden Representation) Validation Complete");


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
 - Current implementation of `run_cluster_validation` only sent unidirectional traffic across links
 - Corrected Codeword Counts are not reported for any link
 - Link health checks are overly restrictive, which can lead to false positives for faulty links
 - Specifically, links are reported as faulty if they have:
    -  A non-zero retrain count
    - A non-zero uncorrected codeword count
    
 
### What's changed
- Generate bidirectional traffic in `send_traffic_and_validate_links`
- Report Corrected Codeword count when dumping link stats
- Modify Link Health Check to match spec from SysEng
- Link is considered unhealthy if:
   - The retrain count is increasing
   - A CRC error is reported
   - Uncorrected codewords are detected but no retrains were issued
   - Uncorrected codewords are increasing
   - A data mismatch is detected  

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes