### PR TITLE
#30439: [skip ci] upstream-tests: improve force-publish functionality so we can forcefully publish only certain images if we want, only passing ones, or all of them

### DIFF
--- a/.github/workflows/job_configs/upstream-tests.json
+++ b/.github/workflows/job_configs/upstream-tests.json
@@ -1,0 +1,20 @@
+{
+  "hw_topologies": {
+    "bh": {
+      "test_job": "test-bh-image",
+      "image_outputs": ["bh-image-tag", "bh-profiler-image-tag"]
+    },
+    "wh-6u": {
+      "test_job": "test-wh-6u-image",
+      "image_outputs": ["wh-6u-image-tag", "wh-6u-profiler-image-tag"]
+    },
+    "bh-multi-card": {
+      "test_job": "test-bh-multicard-image",
+      "image_outputs": ["bh-llmbox-image-tag", "bh-deskbox-image-tag", "bh-loudbox-image-tag", "bh-qb-ge-image-tag"]
+    },
+    "bh-p300": {
+      "test_job": "test-bh-p300-image",
+      "image_outputs": ["bh-p300-image-tag"]
+    }
+  }
+}

--- a/.github/workflows/job_configs/upstream-tests.json
+++ b/.github/workflows/job_configs/upstream-tests.json
@@ -8,9 +8,21 @@
       "test_job": "test-wh-6u-image",
       "image_outputs": ["wh-6u-image-tag", "wh-6u-profiler-image-tag"]
     },
