### PR TITLE
L1FullSliceStrategyConfiguration

### DIFF
--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -46,10 +46,18 @@ class ChannelSliceStrategyConfiguration(SliceStrategyConfiguration):
             raise ValueError(f"Channel slicing requires num_slices > 1")
 
 
+# If slicing is None, DRAM is assumed; Need explicit Strategy for L1
+@dataclass
+class L1FullSliceStrategyConfiguration(SliceStrategyConfiguration):
+    def get_slice_type(self):
+        return ttnn.Conv2dL1Full
+
+
 SliceStrategy = Union[
     HeightSliceStrategyConfiguration,
     WidthSliceStrategyConfiguration,
     ChannelSliceStrategyConfiguration,
+    L1FullSliceStrategyConfiguration,
 ]
 
 


### PR DESCRIPTION
### Problem description
#27147 changes default behavior for convs when slicing config = None

### What's changed
We have to explicitly define L1FullSliceStrategyConfiguration. 
Alternatively we could have None behave as L1FullSliceStrategyConfiguration in TtConv2d; however it's better to keep module compatible with the op. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes