### PR TITLE
Specify grid for sparse matmul unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+import math
 
 from loguru import logger
 import pytest
@@ -20,7 +21,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
-def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype):
+@pytest.mark.parametrize("core_grid", [(4, 4)])
+def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, tile_w, in1_dtype, core_grid):
     torch.manual_seed(0)
     m, k, n = mkn
     b, s = num_tokens
@@ -67,6 +69,7 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, ti
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    core_x, core_y = core_grid
     output_tile = ttnn.Tile([tile_h, tile_w])
     output_t = ttnn.sparse_matmul(
         in0_t,
@@ -75,6 +78,19 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_tokens, tile_h, ti
         nnz=nnz,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // tile_h,
+            per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
     )
 
     output_tensor = ttnn.to_torch(output_t)


### PR DESCRIPTION
### Ticket
N/A
Blackhole APC failing @ https://github.com/tenstorrent/tt-metal/actions/runs/18471138968/job/52625541379

### Problem description
Blackhole has a different grid than wormhole. As a result, the same shape for in1 (e.g. 512 aka 16 tiles) is laid out differently in blackhole vs wormhole when the entire core grid is used. This results in a non-rectangular grid for the same sizes in blackhole vs wormhole.

### What's changed
Provide a custom grid to clarify that the same grid should be used across all families of devices irrespective of the default grid.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18480689224/job/52657589898
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18480694059/job/52657888356
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes