### PR TITLE
[skip ci] Silence codegen.sh on clang-format existence

### DIFF
--- a/tt_metal/llrt/hal/codegen/codegen.sh
+++ b/tt_metal/llrt/hal/codegen/codegen.sh
@@ -55,6 +55,6 @@ fi
 
 # some environment does not have a compatible clang-format, in which case we should
 # ignore the failure
-if clang-format -i "${OUT_INTF_FILE}" "${OUT_IMPL_FILE}"; then
+if clang-format -i "${OUT_INTF_FILE}" "${OUT_IMPL_FILE}" 2> /dev/null; then
     :
 fi


### PR DESCRIPTION
### Ticket
n/a

### Problem description
People want clean build output.

### What's changed
It is not an error if clang-format is not available (the script does not fail).   Do not output anything that looks like an error.

### Checklist
Trival change; a passing build suffices.