### PR TITLE
Change unpack init for pool tiled output

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -219,7 +219,7 @@ void MAIN {
             if constexpr (!is_output_tiled) {
                 cb_reserve_back(out_cb_id, output_faces);
             }
-            if constexpr (tilize_reconfig || is_output_tiled) {
+            if constexpr (tilize_reconfig) {
                 if (first_c_block || last_c_block) {
                     UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
@@ -267,18 +267,18 @@ void MAIN {
             tile_regs_commit();
             tile_regs_wait();
             if constexpr (!return_indices) {
-                 if constexpr (is_output_tiled) {
-                     // TILED output: accumulate sticks and perform tilization when needed
-                     if (last_c_block) {
-                         pack_untilize_dest<partial_iter_output_tiles>(
-                             pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
-                         cb_push_back(pre_tilize_cb_id, partial_iter_output_tiles);
-                         tilize_stick_counter++;
-                     } else {
-                         pack_untilize_dest<max_tiles_per_iter>(
-                             pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
-                         cb_push_back(pre_tilize_cb_id, max_tiles_per_iter);
-                     }
+                if constexpr (is_output_tiled) {
+                    // TILED output: accumulate sticks and perform tilization when needed
+                    if (last_c_block) {
+                        pack_untilize_dest<partial_iter_output_tiles>(
+                            pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                        cb_push_back(pre_tilize_cb_id, partial_iter_output_tiles);
+                        tilize_stick_counter++;
+                    } else {
+                        pack_untilize_dest<max_tiles_per_iter>(
+                            pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                        cb_push_back(pre_tilize_cb_id, max_tiles_per_iter);
+                    }
                     tile_regs_release();
 
                     if (tilize_stick_counter == TILE_HEIGHT) {
@@ -302,6 +302,9 @@ void MAIN {
                         }
 
                         tilize_stick_counter = 0;
+
+                        UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                            in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
                         // init math for reduction again since FPU gets reprogrammed by tilize
                         MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
 #ifdef ARCH_BLACKHOLE


### PR DESCRIPTION
Move `llk_unpack_tilizeA_B_init` to be done after tilization for tiled output path in pool op - on the current main it is done for every stick but it is not needed. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18469168806)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18469181359) (failed test is not related to this change)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18469202307)