### PR TITLE
Add SD unit_tests_eth to Blackhole Multicard Unit Tests

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -50,6 +50,7 @@ jobs:
             cmd: |
               ./build/test/tt_metal/unit_tests_eth
               ./build/test/tt_metal/unit_tests_tunneling
+              TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
             timeout: 15
           - name: multi erisc tests
             cmd: |


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28771

### Problem description
Slow dispatch eth unit tests were not being run in Blackhole Multicard Unit Tests

### What's changed
- Add SD Eth Unit Tests (+40 seconds)

### Checklist
Blackhole Multi Card Unit Tests
https://github.com/tenstorrent/tt-metal/actions/runs/18480661446
https://github.com/tenstorrent/tt-metal/actions/runs/18481033214
https://github.com/tenstorrent/tt-metal/actions/runs/18481034095