### PR TITLE
Tidy up DeepSeek demo experience

### DIFF
--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -13,13 +13,77 @@ This codebase was designed for the model: [deepseek-ai/DeepSeek-R1-0528](https:/
 - Cloned [tt-metal repository](https://github.com/tenstorrent/tt-metal) for source code
 - Installed: [TT-Metalium™ / TT-NN™](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md)
 
-## How to Run
+## Demo CLI
+
+Example (replace the placeholder paths with your environment):
+
+```bash
+python models/demos/deepseek_v3/demo/demo.py \
+  --model-path /abs/path/to/load/hf/deepseek-v3 \
+  --cache-dir /abs/path/to/save/ttnn/cache \
+  --early_print_first_user \
+  "Write a haiku about autumnal days by the sea"
+```
+
+Supported arguments:
+
+- `--model-path PATH`: Local HF model directory. Defaults to `$DEEPSEEK_V3_HF_MODEL` or `models/demos/deepseek_v3/reference`.
+- `--cache-dir PATH`: Where to store converted TTNN weights and caches. Defaults to `$DEEPSEEK_V3_CACHE` or `generated/deepseek_v3`.
+- `--early_print_first_user`: Stream generated tokens for the first prompt as they are produced instead of printing only at the end.
+- `--max-new-tokens N`: Number of tokens to generate (default: 32).
+- `--random-weights`: Use randomly initialized weights (single dense layer only). Does not require tokenizer or safetensors.
+- `--single-layer {mlp,moe}`: With `--random-weights`, request a single layer (mlp supported).
+- `--token-accuracy`: Enable teacher‑forcing decode and report accuracy (requires full‑model mode + tokenizer).
+- `--reference-file PATH`: Path to `.pt/.refpt` reference file (see below).
+- `--tf-prompt-len N`: Override the teacher‑forcing prompt length in tokens (taken from the reference file). Defaults to half+1 if omitted.
+
+You should also provide one or more prompts (each in quotes as in the above example) as positional arguments, unless using `--random-weights`. In `--random-weights` mode, prompts are optional.
+
+Programmatic usage:
+
+```python
+from models.demos.deepseek_v3.demo.demo import run_demo
+
+# Full-model generation (prompt required)
+run_demo(["Write a haiku about hardware"], model_path="/abs/path/to/deepseek-v3")
+
+# Random-weights smoke test (prompt optional)
+run_demo(None, random_weights=True)
+```
+
+### Teacher Forcing Accuracy Verification
+
+You can verify accuracy under teacher forcing using a reference file with tokenized ground‑truth. The expected format matches the tt_transformers demos/tests:
+
+- Keys: `reference_tokens` (LongTensor [1, T]) and optional `top5_tokens` (LongTensor [T, 5]).
+- The demo splits `reference_tokens` at `T//2 + 1` into input prompt and ground‑truth continuation.
+
+Generate a compatible reference file with the tt_transformers helper (use the same tokenizer/model family as your DeepSeek model to ensure token IDs match):
+
+- Hugging Face path:
+  - `python models/tt_transformers/tests/generate_reference_outputs.py --total_length 2048 --output_file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --model deepseek-ai/DeepSeek-V3`
+- Or use the HF‑only variant:
+  - `python models/tt_transformers/tests/generate_reference_hf.py --total_length 2048 --output_file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --model deepseek-ai/DeepSeek-V3`
+
+Run the DeepSeek‑V3 demo with teacher forcing:
+
+- `python models/demos/deepseek_v3/demo/demo.py --model-path /path/to/deepseek-v3 --token-accuracy --reference-file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --max-new-tokens 256`
+  - Optionally control prompt length independently with `--tf-prompt-len`, e.g.:
+  - `... --tf-prompt-len 1024 --max-new-tokens 256`
+
+Notes:
+
+- `--token-accuracy` is not compatible with `--random-weights` and requires tokenizer files in `--model-path`.
+- The demo decodes a single sequence in teacher‑forcing mode. `--max-new-tokens` is capped to the number of available GT tokens in the reference file.
+- If `top5_tokens` is present in the reference, the demo reports both top‑1 and top‑5 accuracies; otherwise, only top‑1.
+
+## How to develop
 
 If you are not running on Tenstorrent internal infrastructure, you need to set the following environment variables:
 
+- `DEEPSEEK_V3_HF_MODEL`: Path to a directory containing the DeepSeek-V3 Hugging Face model weights. Defaults to `models/demos/deepseek_v3/reference`. Download the model from Hugging Face set this to the model directory.
 - `DEEPSEEK_V3_CACHE`: Path to a directory where cached data such as converted weights and test inputs/outputs will be stored.
 
-- `DEEPSEEK_V3_HF_MODEL`: Path to a directory containing the DeepSeek-V3 Hugging Face model weights. Defaults to `models/demos/deepseek_v3/reference`. Download the model from Hugging Face set this to the model directory.
 
 These variables are used in scripts for generating test data and running tests.
 
@@ -80,70 +144,6 @@ model_state = MLP.create_state(hf_config, mesh_device)
 run_config = MLP.run_config(model_config, weight_config, model_state)
 output = MLP.forward_prefill(input_tensor, run_config) # or forward_decode(input_tensor, run_config)
 ```
-
-## Demo CLI
-
-The demo entrypoint `models/demos/deepseek_v3/demo/demo.py` supports:
-
-- `--model-path PATH`: Local HF model directory. Defaults to `$DEEPSEEK_V3_HF_MODEL` or `models/demos/deepseek_v3/reference`.
-- `--cache-dir PATH`: Where to store converted TTNN weights and caches. Defaults to `$DEEPSEEK_V3_CACHE` or `generated/deepseek_v3`.
-- `--max-new-tokens N`: Number of tokens to generate (default: 32).
-- `--random-weights`: Use randomly initialized weights (single dense layer only). Does not require tokenizer or safetensors.
-- `--single-layer {mlp,moe}`: With `--random-weights`, request a single layer (mlp supported).
-- `--token-accuracy`: Enable teacher‑forcing decode and report accuracy (requires full‑model mode + tokenizer).
-- `--reference-file PATH`: Path to `.pt/.refpt` reference file (see below).
-- `--tf-prompt-len N`: Override the teacher‑forcing prompt length in tokens (taken from the reference file). Defaults to half+1 if omitted.
-- `--early_print_first_user`: Stream generated tokens for the first prompt as they are produced instead of printing only at the end.
-
-When not using `--random-weights`, provide at least one prompt as the first positional argument (or pass a list via the `prompts` parameter when calling programmatically). In `--random-weights` mode, prompts are optional—the demo will synthesize an empty placeholder if none are supplied.
-
-Example programmatic usage:
-
-```python
-from models.demos.deepseek_v3.demo.demo import run_demo
-
-# Full-model generation (prompt required)
-run_demo(["Write a haiku about hardware"], model_path="/abs/path/to/deepseek-v3")
-
-# Random-weights smoke test (prompt optional)
-run_demo(None, random_weights=True)
-```
-
-Example CLI invocation (replace the placeholder paths with your environment):
-
-```bash
-python models/demos/deepseek_v3/demo/demo.py \
-  --model-path /abs/path/to/deepseek-v3 \
-  --cache-dir /abs/path/to/cache \
-  --early_print_first_user \
-  "Write a haiku about autumnal days by the sea"
-```
-
-### Teacher Forcing Accuracy Verification
-
-You can verify accuracy under teacher forcing using a reference file with tokenized ground‑truth. The expected format matches the tt_transformers demos/tests:
-
-- Keys: `reference_tokens` (LongTensor [1, T]) and optional `top5_tokens` (LongTensor [T, 5]).
-- The demo splits `reference_tokens` at `T//2 + 1` into input prompt and ground‑truth continuation.
-
-Generate a compatible reference file with the tt_transformers helper (use the same tokenizer/model family as your DeepSeek model to ensure token IDs match):
-
-- Hugging Face path:
-  - `python models/tt_transformers/tests/generate_reference_outputs.py --total_length 2048 --output_file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --model deepseek-ai/DeepSeek-V3`
-- Or use the HF‑only variant:
-  - `python models/tt_transformers/tests/generate_reference_hf.py --total_length 2048 --output_file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --model deepseek-ai/DeepSeek-V3`
-
-Run the DeepSeek‑V3 demo with teacher forcing:
-
-- `python models/demos/deepseek_v3/demo/demo.py --model-path /path/to/deepseek-v3 --token-accuracy --reference-file models/tt_transformers/tests/reference_outputs/DeepSeek-V3.refpt --max-new-tokens 256`
-  - Optionally control prompt length independently with `--tf-prompt-len`, e.g.:
-  - `... --tf-prompt-len 1024 --max-new-tokens 256`
-
-Notes:
-
-- `--token-accuracy` is not compatible with `--random-weights` and requires tokenizer files in `--model-path`.
-- The demo decodes a single sequence in teacher‑forcing mode. `--max-new-tokens` is capped to the number of available GT tokens in the reference file.
-- If `top5_tokens` is present in the reference, the demo reports both top‑1 and top‑5 accuracies; otherwise, only top‑1.
 
 ## Details
 ###  Folder Contents

--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -93,8 +93,31 @@ The demo entrypoint `models/demos/deepseek_v3/demo/demo.py` supports:
 - `--token-accuracy`: Enable teacher‑forcing decode and report accuracy (requires full‑model mode + tokenizer).
 - `--reference-file PATH`: Path to `.pt/.refpt` reference file (see below).
 - `--tf-prompt-len N`: Override the teacher‑forcing prompt length in tokens (taken from the reference file). Defaults to half+1 if omitted.
+- `--early_print_first_user`: Stream generated tokens for the first prompt as they are produced instead of printing only at the end.
 
-When not using `--random-weights`, pass a prompt as the first argument or via the `prompt` parameter when calling programmatically.
+When not using `--random-weights`, provide at least one prompt as the first positional argument (or pass a list via the `prompts` parameter when calling programmatically). In `--random-weights` mode, prompts are optional—the demo will synthesize an empty placeholder if none are supplied.
+
+Example programmatic usage:
+
+```python
+from models.demos.deepseek_v3.demo.demo import run_demo
+
+# Full-model generation (prompt required)
+run_demo(["Write a haiku about hardware"], model_path="/abs/path/to/deepseek-v3")
+
+# Random-weights smoke test (prompt optional)
+run_demo(None, random_weights=True)
+```
+
+Example CLI invocation (replace the placeholder paths with your environment):
+
+```bash
+python models/demos/deepseek_v3/demo/demo.py \
+  --model-path /abs/path/to/deepseek-v3 \
+  --cache-dir /abs/path/to/cache \
+  --early_print_first_user \
+  "Write a haiku about autumnal days by the sea"
+```
 
 ### Teacher Forcing Accuracy Verification
 

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -251,7 +251,7 @@ def main() -> None:
 
     for i, gen_result in enumerate(results["generations"]):
         prompt_text = ""
-        if i < len(args.prompts):
+        if args.prompts is not None and i < len(args.prompts):
             prompt_text = args.prompts[i]
         elif args.random_weights:
             prompt_text = "[random-weights default prompt]"

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -28,7 +28,7 @@ def create_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "prompts",
         type=str,
-        nargs="+",
+        nargs="*",
         help="Prompt text(s) (required for full-model mode; ignored with --random-weights). Can pass multiple prompts.",
     )
     p.add_argument(
@@ -250,8 +250,17 @@ def main() -> None:
     print("\n===== Generated =====\n")
 
     for i, gen_result in enumerate(results["generations"]):
+        prompt_text = ""
+        if i < len(args.prompts):
+            prompt_text = args.prompts[i]
+        elif args.random_weights:
+            prompt_text = "[random-weights default prompt]"
+
         print("-" * 30)
-        print(f"Prompt[{i+1}]: {args.prompts[i]}")
+        if prompt_text:
+            print(f"Prompt[{i+1}]: {prompt_text}")
+        else:
+            print(f"Prompt[{i+1}]: [empty prompt]")
         print(f"Generation[{i+1}]:")
         if gen_result.get("text") is not None:
             print(gen_result["text"])  # type: ignore

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import torch
+from tqdm.auto import tqdm
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
-from tqdm.auto import tqdm
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -9,6 +9,7 @@ import torch
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from tqdm.auto import tqdm
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D
@@ -56,7 +57,10 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     output_path / f"mlp_decoder_block_{layer_idx}",
                     mesh_device,
                 )
-                for layer_idx in range(hf_config.first_k_dense_replace)
+                for layer_idx in tqdm(
+                    range(hf_config.first_k_dense_replace),
+                    desc="Converting MLP layers",
+                )
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock2D.convert_weights(
@@ -65,7 +69,10 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                     output_path / f"moe_decoder_block_{layer_idx}",
                     mesh_device,
                 )
-                for layer_idx in range(hf_config.first_k_dense_replace, hf_config.num_hidden_layers)
+                for layer_idx in tqdm(
+                    range(hf_config.first_k_dense_replace, hf_config.num_hidden_layers),
+                    desc="Converting MoE layers",
+                )
             ],
             "norm": DistributedRMSNorm.convert_weights(
                 hf_config,

--- a/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
@@ -6,10 +6,10 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 import torch
+from tqdm.auto import tqdm
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
-from tqdm.auto import tqdm
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_1d import DecoderBlock1D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_1d import MoEDecoderBlock1D

--- a/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
@@ -73,7 +73,7 @@ class RowPipelinedModel(SharedStateAddOn, AbstractModule):
                     mesh_device,
                 )
                 for meta_layer_idx, layer_indices in enumerate(
-                    tqdm(mlp_meta_layer_indices, desc="Converting MLP layers", leave=False)
+                    tqdm(mlp_meta_layer_indices, desc="Converting MLP multi-layer blocks")
                 )
             ],
             "moe_decoder_block": [
@@ -84,7 +84,7 @@ class RowPipelinedModel(SharedStateAddOn, AbstractModule):
                     mesh_device,
                 )
                 for meta_layer_idx, layer_indices in enumerate(
-                    tqdm(moe_meta_layer_indices, desc="Converting MoE layers", leave=False)
+                    tqdm(moe_meta_layer_indices, desc="Converting MoE multi-layer blocks")
                 )
             ],
             "norm": DistributedRMSNorm.convert_weights(

--- a/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
@@ -9,6 +9,7 @@ import torch
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
+from tqdm.auto import tqdm
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_1d import DecoderBlock1D
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_1d import MoEDecoderBlock1D
@@ -71,7 +72,9 @@ class RowPipelinedModel(SharedStateAddOn, AbstractModule):
                     output_path / f"mlp_decoder_block_{meta_layer_idx}",
                     mesh_device,
                 )
-                for meta_layer_idx, layer_indices in enumerate(mlp_meta_layer_indices)
+                for meta_layer_idx, layer_indices in enumerate(
+                    tqdm(mlp_meta_layer_indices, desc="Converting MLP layers", leave=False)
+                )
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock1D.convert_weights(
@@ -80,7 +83,9 @@ class RowPipelinedModel(SharedStateAddOn, AbstractModule):
                     output_path / f"moe_decoder_block_{meta_layer_idx}",
                     mesh_device,
                 )
-                for meta_layer_idx, layer_indices in enumerate(moe_meta_layer_indices)
+                for meta_layer_idx, layer_indices in enumerate(
+                    tqdm(moe_meta_layer_indices, desc="Converting MoE layers", leave=False)
+                )
             ],
             "norm": DistributedRMSNorm.convert_weights(
                 hf_config,


### PR DESCRIPTION
Tidies up the DeepSeek v3 demo README and added progress bars to the (slow) weight conversion.

### Checklist

[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yieldthought%2Fds-demo-tidy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fds-demo-tidy)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml)