### PR TITLE
Reenable interrupts on aerisc

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -199,7 +199,6 @@ int __attribute__((noinline)) main(void) {
     initialize_local_memory();
     noc_bank_table_init(MEM_AERISC_BANK_TO_NOC_SCRATCH);
 
-    disable_interrupts();
     update_next_link_status_check_timestamp();
 
     noc_index = 0;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30495

### Problem description
- Active eth interrupts were disabled

### What's changed
- Re enable interrupts

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19379149356
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19379140718
Blackhole Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/19379138468