### PR TITLE
Remove installation of debugging dependencies from create_venv.sh

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -42,10 +42,6 @@ fi
 echo "Installing dev dependencies"
 python3 -m pip install -r $(pwd)/tt_metal/python_env/requirements-dev.txt
 
-echo "Installing debugging dependencies"
-. ./scripts/install_debugger.sh
-pip install -r ./tools/triage/requirements.txt
-
 echo "Installing tt-metal"
 pip install -e .
 


### PR DESCRIPTION
Remove installation of debugging dependencies from create_venv.sh as it broke multi-host deployment pipelines.