### PR TITLE
Remove redundant patchify/unpatchify from Stable Diffusion 3.5

### DIFF
--- a/models/experimental/tt_dit/models/transformers/transformer_sd35.py
+++ b/models/experimental/tt_dit/models/transformers/transformer_sd35.py
@@ -632,6 +632,10 @@ class SD35Transformer2DModel:
         batch_size, height, width, channels = latents.shape
         patch = self.patch_size
 
+        if height % patch != 0 or width % patch != 0:
+            msg = f"height ({height}) and width ({width}) must be divisible by patch_size ({patch})"
+            raise ValueError(msg)
+
         latents = latents.reshape([batch_size, height // patch, patch, width // patch, patch, channels])
         return latents.transpose(2, 3).flatten(3, 5).flatten(1, 2).unsqueeze(0)
 
@@ -640,6 +644,10 @@ class SD35Transformer2DModel:
         one, batch_size, _, _ = spatial.shape
         assert one == 1
         patch = self.patch_size
+
+        if height % patch != 0 or width % patch != 0:
+            msg = f"height ({height}) and width ({width}) must be divisible by patch_size ({patch})"
+            raise ValueError(msg)
 
         spatial = spatial.reshape([batch_size, height // patch, width // patch, patch, patch, -1])
         return spatial.transpose(2, 3).flatten(3, 4).flatten(1, 2)

--- a/models/experimental/tt_dit/models/transformers/transformer_sd35.py
+++ b/models/experimental/tt_dit/models/transformers/transformer_sd35.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
 import ttnn
 from ...layers.normalization import DistributedLayerNorm, LayerNorm
 from ...layers.linear import ColParallelLinear, Linear
@@ -550,7 +551,7 @@ class SD35Transformer2DModel:
             pooled_projections: Pooled text projections - replicated
             timestep: Timestep tensor - replicated
         """
-        spatial = self.pos_embed(spatial)
+        spatial = self.pos_embed(spatial, already_unfolded=True)
 
         time_embed = self.time_text_embed(timestep, pooled_projections)
         prompt_embed = self.context_embedder(prompt_embed)
@@ -625,3 +626,20 @@ class SD35Transformer2DModel:
         #     )
 
         return spatial_out
+
+    def patchify(self, latents: torch.Tensor) -> torch.Tensor:
+        # N, H, W, C -> 1, N, (H / P) * (W / P), P * P * C
+        batch_size, height, width, channels = latents.shape
+        patch = self.patch_size
+
+        latents = latents.reshape([batch_size, height // patch, patch, width // patch, patch, channels])
+        return latents.transpose(2, 3).flatten(3, 5).flatten(1, 2).unsqueeze(0)
+
+    def unpatchify(self, spatial: torch.Tensor, *, height: int, width: int) -> torch.Tensor:
+        # 1, N, (H / P) * (W / P), P * P * C -> N, H, W, C
+        one, batch_size, _, _ = spatial.shape
+        assert one == 1
+        patch = self.patch_size
+
+        spatial = spatial.reshape([batch_size, height // patch, width // patch, patch, patch, -1])
+        return spatial.transpose(2, 3).flatten(3, 4).flatten(1, 2)

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -545,6 +545,7 @@ class StableDiffusion3Pipeline:
             if seed is not None:
                 torch.manual_seed(seed)
             latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype)  # .permute([0, 2, 3, 1])
+            latents = self.transformers[0].patchify(latents)
 
             tt_prompt_embeds_list = []
             tt_pooled_prompt_embeds_list = []
@@ -579,7 +580,7 @@ class StableDiffusion3Pipeline:
                 )
 
                 shard_latents_dims = [None, None]
-                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 1  # height of latents
+                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 2
                 tt_initial_latents = ttnn.from_torch(
                     latents,
                     layout=ttnn.TILE_LAYOUT,
@@ -663,7 +664,7 @@ class StableDiffusion3Pipeline:
                 ttnn.synchronize_device(self.vae_device)
                 tt_latents = ttnn.experimental.all_gather_async(
                     input_tensor=tt_latents_step_list[self.vae_submesh_idx],
-                    dim=1,
+                    dim=2,
                     multi_device_global_semaphore=self.ccl_managers[self.vae_submesh_idx].get_ag_ping_pong_semaphore(
                         self.dit_parallel_config.sequence_parallel.mesh_axis
                     ),
@@ -675,6 +676,11 @@ class StableDiffusion3Pipeline:
 
                 torch_latents = ttnn.to_torch(ttnn.get_device_tensors(tt_latents)[0])
                 torch_latents = (torch_latents / self._torch_vae_scaling_factor) + self._torch_vae_shift_factor
+                torch_latents = self.transformers[0].unpatchify(
+                    torch_latents,
+                    width=width // self._torch_vae_scale_factor,
+                    height=height // self._torch_vae_scale_factor,
+                )
 
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
                     # HACK: reshape submesh device 0 from 2D to 1D
@@ -732,7 +738,7 @@ class StableDiffusion3Pipeline:
             else:
                 latent_model_input = latent
 
-            noise_pred = self.transformers[cfg_index](
+            return self.transformers[cfg_index](
                 spatial=latent_model_input,
                 prompt_embed=prompt,
                 pooled_projections=pooled_projection,
@@ -740,14 +746,6 @@ class StableDiffusion3Pipeline:
                 N=spatial_sequence_length,
                 L=prompt_sequence_length,
             )
-
-            noise_pred = _reshape_noise_pred(
-                noise_pred,
-                height=latent.shape[-3] * self.dit_parallel_config.sequence_parallel.factor,
-                width=latent.shape[-2],
-                patch_size=self.patch_size,
-            )
-            return noise_pred
 
         if traced and self._trace is None:
             print(f"Tracing...")
@@ -829,7 +827,7 @@ class StableDiffusion3Pipeline:
                 torch_noise_pred = uncond + guidance_scale * (cond - uncond)
 
                 shard_latents_dims = [None, None]
-                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 1  # height of latents
+                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 2
                 noise_pred_list[0] = ttnn.from_torch(
                     torch_noise_pred,
                     layout=ttnn.TILE_LAYOUT,
@@ -1127,34 +1125,3 @@ def _get_t5_prompt_embeds(
     # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
     prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
     return prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
-
-
-def _reshape_noise_pred(
-    noise_pred: ttnn.Tensor,
-    *,
-    height: int,
-    width: int,
-    patch_size: int,
-) -> ttnn.Tensor:
-    # B, H * W, P * Q * C -> B, H * P, W * Q, C
-
-    patch_count_y = height // patch_size
-    patch_count_x = width // patch_size
-
-    shape1 = (
-        noise_pred.shape[0] * patch_count_y,
-        patch_count_x,
-        patch_size,
-        -1,
-    )
-
-    shape2 = (
-        noise_pred.shape[0],
-        patch_count_y * patch_size,
-        patch_count_x * patch_size,
-        -1,
-    )
-
-    noise_pred = noise_pred.reshape(shape1)
-    noise_pred = ttnn.transpose(noise_pred, 1, 2)
-    return noise_pred.reshape(shape2)

--- a/models/experimental/tt_dit/tests/models/test_transformer_sd35.py
+++ b/models/experimental/tt_dit/tests/models/test_transformer_sd35.py
@@ -309,7 +309,7 @@ def test_sd35_transformer2d_model(
     timestep = torch.randn((B,), dtype=torch_dtype)
 
     # Clone inputs for TT model (to avoid in-place modifications)
-    spatial_input_nhwc_tt = spatial_input_nchw.permute(0, 2, 3, 1).clone()
+    spatial_input_nhwc_tt = tt_model.patchify(spatial_input_nchw.permute(0, 2, 3, 1)).clone()
     prompt_input_tt = prompt_input.clone()
     pooled_projections_tt = pooled_projections.clone()
     timestep_tt = timestep.clone()
@@ -324,10 +324,7 @@ def test_sd35_transformer2d_model(
         )
 
     # Convert inputs to TT tensors with proper sharding
-    # Spatial: sharded on sequence dimension (sp_axis) and feature dimension (tp_axis)
-    tt_spatial = bf16_tensor(
-        spatial_input_nhwc_tt, device=submesh_device, mesh_axis=sp_axis, shard_dim=1
-    )  # Sharded on H
+    tt_spatial = bf16_tensor(spatial_input_nhwc_tt, device=submesh_device, mesh_axis=sp_axis, shard_dim=2)
 
     # Prompt: replicated
     prompt_4d = prompt_input_tt.unsqueeze(0)


### PR DESCRIPTION
### What's changed

In Stable Diffusion 3.5, we convert back and forth between the normal form of the latent tensor and the patchyfied version with every iteration. This PR removes the unnecessary patchify/unpatchify and makes the pipelines of Stable Diffusion 3.5 behave the same as the ones of Flux.1 and Motif in this regard.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes