### PR TITLE
extend model_preprocessing maxpool2d with input channels

### DIFF
--- a/ttnn/ttnn/model_preprocessing.py
+++ b/ttnn/ttnn/model_preprocessing.py
@@ -443,6 +443,7 @@ def infer_ttnn_module_args(*, model, run_model, device):
                         padding=operation.module.padding,
                         dilation=operation.module.dilation,
                         batch_size=input_shape[0],
+                        input_channels=input_shape[1],
                         input_height=input_shape[-2],
                         input_width=input_shape[-1],
                         dtype=ttnn.bfloat16,


### PR DESCRIPTION
(cherry picked from commit de2373409513cfc8cfa9d555609a38fff30abc0a)

### Ticket
#29626

### Problem description
Extending infer_ttnn_module_args to pickup maxpool2d number of input channels from torch model

### What's changed
one liner

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes