### PR TITLE
[skip ci] setup-job composite action to use zstd compression

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: 📂 Extract Build Files
       if: ${{ inputs.build-artifact-name != '' }}
       working-directory: ${{ inputs.path }}
-      run: tar -xf ttm_any.tar
+      run: tar --zstd -xf ttm_any.tar.zst
       shell: bash
 
     - name: 🧪 Download Python Wheel


### PR DESCRIPTION
### Ticket
NA

### Problem description
Currently, we rely on github actions/upload to compress our ginormous build/ directory tarball in CI.
If we start compressing ourselves, we can start acheiving better compression and faster upload/download speeds.

### What's changed
- setup-job action will now decompress a zstd compressed tarball.

This PR will have no effect on current main as long as https://github.com/tenstorrent/tt-metal/pull/30485 is merged first.

A follow up PR will make the corresponding changes to build-artifact to compress the tarball.