### PR TITLE
[ttnn] Fuse negation into compute kernel for "min" reduction OP #25547

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/reduce.h"
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/negative.h"
+#include "api/compute/tile_move_copy.h"
+
+void kernel_main() {
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+    uint32_t row_chunk = get_compile_time_arg_val(3);
+
+    // Circular buffers:
+    constexpr uint32_t cb_input = tt::CBIndex::c_0;
+    constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
+    constexpr uint32_t cb_output = tt::CBIndex::c_3;
+    constexpr uint32_t cb_acc = tt::CBIndex::c_4;
+    constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
+
+    compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+
+    constexpr int onetile = 1;
+
+    // tiles are expected to come in the N C W_skip H W_chunk order
+    // W_skip(chunk size) represents the number of tile columns whose reduction will be intertwined
+    // H W_chunk represent tiles of the chunk in row major order
+    // each column in the chunk will have its intermediate result in a separate tile of DST
+    // chunk size is calculated based on the number of available tiles in DST
+    // exmpl. Ht = 3; Wt = 4; row_chunk = 2;
+    //        tile order (H, W):
+    //        1. chunk: (0, 0); (0, 1); (1, 0); (1, 1); (2, 0); (2, 1);
+    //        2. chunk: (0, 2); (0, 3); (1, 2); (1, 3); (2, 2); (2, 3);
+    for (uint32_t nc = 0; nc < NC; ++nc) {
+        for (uint32_t wt = 0; wt < Wt; wt += row_chunk) {
+            uint32_t chunk_end = std::min(wt + row_chunk, Wt);
+            int reduce_dst_idx = 0;
+            uint32_t ntiles = chunk_end - wt;
+
+            // reduction for one chunk
+            // accumulation of Ht results in separate DST indexes
+            for (uint32_t ht = 0; ht < Ht; ++ht) {
+                reduce_dst_idx = 0;
+                tile_regs_acquire();
+                cb_wait_front(cb_input, ntiles);
+
+                reconfig_data_format_srca(cb_input);
+                copy_tile_init(cb_input);
+                negative_tile_init();
+                for (uint32_t i = 0; i < ntiles; ++i) {
+                    copy_tile(cb_input, i, i);
+                    negative_tile(i);
+                }
+
+                tile_regs_commit();
+                cb_pop_front(cb_input, chunk_end - wt);
+                cb_reserve_back(cb_ineg, ntiles);
+                tile_regs_wait();
+                pack_reconfig_data_format(cb_ineg);
+                for (uint32_t i = 0; i < ntiles; ++i) {
+                    pack_tile(i, cb_ineg);
+                }
+                tile_regs_release();
+                cb_push_back(cb_ineg, ntiles);
+
+                tile_regs_acquire();
+
+                if (ht > 0) {
+                    cb_wait_front(cb_acc, ntiles);
+                }
+
+                cb_wait_front(cb_ineg, ntiles);
+
+                if (ht > 0) {
+                    reconfig_data_format_srca(cb_acc);
+                    copy_tile_init(cb_acc);
+                    for (uint32_t i = 0; i < ntiles; ++i) {
+                        copy_tile(cb_acc, i, i);
+                    }
+                }
+                reduce_init(cb_ineg, cb_scaler, cb_acc);
+                pack_reconfig_data_format(cb_acc);
+                for (uint32_t i = 0; i < ntiles; ++i) {
+                    reduce_tile(cb_ineg, cb_scaler, i, 0, i);
+                }
+                reduce_uninit(cb_ineg);
+                tile_regs_commit();
+                cb_pop_front(cb_ineg, ntiles);
+
+                if (ht > 0) {
+                    cb_pop_front(cb_acc, ntiles);
+                }
+                cb_reserve_back(cb_acc, ntiles);
+                tile_regs_wait();
+                for (uint32_t i = 0; i < ntiles; ++i) {
+                    pack_tile(i, cb_acc);
+                }
+                tile_regs_release();
+                cb_push_back(cb_acc, ntiles);
+            }
+
+            tile_regs_acquire();
+
+            cb_wait_front(cb_acc, ntiles);
+
+            reconfig_data_format_srca(cb_acc);
+            copy_tile_init(cb_acc);
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                copy_tile(cb_acc, i, i);
+            }
+            negative_tile_init();
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                negative_tile(i);
+            }
+
+            tile_regs_commit();
+            cb_pop_front(cb_acc, ntiles);
+            cb_reserve_back(cb_output, ntiles);
+            tile_regs_wait();
+            pack_reconfig_data_format(cb_output);
+            for (uint32_t i = 0; i < ntiles; ++i) {
+                pack_tile(i, cb_output);
+            }
+            tile_regs_release();
+            cb_push_back(cb_output, ntiles);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw_neg.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/reduce.h"
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/negative.h"
+#include "api/compute/tile_move_copy.h"
+
+void kernel_main() {
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+
+    constexpr uint32_t cb_input = tt::CBIndex::c_0;
+    constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
+    constexpr uint32_t cb_output = tt::CBIndex::c_3;
+    constexpr uint32_t cb_acc = tt::CBIndex::c_4;
+    constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
+
+    compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        constexpr int onetile = 1;
+        int reduce_dst_idx = 0;
+        for (uint32_t ht = 0; ht < Ht; ++ht) {
+            // tiles are expected to be coming in in NCHW order (W-contiguous)
+            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the W-tiles in a row
+            for (uint32_t wt = 0; wt < Wt; ++wt) {
+                acquire_dst();
+                cb_wait_front(cb_input, onetile);
+                copy_tile_init(cb_input);
+                copy_tile(cb_input, 0, reduce_dst_idx);
+                negative_tile_init();
+                negative_tile(reduce_dst_idx);
+                cb_pop_front(cb_input, onetile);
+                cb_reserve_back(cb_ineg, onetile);
+                pack_tile(reduce_dst_idx, cb_ineg);
+                cb_push_back(cb_ineg, onetile);
+                release_dst();
+
+                acquire_dst();
+                if (wt > 0 || ht > 0) {
+                    cb_wait_front(cb_acc, onetile);
+                    copy_tile_init(cb_acc);
+                    copy_tile(cb_acc, 0, reduce_dst_idx);
+                }
+
+                cb_wait_front(cb_ineg, onetile);
+                reduce_init(cb_ineg, cb_scaler, cb_acc);
+                reduce_tile(cb_ineg, cb_scaler, 0, 0, reduce_dst_idx);
+                reduce_uninit();
+                cb_pop_front(cb_ineg, onetile);
+                if (wt > 0 || ht > 0) {
+                    cb_pop_front(cb_acc, onetile);
+                }
+                cb_reserve_back(cb_acc, onetile);
+                pack_tile(reduce_dst_idx, cb_acc);
+                cb_push_back(cb_acc, onetile);
+                release_dst();
+            }  // wt
+        }  // ht
+
+        acquire_dst();
+        cb_wait_front(cb_acc, onetile);
+        copy_tile_init(cb_acc);
+        copy_tile(cb_acc, 0, reduce_dst_idx);
+        negative_tile_init();
+        negative_tile(reduce_dst_idx);
+        cb_pop_front(cb_acc, onetile);
+        cb_reserve_back(cb_output, onetile);
+        pack_tile(reduce_dst_idx, cb_output);
+        cb_push_back(cb_output, onetile);
+        release_dst();
+    }  // nc
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/reduce.h"
+
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/eltwise_unary/negative.h"
+#include "api/compute/tile_move_copy.h"
+
+#include "llk_math_eltwise_binary.h"
+
+void kernel_main() {
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+
+    // Circular buffers:
+    constexpr uint32_t cb_input = tt::CBIndex::c_0;
+    constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
+    constexpr uint32_t cb_output = tt::CBIndex::c_3;
+    constexpr uint32_t cb_acc = tt::CBIndex::c_4;
+    constexpr uint32_t cb_ineg = tt::CBIndex::c_5;
+
+    compute_kernel_hw_startup(cb_input, cb_scaler, cb_output);
+
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        constexpr int onetile = 1;
+        int dst_idx = 0;
+        for (uint32_t ht = 0; ht < Ht; ++ht) {
+            // tiles are expected to be coming in in NCHW order (W-contiguous)
+            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the W-tiles in a row
+            for (uint32_t wt = 0; wt < Wt; ++wt) {
+                cb_wait_front(cb_input, onetile);
+                tile_regs_acquire();
+                copy_tile_init(cb_input);
+                copy_tile(cb_input, 0, dst_idx);
+                negative_tile_init();
+                negative_tile(dst_idx);
+                tile_regs_wait();
+                cb_pop_front(cb_input, onetile);
+                cb_reserve_back(cb_ineg, onetile);
+                tile_regs_commit();
+                pack_tile(dst_idx, cb_ineg);
+                tile_regs_release();
+                cb_push_back(cb_ineg, onetile);
+
+                tile_regs_acquire();
+                if (wt > 0) {
+                    cb_wait_front(cb_acc, onetile);
+                    copy_tile_init(cb_acc);
+                    copy_tile(cb_acc, 0, dst_idx);
+                }
+
+                cb_wait_front(cb_ineg, onetile);
+                reduce_init(cb_ineg, cb_scaler, cb_acc);
+                reduce_tile(cb_ineg, cb_scaler, 0, 0, dst_idx);
+                reduce_uninit();
+                tile_regs_wait();
+                cb_pop_front(cb_ineg, onetile);
+                if (wt > 0) {
+                    cb_pop_front(cb_acc, onetile);
+                }
+                cb_reserve_back(cb_acc, onetile);
+                tile_regs_commit();
+                pack_tile(dst_idx, cb_acc);
+                tile_regs_release();
+                cb_push_back(cb_acc, onetile);
+            }  // wt
+
+            cb_wait_front(cb_acc, onetile);
+            tile_regs_acquire();
+            copy_tile_init(cb_acc);
+            copy_tile(cb_acc, 0, dst_idx);
+            negative_tile_init();
+            negative_tile(dst_idx);
+            tile_regs_wait();
+            cb_pop_front(cb_acc, onetile);
+            cb_reserve_back(cb_output, onetile);
+            tile_regs_commit();
+            pack_tile(dst_idx, cb_output);
+            tile_regs_release();
+            cb_push_back(cb_output, onetile);
+        }  // ht
+    }  // nc
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -53,17 +53,16 @@ Tensor reduce_min(
         input.storage_type() == tt::tt_metal::StorageType::DEVICE) {
         input = ttnn::operations::unary_backward::change_layout_to_tile(input, output_mem_config);
     }
-    Tensor n_input_tensor = ttnn::neg(input, output_mem_config);
-    Tensor max_reduce = detail::reduce(
-        n_input_tensor,
+    return detail::reduce(
+        input,
         tt::tt_metal::ReduceOpMath::MAX,
         reduce_dim,
         scaler,
         output_mem_config,
         std::nullopt,
-        compute_kernel_config);
-    Tensor min_tensor = ttnn::neg(max_reduce, output_mem_config);
-    return min_tensor;
+        compute_kernel_config,
+        std::nullopt,
+        true);
 }
 
 Tensor reduce(
@@ -74,7 +73,8 @@ Tensor reduce(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
+    bool negate) {
     if (reduce_math == tt::tt_metal::ReduceOpMath::MIN) {
         return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config);
     }
@@ -109,7 +109,8 @@ Tensor reduce(
             output_mem_config,
             output_dtype.value_or(input_tensor.dtype()),
             config,
-            sub_core_grids);
+            sub_core_grids,
+            negate);
 
         return ttnn::prim::reduce(
             output_tensor,
@@ -119,7 +120,8 @@ Tensor reduce(
             output_mem_config,
             output_dtype.value_or(input_tensor.dtype()),
             config,
-            sub_core_grids);
+            sub_core_grids,
+            negate);
     }
     return ttnn::prim::reduce(
         tilized_input,
@@ -129,7 +131,8 @@ Tensor reduce(
         output_mem_config,
         output_dtype.value_or(input_tensor.dtype()),
         config,
-        sub_core_grids);
+        sub_core_grids,
+        negate);
 }
 
 }  // namespace ttnn::operations::reduction::generic::detail

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -22,7 +22,8 @@ Tensor reduce(
     const tt::tt_metal::MemoryConfig& output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
+    bool negate = false);
 
 }  // namespace ttnn::operations::reduction::generic::detail
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -96,6 +96,7 @@ tt::stl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
         operation_attributes.output_dtype,
         operation_attributes.compute_kernel_config,
         operation_attributes.sub_core_grids,
