### PR TITLE
refactor: improve clarity of unary_sfpu_typecast by casting only once

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -12,115 +12,118 @@ namespace ckernel {
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
+    constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
+
+    if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by unpacker/packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by unpacker/packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -12,115 +12,118 @@ namespace ckernel {
 
 template <bool APPROXIMATE, uint32_t IN_DTYPE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    constexpr DataFormat in_format = static_cast<DataFormat>(IN_DTYPE);
+    constexpr DataFormat out_format = static_cast<DataFormat>(OUT_DTYPE);
+
+    if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by unpacker/packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt16 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Int32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Int32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::UInt32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float16_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp8_b) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Bfp8_b) {
         // no SFPU kernel needed, handled by unpacker
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp8_b && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Bfp4_b && OUT_DTYPE == (uint32_t)DataFormat::Float32) {
+    } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by unpacker/packer
-    } else if constexpr (IN_DTYPE == (uint32_t)DataFormat::Float32 && OUT_DTYPE == (uint32_t)DataFormat::Bfp4_b) {
+    } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Bfp4_b) {
         // no SFPU kernel needed, handled by packer
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
These functions were very hard to read with all the C-style casts scattered all over.

### What's changed
Refactored the unary SFPU typecast helper to eliminate repeated static casts by introducing constexpr DataFormat variables for input and output types, improving readability and reducing duplication of cast expressions.
- Introduced constexpr in_format and out_format variables.
- Replaced raw integer comparisons with direct enum comparisons in both wormhole_b0 and blackhole variants.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes