### PR TITLE
[skip ci] Don't propagate CMAKE_CXX_FLAGS into protobuf

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -63,7 +63,6 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "protobuf_BUILD_TESTS OFF"
-        "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations"
         "protobuf_INSTALL OFF"
         "BUILD_TESTING OFF"
         "protobuf_BUILD_EXAMPLES OFF"
@@ -86,7 +85,12 @@ set_target_properties(
 # Setting link and compile flags to avoid symbol conflicts with other protobuf libraries when tt-metal package is used.
 # Ensures that tt-metal package only uses its own protobuf library and not the one from the system.
 target_link_options(libprotobuf PRIVATE -Wl,-Bsymbolic)
-target_compile_options(libprotobuf PRIVATE -fno-semantic-interposition)
+target_compile_options(
+    libprotobuf
+    PRIVATE
+        -fno-semantic-interposition
+        -Wno-deprecated-declarations
+)
 
 ############################################################################################################################
 # yaml-cpp


### PR DESCRIPTION
Don't propagate CMAKE_CXX_FLAGS into protobuf

Might help with https://github.com/orgs/tenstorrent/projects/41?pane=issue&itemId=130347731&issue=tenstorrent%7Ctt-metal%7C29192