-    "bh-multi-card": {
+    "bh-llmbox": {
       "test_job": "test-bh-multicard-image",
-      "image_outputs": ["bh-llmbox-image-tag", "bh-deskbox-image-tag", "bh-loudbox-image-tag", "bh-qb-ge-image-tag"]
+      "image_outputs": ["bh-llmbox-image-tag"]
+    },
+    "bh-deskbox": {
+      "test_job": "test-bh-multicard-image",
+      "image_outputs": ["bh-deskbox-image-tag"]
+    },
+    "bh-loudbox": {
+      "test_job": "test-bh-multicard-image",
+      "image_outputs": ["bh-loudbox-image-tag"]
+    },
+    "bh-qb-ge": {
+      "test_job": "test-bh-multicard-image",
+      "image_outputs": ["bh-qb-ge-image-tag"]
     },
     "bh-p300": {
       "test_job": "test-bh-p300-image",

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -24,16 +24,6 @@ env:
   BLACKHOLE_QB_GE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge
 
 jobs:
-  build-artifact:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      version: 22.04
-      build-wheel: true
-      build-umd-tests: true
-      tracy: true
   get-image-tags:
     runs-on: ubuntu-latest
     outputs:
@@ -54,7 +44,7 @@ jobs:
           fetch-tags: true
       - name: Get tag to use everywhere
         id: set-image-tag-suffix
-        run: echo "image-tag-suffix=$(git describe)" >> "$GITHUB_OUTPUT"
+        run: echo "image-tag-suffix=v0.64.0-dev20251102-8-g4b64346122" >> "$GITHUB_OUTPUT"
       - name: Set image tags
         id: set-image-tags
         run: |
@@ -69,8 +59,6 @@ jobs:
           echo "bh-qb-ge-image-tag=${{ env.BLACKHOLE_QB_GE_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
   build-images:
     needs:
-      - build-artifact
-      - build-artifact
       - get-image-tags
     permissions:
       packages: write
@@ -84,121 +72,51 @@ jobs:
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: wh_6u
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
             test-command: tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
             hw-topology: wh_6u
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
             test-command: tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
             hw-topology: blackhole
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_llmbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_deskbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_loudbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_p300
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_qb_ge
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
     runs-on: tt-ubuntu-2204-large-stable
     steps:
       - uses: actions/checkout@v4
-      - name: Download artifacts from metal
-        id: download-artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          # 22.04 artifact... we'll probably need to key on that in the original action in metal
-          name: ${{ matrix.image-config.build-artifact-name }}
-      - run: mkdir -p _tt-metal
-      - run: tar --zstd -xvf ttm_any.tar.zst -C _tt-metal/
-      - run: ls -hal _tt-metal
-      - name: 🧪 Download Python Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: ${{ matrix.image-config.wheel-artifact-name }}
-      - name: 💿 Verify Wheel exists
-        shell: bash
-        run: |
-          echo "📂 In directory: $(pwd)"
-          echo "📄 Files:"
-          ls -la .
-      # Do not set up docker buildx because of https://github.com/docker/setup-buildx-action/issues/57
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate Dockerfile
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install -y gettext
-          export TEST_COMMAND=${{ matrix.image-config.test-command }}
-          export HW_TOPOLOGY=${{ matrix.image-config.hw-topology }}
-          export TT_METAL_DEV_VERSION=latest
-          export TT_METAL_COMMIT_SHA=${{ github.sha }}
-          envsubst < dockerfile/upstream_test_images/Dockerfile.template > dockerfile/upstream_test_images/Dockerfile-generated
-          cat dockerfile/upstream_test_images/Dockerfile-generated
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          file: dockerfile/upstream_test_images/Dockerfile-generated
-          platforms: linux/amd64
-          pull: true
-          push: true
-          tags: ${{ matrix.image-config.image-tag }}
-          context: ${{ github.workspace }}
-          build-args: |
-            TECHDEBT_INSTALL_TTT_REQS=${{ matrix.image-config.techdebt-install-ttt-reqs && 'true' || 'false' }}
   test-wh-6u-image:
     needs:
       - get-image-tags
       - build-images
-    runs-on:
-      - arch-wormhole_b0
-      - topology-6u
-      - in-service
-      - pipeline-functional
+    runs-on: ubuntu-latest
     steps:
       # TODO -likely need to put this into a script which can be parameterized on the build number
       # and whether to only pull
@@ -207,13 +125,10 @@ jobs:
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
         timeout-minutes: 45
-        env:
-          SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-          LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
   test-bh-multicard-image:
     needs:
       - get-image-tags
@@ -230,16 +145,13 @@ jobs:
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
           - runner-label: BH-QB-GE
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
-    runs-on:
-      - ${{ matrix.bh-config.runner-label }}
-      - in-service
-      - pipeline-perf
+    runs-on: ubuntu-latest
     steps:
       - name: Run image
         timeout-minutes: 30
-        env:
-          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+        run: |
+          docker pull ${{ matrix.bh-config.image-name }}
+          docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags
@@ -250,20 +162,13 @@ jobs:
         bh-config:
           - runner-label: P300
             image-name: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
-    runs-on:
-      - ${{ matrix.bh-config.runner-label }}
-      - in-service
+    runs-on: ubuntu-latest
     steps:
-      - name: Download Llama model weights from LFC
-        timeout-minutes: 15
-        run: |
-          mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
-          wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run image
         timeout-minutes: 60
-        env:
-          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run --network none --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+        run: |
+          docker pull ${{ matrix.bh-config.image-name }}
+          docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags
@@ -274,23 +179,14 @@ jobs:
         bh-card:
           - P100
           - P150
-    runs-on:
-      - ${{ matrix.bh-card }}
-      - in-service
-      - cloud-virtual-machine
-      # Targeting cloud machines with pipeline-functional per now per
-      # https://github.com/tenstorrent/tt-metal/issues/21738#issuecomment-2925788342
-      - pipeline-functional
+    runs-on: ubuntu-latest
     steps:
       - name: Run image
         timeout-minutes: 30
-        env:
-          # For different environments, yyz BH VLAN vs. cloud
-          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
   calculate-to-publish:
     if: ${{ !cancelled() }}
     needs:
@@ -465,7 +361,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Show image
+        run: echo "${{ matrix.image-config.image-tag }}"
       - uses: ./.github/actions/push-latest-image-to-ghcr
+        if: false
         with:
           docker-image-tag: ${{ matrix.image-config.image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -298,6 +298,8 @@ jobs:
             done
 
           else
+            echo ${request_input}
+            echo ${request_input} | jq 'type'
             echo "Mode: Publishing specific hw_topology list"
 
             # Validate it's a JSON array
@@ -309,9 +311,11 @@ jobs:
             # Get valid hw_topology values for error messages
             valid_topologies=$(printf '%s ' "${hw_topologies[@]}")
 
+            echo "Valid JSON array is provided"
+
             # Process each requested hw_topology
             while IFS= read -r hw_topology; do
-              hw_topology=$(echo "$hw_topology" | jq -r '.')
+              hw_topology=$(echo ${hw_topology} | jq -r '.')
               echo "Processing requested hw_topology: $hw_topology"
 
               # Validate hw_topology exists in config

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -201,7 +201,9 @@ jobs:
     steps:
       - name: Run image
         timeout-minutes: 30
-        run: docker image inspect ${{ matrix.bh-config.image-name }}
+        run: |
+          docker pull ${{ matrix.bh-config.image-name }}
+          docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags
@@ -216,7 +218,9 @@ jobs:
     steps:
       - name: Run image
         timeout-minutes: 60
-        run: docker image inspect ${{ matrix.bh-config.image-name }}
+        run: |
+          docker pull ${{ matrix.bh-config.image-name }}
+          docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -315,6 +315,7 @@ jobs:
 
             # Process each requested hw_topology
             while IFS= read -r hw_topology; do
+              echo $hw_topology
               hw_topology=$(echo ${hw_topology} | jq -r '.')
               echo "Processing requested hw_topology: $hw_topology"
 

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -314,7 +314,7 @@ jobs:
             echo "Valid JSON array is provided"
 
             # Process each requested requested_hw_topology
-            while IFS= read -r requested_requested_hw_topology; do
+            while IFS= read -r requested_hw_topology; do
               echo "Processing requested hw_topology: $requested_hw_topology"
 
               # Validate requested_hw_topology exists in config

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -414,7 +414,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Show image
+        run: echo "${{ matrix.image-config.image-tag }}"
       - uses: ./.github/actions/push-latest-image-to-ghcr
+        if: false
         with:
           docker-image-tag: ${{ matrix.image-config.image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -44,7 +44,7 @@ jobs:
           fetch-tags: true
       - name: Get tag to use everywhere
         id: set-image-tag-suffix
-        run: echo "image-tag-suffix=$(git describe)" >> "$GITHUB_OUTPUT"
+        run: echo "image-tag-suffix=v0.64.0-dev20251102-8-g4b64346122" >> "$GITHUB_OUTPUT"
       - name: Set image tags
         id: set-image-tags
         run: |
@@ -112,58 +112,6 @@ jobs:
     runs-on: tt-ubuntu-2204-large-stable
     steps:
       - uses: actions/checkout@v4
-      - name: Download artifacts from metal
-        id: download-artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          # 22.04 artifact... we'll probably need to key on that in the original action in metal
-          name: TTMetal_build_any_22.04_amd64_x86_64-linux-clang-17-libstdcpp_profiler_e216dd6fdfb415f28fe25b545050d7e9306ba6ae_19017889835
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 19017889835
-      - run: mkdir -p _tt-metal
-      - run: tar --zstd -xvf ttm_any.tar.zst -C _tt-metal/
-      - run: ls -hal _tt-metal
-      - name: 🧪 Download Python Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: eager-dist-cp310-ubuntu-22.04-any-profiler-e216dd6fdfb415f28fe25b545050d7e9306ba6ae-19017889835
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 19017889835
-      - name: 💿 Verify Wheel exists
-        shell: bash
-        run: |
-          echo "📂 In directory: $(pwd)"
-          echo "📄 Files:"
-          ls -la .
-      # Do not set up docker buildx because of https://github.com/docker/setup-buildx-action/issues/57
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate Dockerfile
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install -y gettext
-          export TEST_COMMAND=${{ matrix.image-config.test-command }}
-          export HW_TOPOLOGY=${{ matrix.image-config.hw-topology }}
-          export TT_METAL_DEV_VERSION=latest
-          export TT_METAL_COMMIT_SHA=${{ github.sha }}
-          envsubst < dockerfile/upstream_test_images/Dockerfile.template > dockerfile/upstream_test_images/Dockerfile-generated
-          cat dockerfile/upstream_test_images/Dockerfile-generated
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          file: dockerfile/upstream_test_images/Dockerfile-generated
-          platforms: linux/amd64
-          pull: true
-          push: true
-          tags: ${{ matrix.image-config.image-tag }}
-          context: ${{ github.workspace }}
-          build-args: |
-            TECHDEBT_INSTALL_TTT_REQS=${{ matrix.image-config.techdebt-install-ttt-reqs && 'true' || 'false' }}
   test-wh-6u-image:
     needs:
       - get-image-tags

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -298,8 +298,6 @@ jobs:
             done
 
           else
-            echo ${request_input}
-            echo ${request_input} | jq 'type'
             echo "Mode: Publishing specific hw_topology list"
 
             # Validate it's a JSON array

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -353,13 +353,13 @@ jobs:
             echo "Mode: Publishing specific hw_topology list"
 
             # Validate JSON format
-            if ! echo "$request_input" | jq empty 2>/dev/null; then
+            if ! echo "${request_input}" | jq empty 2>/dev/null; then
               echo "ERROR: request-force-publish must be 'passing-only', 'all', or a valid JSON array" >&2
               exit 1
             fi
 
             # Validate it's a JSON array
-            if [[ $(echo "$request_input" | jq 'type') != '"array"' ]]; then
+            if [[ $(echo "${request_input}" | jq 'type') != '"array"' ]]; then
               echo "ERROR: When providing specific hw_topology values, input must be a JSON array like [\"wh-6u\", \"bh\"]" >&2
               exit 1
             fi
@@ -379,7 +379,7 @@ jobs:
               fi
 
               add_images_for_topology "$hw_topology" "forced specific"
-            done < <(echo "$request_input" | jq -r '.[]')
+            done < <(echo "${request_input}" | jq -r '.[]')
           fi
 
           # Convert bash array to JSON (optimized single conversion)

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -313,19 +313,17 @@ jobs:
 
             echo "Valid JSON array is provided"
 
-            # Process each requested hw_topology
-            while IFS= read -r hw_topology; do
-              echo $hw_topology
-              hw_topology=$(echo ${hw_topology} | jq -r '.')
-              echo "Processing requested hw_topology: $hw_topology"
+            # Process each requested requested_hw_topology
+            while IFS= read -r requested_requested_hw_topology; do
+              echo "Processing requested hw_topology: $requested_hw_topology"
 
-              # Validate hw_topology exists in config
-              if ! jq -e ".hw_topologies[\"$hw_topology\"]" "$config_file" >/dev/null; then
-                echo "ERROR: Unknown hw_topology '$hw_topology'. Valid values are: $valid_topologies" >&2
+              # Validate requested_hw_topology exists in config
+              if ! jq -e ".hw_topologies[\"$requested_hw_topology\"]" "$config_file" >/dev/null; then
+                echo "ERROR: Unknown hw_topology '$requested_hw_topology'. Valid values are: $valid_topologies" >&2
                 exit 1
               fi
 
-              add_images_for_topology "$hw_topology" "forced specific"
+              add_images_for_topology "$requested_hw_topology" "forced specific"
             done < <(echo ${request_input} | jq -r '.[]')
           fi
 

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -168,11 +168,7 @@ jobs:
     needs:
       - get-image-tags
       - build-images
-    runs-on:
-      - arch-wormhole_b0
-      - topology-6u
-      - in-service
-      - pipeline-functional
+    runs-on: ubuntu-latest
     steps:
       # TODO -likely need to put this into a script which can be parameterized on the build number
       # and whether to only pull
@@ -181,13 +177,10 @@ jobs:
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
         timeout-minutes: 45
-        env:
-          SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-          LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
   test-bh-multicard-image:
     needs:
       - get-image-tags
@@ -204,16 +197,11 @@ jobs:
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
           - runner-label: BH-QB-GE
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
-    runs-on:
-      - ${{ matrix.bh-config.runner-label }}
-      - in-service
-      - pipeline-perf
+    runs-on: ubuntu-latest
     steps:
       - name: Run image
         timeout-minutes: 30
-        env:
-          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+        run: docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags
@@ -224,20 +212,11 @@ jobs:
         bh-config:
           - runner-label: P300
             image-name: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
-    runs-on:
-      - ${{ matrix.bh-config.runner-label }}
-      - in-service
+    runs-on: ubuntu-latest
     steps:
-      - name: Download Llama model weights from LFC
-        timeout-minutes: 15
-        run: |
-          mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
-          wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run image
         timeout-minutes: 60
-        env:
-          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run --network none --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
+        run: docker image inspect ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags
@@ -248,23 +227,14 @@ jobs:
         bh-card:
           - P100
           - P150
-    runs-on:
-      - ${{ matrix.bh-card }}
-      - in-service
-      - cloud-virtual-machine
-      # Targeting cloud machines with pipeline-functional per now per
-      # https://github.com/tenstorrent/tt-metal/issues/21738#issuecomment-2925788342
-      - pipeline-functional
+    runs-on: ubuntu-latest
     steps:
       - name: Run image
         timeout-minutes: 30
-        env:
-          # For different environments, yyz BH VLAN vs. cloud
-          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
   calculate-to-publish:
     if: ${{ !cancelled() }}
     needs:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -301,7 +301,7 @@ jobs:
             echo "Mode: Publishing specific hw_topology list"
 
             # Validate it's a JSON array
-            if [[ $(echo "${request_input}" | jq 'type') != '"array"' ]]; then
+            if [[ $(echo ${request_input} | jq 'type') != '"array"' ]]; then
               echo "ERROR: When providing specific hw_topology values, input must be a JSON array like [\"wh-6u\", \"bh\"]" >&2
               exit 1
             fi
@@ -321,7 +321,7 @@ jobs:
               fi
 
               add_images_for_topology "$hw_topology" "forced specific"
-            done < <(echo "${request_input}" | jq -r '.[]')
+            done < <(echo ${request_input} | jq -r '.[]')
           fi
 
           # Convert bash array to JSON (optimized single conversion)

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -24,16 +24,6 @@ env:
   BLACKHOLE_QB_GE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge
 
 jobs:
-  build-artifact:
-    uses: ./.github/workflows/build-artifact.yaml
-    permissions:
-      packages: write
-    secrets: inherit
-    with:
-      version: 22.04
-      build-wheel: true
-      build-umd-tests: true
-      tracy: true
   get-image-tags:
     runs-on: ubuntu-latest
     outputs:
@@ -69,8 +59,6 @@ jobs:
           echo "bh-qb-ge-image-tag=${{ env.BLACKHOLE_QB_GE_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
   build-images:
     needs:
-      - build-artifact
-      - build-artifact
       - get-image-tags
     permissions:
       packages: write
@@ -84,60 +72,42 @@ jobs:
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: wh_6u
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
             test-command: tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
             hw-topology: wh_6u
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
             test-command: tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
             hw-topology: blackhole
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_llmbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_deskbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_loudbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_p300
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_qb_ge
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
     runs-on: tt-ubuntu-2204-large-stable
     steps:
@@ -147,14 +117,18 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
           # 22.04 artifact... we'll probably need to key on that in the original action in metal
-          name: ${{ matrix.image-config.build-artifact-name }}
+          name: TTMetal_build_any_22.04_amd64_x86_64-linux-clang-17-libstdcpp_profiler_e216dd6fdfb415f28fe25b545050d7e9306ba6ae_19017889835
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 19017889835
       - run: mkdir -p _tt-metal
       - run: tar --zstd -xvf ttm_any.tar.zst -C _tt-metal/
       - run: ls -hal _tt-metal
       - name: 🧪 Download Python Wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: ${{ matrix.image-config.wheel-artifact-name }}
+          name: eager-dist-cp310-ubuntu-22.04-any-profiler-e216dd6fdfb415f28fe25b545050d7e9306ba6ae-19017889835
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 19017889835
       - name: 💿 Verify Wheel exists
         shell: bash
         run: |

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -291,7 +291,8 @@ jobs:
           images_to_push_array=()
 
           # Parse the request-force-publish input
-          request_input="${{ inputs.request-force-publish || 'passing-only' }}"
+          # Single-quotes because of the doubles in this string for JSON
+          request_input='${{ inputs.request-force-publish || 'passing-only' }}'
 
           echo "Processing request: $request_input"
 
@@ -353,7 +354,7 @@ jobs:
               exit 1
             fi
 
-            # Validate it's an array
+            # Validate it's a JSON array
             if [[ $(echo "$request_input" | jq 'type') != '"array"' ]]; then
               echo "ERROR: When providing specific hw_topology values, input must be a JSON array like [\"wh-6u\", \"bh\"]" >&2
               exit 1
@@ -384,7 +385,8 @@ jobs:
             echo "No images to push"
           else
             echo "Converting ${#images_to_push_array[@]} images to JSON for next job's matrix"
-            images_to_push_json=$(printf '%s\n' "${images_to_push_array[@]}" | jq -R '.' | jq -s 'map({"image-tag": .})')
+            # Use -c because whitespace in GITHUB_OUTPUT might cause issues
+            images_to_push_json=$(printf '%s\n' "${images_to_push_array[@]}" | jq -R '.' | jq -c -s 'map({"image-tag": .})')
           fi
 
           echo "Final images to push:"

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -24,6 +24,16 @@ env:
   BLACKHOLE_QB_GE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      version: 22.04
+      build-wheel: true
+      build-umd-tests: true
+      tracy: true
   get-image-tags:
     runs-on: ubuntu-latest
     outputs:
@@ -44,7 +54,7 @@ jobs:
           fetch-tags: true
       - name: Get tag to use everywhere
         id: set-image-tag-suffix
-        run: echo "image-tag-suffix=v0.64.0-dev20251102-8-g4b64346122" >> "$GITHUB_OUTPUT"
+        run: echo "image-tag-suffix=$(git describe)" >> "$GITHUB_OUTPUT"
       - name: Set image tags
         id: set-image-tags
         run: |
@@ -59,6 +69,8 @@ jobs:
           echo "bh-qb-ge-image-tag=${{ env.BLACKHOLE_QB_GE_IMAGE_NAME }}:${{ steps.set-image-tag-suffix.outputs.image-tag-suffix }}" >> "$GITHUB_OUTPUT"
   build-images:
     needs:
+      - build-artifact
+      - build-artifact
       - get-image-tags
     permissions:
       packages: write
@@ -72,51 +84,121 @@ jobs:
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: wh_6u
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
             test-command: tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
             hw-topology: wh_6u
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
             test-command: tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
             hw-topology: blackhole
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_llmbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_deskbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_loudbox
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_p300
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
             hw-topology: blackhole_qb_ge
+            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
             techdebt-install-ttt-reqs: true
     runs-on: tt-ubuntu-2204-large-stable
     steps:
       - uses: actions/checkout@v4
+      - name: Download artifacts from metal
+        id: download-artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          # 22.04 artifact... we'll probably need to key on that in the original action in metal
+          name: ${{ matrix.image-config.build-artifact-name }}
+      - run: mkdir -p _tt-metal
+      - run: tar --zstd -xvf ttm_any.tar.zst -C _tt-metal/
+      - run: ls -hal _tt-metal
+      - name: 🧪 Download Python Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: ${{ matrix.image-config.wheel-artifact-name }}
+      - name: 💿 Verify Wheel exists
+        shell: bash
+        run: |
+          echo "📂 In directory: $(pwd)"
+          echo "📄 Files:"
+          ls -la .
+      # Do not set up docker buildx because of https://github.com/docker/setup-buildx-action/issues/57
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate Dockerfile
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y gettext
+          export TEST_COMMAND=${{ matrix.image-config.test-command }}
+          export HW_TOPOLOGY=${{ matrix.image-config.hw-topology }}
+          export TT_METAL_DEV_VERSION=latest
+          export TT_METAL_COMMIT_SHA=${{ github.sha }}
+          envsubst < dockerfile/upstream_test_images/Dockerfile.template > dockerfile/upstream_test_images/Dockerfile-generated
+          cat dockerfile/upstream_test_images/Dockerfile-generated
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: dockerfile/upstream_test_images/Dockerfile-generated
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ matrix.image-config.image-tag }}
+          context: ${{ github.workspace }}
+          build-args: |
+            TECHDEBT_INSTALL_TTT_REQS=${{ matrix.image-config.techdebt-install-ttt-reqs && 'true' || 'false' }}
   test-wh-6u-image:
     needs:
       - get-image-tags
       - build-images
-    runs-on: ubuntu-latest
+    runs-on:
+      - arch-wormhole_b0
+      - topology-6u
+      - in-service
+      - pipeline-functional
     steps:
       # TODO -likely need to put this into a script which can be parameterized on the build number
       # and whether to only pull
@@ -125,10 +207,13 @@ jobs:
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
         timeout-minutes: 45
-        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+        env:
+          SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
+          LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker image inspect ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
   test-bh-multicard-image:
     needs:
       - get-image-tags
@@ -145,13 +230,16 @@ jobs:
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
           - runner-label: BH-QB-GE
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - ${{ matrix.bh-config.runner-label }}
+      - in-service
+      - pipeline-perf
     steps:
       - name: Run image
         timeout-minutes: 30
-        run: |
-          docker pull ${{ matrix.bh-config.image-name }}
-          docker image inspect ${{ matrix.bh-config.image-name }}
+        env:
+          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
+        run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:
       - get-image-tags
@@ -162,13 +250,20 @@ jobs:
         bh-config:
           - runner-label: P300
             image-name: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - ${{ matrix.bh-config.runner-label }}
+      - in-service
     steps:
+      - name: Download Llama model weights from LFC
+        timeout-minutes: 15
+        run: |
+          mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
+          wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: Run image
         timeout-minutes: 60
-        run: |
-          docker pull ${{ matrix.bh-config.image-name }}
-          docker image inspect ${{ matrix.bh-config.image-name }}
+        env:
+          LLAMA_DIR: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
+        run: docker run --network none --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ matrix.bh-config.image-name }}
   test-bh-image:
     needs:
       - get-image-tags
@@ -179,14 +274,23 @@ jobs:
         bh-card:
           - P100
           - P150
-    runs-on: ubuntu-latest
+    runs-on:
+      - ${{ matrix.bh-card }}
+      - in-service
+      - cloud-virtual-machine
+      # Targeting cloud machines with pipeline-functional per now per
+      # https://github.com/tenstorrent/tt-metal/issues/21738#issuecomment-2925788342
+      - pipeline-functional
     steps:
       - name: Run image
         timeout-minutes: 30
-        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-image-tag }}
+        env:
+          # For different environments, yyz BH VLAN vs. cloud
+          LLAMA_DIR: ${{ contains(runner.name, 'gh') && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.bh-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
-        run: docker image inspect ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
   calculate-to-publish:
     if: ${{ !cancelled() }}
     needs:
@@ -361,10 +465,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Show image
-        run: echo "${{ matrix.image-config.image-tag }}"
       - uses: ./.github/actions/push-latest-image-to-ghcr
-        if: false
         with:
           docker-image-tag: ${{ matrix.image-config.image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -300,12 +300,6 @@ jobs:
           else
             echo "Mode: Publishing specific hw_topology list"
 
-            # Validate JSON format
-            if ! echo "${request_input}" | jq empty 2>/dev/null; then
-              echo "ERROR: request-force-publish must be 'passing-only', 'all', or a valid JSON array" >&2
-              exit 1
-            fi
-
             # Validate it's a JSON array
             if [[ $(echo "${request_input}" | jq 'type') != '"array"' ]]; then
               echo "ERROR: When providing specific hw_topology values, input must be a JSON array like [\"wh-6u\", \"bh\"]" >&2

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -3,10 +3,10 @@ name: Build test and publish upstream tests
 on:
   workflow_dispatch:
     inputs:
-      tag-as-latest:
-        default: false
-        type: boolean
-        description: "(FORCE) Tag this run as latest, even if tests fail"
+      request-force-publish:
+        default: "passing-only"
+        type: string
+        description: "Control image publishing: 'passing-only' (default), 'all', or JSON array of hw_topology values like [\"wh-6u\", \"bh\"]"
   schedule:
     - cron: '0 12 * * *'
 
@@ -291,43 +291,180 @@ jobs:
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
-  push-latest:
-    # This joyously long condition allows us to do a couple of things we want:
-    # - Forcefully publish a latest image if the user requested such,
-    #   regardless of the statuses of the test jobs Recall that jobs which depend
-    #   on other upstreams which fail will never get to run even if their
-    #   conditions are met, unless we use things like !cancelled()
-    # - On main branch, don't publish an image unless the tests pass. We want to keep
-    #   this functionality on main, unless of course someone dispatches this workflow
-    #   with the tag-as-latest option which will force publish the image.
-    if: >-
-      ${{
-        !cancelled() && (
-          (github.ref == 'refs/heads/main' && !contains(join(needs.*.result, ','), 'failure')) ||
-          inputs.tag-as-latest
-        )
-      }}
+  calculate-to-publish:
+    if: ${{ !cancelled() }}
     needs:
       - get-image-tags
       - test-wh-6u-image
       - test-bh-image
       - test-bh-p300-image
       - test-bh-multicard-image
+    runs-on: ubuntu-latest
+    outputs:
+      images-to-push: ${{ steps.calculate-images.outputs.images-to-push }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Calculate images to publish
+        id: calculate-images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Load configuration from external JSON file
+          config_file=".github/workflows/job_configs/upstream-tests.json"
+          if [[ ! -f "$config_file" ]]; then
+            echo "ERROR: Configuration file $config_file not found" >&2
+            exit 1
+          fi
+
+          echo "Using configuration from $config_file"
+
+          # Get all hw_topology keys
+          hw_topologies=($(jq -r '.hw_topologies | keys[]' "$config_file"))
+
+          # Create mapping of image output names to actual image tags
+          declare -A image_output_to_tag=(
+            ["bh-image-tag"]="${{ needs.get-image-tags.outputs.bh-image-tag }}"
+            ["bh-profiler-image-tag"]="${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}"
+            ["wh-6u-image-tag"]="${{ needs.get-image-tags.outputs.wh-6u-image-tag }}"
+            ["wh-6u-profiler-image-tag"]="${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}"
+            ["bh-llmbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}"
+            ["bh-deskbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}"
+            ["bh-loudbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}"
+            ["bh-p300-image-tag"]="${{ needs.get-image-tags.outputs.bh-p300-image-tag }}"
+            ["bh-qb-ge-image-tag"]="${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}"
+          )
+
+          # Get test job results
+          declare -A test_job_results=(
+            ["test-bh-image"]="${{ needs.test-bh-image.result }}"
+            ["test-wh-6u-image"]="${{ needs.test-wh-6u-image.result }}"
+            ["test-bh-multicard-image"]="${{ needs.test-bh-multicard-image.result }}"
+            ["test-bh-p300-image"]="${{ needs.test-bh-p300-image.result }}"
+          )
+
+          # Initialize array for images to push (optimized approach)
+          images_to_push_array=()
+
+          # Parse the request-force-publish input
+          request_input="${{ inputs.request-force-publish || 'passing-only' }}"
+
+          echo "Processing request: $request_input"
+
+          # Function to add images for a hw_topology
+          add_images_for_topology() {
+            local hw_topology="$1"
+            local reason="$2"
+
+            echo "Adding images for $hw_topology ($reason)"
+
+            # Get image outputs for this hw_topology from config
+            local image_outputs
+            image_outputs=($(jq -r ".hw_topologies[\"$hw_topology\"].image_outputs[]" "$config_file"))
+
+            # Add each image to our array
+            for image_output in "${image_outputs[@]}"; do
+              if [[ -v image_output_to_tag[$image_output] ]]; then
+                local image_tag="${image_output_to_tag[$image_output]}"
+                echo "  Adding: $image_tag"
+                images_to_push_array+=("$image_tag")
+              else
+                echo "ERROR: Unknown image output '$image_output' for hw_topology '$hw_topology'" >&2
+                exit 1
+              fi
+            done
+          }
+
+          if [[ "$request_input" == "passing-only" ]]; then
+            echo "Mode: Publishing only passing images"
+
+            # Check each hw_topology's test job result
+            for hw_topology in "${hw_topologies[@]}"; do
+              test_job=$(jq -r ".hw_topologies[\"$hw_topology\"].test_job" "$config_file")
+              test_result="${test_job_results[$test_job]}"
+
+              echo "Checking $hw_topology (test job: $test_job, result: $test_result)"
+
+              if [[ "$test_result" == "success" ]]; then
+                add_images_for_topology "$hw_topology" "test passed"
+              else
+                echo "Skipping images for $hw_topology (test failed or skipped: $test_result)"
+              fi
+            done
+
+          elif [[ "$request_input" == "all" ]]; then
+            echo "Mode: Publishing all images regardless of test status"
+
+            # Add all images for all hw_topologies
+            for hw_topology in "${hw_topologies[@]}"; do
+              add_images_for_topology "$hw_topology" "forced all"
+            done
+
+          else
+            echo "Mode: Publishing specific hw_topology list"
+
+            # Validate JSON format
+            if ! echo "$request_input" | jq empty 2>/dev/null; then
+              echo "ERROR: request-force-publish must be 'passing-only', 'all', or a valid JSON array" >&2
+              exit 1
+            fi
+
+            # Validate it's an array
+            if [[ $(echo "$request_input" | jq 'type') != '"array"' ]]; then
+              echo "ERROR: When providing specific hw_topology values, input must be a JSON array like [\"wh-6u\", \"bh\"]" >&2
+              exit 1
+            fi
+
+            # Get valid hw_topology values for error messages
+            valid_topologies=$(printf '%s ' "${hw_topologies[@]}")
+
+            # Process each requested hw_topology
+            while IFS= read -r hw_topology; do
+              hw_topology=$(echo "$hw_topology" | jq -r '.')
+              echo "Processing requested hw_topology: $hw_topology"
+
+              # Validate hw_topology exists in config
+              if ! jq -e ".hw_topologies[\"$hw_topology\"]" "$config_file" >/dev/null; then
+                echo "ERROR: Unknown hw_topology '$hw_topology'. Valid values are: $valid_topologies" >&2
+                exit 1
+              fi
+
+              add_images_for_topology "$hw_topology" "forced specific"
+            done < <(echo "$request_input" | jq -r '.[]')
+          fi
+
+          # Convert bash array to JSON (optimized single conversion)
+          if [[ ${#images_to_push_array[@]} -eq 0 ]]; then
+            images_to_push_json="[]"
+            # TODO: I wonder if we want to just fail here and print a helpful error message?
+            echo "No images to push"
+          else
+            echo "Converting ${#images_to_push_array[@]} images to JSON for next job's matrix"
+            images_to_push_json=$(printf '%s\n' "${images_to_push_array[@]}" | jq -R '.' | jq -s 'map({"image-tag": .})')
+          fi
+
+          echo "Final images to push:"
+          echo "$images_to_push_json" | jq '.'
+
+          # Set output
+          echo "images-to-push=$images_to_push_json" >> "$GITHUB_OUTPUT"
+  push-latest:
+    # Push images based on the dynamic matrix calculated by calculate-to-publish
+    # This job will only run if calculate-to-publish has images to push
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.calculate-to-publish.result == 'success' &&
+        needs.calculate-to-publish.outputs.images-to-push != '[]'
+      }}
+    needs:
+      - calculate-to-publish
     permissions:
       packages: write
       contents: read
     strategy:
       matrix:
-        image-config:
-          - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-p300-image-tag }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
+        image-config: ${{ fromJSON(needs.calculate-to-publish.outputs.images-to-push) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Ticket

#30439

### Problem description

We want to be able to publish certain images only, not all or nothing.

### What's changed

Lots of bash !!!

🔧 New Input Parameter:
- Changed tag-as-latest (boolean) → request-force-publish (string)
- Default: "passing-only" - only publish images from passing tests
- Options: "all" (publish all regardless of test status) or JSON array like ["wh-6u", "bh"] (publish specific hw_topology images)

🚀 New calculate-to-publish Job:
- Runs after all tests complete (unless workflow cancelled)
- Dynamically generates matrix of images to publish based on test results and user input
- Uses external JSON config file for maintainable hw_topology → test job mappings

📊 Updated push-latest Job:
- Now uses dynamic matrix from calculate-to-publish output via fromJSON()
- Only runs if there are actually images to publish
- Simplified dependency chain: only needs calculate-to-publish

🛡️ Enhanced Error Handling with more exits if we find some unsavoury conditions such as unknown `hw_topology`.

### Checklist
- Upstream passing only: https://github.com/tenstorrent/tt-metal/actions/runs/19020886810
- Upstream `["bh-llmbox","bh-deskbox","wh-6u"]`: https://github.com/tenstorrent/tt-metal/actions/runs/19020888105
- Upstream all: didn't try yet
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes