### PR TITLE
RS-Line Dim 1 & 2 Native Support

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -36,7 +36,7 @@ ttnn::Tensor ExecuteReduceScatter::invoke(
     // when not all devices are mmio capable. Manually doing it requires the use of "is_mmio_capable" counting, but as
     // the one link that's subtracted out is only along one cluster axis, we will be using less links we would like
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, cluster_axis));
-    if (composite_common::use_composite_reduce_scatter(input_tensor, topology_, dim, cluster_axis)) {
+    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
         return composite_common::composite_reduce_scatter(
             input_tensor, dim, num_links_, memory_config_, subdevice_id, cluster_axis);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -199,7 +199,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool composite_all_gather =
         composite_common::use_composite_all_gather(padded_tensor, composite_dim, out_memory_config);
     bool composite_reduce_scatter =
-        composite_common::use_composite_reduce_scatter(padded_tensor, topology, composite_dim, std::nullopt);
+        composite_common::use_composite_reduce_scatter(padded_tensor, composite_dim, std::nullopt);
 
     // when input is sharded, shard specs are not compatible with the intermediate tensor shapes of the composite ops
     // convert to interleaved in this case
@@ -326,7 +326,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool composite_all_gather =
         composite_common::use_composite_all_gather(padded_tensor, composite_dim, out_memory_config);
     bool composite_reduce_scatter =
-        composite_common::use_composite_reduce_scatter(padded_tensor, topology, composite_dim, cluster_axis);
+        composite_common::use_composite_reduce_scatter(padded_tensor, composite_dim, cluster_axis);
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) || is_fabric_2d()) {
         // All reduce = all gather + local reduce
         composite_dim = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -24,8 +24,7 @@
 
 namespace composite_common {
 
-bool use_composite_reduce_scatter(
-    const ttnn::Tensor& input_tensor, ttnn::ccl::Topology topology, int32_t dim, std::optional<uint32_t> cluster_axis);
+bool use_composite_reduce_scatter(const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis);
 bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const ttnn::MemoryConfig& output_mem_config);
 bool use_composite_all_gather(
     const ttnn::Tensor& input_tensor, int32_t dim, const std::optional<ttnn::MemoryConfig>& memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -27,15 +27,12 @@ constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(7);
 constexpr uint32_t ring_size = get_compile_time_arg_val(8);
 constexpr uint32_t num_batches = get_compile_time_arg_val(9);
 constexpr uint32_t fuse_op = get_compile_time_arg_val(10);
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(11);
-constexpr bool is_forward = get_compile_time_arg_val(12);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(13);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(14);
-constexpr uint32_t num_intermediate_reduction_steps = get_compile_time_arg_val(15);
-constexpr bool do_final_reduction = get_compile_time_arg_val(16);
-constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(17);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(18);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(19);
+constexpr bool is_forward = get_compile_time_arg_val(11);
+constexpr bool is_first_device_in_direction = get_compile_time_arg_val(12);
+constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(13);
+constexpr bool do_final_reduction = get_compile_time_arg_val(14);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(15);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -52,7 +49,7 @@ void kernel_main() {
     uint32_t num_links = get_arg_val<uint32_t>(arg_idx++);
     uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
-    constexpr uint32_t ct_idx = 20;
+    constexpr uint32_t ct_idx = 17;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset_one = 7;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -134,8 +134,10 @@ void kernel_main() {
     }
 
     constexpr uint32_t slice_Wt = input_tensor_Wt / ring_size;
-    constexpr uint32_t batch_num_pages = batch_slice_num_pages * ring_size;
-    constexpr uint32_t intermediate_num_pages = batch_num_pages * input_tensor_B;
+    constexpr uint32_t input_batch_num_pages = batch_slice_num_pages * ring_size;
+    constexpr uint32_t intermediate_num_pages = input_batch_num_pages * input_tensor_B;
+
+    constexpr uint32_t output_batch_num_pages = batch_slice_num_pages;
 
     /**
      * Intermediate buffer is double-sized (shape [2, *input_shape]) to accommodate forward and backward.
@@ -152,7 +154,7 @@ void kernel_main() {
             matmul_receiver.wait_for_matmul_batch(b);
         }
         int slice_idx = is_forward ? ring_size - 1 : 0;
-        uint32_t batch_offset = batch_num_pages * b;
+        uint32_t batch_offset = input_batch_num_pages * b;
 
         // Iterate over the slices in the direction we are going.
         // In forwards direction, count down from slice (ring_size -1) down to (my_chip_id+1), inclusive
@@ -167,7 +169,7 @@ void kernel_main() {
             uint32_t input_pages_read_in_row = start_pages_read_in_row;
             uint32_t input_row_offset = start_row_offset;
 
-            uint32_t intermediate_tile_id_start = intermediate_full_offset + batch_offset + slice_idx * slice_Wt;
+            uint32_t intermediate_tile_id_start = input_tile_id_start + intermediate_full_offset;
             uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
             uint32_t intermediate_row_offset = input_row_offset;
 
@@ -269,15 +271,21 @@ void kernel_main() {
             uint32_t input_tile_id_start = my_chip_id * slice_Wt + batch_offset;
             uint32_t input_pages_read_in_row = start_pages_read_in_row;
             uint32_t input_row_offset = start_row_offset;
+            uint32_t input_stride_Wt = input_tensor_Wt;
 
-            uint32_t intermediate_tile_id_start = intermediate_full_offset + batch_offset + my_chip_id * slice_Wt;
+            uint32_t intermediate_tile_id_start = input_tile_id_start + intermediate_full_offset;
             uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
             uint32_t intermediate_row_offset = input_row_offset;
+            uint32_t intermediate_stride_Wt = input_tensor_Wt;
+
+            uint32_t output_tile_id_start = b * output_batch_num_pages;
+            uint32_t output_pages_read_in_row = input_pages_read_in_row;
+            uint32_t output_row_offset =
+                input_row_offset / input_tensor_Wt * slice_Wt;  // TODO: (GR) extract out of kernel
+            uint32_t output_stride_Wt = slice_Wt;
 
             uint32_t tiles_read = start_tiles_read;
             uint32_t tiles_to_read = start_tiles_to_read;
-
-            uint32_t input_stride_Wt = input_tensor_Wt;
 
             /**
              * If two cores are doing final reduction, BWD core will accumulate output with
@@ -285,10 +293,20 @@ void kernel_main() {
              * If true, output += intermediate. Otherwise, output = input + intermediate
              */
             constexpr bool accumulate_output = sync_with_other_direction && !is_forward;
-            if (accumulate_output) {
-                input_tile_id_start = b * batch_slice_num_pages;  // output batch offset
-                input_row_offset = input_row_offset / input_tensor_Wt * slice_Wt;
-                input_stride_Wt = slice_Wt;
+            uint32_t tile_id_start;
+            uint32_t pages_read_in_row;
+            uint32_t row_offset;
+            uint32_t stride_Wt;
+            if constexpr (accumulate_output) {
+                tile_id_start = output_tile_id_start;
+                pages_read_in_row = output_pages_read_in_row;
+                row_offset = output_row_offset;
+                stride_Wt = output_stride_Wt;
+            } else {
+                tile_id_start = input_tile_id_start;
+                pages_read_in_row = input_pages_read_in_row;
+                row_offset = input_row_offset;
+                stride_Wt = input_stride_Wt;
             }
 
             uint32_t cb_in0 = cb_input_id;
@@ -305,16 +323,16 @@ void kernel_main() {
                 cb_reserve_back(cb_in0, tile_granularity);
                 uint32_t l1_write_addr = get_write_ptr(cb_in0);
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
-                    uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
+                    uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
                     uint64_t noc_read_addr = accumulate_output ? get_noc_addr(tile_id, output_tensor_addrgen)
                                                                : get_noc_addr(tile_id, input_tensor_addrgen);
                     noc_async_read(noc_read_addr, l1_write_addr, page_size);
                     l1_write_addr += page_size;
 
-                    input_pages_read_in_row++;
-                    if (input_pages_read_in_row == slice_Wt) {
-                        input_row_offset += input_stride_Wt;
-                        input_pages_read_in_row -= slice_Wt;
+                    pages_read_in_row++;
+                    if (pages_read_in_row == slice_Wt) {
+                        row_offset += stride_Wt;
+                        pages_read_in_row -= slice_Wt;
                     }
                 }
                 tiles_read += num_pages_to_read;
@@ -336,7 +354,7 @@ void kernel_main() {
 
                     intermediate_pages_read_in_row++;
                     if (intermediate_pages_read_in_row == slice_Wt) {
-                        intermediate_row_offset += input_tensor_Wt;
+                        intermediate_row_offset += intermediate_stride_Wt;
                         intermediate_pages_read_in_row -= slice_Wt;
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -21,11 +21,11 @@ constexpr uint32_t cb_input_id = get_compile_time_arg_val(1);
 constexpr uint32_t cb_intermediate_id = get_compile_time_arg_val(2);
 constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(3);
 constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
-constexpr uint32_t input_tensor_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t page_size = get_compile_time_arg_val(5);
 constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(6);
 constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(7);
 constexpr uint32_t ring_size = get_compile_time_arg_val(8);
-constexpr uint32_t num_batches = get_compile_time_arg_val(9);
+constexpr uint32_t input_tensor_B = get_compile_time_arg_val(9);
 constexpr uint32_t fuse_op = get_compile_time_arg_val(10);
 constexpr bool is_forward = get_compile_time_arg_val(11);
 constexpr bool is_first_device_in_direction = get_compile_time_arg_val(12);
@@ -33,6 +33,10 @@ constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(13);
 constexpr bool do_final_reduction = get_compile_time_arg_val(14);
 constexpr bool sync_with_other_direction = get_compile_time_arg_val(15);
 constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
+constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(17);
+constexpr uint32_t start_row_offset = get_compile_time_arg_val(18);
+constexpr uint32_t start_tiles_read = get_compile_time_arg_val(19);
+constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(20);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -45,11 +49,9 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t link = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_links = get_arg_val<uint32_t>(arg_idx++);
     uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
-    constexpr uint32_t ct_idx = 17;
+    constexpr uint32_t ct_idx = 21;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset_one = 7;
@@ -72,7 +74,7 @@ void kernel_main() {
 #else
     constexpr auto input_tensor_args = TensorAccessorArgs<ct_idx>();
     constexpr uint32_t ct_offset_one = input_tensor_args.num_compile_time_args();
-    auto input_tensor_addrgen = TensorAccessor(input_tensor_args, input_tensor_address, input_tensor_page_size);
+    auto input_tensor_addrgen = TensorAccessor(input_tensor_args, input_tensor_address, page_size);
 #endif
 
 #ifdef INTERMEDIATE_IS_SHARDED
@@ -99,8 +101,7 @@ void kernel_main() {
 #else
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx + ct_offset_one>();
     constexpr uint32_t ct_offset_two = intermediate_tensor_args.num_compile_time_args();
-    auto intermediate_tensor_addrgen =
-        TensorAccessor(intermediate_tensor_args, intermediate_tensor_address, input_tensor_page_size);
+    auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address, page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -124,7 +125,7 @@ void kernel_main() {
     arg_idx += output_rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset_one + ct_offset_two>();
-    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address, input_tensor_page_size);
+    auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address, page_size);
 #endif
 
     ReduceScatterOpReceiver matmul_receiver;
@@ -133,9 +134,9 @@ void kernel_main() {
     }
 
     constexpr uint32_t slice_Wt = input_tensor_Wt / ring_size;
-
     constexpr uint32_t batch_num_pages = batch_slice_num_pages * ring_size;
-    constexpr uint32_t intermediate_num_pages = batch_num_pages * num_batches;
+    constexpr uint32_t intermediate_num_pages = batch_num_pages * input_tensor_B;
+
     /**
      * Intermediate buffer is double-sized (shape [2, *input_shape]) to accommodate forward and backward.
      * BWD indexes into second half of intermediate buffer.
@@ -146,7 +147,7 @@ void kernel_main() {
     uint32_t fwd_sync_cnt = 0;
     uint32_t sem_target = 0;
 
-    for (uint32_t b = 0; b < num_batches; b++) {
+    for (uint32_t b = 0; b < input_tensor_B; b++) {
         if (fuse_op) {
             matmul_receiver.wait_for_matmul_batch(b);
         }
@@ -163,61 +164,65 @@ void kernel_main() {
         for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
             chunk_count = 0;
             uint32_t input_tile_id_start = slice_idx * slice_Wt + batch_offset;
+            uint32_t input_pages_read_in_row = start_pages_read_in_row;
+            uint32_t input_row_offset = start_row_offset;
+
             uint32_t intermediate_tile_id_start = intermediate_full_offset + batch_offset + slice_idx * slice_Wt;
-            uint32_t stride_Wt = input_tensor_Wt;
-            uint32_t pages_read_in_row = (link * batch_slice_num_pages / num_links) % slice_Wt;
-            uint32_t row_offset = (link * batch_slice_num_pages / num_links) / slice_Wt * stride_Wt;
-            uint32_t intermediate_pages_read_in_row = (link * batch_slice_num_pages / num_links) % slice_Wt;
-            uint32_t intermediate_row_offset = (link * batch_slice_num_pages / num_links) / slice_Wt * stride_Wt;
-            uint32_t tiles_read = (link * batch_slice_num_pages / num_links);
-            uint32_t tiles_to_read = (link + 1) * batch_slice_num_pages / num_links;
+            uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
+            uint32_t intermediate_row_offset = input_row_offset;
+
+            uint32_t tiles_read = start_tiles_read;
+            uint32_t tiles_to_read = start_tiles_to_read;
 
             if constexpr (is_first_device_in_direction) {
-                // We have no incoming slices, so forward directly to writer.
+                // We have no incoming slices, so forward directly to writer
+
                 uint32_t cb_in0 = cb_reader_output_id;
                 while (tiles_read < tiles_to_read) {
-                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_reserve_back(cb_in0, tile_granularity);
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
-                    for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                        uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
+                    for (uint32_t j = 0; j < num_pages_to_read; ++j) {
+                        uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
                         uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
-                        l1_write_addr += input_tensor_page_size;
-                        pages_read_in_row++;
-                        if (pages_read_in_row >= slice_Wt) {
-                            row_offset += stride_Wt;
-                            pages_read_in_row = 0;
+                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        l1_write_addr += page_size;
+
+                        input_pages_read_in_row++;
+                        if (input_pages_read_in_row == slice_Wt) {
+                            input_row_offset += input_tensor_Wt;
+                            input_pages_read_in_row -= slice_Wt;
                         }
                     }
                     tiles_read += num_pages_to_read;
+
                     noc_async_read_barrier();
                     cb_push_back(cb_in0, tile_granularity);
                 }
             } else {
                 // I have incoming slices, so write my output to compute kernel and read intermediate input
-                uint32_t cb_in0 = cb_input_id;
-                // Wait on output semaphore
 
+                uint32_t cb_in0 = cb_input_id;
                 while (tiles_read < tiles_to_read) {
-                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_reserve_back(cb_in0, tile_granularity);
-
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
-                    for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                        uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
+                    for (uint32_t j = 0; j < num_pages_to_read; ++j) {
+                        uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
                         uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
-                        l1_write_addr += input_tensor_page_size;
-                        pages_read_in_row++;
-                        if (pages_read_in_row >= slice_Wt) {
-                            row_offset += stride_Wt;
-                            pages_read_in_row = 0;
+                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        l1_write_addr += page_size;
+
+                        input_pages_read_in_row++;
+                        if (input_pages_read_in_row == slice_Wt) {
+                            input_row_offset += input_tensor_Wt;
+                            input_pages_read_in_row -= slice_Wt;
                         }
                     }
-
                     tiles_read += num_pages_to_read;
 
                     if (chunk_count % chunks_per_sync == 0) {
@@ -225,20 +230,21 @@ void kernel_main() {
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                     }
                     chunk_count++;
+
                     // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
                     cb_reserve_back(cb_intermediate_id, tile_granularity);
-
                     l1_write_addr = get_write_ptr(cb_intermediate_id);
-                    for (uint32_t j = 0; j < num_pages_to_read; j++) {
+                    for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id =
                             intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
                         uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
-                        l1_write_addr += input_tensor_page_size;
+                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        l1_write_addr += page_size;
+
                         intermediate_pages_read_in_row++;
-                        if (intermediate_pages_read_in_row >= slice_Wt) {
-                            intermediate_row_offset += stride_Wt;
-                            intermediate_pages_read_in_row = 0;
+                        if (intermediate_pages_read_in_row == slice_Wt) {
+                            intermediate_row_offset += input_tensor_Wt;
+                            intermediate_pages_read_in_row -= slice_Wt;
                         }
                     }
 
@@ -259,85 +265,79 @@ void kernel_main() {
         // Do the final reduction. Synchronize with other direction.
         if constexpr (do_final_reduction) {
             chunk_count = 0;
-            bool accumulate_output =
-                false;  // If true, output += intermediate. Otherwise, output = input + intermediate
-            constexpr bool use_output_tensor_addrgen = sync_with_other_direction && !is_forward;
-            if constexpr (use_output_tensor_addrgen) {
-                /**
-                 * If two cores are doing final reduction, BWD core will accumulate output with
-                 * incoming BWD intermediate. Use output address generator.
-                 */
-                accumulate_output = true;
-            }
 
-            uint32_t slice_idx = my_chip_id;
-            uint32_t intermediate_slice_idx = my_chip_id;
+            uint32_t input_tile_id_start = my_chip_id * slice_Wt + batch_offset;
+            uint32_t input_pages_read_in_row = start_pages_read_in_row;
+            uint32_t input_row_offset = start_row_offset;
 
-            uint32_t input_tile_id_start = slice_idx * slice_Wt + batch_offset;
-            uint32_t intermediate_tile_id_start =
-                intermediate_full_offset + batch_offset + intermediate_slice_idx * slice_Wt;
-            uint32_t stride_Wt = input_tensor_Wt;
-            uint32_t intermediate_stride_Wt = input_tensor_Wt;
-            uint32_t pages_read_in_row = (link * batch_slice_num_pages / num_links) % slice_Wt;
-            uint32_t row_offset = (link * batch_slice_num_pages / num_links) / slice_Wt * stride_Wt;
-            uint32_t intermediate_pages_read_in_row = (link * batch_slice_num_pages / num_links) % slice_Wt;
-            uint32_t intermediate_row_offset = (link * batch_slice_num_pages / num_links) / slice_Wt * stride_Wt;
-            uint32_t tiles_read = (link * batch_slice_num_pages / num_links);
-            uint32_t tiles_to_read = (link + 1) * batch_slice_num_pages / num_links;
-            uint32_t cb_in0 = cb_input_id;
+            uint32_t intermediate_tile_id_start = intermediate_full_offset + batch_offset + my_chip_id * slice_Wt;
+            uint32_t intermediate_pages_read_in_row = input_pages_read_in_row;
+            uint32_t intermediate_row_offset = input_row_offset;
 
+            uint32_t tiles_read = start_tiles_read;
+            uint32_t tiles_to_read = start_tiles_to_read;
+
+            uint32_t input_stride_Wt = input_tensor_Wt;
+
+            /**
+             * If two cores are doing final reduction, BWD core will accumulate output with
+             * incoming BWD intermediate. Use output address generator.
+             * If true, output += intermediate. Otherwise, output = input + intermediate
+             */
+            constexpr bool accumulate_output = sync_with_other_direction && !is_forward;
             if (accumulate_output) {
                 input_tile_id_start = b * batch_slice_num_pages;  // output batch offset
-                pages_read_in_row = (link * batch_slice_num_pages / num_links) % slice_Wt;
-                row_offset = (link * batch_slice_num_pages / num_links) / slice_Wt * slice_Wt;
-                stride_Wt = slice_Wt;
+                input_row_offset = input_row_offset / input_tensor_Wt * slice_Wt;
+                input_stride_Wt = slice_Wt;
             }
-            // Wait on output semaphore
-            while (tiles_read < tiles_to_read) {
-                uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
-                cb_reserve_back(cb_in0, tile_granularity);
 
+            uint32_t cb_in0 = cb_input_id;
+            while (tiles_read < tiles_to_read) {
                 // Wait for FWD writer to signal that it has done its final reduction
                 if constexpr (sync_with_other_direction && !is_forward) {
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
                 }
 
+                uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+                uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
+
+                cb_reserve_back(cb_in0, tile_granularity);
                 uint32_t l1_write_addr = get_write_ptr(cb_in0);
-                for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                    uint32_t tile_id = input_tile_id_start + row_offset + pages_read_in_row;
-                    uint64_t noc_read_addr = use_output_tensor_addrgen ? get_noc_addr(tile_id, output_tensor_addrgen)
-                                                                       : get_noc_addr(tile_id, input_tensor_addrgen);
-                    noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
-                    l1_write_addr += input_tensor_page_size;
-                    pages_read_in_row++;
-                    if (pages_read_in_row >= slice_Wt) {
-                        row_offset += stride_Wt;
-                        pages_read_in_row = 0;
+                for (uint32_t j = 0; j < num_pages_to_read; ++j) {
+                    uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
+                    uint64_t noc_read_addr = accumulate_output ? get_noc_addr(tile_id, output_tensor_addrgen)
+                                                               : get_noc_addr(tile_id, input_tensor_addrgen);
+                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                    l1_write_addr += page_size;
+
+                    input_pages_read_in_row++;
+                    if (input_pages_read_in_row == slice_Wt) {
+                        input_row_offset += input_stride_Wt;
+                        input_pages_read_in_row -= slice_Wt;
                     }
                 }
-
                 tiles_read += num_pages_to_read;
 
                 if (chunk_count % chunks_per_sync == 0) {
                     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                 }
-
                 chunk_count++;
+
                 // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
                 cb_reserve_back(cb_intermediate_id, tile_granularity);
-
                 l1_write_addr = get_write_ptr(cb_intermediate_id);
-                for (uint32_t j = 0; j < num_pages_to_read; j++) {
+                for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t tile_id =
                         intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
                     uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
-                    noc_async_read(noc_read_addr, l1_write_addr, input_tensor_page_size);
-                    l1_write_addr += input_tensor_page_size;
+                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                    l1_write_addr += page_size;
+
                     intermediate_pages_read_in_row++;
-                    if (intermediate_pages_read_in_row >= slice_Wt) {
-                        intermediate_row_offset += intermediate_stride_Wt;
-                        intermediate_pages_read_in_row = 0;
+                    if (intermediate_pages_read_in_row == slice_Wt) {
+                        intermediate_row_offset += input_tensor_Wt;
+                        intermediate_pages_read_in_row -= slice_Wt;
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -27,42 +27,39 @@ using namespace tt::tt_fabric::linear::experimental;
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 
-constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
-constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(1);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(2);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
-constexpr uint32_t intermediate_page_size = get_compile_time_arg_val(4);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(5);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(6);
-constexpr uint32_t ring_size = get_compile_time_arg_val(7);
-constexpr uint32_t num_batches = get_compile_time_arg_val(8);
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(9);
-constexpr bool is_forward = get_compile_time_arg_val(10);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(11);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(12);
-constexpr uint32_t num_intermediate_reduction_steps = get_compile_time_arg_val(13);
-constexpr bool do_final_reduction = get_compile_time_arg_val(14);
-constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(15);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(16);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(17);
+constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(1);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(2);
+constexpr uint32_t page_size = get_compile_time_arg_val(3);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(4);
+constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(5);
+constexpr uint32_t ring_size = get_compile_time_arg_val(6);
+constexpr uint32_t num_batches = get_compile_time_arg_val(7);
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(8);
+constexpr bool is_forward = get_compile_time_arg_val(9);
+constexpr bool is_first_device_in_direction = get_compile_time_arg_val(10);
+constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(11);
+constexpr bool do_final_reduction = get_compile_time_arg_val(12);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(13);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(14);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(18);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
+constexpr bool is_termination_master = get_compile_time_arg_val(15);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(16);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(17);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(18);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(19);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(20);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(21);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(22);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(23);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(24);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(25);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(27);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<28>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<28 + ccl_routing_utils::num_line_unicast_args>();
 
 constexpr uint32_t batch_num_pages = batch_slice_num_pages * ring_size;
 constexpr uint32_t intermediate_num_pages = batch_num_pages * num_batches;
@@ -79,18 +76,15 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    size_t final_reduction_slot_sem = get_arg_val<uint32_t>(arg_idx++);
-    size_t batch_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     uint32_t link = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_links = get_arg_val<uint32_t>(arg_idx++);
     uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
-
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
-    bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
 
+    bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -101,7 +95,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        28 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -125,7 +119,7 @@ void kernel_main() {
 #else
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<ct_idx>();
     constexpr uint32_t ct_offset = intermediate_tensor_args.num_compile_time_args();
-    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, intermediate_page_size);
+    auto intermediate_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_address, page_size);
 #endif
 
 #ifdef OUTPUT_IS_SHARDED
@@ -148,7 +142,7 @@ void kernel_main() {
     arg_idx += output_rt_increment;
 #else
     constexpr auto output_tensor_args = TensorAccessorArgs<ct_idx + ct_offset>();
-    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, intermediate_page_size);
+    auto output_addrgen = TensorAccessor(output_tensor_args, output_address, page_size);
 #endif
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;
@@ -241,7 +235,7 @@ void kernel_main() {
         page_size * 2);
 
     fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
-        pkt_unicast_hdr, static_cast<uint8_t>(unicast_route_info.distance_in_hops), nullptr, intermediate_page_size);
+        pkt_unicast_hdr, static_cast<uint8_t>(unicast_route_info.distance_in_hops), nullptr, page_size);
 
     fabric_unicast_noc_unicast_atomic_inc_set_state<
         UnicastAtomicIncUpdateMask::Wrap | UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
@@ -298,7 +292,7 @@ void kernel_main() {
                             pkt_unicast_hdr,
                             l1_read_addr,
                             NocUnicastCommandHeader{noc_address0});
-                        l1_read_addr += intermediate_page_size;
+                        l1_read_addr += page_size;
                     } else if (num_pages_to_write == 2) {
                         uint32_t second_tile_id = input_tile_id_start + row_offset + pages_read_in_row;
 
@@ -368,8 +362,8 @@ void kernel_main() {
                 for (uint32_t j = 0; j < num_pages_to_read; j++) {
                     uint32_t tile_id = tile_id_start + tiles_read;
                     uint64_t local_noc_addr = get_noc_addr(tile_id, output_addrgen);
-                    noc_async_write(l1_read_addr, local_noc_addr, intermediate_page_size);
-                    l1_read_addr += intermediate_page_size;
+                    noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                    l1_read_addr += page_size;
                     tiles_read++;
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -46,24 +46,27 @@ constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(15);
 constexpr uint32_t start_row_offset = get_compile_time_arg_val(16);
 constexpr uint32_t start_tiles_read = get_compile_time_arg_val(17);
 constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(18);
+constexpr uint32_t input_channel_num_pages = get_compile_time_arg_val(19);
+constexpr uint32_t output_channel_num_pages = get_compile_time_arg_val(20);
+constexpr uint32_t slice_C = get_compile_time_arg_val(21);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(21);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(28);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(29);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(31);
+constexpr bool is_termination_master = get_compile_time_arg_val(22);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(23);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(24);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(28);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(30);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(31);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(32);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(33);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(34);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<32>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<35>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<32 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<35 + ccl_routing_utils::num_line_unicast_args>();
 
 constexpr uint32_t input_batch_num_pages = batch_slice_num_pages * ring_size;
 constexpr uint32_t input_num_pages = input_batch_num_pages * input_tensor_B;
@@ -98,7 +101,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        32 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        35 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -256,49 +259,31 @@ void kernel_main() {
 
         uint32_t batch_offset = input_batch_num_pages * b;
         for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
+            constexpr uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
             chunk_count = 0;
 
-            constexpr uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
+            uint32_t intermediate_tile_id_start = slice_idx * slice_Wt + batch_offset + intermediate_full_offset;
+            for (uint32_t c = 0; c < slice_C; ++c) {
+                uint32_t intermediate_pages_read_in_row = start_pages_read_in_row;
+                uint32_t intermediate_row_offset = start_row_offset;
 
-            uint32_t intermediate_tile_id_start = slice_idx * slice_Wt + intermediate_full_offset + batch_offset;
-            uint32_t intermediate_pages_read_in_row = start_pages_read_in_row;
-            uint32_t intermediate_row_offset = start_row_offset;
+                uint32_t tiles_read = start_tiles_read;
+                uint32_t tiles_to_read = start_tiles_to_read;
 
-            uint32_t tiles_read = start_tiles_read;
-            uint32_t tiles_to_read = start_tiles_to_read;
+                // Write to remote intermediate buffer
+                while (tiles_read < tiles_to_read) {
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-            // Write to remote intermediate buffer
-            while (tiles_read < tiles_to_read) {
-                uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
-                uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
+                    cb_wait_front(cb_output_id, tile_granularity);
+                    size_t l1_read_addr = get_read_ptr(cb_output_id);
+                    for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
+                        uint32_t num_pages_to_write = std::min(contig_pages_advanced, num_pages_to_read - j);
 
-                cb_wait_front(cb_output_id, tile_granularity);
-                size_t l1_read_addr = get_read_ptr(cb_output_id);
-                for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                    uint32_t num_pages_to_write = std::min(contig_pages_advanced, num_pages_to_read - j);
-
-                    uint32_t first_tile_id =
-                        intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                    auto noc_address0 =
-                        tt::tt_fabric::linear::addrgen_detail::get_noc_address(intermediate_addrgen, first_tile_id, 0);
-
-                    intermediate_pages_read_in_row++;
-                    if (intermediate_pages_read_in_row == slice_Wt) {
-                        intermediate_row_offset += input_tensor_Wt;
-                        intermediate_pages_read_in_row -= slice_Wt;
-                    }
-
-                    uint32_t payload_size;
-                    if (num_pages_to_write == 1) {
-                        fabric_unicast_noc_unicast_write_with_state<UnicastWriteUpdateMask::DstAddr>(
-                            mux_connection_handle,
-                            pkt_unicast_hdr,
-                            l1_read_addr,
-                            NocUnicastCommandHeader{noc_address0});
-                        l1_read_addr += page_size;
-                    } else if (num_pages_to_write == 2) {
-                        uint32_t second_tile_id =
+                        uint32_t first_intermediate_tile_id =
                             intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
+                        auto noc_address0 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(
+                            intermediate_addrgen, first_intermediate_tile_id, 0);
 
                         intermediate_pages_read_in_row++;
                         if (intermediate_pages_read_in_row == slice_Wt) {
@@ -306,33 +291,54 @@ void kernel_main() {
                             intermediate_pages_read_in_row -= slice_Wt;
                         }
 
-                        auto noc_address1 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(
-                            intermediate_addrgen, second_tile_id, 0);
-                        fabric_unicast_noc_scatter_write_with_state<UnicastScatterWriteUpdateMask::DstAddrs>(
-                            mux_connection_handle,
-                            pkt_scatter_hdr,
-                            l1_read_addr,
-                            NocUnicastScatterCommandHeader{{noc_address0, noc_address1}, 0});
-                        l1_read_addr += page_size * 2;
-                    } else {
-                        ASSERT(false);
-                    }
-                    noc_async_writes_flushed();
-                    tiles_read += num_pages_to_write;
-                }
-                cb_pop_front(cb_output_id, tile_granularity);
+                        uint32_t payload_size;
+                        if (num_pages_to_write == 1) {
+                            fabric_unicast_noc_unicast_write_with_state<UnicastWriteUpdateMask::DstAddr>(
+                                mux_connection_handle,
+                                pkt_unicast_hdr,
+                                l1_read_addr,
+                                NocUnicastCommandHeader{noc_address0});
+                            l1_read_addr += page_size;
+                        } else if (num_pages_to_write == 2) {
+                            uint32_t second_intermediate_tile_id =
+                                intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
 
-                chunk_count++;
-                if (chunk_count % chunks_per_sync == 0) {
-                    // 2. unicast output ready semaphore
-                    fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-                        mux_connection_handle,
-                        pkt_hdr_seminc,
-                        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-                            out_ready_sem_noc_addr_in_pkt, 0, 0  // ignore
-                        });
+                            intermediate_pages_read_in_row++;
+                            if (intermediate_pages_read_in_row == slice_Wt) {
+                                intermediate_row_offset += input_tensor_Wt;
+                                intermediate_pages_read_in_row -= slice_Wt;
+                            }
+
+                            auto noc_address1 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(
+                                intermediate_addrgen, second_intermediate_tile_id, 0);
+                            fabric_unicast_noc_scatter_write_with_state<UnicastScatterWriteUpdateMask::DstAddrs>(
+                                mux_connection_handle,
+                                pkt_scatter_hdr,
+                                l1_read_addr,
+                                NocUnicastScatterCommandHeader{{noc_address0, noc_address1}, 0});
+                            l1_read_addr += page_size * 2;
+                        } else {
+                            ASSERT(false);
+                        }
+                        noc_async_writes_flushed();
+                        tiles_read += num_pages_to_write;
+                    }
+                    cb_pop_front(cb_output_id, tile_granularity);
+
+                    chunk_count++;
+                    if (chunk_count % chunks_per_sync == 0) {
+                        // 2. unicast output ready semaphore
+                        fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                            mux_connection_handle,
+                            pkt_hdr_seminc,
+                            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                                out_ready_sem_noc_addr_in_pkt, 0, 0  // ignore
+                            });
+                    }
                 }
+                intermediate_tile_id_start += input_channel_num_pages;
             }
+
             if (chunk_count % chunks_per_sync != 0) {
                 // 2. unicast output ready semaphore
                 fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
@@ -354,35 +360,39 @@ void kernel_main() {
         // Do write of final reduction and sync local FWD/BWD cores
         if constexpr (do_final_reduction) {
             // Write output
-            uint32_t tiles_read = start_tiles_read;
-            uint32_t tiles_to_read = start_tiles_to_read;
             uint32_t output_tile_id_start = b * output_batch_num_pages;
-            while (tiles_read < tiles_to_read) {
-                uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
-                uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
+            for (uint32_t c = 0; c < slice_C; ++c) {
+                uint32_t tiles_read = start_tiles_read;
+                uint32_t tiles_to_read = start_tiles_to_read;
 
-                cb_wait_front(cb_compute_output_id, tile_granularity);
-                size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
-                for (uint32_t j = 0; j < num_pages_to_read; ++j) {
-                    uint32_t tile_id = output_tile_id_start + tiles_read;
-                    uint64_t local_noc_addr = get_noc_addr(tile_id, output_addrgen);
-                    noc_async_write(l1_read_addr, local_noc_addr, page_size);
-                    l1_read_addr += page_size;
-                    tiles_read++;
-                }
+                while (tiles_read < tiles_to_read) {
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                if constexpr (sync_with_other_direction && is_forward) {
-                    noc_async_write_barrier();
-                } else {
-                    noc_async_writes_flushed();
+                    cb_wait_front(cb_compute_output_id, tile_granularity);
+                    size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
+                    for (uint32_t j = 0; j < num_pages_to_read; ++j) {
+                        uint32_t output_tile_id = output_tile_id_start + tiles_read;
+                        uint64_t local_noc_addr = get_noc_addr(output_tile_id, output_addrgen);
+                        noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                        l1_read_addr += page_size;
+                        tiles_read++;
+                    }
+
+                    if constexpr (sync_with_other_direction && is_forward) {
+                        noc_async_write_barrier();
+                    } else {
+                        noc_async_writes_flushed();
+                    }
+                    cb_pop_front(cb_compute_output_id, tile_granularity);
+                    if constexpr (sync_with_other_direction && is_forward) {
+                        // Tell local backwards reader that it can proceed
+                        uint64_t fwd_bwd_sem_noc_addr =
+                            safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
+                        noc_semaphore_inc(fwd_bwd_sem_noc_addr, 1);
+                    }
                 }
-                cb_pop_front(cb_compute_output_id, tile_granularity);
-                if constexpr (sync_with_other_direction && is_forward) {
-                    // Tell local backwards reader that it can proceed
-                    uint64_t fwd_bwd_sem_noc_addr =
-                        safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
-                    noc_semaphore_inc(fwd_bwd_sem_noc_addr, 1);
-                }
+                output_tile_id_start += output_channel_num_pages;
             }
             noc_async_write_barrier();
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -227,7 +227,6 @@ void kernel_main() {
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
-    auto page_size = tt::tt_fabric::linear::addrgen_detail::get_page_size(intermediate_addrgen);
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -49,24 +49,27 @@ constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(18);
 constexpr uint32_t input_channel_num_pages = get_compile_time_arg_val(19);
 constexpr uint32_t output_channel_num_pages = get_compile_time_arg_val(20);
 constexpr uint32_t slice_C = get_compile_time_arg_val(21);
+constexpr uint32_t slice_Ht = get_compile_time_arg_val(22);
+constexpr uint32_t slice_Wt = get_compile_time_arg_val(23);
+constexpr uint32_t dim = get_compile_time_arg_val(24);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(22);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(23);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(24);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(28);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(31);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(32);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(33);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(34);
+constexpr bool is_termination_master = get_compile_time_arg_val(25);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(26);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(27);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(28);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(30);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(31);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(32);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(33);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(34);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(35);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(36);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(37);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<35>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<38>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<35 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<38 + ccl_routing_utils::num_line_unicast_args>();
 
 constexpr uint32_t input_batch_num_pages = batch_slice_num_pages * ring_size;
 constexpr uint32_t input_num_pages = input_batch_num_pages * input_tensor_B;
@@ -101,7 +104,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        35 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        38 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -186,8 +189,6 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_scatter_hdr, unicast_route_info);
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_unicast_hdr, unicast_route_info);
 
-    uint32_t slice_Wt = input_tensor_Wt / ring_size;
-
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_connect_finish(*mux_connection_handle);
     }
@@ -261,7 +262,17 @@ void kernel_main() {
             constexpr uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
             chunk_count = 0;
 
-            uint32_t intermediate_tile_id_start = slice_idx * slice_Wt + batch_offset + intermediate_full_offset;
+            uint32_t intermediate_tile_id_start;
+            if constexpr (dim == 3) {
+                intermediate_tile_id_start = slice_idx * slice_Wt + batch_offset + intermediate_full_offset;
+            } else if constexpr (dim == 2) {
+                intermediate_tile_id_start = slice_idx * slice_Ht * slice_Wt + batch_offset + intermediate_full_offset;
+            } else if constexpr (dim == 1) {
+                intermediate_tile_id_start =
+                    slice_idx * slice_C * slice_Ht * slice_Wt + batch_offset + intermediate_full_offset;
+            } else {
+                ASSERT(false);
+            }
             for (uint32_t c = 0; c < slice_C; ++c) {
                 uint32_t intermediate_pages_read_in_row = start_pages_read_in_row;
                 uint32_t intermediate_row_offset = start_row_offset;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -27,54 +27,51 @@ using namespace tt::tt_fabric::linear::experimental;
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////
 
-constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(0);
-constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(1);
-constexpr uint32_t tile_granularity = get_compile_time_arg_val(2);
-constexpr uint32_t page_size = get_compile_time_arg_val(3);
-constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(4);
-constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(5);
-constexpr uint32_t ring_size = get_compile_time_arg_val(6);
-constexpr uint32_t input_tensor_B = get_compile_time_arg_val(7);
-constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(8);
-constexpr bool is_forward = get_compile_time_arg_val(9);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(10);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(11);
-constexpr bool do_final_reduction = get_compile_time_arg_val(12);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(13);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(14);
-constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(15);
-constexpr uint32_t start_row_offset = get_compile_time_arg_val(16);
-constexpr uint32_t start_tiles_read = get_compile_time_arg_val(17);
-constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(18);
-constexpr uint32_t input_channel_num_pages = get_compile_time_arg_val(19);
-constexpr uint32_t output_channel_num_pages = get_compile_time_arg_val(20);
-constexpr uint32_t slice_C = get_compile_time_arg_val(21);
-constexpr uint32_t slice_Ht = get_compile_time_arg_val(22);
-constexpr uint32_t slice_Wt = get_compile_time_arg_val(23);
-constexpr uint32_t dim = get_compile_time_arg_val(24);
+constexpr uint32_t ring_size = get_compile_time_arg_val(0);
+constexpr uint32_t cb_compute_output_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_reader_output_id = get_compile_time_arg_val(2);
+constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
+constexpr uint32_t page_size = get_compile_time_arg_val(4);
+constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(5);
+constexpr uint32_t input_num_pages = get_compile_time_arg_val(6);
+constexpr uint32_t input_batch_num_pages = get_compile_time_arg_val(7);
+constexpr uint32_t input_channel_num_pages = get_compile_time_arg_val(8);
+constexpr uint32_t output_batch_num_pages = get_compile_time_arg_val(9);
+constexpr uint32_t output_channel_num_pages = get_compile_time_arg_val(10);
+constexpr uint32_t input_tensor_B = get_compile_time_arg_val(11);
+constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(12);
+constexpr uint32_t slice_C = get_compile_time_arg_val(13);
+constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
+constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
+constexpr bool is_forward = get_compile_time_arg_val(16);
+constexpr bool is_first_device_in_direction = get_compile_time_arg_val(17);
+constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(18);
+constexpr bool do_final_reduction = get_compile_time_arg_val(19);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(20);
+constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(21);
+constexpr uint32_t dim = get_compile_time_arg_val(22);
+constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(23);
+constexpr uint32_t start_row_offset = get_compile_time_arg_val(24);
+constexpr uint32_t start_tiles_read = get_compile_time_arg_val(25);
+constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(26);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(25);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(26);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(27);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(28);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(31);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(32);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(33);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(34);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(35);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(36);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(37);
+constexpr bool is_termination_master = get_compile_time_arg_val(27);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(28);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(29);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(30);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(31);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(32);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(33);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(34);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(35);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(36);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(37);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(38);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(39);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<38>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<40>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<38 + ccl_routing_utils::num_line_unicast_args>();
-
-constexpr uint32_t input_batch_num_pages = batch_slice_num_pages * ring_size;
-constexpr uint32_t input_num_pages = input_batch_num_pages * input_tensor_B;
-constexpr uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
-constexpr uint32_t output_batch_num_pages = batch_slice_num_pages;
+    ccl_routing_utils::get_line_multicast_route_info_from_args<40 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -104,7 +101,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        38 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        40 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -252,6 +249,8 @@ void kernel_main() {
             static_cast<uint16_t>(1),  // increment 1
             static_cast<uint16_t>(0xFFFF)});
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_seminc, unicast_route_info);
+
+    constexpr uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
 
     uint32_t chunk_count = 0;
     for (uint32_t b = 0; b < input_tensor_B; b++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -28,7 +28,7 @@ void MAIN {
                 uint32_t tiles_to_read = start_tiles_to_read;
 
                 while (tiles_read < tiles_to_read) {
-                    uint32_t tiles_remaining_to_read = tiles_read - tiles_to_read;
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_wait_front(input_cb_id, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -28,7 +28,7 @@ void MAIN {
                 uint32_t tiles_to_read = start_tiles_to_read;
 
                 while (tiles_read < tiles_to_read) {
-                    uint32_t tiles_remaining_to_read = tiles_read < tiles_to_read;
+                    uint32_t tiles_remaining_to_read = tiles_read - tiles_to_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_wait_front(input_cb_id, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -13,19 +13,14 @@ void MAIN {
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t intermediate_cb = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
-    constexpr uint32_t batch_slice_num_pages = get_compile_time_arg_val(3);
-    constexpr uint32_t tile_granularity = get_compile_time_arg_val(4);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(5);
-    constexpr uint32_t num_batches = get_compile_time_arg_val(6);
-    constexpr uint32_t num_links = get_compile_time_arg_val(7);
-    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(8);
+    constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
+    constexpr uint32_t num_batches = get_compile_time_arg_val(4);
+    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_read = get_compile_time_arg_val(6);
+    constexpr uint32_t tiles_to_read = get_compile_time_arg_val(7);
 
-    uint32_t arg_idx = 0;
-    uint32_t link = get_arg_val<uint32_t>(arg_idx++);
+    constexpr uint32_t num_packets = div_up(tiles_to_read - tiles_read, tile_granularity);
 
-    uint32_t tiles_read = (link * batch_slice_num_pages / num_links);
-    uint32_t tiles_to_read = (link + 1) * batch_slice_num_pages / num_links;
-    uint32_t num_packets = div_up(tiles_to_read - tiles_read, tile_granularity);
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
 
-constexpr uint32_t div_up(uint32_t a, uint32_t b) { return (a + b - 1) / b; }
-
 namespace NAMESPACE {
 void MAIN {
     // Define all compile-time arguments at the beginning
@@ -14,35 +12,39 @@ void MAIN {
     constexpr uint32_t intermediate_cb = get_compile_time_arg_val(1);
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
-    constexpr uint32_t num_batches = get_compile_time_arg_val(4);
+    constexpr uint32_t input_tensor_B = get_compile_time_arg_val(4);
     constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(5);
-    constexpr uint32_t tiles_read = get_compile_time_arg_val(6);
-    constexpr uint32_t tiles_to_read = get_compile_time_arg_val(7);
-
-    constexpr uint32_t num_packets = div_up(tiles_to_read - tiles_read, tile_granularity);
+    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(6);
+    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(7);
+    constexpr uint32_t slice_C = get_compile_time_arg_val(8);
 
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);
 
-    for (uint32_t b = 0; b < num_batches; b++) {
+    for (uint32_t b = 0; b < input_tensor_B; b++) {
         for (uint32_t i = 0; i < num_total_reduction_steps; i++) {  // Don't reduce on the first slice
-            // Initialize binary operations - use the same constants consistently
+            for (uint32_t c = 0; c < slice_C; ++c) {
+                uint32_t tiles_read = start_tiles_read;
+                uint32_t tiles_to_read = start_tiles_to_read;
 
-            // Wait for input data once before beginning processing
-            for (uint32_t packet_id = 0; packet_id < num_packets; packet_id++) {
-                cb_wait_front(input_cb_id, tile_granularity);
-                // Reserve output space once before processing
-                cb_wait_front(intermediate_cb, tile_granularity);
-                cb_reserve_back(output_cb, tile_granularity);
-                acquire_dst();
-                for (uint32_t tile_id = 0; tile_id < tile_granularity; tile_id++) {
-                    add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
-                    pack_tile(tile_id, output_cb);
+                while (tiles_read < tiles_to_read) {
+                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+
+                    cb_wait_front(input_cb_id, tile_granularity);
+                    cb_wait_front(intermediate_cb, tile_granularity);
+                    cb_reserve_back(output_cb, tile_granularity);
+                    acquire_dst();
+                    for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
+                        add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
+                        pack_tile(tile_id, output_cb);
+                    }
+                    release_dst();
+                    cb_pop_front(input_cb_id, tile_granularity);
+                    cb_pop_front(intermediate_cb, tile_granularity);
+                    cb_push_back(output_cb, tile_granularity);
+
+                    tiles_read += num_pages_to_read;
                 }
-                release_dst();
-                cb_pop_front(input_cb_id, tile_granularity);
-                cb_pop_front(intermediate_cb, tile_granularity);
-                cb_push_back(output_cb, tile_granularity);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -13,10 +13,10 @@ void MAIN {
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t input_tensor_B = get_compile_time_arg_val(4);
-    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(5);
-    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(6);
-    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(7);
-    constexpr uint32_t slice_C = get_compile_time_arg_val(8);
+    constexpr uint32_t slice_C = get_compile_time_arg_val(5);
+    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(6);
+    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(7);
+    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(8);
 
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -28,7 +28,8 @@ void MAIN {
                 uint32_t tiles_to_read = start_tiles_to_read;
 
                 while (tiles_read < tiles_to_read) {
-                    uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                    uint32_t tiles_remaining_to_read = tiles_read < tiles_to_read;
+                    uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_wait_front(input_cb_id, tile_granularity);
                     cb_wait_front(intermediate_cb, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -201,7 +201,6 @@ void kernel_main() {
                         uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
-                        tiles_read++;
 
                         input_pages_read_in_row++;
                         if (input_pages_read_in_row == slice_Wt) {
@@ -209,6 +208,7 @@ void kernel_main() {
                             input_pages_read_in_row -= slice_Wt;
                         }
                     }
+                    tiles_read += tiles_to_read_in_current_direction;
 
                     if (do_reduce) {
                         // read next intermediate slice out of the intermediate buffer, and put it in intermediate CB

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -197,8 +197,8 @@ void kernel_main() {
                     cb_reserve_back(cb_in0, tile_granularity);
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
-                        uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                        uint32_t input_tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
+                        uint64_t noc_read_addr = get_noc_addr(input_tile_id, input_tensor_addrgen);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -141,8 +141,8 @@ void kernel_main() {
                 input_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt + batch_offset;
                 intermediate_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
             } else if constexpr (dim == 1) {
-                input_tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C + batch_offset;
-                intermediate_tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C;
+                input_tile_id_start = actual_slice_idx * slice_C * slice_Ht * slice_Wt + batch_offset;
+                intermediate_tile_id_start = actual_slice_idx * slice_C * slice_Ht * slice_Wt;
             } else {
                 ASSERT(false);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -35,6 +35,10 @@ constexpr uint32_t fuse_op = get_compile_time_arg_val(14);
 constexpr bool direction = get_compile_time_arg_val(15);
 constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
 constexpr uint32_t dim = get_compile_time_arg_val(17);
+constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(18);
+constexpr uint32_t start_row_offset = get_compile_time_arg_val(19);
+constexpr int32_t start_tiles_read = get_compile_time_arg_val(20);
+constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(21);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -47,12 +51,7 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
-    int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
-
-    constexpr uint32_t ct_idx = 18;
+    constexpr uint32_t ct_idx = 22;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset = 7;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -241,7 +241,7 @@ void kernel_main() {
                 } else if constexpr (dim == 2) {
                     intermediate_tile_id_start = actual_slice_idx * slice_Ht * slice_Wt;
                 } else if constexpr (dim == 1) {
-                    intermediate_tile_id_start = actual_slice_idx * input_channel_num_pages * slice_C;
+                    intermediate_tile_id_start = actual_slice_idx * slice_C * slice_Ht * slice_Wt;
                 } else {
                     ASSERT(false);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -44,24 +44,28 @@ constexpr uint32_t slice_Wt = get_compile_time_arg_val(14);
 constexpr bool direction = get_compile_time_arg_val(15);
 constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
 constexpr uint32_t dim = get_compile_time_arg_val(17);
+constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(18);
+constexpr uint32_t start_row_offset = get_compile_time_arg_val(19);
+constexpr uint32_t start_tiles_read = get_compile_time_arg_val(20);
+constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(21);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(18);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
+constexpr bool is_termination_master = get_compile_time_arg_val(22);
+constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(23);
+constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(24);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(25);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(26);
+constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(27);
+constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(28);
+constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(29);
+constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(30);
+constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(31);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(32);
+constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(33);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(34);
 constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
+    ccl_routing_utils::get_line_unicast_route_info_from_args<35>();
 constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<35 + ccl_routing_utils::num_line_unicast_args>();
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -76,10 +80,6 @@ void kernel_main() {
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t batch_ready_sem = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
-    int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
 
@@ -94,7 +94,7 @@ void kernel_main() {
     uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx =
-        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        35 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -39,11 +39,12 @@ void MAIN {
 
                 // Wait for input data once before beginning processing
                 while (tiles_read < tiles_to_read) {
+                    uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = 0;
                     if constexpr (direction) {
-                        num_pages_to_read = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
+                        num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                     } else {
-                        num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                        num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
                     }
                     cb_wait_front(input_cb_id, tile_granularity);
                     cb_wait_front(intermediate_cb, tile_granularity);
@@ -60,12 +61,13 @@ void MAIN {
                     tiles_read += num_pages_to_read;
 
                     // Skip the tiles going the other direction
-                    if (tiles_read < tiles_to_read) {
+                    tiles_remaining_to_read = tiles_to_read - tiles_read;
+                    if (tiles_remaining_to_read > 0) {
                         num_pages_to_read = 0;
                         if constexpr (!direction) {
-                            num_pages_to_read = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
+                            num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                         } else {
-                            num_pages_to_read = std::min(tiles_to_read - tiles_read, tile_granularity);
+                            num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
                         }
                         tiles_read += num_pages_to_read;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -26,16 +26,10 @@ void reduce_scatter_common_validates(
     TT_FATAL(
         page_size % input_tensor.buffer()->alignment() == 0,
         "reduce_scatter_minimal_async currently requires aligned pages");
-    if (topology == ::ttnn::ccl::Topology::Linear) {
-        TT_FATAL(
-            dim == 3, "reduce_scatter_minimal_async line topology implementation only supports scattering on dim 3");
-    } else if (topology == ::ttnn::ccl::Topology::Ring) {
-        TT_FATAL(
-            dim == 1 || dim == 2 || dim == 3,
-            "reduce_scatter_minimal_async ring topology implementation only supports scattering on dim 1, 2, or 3");
-    } else {
-        TT_FATAL(false, "reduce_scatter_minimal_async only supports linear or ring topology");
-    }
+
+    TT_FATAL(
+        dim == 1 || dim == 2 || dim == 3, "reduce_scatter_minimal_async only supports scattering on dim 1, 2, or 3");
+
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(
         input_tensor.buffer() != nullptr,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1253,7 +1253,9 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     input_channel_num_pages,
                     output_channel_num_pages,
                     slice_C,
-                };
+                    slice_Ht,
+                    slice_Wt,
+                    dim};
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
                 } else {
@@ -1324,7 +1326,9 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     input_channel_num_pages,
                     output_channel_num_pages,
                     slice_C,
-                };
+                    slice_Ht,
+                    slice_Wt,
+                    dim};
                 append_fabric_mux_connection_ct_args(
                     worker == 0,
                     mux_virtual_core,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1094,9 +1094,9 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         TT_FATAL(false, "reduce_scatter_minimal_async line implementation only supports scattering on dim 1, 2, or 3");
     }
 
-    const uint32_t input_tensor_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t batch_slice_num_pages = input_tensor_num_pages / ring_size / input_tensor_B;
-    const uint32_t input_batch_num_pages = input_tensor_num_pages / input_tensor_B;
+    const uint32_t input_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t batch_slice_num_pages = input_num_pages / ring_size / input_tensor_B;
+    const uint32_t input_batch_num_pages = input_num_pages / input_tensor_B;
     const uint32_t output_batch_num_pages = input_batch_num_pages / ring_size;
     const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
     const uint32_t output_channel_num_pages = output_batch_num_pages / slice_C;
@@ -1229,33 +1229,35 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
 
                 // Reader
                 std::vector<uint32_t> sender_reader_compile_args = {
-                    ring_index,              // my_chip_id
-                    input_cb_index,          // cb_input_id
-                    intermediate_cb_index,   // cb_intermediate_id
-                    reader_output_cb_index,  // cb_reader_output_id
-                    tile_granularity,        // packet_size_in_pages
-                    page_size,               // tensor0_page_size
-                    input_tensor_Wt,         // input_tensor_Wt
-                    batch_slice_num_pages,   // batch_slice_num_pages
-                    ring_size,               // ring_size
-                    input_tensor_B,          // num_batches
-                    fuse_op,                 // fused op
-                    is_forward,              // direction
-                    is_first_device_in_direction,
-                    num_targets_in_direction,
-                    do_final_reduction,
-                    sync_with_other_direction,
-                    chunks_per_sync_val,
-                    start_pages_read_in_row,
-                    start_row_offset,
-                    start_tiles_read,
-                    start_tiles_to_read,
-                    input_channel_num_pages,
-                    output_channel_num_pages,
-                    slice_C,
-                    slice_Ht,
-                    slice_Wt,
-                    dim};
+                    ring_index,                    // my_chip_id
+                    ring_size,                     // ring_size
+                    input_cb_index,                // cb_input_id
+                    intermediate_cb_index,         // cb_intermediate_id
+                    reader_output_cb_index,        // cb_reader_output_id
+                    tile_granularity,              // packet_size_in_pages
+                    page_size,                     // tensor0_page_size
+                    input_num_pages,               // input_num_pages
+                    input_batch_num_pages,         // input_batch_num_pages
+                    input_channel_num_pages,       // input_channel_num_pages
+                    output_batch_num_pages,        // output_batch_num_pages
+                    output_channel_num_pages,      // output_channel_num_pages
+                    input_tensor_B,                // input_tensor_B
+                    input_tensor_Wt,               // input_tensor_Wt
+                    slice_C,                       // slice_C
+                    slice_Ht,                      // slice_Ht
+                    slice_Wt,                      // slice_Wt
+                    fuse_op,                       // fuse_op
+                    is_forward,                    // is_forward
+                    is_first_device_in_direction,  // is_first_device_in_direction
+                    num_targets_in_direction,      // num_targets_in_direction
+                    do_final_reduction,            // do_final_reduction
+                    sync_with_other_direction,     // sync_with_other_direction
+                    chunks_per_sync_val,           // chunks_per_sync_val
+                    dim,                           // dim
+                    start_pages_read_in_row,       // start_pages_read_in_row
+                    start_row_offset,              // start_row_offset
+                    start_tiles_read,              // start_tiles_read
+                    start_tiles_to_read};          // start_tiles_to_read
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
                 } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1406,10 +1406,10 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     compute_output_cb_index,
                     tile_granularity,
                     input_tensor_B,
+                    slice_C,
                     num_total_reduction_steps,
                     start_tiles_read,
                     start_tiles_to_read,
-                    slice_C,
                 };
                 auto reduce_kernel_id = tt::tt_metal::CreateKernel(
                     program,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1095,7 +1095,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     }
 
     const uint32_t input_num_pages = input_tensor.buffer()->num_pages();
-    const uint32_t batch_slice_num_pages = input_num_pages / ring_size / input_tensor_B;
     const uint32_t input_batch_num_pages = input_num_pages / input_tensor_B;
     const uint32_t output_batch_num_pages = input_batch_num_pages / ring_size;
     const uint32_t input_channel_num_pages = input_batch_num_pages / input_tensor_C;
@@ -1234,8 +1233,8 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     input_cb_index,                // cb_input_id
                     intermediate_cb_index,         // cb_intermediate_id
                     reader_output_cb_index,        // cb_reader_output_id
-                    tile_granularity,              // packet_size_in_pages
-                    page_size,                     // tensor0_page_size
+                    tile_granularity,              // tile_granularity
+                    page_size,                     // page_size
                     input_num_pages,               // input_num_pages
                     input_batch_num_pages,         // input_batch_num_pages
                     input_channel_num_pages,       // input_channel_num_pages
@@ -1252,7 +1251,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     num_targets_in_direction,      // num_targets_in_direction
                     do_final_reduction,            // do_final_reduction
                     sync_with_other_direction,     // sync_with_other_direction
-                    chunks_per_sync_val,           // chunks_per_sync_val
+                    chunks_per_sync_val,           // chunks_per_sync
                     dim,                           // dim
                     start_pages_read_in_row,       // start_pages_read_in_row
                     start_row_offset,              // start_row_offset
@@ -1306,31 +1305,34 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     mesh_device->worker_core_from_logical_core(termination_master_logical_core);
                 // Writer
                 std::vector<uint32_t> sender_writer_compile_args = {
-                    compute_output_cb_index,    // cb_compute_output_id
-                    reader_output_cb_index,     // cb_reader_output_id
-                    tile_granularity,           // packet_size_in_pages
-                    page_size,                  // tensor0_page_size
-                    input_tensor_Wt,            // input_tensor_Wt
-                    batch_slice_num_pages,      // batch_slice_num_pages
-                    ring_size,                  // ring_size
-                    input_tensor_B,             // num_batches
-                    tiles_to_write_per_packet,  // contig_pages_advanced
-                    is_forward,                 // direction
-                    is_first_device_in_direction,
-                    num_targets_in_direction,
-                    do_final_reduction,
-                    sync_with_other_direction,
-                    chunks_per_sync_val,
-                    start_pages_read_in_row,
-                    start_row_offset,
-                    start_tiles_read,
-                    start_tiles_to_read,
-                    input_channel_num_pages,
-                    output_channel_num_pages,
-                    slice_C,
-                    slice_Ht,
-                    slice_Wt,
-                    dim};
+                    ring_size,                     // ring_size
+                    compute_output_cb_index,       // cb_compute_output_id
+                    reader_output_cb_index,        // cb_reader_output_id
+                    tile_granularity,              // tile_granularity
+                    page_size,                     // page_size
+                    tiles_to_write_per_packet,     // contig_pages_advanced
+                    input_num_pages,               // input_num_pages
+                    input_batch_num_pages,         // input_batch_num_pages
+                    input_channel_num_pages,       // input_channel_num_pages
+                    output_batch_num_pages,        // output_batch_num_pages
+                    output_channel_num_pages,      // output_channel_num_pages
+                    input_tensor_B,                // input_tensor_b
+                    input_tensor_Wt,               // input_tensor_Wt
+                    slice_C,                       // slice_C
+                    slice_Ht,                      // slice_Ht
+                    slice_Wt,                      // slice_Wt
+                    is_forward,                    // is_forward
+                    is_first_device_in_direction,  // is_first_device_in_direction
+                    num_targets_in_direction,      // num_targets_in_direction
+                    do_final_reduction,            // do_final_reduction
+                    sync_with_other_direction,     // sync_with_other_direction
+                    chunks_per_sync_val,           // chunks_per_sync
+                    dim,                           // dim
+                    start_pages_read_in_row,       // start_pages_read_in_row
+                    start_row_offset,              // start_row_offset
+                    start_tiles_read,              // start_tiles_read
+                    start_tiles_to_read,           // start_tiles_to_read
+                };
                 append_fabric_mux_connection_ct_args(
                     worker == 0,
                     mux_virtual_core,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -789,7 +789,7 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 worker_writer_sender_runtime_args[5] = semaphore.at(num_directions_per_link).address();
 
                 if (barrier_semaphore.has_value()) {
-                    worker_writer_sender_runtime_args[11] = barrier_semaphore.value().address();
+                    worker_writer_sender_runtime_args[7] = barrier_semaphore.value().address();
                 }
 
                 core_idx++;
@@ -1476,11 +1476,9 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 worker_writer_sender_runtime_args[0] = intermed.buffer()->address();
                 worker_writer_sender_runtime_args[1] = output.buffer()->address();
                 worker_writer_sender_runtime_args[4] = semaphore.at(0).address();
-                worker_writer_sender_runtime_args[5] = semaphore.at(1).address();
-                worker_writer_sender_runtime_args[6] = semaphore.at(2).address();
 
                 if (barrier_semaphore.has_value()) {
-                    worker_writer_sender_runtime_args[13] = barrier_semaphore.value().address();
+                    worker_writer_sender_runtime_args[9] = barrier_semaphore.value().address();
                 }
 
                 core_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -31,7 +31,7 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel) {
     log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
-    if (composite_common::use_composite_reduce_scatter(input_tensor, topology, dim, cluster_axis)) {
+    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
             input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27204)

### Problem description
- RS-Line previously only supported native dim 3, and we were using the composite implementation for the other dims

### What's changed
- Add native support for dims 1 and 2
- Made some small tweaks to RS-Ring so that the naming conventions match between the Ring and Line implementations, and moved a few runtime args to compile time (where applicable), no functional changes though
- There should also be some small perf improvements for any existing uses of RS-line
  - There were a bunch of repeated calculations involving division and mod within the kernel that were able to be lifted to the program factory

TLDR: RS now natively supports dims 1, 2, and 3 for both line and ring topology

### Pipelines
- APC https://github.com/tenstorrent/tt-metal/actions/runs/18453702311
- BH APC https://github.com/tenstorrent/tt-metal/actions/runs/18453704736
- Galaxy Quick https://github.com/tenstorrent/tt-metal/actions/runs/18453706407
- Galaxy Demo Tests https://github.com/tenstorrent/tt-metal/actions/runs/18453707439
- Galaxy Frequent https://github.com/tenstorrent/tt-metal/actions/runs/18453717722
- T3K Unit https://github.com/tenstorrent/tt-metal/actions/runs/18453709425
- T3K Demo https://github.com/tenstorrent/tt-metal/actions/runs/18453709949
- T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/18453715148
- BH Nightly https://github.com/tenstorrent/tt-metal/actions/runs/18453714086

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes