### PR TITLE
Add missing l1 invalidation

### DIFF
--- a/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
@@ -64,10 +64,11 @@ FORCE_INLINE void wait_for_fabric_endpoint_ready(
     auto local_fabric_ep_status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_fabric_ep_status_address);
 
     local_fabric_ep_status_ptr[0] = tt::tt_fabric::FabricEndpointStatus::TERMINATED;
-    while (local_fabric_ep_status_ptr[0] != tt::tt_fabric::FabricEndpointStatus::READY_FOR_TRAFFIC) {
+    do {
+        invalidate_l1_cache();
         noc_async_read_one_packet(noc_addr, local_fabric_ep_status_address, 4);
         noc_async_read_barrier();
-    }
+    } while (local_fabric_ep_status_ptr[0] != tt::tt_fabric::FabricEndpointStatus::READY_FOR_TRAFFIC);
 }
 
 template <uint8_t FABRIC_MUX_CHANNEL_NUM_BUFFERS = 0>

--- a/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp
@@ -65,9 +65,9 @@ FORCE_INLINE void wait_for_fabric_endpoint_ready(
 
     local_fabric_ep_status_ptr[0] = tt::tt_fabric::FabricEndpointStatus::TERMINATED;
     do {
-        invalidate_l1_cache();
         noc_async_read_one_packet(noc_addr, local_fabric_ep_status_address, 4);
         noc_async_read_barrier();
+        invalidate_l1_cache();
     } while (local_fabric_ep_status_ptr[0] != tt::tt_fabric::FabricEndpointStatus::READY_FOR_TRAFFIC);
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25427

### Problem description
This function is used in various kernels and also dispatch. It's missing l1 invalidation.

### What's changed
- Change it to a do-while loop and add `invalidate_l1_cache()`

### Checklist
BH Demo
https://github.com/tenstorrent/tt-metal/actions/runs/18472452835
BH APC
https://github.com/tenstorrent/tt-metal/actions/runs/18472449514
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18472446432