+        operation_attributes.negate,
         program_factory.index(),
         tensor_args.dtype(),
         tensor_args.memory_config(),
@@ -110,7 +111,8 @@ ttnn::Tensor reduce(
     const MemoryConfig& output_mem_config,
     const std::optional<DataType>& output_dtype,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool negate) {
     return ttnn::device_operation::launch<ReduceDeviceOperation>(
         ReduceParams{
             reduce_math,
@@ -119,7 +121,8 @@ ttnn::Tensor reduce(
             output_mem_config,
             output_dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
-            sub_core_grids},
+            sub_core_grids,
+            negate},
         input_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -49,6 +49,7 @@ ttnn::Tensor reduce(
     const MemoryConfig& output_mem_config,
     const std::optional<DataType>& output_dtype,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    const std::optional<CoreRangeSet>& sub_core_grids);
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool negate = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -20,6 +20,7 @@ struct ReduceParams {
     tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
     ttnn::DeviceComputeKernelConfig compute_kernel_config;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+    bool negate{false};
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket

#25547

Do not merge (yet).

### Problem description
Operation `ttnn.min` is implemented as composed op around `ttnn.max`: `min(T)=neg(max(neg(T)))`, thus is significantly slower than `ttnn.max`. 

### What's changed
Negation of output tiles has been fused into `reduce_*` kernels, effectively changing this operation to: `min(T)=max_and_neg(neg(T))`. Sadly, no performance improvement (except for queuing part).

To my surprise it does not seem to impact `ttnn.min()` performance in any meaningful way. More details on corresponding issue.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212806203871136