### PR TITLE
[skip ci] Galaxy workflow naming consistency — additional updates

### DIFF
--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy demo tests"
+name: "(Galaxy) demo tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/galaxy-frequent-tests.yaml
+++ b/.github/workflows/galaxy-frequent-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy frequent tests"
+name: "(Galaxy) frequent tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy model perf tests"
+name: "(Galaxy) model perf tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -1,4 +1,4 @@
-name: Galaxy Multi-user Isolation Tests
+name: (Galaxy) Multi-user Isolation Tests
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy nightly tests"
+name: "(Galaxy) nightly tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy profiler tests"
+name: "(Galaxy) profiler tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/galaxy-stress-tests.yaml
+++ b/.github/workflows/galaxy-stress-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy Stress"
+name: "(Galaxy) Stress"
 
 on:
   schedule:

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: "Galaxy unit tests"
+name: "(Galaxy) unit tests"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description
While PR #30431 introduced the initial consistency pass, a few remaining workflows and metadata references still required alignment with the (Galaxy) format used GitHub Actions.

### Changes
Updated workflow names to include (Galaxy) for full consistency.
Corrected any residual naming mismatches found after #30431.
No logic or functionality changes — purely naming refinements.

### Related PRs
Builds on: #30431 — “Standardize Galaxy workflow naming with parentheses”
Related to: #29997 — “Add Galaxy pipelines to produce data workflow and remove the disabled TG pipelines”