### PR TITLE
Use Module base class in tt_dit layer modules

### DIFF
--- a/models/experimental/tt_dit/layers/conv2d.py
+++ b/models/experimental/tt_dit/layers/conv2d.py
@@ -2,13 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
 import ttnn
+
 from ..parallel.config import vae_all_gather
-from ..utils.tensor import bf16_tensor_host
+from .module import Module, Parameter
 
 
 # TODO: Add support for coll and row parallel conv2d
-class Conv2d:
+class Conv2d(Module):
     """
     Conv2d with support for tensor parallelism. Data and Seqence Parallelism TBD.
 
@@ -94,6 +96,7 @@ class Conv2d:
         Returns:
             Conv2d layer.
         """
+        super().__init__()
 
         self.in_channels = in_channels or torch_ref.in_channels
         self.out_channels = out_channels or torch_ref.out_channels
@@ -101,14 +104,28 @@ class Conv2d:
         self.stride = stride or torch_ref.stride
         self.padding = padding or torch_ref.padding
         self.dilation = dilation or torch_ref.dilation
-        self.bias = None
-        self.weight = None
         self.mesh_device = mesh_device
         self.mesh_axis = mesh_axis
         self.ccl_manager = ccl_manager
 
+        self.weight = Parameter(
+            total_shape=[self.out_channels, self.in_channels, *self.kernel_size],
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            mesh_axes=[mesh_axis, None, None, None],
+            on_host=True,
+        )
+
+        self.bias = Parameter(
+            total_shape=[1, 1, 1, self.out_channels],
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            mesh_axes=[None, None, None, mesh_axis],
+            on_host=True,
+        )
+
         if torch_ref is not None:
-            self.load_state_dict(torch_ref.state_dict())
+            self.load_torch_state_dict(torch_ref.state_dict())
 
     @classmethod
     def from_torch(cls, torch_ref, mesh_device, mesh_axis, ccl_manager):
@@ -120,27 +137,9 @@ class Conv2d:
         )
         return layer
 
-    def load_state_dict(self, state_dict):
-        weight = state_dict["weight"]
-        bias = state_dict.get("bias", None)
-        self.weight = bf16_tensor_host(
-            weight,
-            device=self.mesh_device,
-            mesh_axis=self.mesh_axis,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            shard_dim=0 if self.mesh_axis is not None else None,
-        )
-        self.bias = (
-            bf16_tensor_host(
-                bias.reshape((1, 1, 1, -1)),
-                device=self.mesh_device,
-                mesh_axis=self.mesh_axis,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                shard_dim=-1 if self.mesh_axis is not None else None,
-            )
-            if bias is not None
-            else None
-        )
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "bias" in state:
+            state["bias"] = state["bias"].reshape([1, 1, 1, -1])
 
     def is_sharded_tensor(self, x):
         """
@@ -149,7 +148,7 @@ class Conv2d:
         """
         return x.shape[3] < self.in_channels
 
-    def __call__(self, x):
+    def forward(self, x: ttnn.Tensor, /) -> ttnn.Tensor:
         """
         Gather the tensor if it is sharded, since we only support TP. Will be extended to support DP and SP as needed.
         Data is left in the state of the final compute. The burden is on the next layer to prepare its input as needed.
@@ -166,10 +165,10 @@ class Conv2d:
 
         output_tensor, [_out_height, _out_width] = ttnn.conv2d(
             input_tensor=x,
-            weight_tensor=self.weight,
-            bias_tensor=self.bias,
+            weight_tensor=self.weight.data,
+            bias_tensor=self.bias.data if self.bias is not None else None,
             in_channels=c,
-            out_channels=self.weight.shape[0],
+            out_channels=self.weight.data.shape[0],
             device=self.mesh_device,
             kernel_size=self.kernel_size,
             stride=self.stride,

--- a/models/experimental/tt_dit/layers/embeddings.py
+++ b/models/experimental/tt_dit/layers/embeddings.py
@@ -3,17 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+
 import torch
 import ttnn
 
-from ..utils.tensor import bf16_tensor, bf16_tensor_2dshard
-from ..utils.substate import substate
+from ..utils.tensor import bf16_tensor
 from .linear import Linear
+from .module import Module, Parameter
 
 
 # Helper classes for SD35Transformer2DModel
-class TimestepEmbedding:
+class TimestepEmbedding(Module):
     def __init__(self, in_channels, time_embed_dim, mesh_device=None):
+        super().__init__()
+
         self.in_channels = in_channels
         self.time_embed_dim = time_embed_dim
         self.mesh_device = mesh_device
@@ -21,34 +24,16 @@ class TimestepEmbedding:
         self.linear_1 = Linear(in_channels, time_embed_dim, bias=True, mesh_device=mesh_device)
         self.linear_2 = Linear(time_embed_dim, time_embed_dim, bias=True, mesh_device=mesh_device)
 
-    def to_cached_state_dict(self, path_prefix):
-        linear_1_cache = self.linear_1.to_cached_state_dict(path_prefix + "linear_1.")
-        linear_2_cache = self.linear_2.to_cached_state_dict(path_prefix + "linear_2.")
-        cache_dict = {}
-        # Add linear_1. prefix to all keys from linear_1_cache
-        for key, value in linear_1_cache.items():
-            cache_dict[f"linear_1.{key}"] = value
-        # Add linear_2. prefix to all keys from linear_2_cache
-        for key, value in linear_2_cache.items():
-            cache_dict[f"linear_2.{key}"] = value
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.linear_1.from_cached_state_dict(substate(cache_dict, "linear_1"))
-        self.linear_2.from_cached_state_dict(substate(cache_dict, "linear_2"))
-
-    def load_state_dict(self, state_dict):
-        self.linear_1.load_state_dict(substate(state_dict, "linear_1"))
-        self.linear_2.load_state_dict(substate(state_dict, "linear_2"))
-
-    def __call__(self, x):
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = self.linear_1(x)
         x = ttnn.silu(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return self.linear_2(x)
 
 
-class PixartAlphaTextProjection:
+class PixartAlphaTextProjection(Module):
     def __init__(self, in_features, hidden_size, mesh_device=None):
+        super().__init__()
+
         self.in_features = in_features
         self.hidden_size = hidden_size
         self.mesh_device = mesh_device
@@ -56,34 +41,16 @@ class PixartAlphaTextProjection:
         self.linear_1 = Linear(in_features, hidden_size, bias=True, mesh_device=mesh_device)
         self.linear_2 = Linear(hidden_size, hidden_size, bias=True, mesh_device=mesh_device)
 
-    def to_cached_state_dict(self, path_prefix):
-        linear_1_cache = self.linear_1.to_cached_state_dict(path_prefix + "linear_1.")
-        linear_2_cache = self.linear_2.to_cached_state_dict(path_prefix + "linear_2.")
-        cache_dict = {}
-        # Add linear_1. prefix to all keys from linear_1_cache
-        for key, value in linear_1_cache.items():
-            cache_dict[f"linear_1.{key}"] = value
-        # Add linear_2. prefix to all keys from linear_2_cache
-        for key, value in linear_2_cache.items():
-            cache_dict[f"linear_2.{key}"] = value
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.linear_1.from_cached_state_dict(substate(cache_dict, "linear_1"))
-        self.linear_2.from_cached_state_dict(substate(cache_dict, "linear_2"))
-
-    def load_state_dict(self, state_dict):
-        self.linear_1.load_state_dict(substate(state_dict, "linear_1"))
-        self.linear_2.load_state_dict(substate(state_dict, "linear_2"))
-
-    def __call__(self, x):
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = self.linear_1(x)
         x = ttnn.silu(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return self.linear_2(x)
 
 
-class SD35CombinedTimestepTextProjEmbeddings:
+class SD35CombinedTimestepTextProjEmbeddings(Module):
     def __init__(self, embedding_dim, pooled_projection_dim, mesh_device=None):
+        super().__init__()
+
         self.embedding_dim = embedding_dim
         self.pooled_projection_dim = pooled_projection_dim
         self.mesh_device = mesh_device
@@ -92,28 +59,6 @@ class SD35CombinedTimestepTextProjEmbeddings:
         self.text_embedder = PixartAlphaTextProjection(pooled_projection_dim, embedding_dim, mesh_device=mesh_device)
 
         self.time_proj_factor = self._create_time_proj_factor(256)
-
-    def to_cached_state_dict(self, path_prefix):
-        timestep_embedder_cache = self.timestep_embedder.to_cached_state_dict(path_prefix + "timestep_embedder.")
-        text_embedder_cache = self.text_embedder.to_cached_state_dict(path_prefix + "text_embedder.")
-
-        cache_dict = {}
-        # Add timestep_embedder. prefix to all keys from timestep_embedder_cache
-        for key, value in timestep_embedder_cache.items():
-            cache_dict[f"timestep_embedder.{key}"] = value
-        # Add text_embedder. prefix to all keys from text_embedder_cache
-        for key, value in text_embedder_cache.items():
-            cache_dict[f"text_embedder.{key}"] = value
-
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.timestep_embedder.from_cached_state_dict(substate(cache_dict, "timestep_embedder"))
-        self.text_embedder.from_cached_state_dict(substate(cache_dict, "text_embedder"))
-
-    def load_state_dict(self, state_dict):
-        self.timestep_embedder.load_state_dict(substate(state_dict, "timestep_embedder"))
-        self.text_embedder.load_state_dict(substate(state_dict, "text_embedder"))
 
     def _create_time_proj_factor(self, num_channels) -> ttnn.Tensor:
         assert num_channels % 2 == 0
@@ -127,7 +72,7 @@ class SD35CombinedTimestepTextProjEmbeddings:
 
         return ttnn.unsqueeze_to_4D(bf16_tensor(factor, device=self.mesh_device))
 
-    def __call__(self, timestep, pooled_projection):
+    def forward(self, timestep: ttnn.Tensor, pooled_projection: ttnn.Tensor) -> ttnn.Tensor:
         # Time projection (sinusoidal embedding)
         emb = timestep * self.time_proj_factor
         c = ttnn.cos(emb)
@@ -138,7 +83,7 @@ class SD35CombinedTimestepTextProjEmbeddings:
         return timesteps_emb + text_emb
 
 
-class PatchEmbed:
+class PatchEmbed(Module):
     """
     Patch embedding with unfolded conv2d implementation.
     Converts input images to patch embeddings with positional encoding.
@@ -156,6 +101,8 @@ class PatchEmbed:
         sp_mesh_axis,
         mesh_device=None,
     ):
+        super().__init__()
+
         self.height = height // patch_size
         self.width = width // patch_size
         self.patch_size = patch_size
@@ -165,12 +112,6 @@ class PatchEmbed:
         self.mesh_device = mesh_device
         self.tp_mesh_axis = tp_mesh_axis
         self.sp_mesh_axis = sp_mesh_axis
-
-        # Conv2d projection weights (unfolded)
-        # Weight shape: (kernel_h * kernel_w * in_channels, out_channels)
-        conv_in_features = patch_size * patch_size * in_channels
-        self.proj_weight = None
-        self.proj_bias = None
 
         # Position embeddings
         self.pos_embed = None
@@ -184,6 +125,20 @@ class PatchEmbed:
             packer_l1_acc=False,
         )
 
+        self.proj_weight = Parameter(
+            total_shape=[in_channels * patch_size * patch_size, embed_dim],
+            mesh_axes=[None, tp_mesh_axis],
+            device=mesh_device,
+        )
+        self.proj_bias = Parameter(
+            total_shape=[1, 1, 1, embed_dim], mesh_axes=[None, None, None, tp_mesh_axis], device=mesh_device
+        )
+        self.pos_embed = Parameter(
+            total_shape=[1, self.height * self.width, embed_dim],
+            device=mesh_device,
+            mesh_axes=[None, sp_mesh_axis, tp_mesh_axis],
+        )
+
     def _cropped_pos_embed(self, pos_embed_param):
         pos_embed_max_size = math.isqrt(pos_embed_param.shape[1])
         top = (pos_embed_max_size - self.height) // 2
@@ -193,68 +148,23 @@ class PatchEmbed:
         spatial_pos_embed = spatial_pos_embed[:, top : top + self.height, left : left + self.width, :]
         return spatial_pos_embed.reshape([1, -1, spatial_pos_embed.shape[-1]])
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        conv_weight = state.pop("proj.weight", None)
+        if conv_weight is not None:
+            # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
+            out_channels, in_c, kh, kw = conv_weight.shape
+            conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
+            conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
 
-        # Cache proj_weight
-        proj_weight_path = path_prefix + "proj_weight" + path_suffix
-        ttnn.dump_tensor(proj_weight_path, self.proj_weight)
-        cache_dict["proj_weight"] = proj_weight_path
+            state["proj_weight"] = conv_weight
 
-        # Cache proj_bias if it exists
-        if self.proj_bias is not None:
-            proj_bias_path = path_prefix + "proj_bias" + path_suffix
-            ttnn.dump_tensor(proj_bias_path, self.proj_bias)
-            cache_dict["proj_bias"] = proj_bias_path
+        if "proj.bias" in state:
+            state["proj_bias"] = state.pop("proj.bias").reshape(1, 1, 1, -1)
 
-        # Cache pos_embed
-        pos_embed_path = path_prefix + "pos_embed" + path_suffix
-        ttnn.dump_tensor(pos_embed_path, self.pos_embed)
-        cache_dict["pos_embed"] = pos_embed_path
+        if "pos_embed" in state:
+            state["pos_embed"] = self._cropped_pos_embed(state.pop("pos_embed"))
 
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.proj_weight = ttnn.load_tensor(cache_dict["proj_weight"], device=self.mesh_device)
-        if "proj_bias" in cache_dict:
-            self.proj_bias = ttnn.load_tensor(cache_dict["proj_bias"], device=self.mesh_device)
-        self.pos_embed = ttnn.load_tensor(cache_dict["pos_embed"], device=self.mesh_device)
-
-    def load_state_dict(self, state_dict):
-        """Load weights from PyTorch state dict."""
-        # Load conv2d projection weights
-        conv_weight = state_dict["proj.weight"]
-        # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
-        out_channels, in_c, kh, kw = conv_weight.shape
-        conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
-        conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
-
-        self.proj_weight = bf16_tensor(
-            conv_weight,
-            device=self.mesh_device,
-            mesh_axis=self.tp_mesh_axis,
-            shard_dim=1,
-        )
-
-        if "proj.bias" in state_dict:
-            bias = state_dict["proj.bias"].reshape(1, 1, 1, -1)
-            self.proj_bias = bf16_tensor(
-                bias,
-                device=self.mesh_device,
-                mesh_axis=self.tp_mesh_axis,
-                shard_dim=3,
-            )
-
-        # Load position embeddings
-        pos_embed_param = state_dict["pos_embed"]
-        cropped_pos_embed = self._cropped_pos_embed(pos_embed_param)
-        self.pos_embed = bf16_tensor_2dshard(
-            cropped_pos_embed,
-            device=self.mesh_device,
-            shard_mapping={self.sp_mesh_axis: 1, self.tp_mesh_axis: 2},
-        )
-
-    def __call__(self, latent):
+    def forward(self, latent: ttnn.Tensor) -> ttnn.Tensor:
         """
         Forward pass: apply patch projection and add position embeddings.
 
@@ -270,7 +180,7 @@ class PatchEmbed:
 
         # Apply unfolded conv2d projection
         latent = self._unfold_conv2d(latent)
-        return latent + self.pos_embed
+        return latent + self.pos_embed.data
 
     def _unfold_conv2d(self, x):
         """
@@ -304,8 +214,8 @@ class PatchEmbed:
         # Apply linear projection (equivalent to conv2d)
         out = ttnn.linear(
             x,
-            self.proj_weight,
-            bias=self.proj_bias,
+            self.proj_weight.data,
+            bias=self.proj_bias.data,
             dtype=ttnn.bfloat16,
             compute_kernel_config=self.compute_kernel_config,
         )
@@ -314,7 +224,7 @@ class PatchEmbed:
         return out
 
 
-class MochiPatchEmbed:
+class MochiPatchEmbed(Module):
     def __init__(
         self,
         patch_size,
@@ -322,16 +232,12 @@ class MochiPatchEmbed:
         embed_dim,
         mesh_device=None,
     ):
+        super().__init__()
+
         self.patch_size = patch_size
         self.in_channels = in_channels
         self.embed_dim = embed_dim
         self.mesh_device = mesh_device
-
-        # Conv2d projection weights (unfolded)
-        # Weight shape: (kernel_h * kernel_w * in_channels, out_channels)
-        conv_in_features = patch_size * patch_size * in_channels
-        self.proj_weight = None
-        self.proj_bias = None
 
         # Compute kernel config for linear operations
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
@@ -342,49 +248,24 @@ class MochiPatchEmbed:
             packer_l1_acc=False,
         )
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+        # Conv2d projection weights (unfolded)
+        self.proj_weight = Parameter(total_shape=[in_channels * patch_size * patch_size, embed_dim], device=mesh_device)
+        self.proj_bias = Parameter(total_shape=[1, 1, 1, embed_dim], device=mesh_device)
 
-        # Cache proj_weight
-        proj_weight_path = path_prefix + "proj_weight" + path_suffix
-        ttnn.dump_tensor(proj_weight_path, self.proj_weight)
-        cache_dict["proj_weight"] = proj_weight_path
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        conv_weight = state.pop("proj.weight", None)
+        if conv_weight is not None:
+            # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
+            out_channels, in_c, kh, kw = conv_weight.shape
+            conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
+            conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
+            state["proj_weight"] = conv_weight
 
-        # Cache proj_bias if it exists
-        if self.proj_bias is not None:
-            proj_bias_path = path_prefix + "proj_bias" + path_suffix
-            ttnn.dump_tensor(proj_bias_path, self.proj_bias)
-            cache_dict["proj_bias"] = proj_bias_path
+        conv_bias = state.pop("proj.bias", None)
+        if conv_bias is not None:
+            state["proj_bias"] = conv_bias.reshape([1, 1, 1, -1])
 
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.proj_weight = ttnn.load_tensor(cache_dict["proj_weight"], device=self.mesh_device)
-        if "proj_bias" in cache_dict:
-            self.proj_bias = ttnn.load_tensor(cache_dict["proj_bias"], device=self.mesh_device)
-
-    def load_state_dict(self, state_dict):
-        """Load weights from PyTorch state dict."""
-        # Load conv2d projection weights
-        conv_weight = state_dict["proj.weight"]
-        # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
-        out_channels, in_c, kh, kw = conv_weight.shape
-        conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
-        conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
-
-        self.proj_weight = bf16_tensor(
-            conv_weight,
-            device=self.mesh_device,
-        )
-
-        if "proj.bias" in state_dict:
-            bias = state_dict["proj.bias"].reshape(1, 1, 1, -1)
-            self.proj_bias = bf16_tensor(
-                bias,
-                device=self.mesh_device,
-            )
-
-    def __call__(self, latent_1BNI):
+    def forward(self, latent_1BNI: ttnn.Tensor) -> ttnn.Tensor:
         """
         latent_1BNI: (1, batch, T * patches_height * patches_width, patch_size * patch_size * in_channels
 
@@ -395,8 +276,8 @@ class MochiPatchEmbed:
         # Apply unfolded conv2d projection
         latent_1BND = ttnn.linear(
             latent_1BNI,
-            self.proj_weight,
-            bias=self.proj_bias,
+            self.proj_weight.data,
+            bias=self.proj_bias.data,
             dtype=ttnn.bfloat16,
             compute_kernel_config=self.compute_kernel_config,
         )
@@ -404,7 +285,7 @@ class MochiPatchEmbed:
         return latent_1BND
 
 
-class WanPatchEmbed:
+class WanPatchEmbed(Module):
     def __init__(
         self,
         patch_size,
@@ -414,14 +295,14 @@ class WanPatchEmbed:
         init=False,
         tp_mesh_axis=None,
     ):
+        super().__init__()
+
         self.patch_size = patch_size
         self.in_channels = in_channels
         self.embed_dim = embed_dim
         self.mesh_device = mesh_device
         # Optionally output tensor parallel
         self.tp_mesh_axis = tp_mesh_axis
-        self.proj_weight = None
-        self.proj_bias = None
 
         assert not init, "WanPatchEmbed does not support initialization"
 
@@ -434,59 +315,37 @@ class WanPatchEmbed:
             packer_l1_acc=False,
         )
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
-
-        # Cache proj_weight
-        proj_weight_path = path_prefix + "weight" + path_suffix
-        ttnn.dump_tensor(proj_weight_path, self.proj_weight)
-        cache_dict["weight"] = proj_weight_path
-
-        # Cache proj_bias if it exists
-        if self.proj_bias is not None:
-            proj_bias_path = path_prefix + "bias" + path_suffix
-            ttnn.dump_tensor(proj_bias_path, self.proj_bias)
-            cache_dict["bias"] = proj_bias_path
-
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        self.proj_weight = ttnn.load_tensor(cache_dict["weight"], device=self.mesh_device)
-        if "bias" in cache_dict:
-            self.proj_bias = ttnn.load_tensor(cache_dict["bias"], device=self.mesh_device)
-
-    def load_state_dict(self, state_dict):
-        """Load weights from PyTorch state dict."""
-        # Load conv2d projection weights
-        conv_weight = state_dict["weight"]
-        # Convert from (out_channels, in_channels, kt, kh, kw) to (kt*kh*kw*in_channels, out_channels)
-        out_channels, in_c, kt, kh, kw = conv_weight.shape
-        assert out_channels == self.embed_dim, "Output channels do not match embed_dim"
-        assert in_c == self.in_channels, "Input channels do not match in_channels"
-        assert kt == self.patch_size[0], "Patch size does not match patch_size[0]"
-        assert kh == self.patch_size[1], "Patch size does not match patch_size[1]"
-        assert kw == self.patch_size[2], "Patch size does not match patch_size[2]"
-
-        conv_weight = conv_weight.permute(2, 3, 4, 1, 0)  # (kt, kh, kw, in_c, out_channels)
-        conv_weight = conv_weight.reshape(kt * kh * kw * in_c, out_channels)
-
-        self.proj_weight = bf16_tensor(
-            conv_weight,
-            device=self.mesh_device,
-            mesh_axis=self.tp_mesh_axis,
-            shard_dim=-1,
+        self.proj_weight = Parameter(
+            total_shape=[in_channels * patch_size[0] * patch_size[1] * patch_size[2], embed_dim],
+            device=mesh_device,
+            mesh_axes=[None, self.tp_mesh_axis],
+        )
+        self.proj_bias = Parameter(
+            total_shape=[1, embed_dim],
+            device=mesh_device,
+            mesh_axes=[None, self.tp_mesh_axis],
         )
 
-        if "bias" in state_dict:
-            bias = state_dict["bias"].reshape(1, -1)
-            self.proj_bias = bf16_tensor(
-                bias,
-                device=self.mesh_device,
-                mesh_axis=self.tp_mesh_axis,
-                shard_dim=-1,
-            )
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        conv_weight = state.pop("weight", None)
+        if conv_weight is not None:
+            out_channels, in_c, kt, kh, kw = conv_weight.shape
+            assert out_channels == self.embed_dim, "Output channels do not match embed_dim"
+            assert in_c == self.in_channels, "Input channels do not match in_channels"
+            assert kt == self.patch_size[0], "Patch size does not match patch_size[0]"
+            assert kh == self.patch_size[1], "Patch size does not match patch_size[1]"
+            assert kw == self.patch_size[2], "Patch size does not match patch_size[2]"
 
-    def __call__(self, latent_1BNI):
+            conv_weight = conv_weight.permute(2, 3, 4, 1, 0)  # (kt, kh, kw, in_c, out_channels)
+            conv_weight = conv_weight.reshape(kt * kh * kw * in_c, out_channels)
+
+            state["proj_weight"] = conv_weight
+
+        conv_weight = state.pop("bias", None)
+        if conv_weight is not None:
+            state["proj_bias"] = conv_weight.reshape(1, -1)
+
+    def forward(self, latent_1BNI: ttnn.Tensor) -> ttnn.Tensor:
         """
         latent_1BNI: (1, batch, pt * ph * pw, kt * kh * kw * in_channels
 
@@ -497,8 +356,8 @@ class WanPatchEmbed:
         # Apply unfolded conv2d projection
         latent_1BND = ttnn.linear(
             latent_1BNI,
-            self.proj_weight,
-            bias=self.proj_bias,
+            self.proj_weight.data,
+            bias=self.proj_bias.data,
             dtype=ttnn.bfloat16,
             compute_kernel_config=self.compute_kernel_config,
         )

--- a/models/experimental/tt_dit/layers/module.py
+++ b/models/experimental/tt_dit/layers/module.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple, overload
+
+import ttnn
+from typing_extensions import deprecated
+
+from ..utils import tensor
+from ..utils.substate import pop_substate
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping, MutableSequence, Sequence
+    from typing import Any
+
+    import torch
+
+
+class IncompatibleKeys(NamedTuple):
+    missing_keys: list[str]
+    unexpected_keys: list[str]
+
+
+class ParameterLoadingError(Exception):
+    pass
+
+
+class Module(ABC):
+    def __init__(self) -> None:
+        self._children = {}
+        self._parameters = {}
+
+    def named_children(self) -> Iterator[tuple[str, Module]]:
+        yield from self._children.items()
+
+    def named_parameters(self) -> Iterator[tuple[str, Parameter]]:
+        yield from self._parameters.items()
+
+    def __setattr__(self, name: str, value: Any) -> None:  # noqa: ANN401
+        super().__setattr__(name, value)
+
+        if name in ("_children", "_parameters"):
+            return
+
+        children = self.__dict__.get("_children")
+        parameters = self.__dict__.get("_parameters")
+
+        if isinstance(value, Module):
+            if children is None:
+                msg = "cannot assign child module before Module.__init__() call"
+                raise AttributeError(msg)
+            self._children[name] = value
+        elif isinstance(value, Parameter):
+            if parameters is None:
+                msg = "cannot assign parameter before Module.__init__() call"
+                raise AttributeError(msg)
+            self._parameters[name] = value
+        else:
+            if children is not None:
+                children.pop(name, None)
+            if parameters is not None:
+                parameters.pop(name, None)
+
+    def __delattr__(self, name: str) -> None:
+        children = self.__dict__.get("_children")
+        parameters = self.__dict__.get("_parameters")
+
+        if children is not None:
+            children.pop(name, None)
+        if parameters is not None:
+            parameters.pop(name, None)
+
+        super().__delattr__(name)
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:  # noqa: B027
+        """Prepare a PyTorch `state_dict` in place before loading.
+
+        Override this method to adjust entries before loading them into submodules and parameters.
+
+        This method should modify `state` in place and, where possible, avoid raising exceptions for
+        missing keys; skip them instead. This way, missing keys can be collected and returned by
+        `load_torch_state_dict`.
+        """
+
+    def _load_torch_state_dict_inner(
+        self,
+        state_dict: Mapping[str, torch.Tensor],
+        *,
+        module_key_prefix: str,
+        missing_keys: MutableSequence[str],
+        unexpected_keys: MutableSequence[str],
+    ) -> None:
+        state_dict = dict(state_dict)
+        self._prepare_torch_state(state_dict)
+
+        for name, child in self.named_children():
+            child_state = pop_substate(state_dict, name)
+
+            child._load_torch_state_dict_inner(  # noqa: SLF001
+                child_state,
+                module_key_prefix=f"{module_key_prefix}{name}.",
+                missing_keys=missing_keys,
+                unexpected_keys=unexpected_keys,
+            )
+
+        for name, parameter in self.named_parameters():
+            if name in state_dict:
+                try:
+                    parameter.load_torch_tensor(state_dict.pop(name))
+                except ParameterLoadingError as err:
+                    msg = f"while loading '{module_key_prefix}{name}': {err}"
+                    raise ParameterLoadingError(msg) from err
+            else:
+                missing_keys.append(f"{module_key_prefix}{name}")
+
+        for name in state_dict:
+            unexpected_keys.append(f"{module_key_prefix}{name}")
+
+    def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
+        missing_keys = []
+        unexpected_keys = []
+
+        self._load_torch_state_dict_inner(
+            state_dict, module_key_prefix="", missing_keys=missing_keys, unexpected_keys=unexpected_keys
+        )
+
+        if strict and (missing_keys or unexpected_keys):
+            parts = []
+            if missing_keys:
+                parts.append("missing Torch state keys: " + ", ".join(missing_keys))
+            if unexpected_keys:
+                parts.append("unexpected Torch state keys: " + ", ".join(unexpected_keys))
+            raise ValueError("; ".join(parts))
+
+        return IncompatibleKeys(missing_keys, unexpected_keys)
+
+    @deprecated("Use load_torch_state_dict instead")
+    def load_state_dict(self, state_dict: Mapping[str, torch.Tensor]) -> None:
+        self.load_torch_state_dict(state_dict)
+
+    def save(self, directory: str | Path, /) -> None:
+        directory = Path(directory)
+        directory.mkdir(exist_ok=True)
+
+        for name, child in self.named_children():
+            child.save(directory / name)
+
+        for name, parameter in self.named_parameters():
+            parameter.save(directory / f"{name}.tensorbin")
+
+    def load(self, directory: str | Path, /) -> None:
+        directory = Path(directory)
+        if not directory.exists():
+            msg = f"directory does not exist: {directory}"
+            raise RuntimeError(msg)
+
+        for name, child in self.named_children():
+            child.load(directory / name)
+
+        for name, parameter in self.named_parameters():
+            path = directory / f"{name}.tensorbin"
+            try:
+                parameter.load(path)
+            except ParameterLoadingError as err:
+                msg = f"{err} while loading '{path}'"
+                raise ParameterLoadingError(msg) from err
+
+    def to_cached_state_dict(self, path_prefix: str) -> dict[str, str]:
+        cache_dict = {}
+
+        for name, child in self.named_children():
+            child_cache_dict = child.to_cached_state_dict(f"{path_prefix}{name}.")
+            cache_dict.update({f"{name}.{k}": v for k, v in child_cache_dict.items()})
+
+        for name, parameter in self.named_parameters():
+            cache_dict[name] = path = f"{path_prefix}{name}.tensorbin"
+            parameter.save(path)
+
+        return cache_dict
+
+    def from_cached_state_dict(self, cache_dict: Mapping[str, str]) -> None:
+        def substate(state: Mapping[str, str], key: str) -> dict[str, str]:
+            prefix = f"{key}."
+            return {k.removeprefix(prefix): v for k, v in state.items() if k.startswith(prefix)}
+
+        for name, child in self.named_children():
+            child.from_cached_state_dict(substate(cache_dict, name))
+
+        for name, parameter in self.named_parameters():
+            path = cache_dict[name]
+            try:
+                parameter.load(path)
+            except ParameterLoadingError as err:
+                msg = f"{err} while loading '{path}'"
+                raise ParameterLoadingError(msg) from err
+
+    @abstractmethod
+    def forward(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        pass
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        return self.forward(*args, **kwargs)
+
+
+class ModuleList(Module):
+    def __init__(self, modules: Iterable[Module] = ()) -> None:
+        super().__init__()
+
+        for i, m in enumerate(modules):
+            self._children[str(i)] = m
+
+    def __len__(self) -> int:
+        return len(self._children)
+
+    @overload
+    def __getitem__(self, key: int) -> Module:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> ModuleList:
+        ...
+
+    def __getitem__(self, key: int | slice) -> Module | ModuleList:
+        n = len(self._children)
+
+        if isinstance(key, slice):
+            start, stop, step = key.indices(n)
+            return ModuleList(self._children[str(i)] for i in range(start, stop, step))
+
+        if isinstance(key, int):
+            if key < 0:
+                key += n
+            if key < 0 or key >= n:
+                raise IndexError
+            return self._children[str(key)]
+
+        msg = f"expected int or slice argument, got {key}"
+        raise ValueError(msg)
+
+
+class Parameter:
+    def __init__(
+        self,
+        *,
+        total_shape: Sequence[int],
+        device: ttnn.MeshDevice,
+        layout: ttnn.Layout = ttnn.Layout.TILE,
+        dtype: ttnn.DataType = ttnn.bfloat16,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+        pad_value: float | None = None,
+        mesh_axes: Sequence[int | None] | None = None,
+        on_host: bool = False,
+    ) -> None:
+        total_shape = tuple(total_shape)
+        mesh_axes = tuple(mesh_axes) if mesh_axes is not None else (None,) * len(total_shape)
+
+        tensor.verify_tensor_mesh_axes(mesh_axes, tensor_rank=len(total_shape), mesh_rank=len(list(device.shape)))
+
+        local_shape = list(total_shape)
+        for tensor_dim, mesh_axis in enumerate(mesh_axes):
+            if mesh_axis is not None:
+                n = device.shape[mesh_axis]
+                if local_shape[tensor_dim] % n != 0:
+                    msg = (
+                        f"shape {total_shape} cannot be evenly distributed over mesh {device.shape} "
+                        f"along tensor dim {tensor_dim}"
+                    )
+                    raise ValueError(msg)
+                local_shape[tensor_dim] //= n
+        local_shape = tuple(local_shape)
+
+        self.total_shape = total_shape
+        self.local_shape = local_shape
+        self.device = device
+        self.layout = layout
+        self.dtype = dtype
+        self.memory_config = memory_config
+        self.pad_value = pad_value
+        self.mesh_axes = mesh_axes
+        self.on_host = on_host
+        self._data = None
+
+    def load_torch_tensor(self, torch_tensor: torch.Tensor, /) -> None:
+        shape = tuple(torch_tensor.shape)
+        if shape != self.total_shape:
+            msg = f"expected tensor shape {self.total_shape}, got {shape}"
+            raise ParameterLoadingError(msg)
+
+        self.data = tensor.from_torch(
+            torch_tensor,
+            device=self.device,
+            layout=self.layout,
+            dtype=self.dtype,
+            memory_config=self.memory_config,
+            pad_value=self.pad_value,
+            mesh_axes=self.mesh_axes,
+            on_host=self.on_host,
+        )
+
+    def save(self, path: str | Path, /) -> None:
+        ttnn.dump_tensor(path, self.data)
+
+    def load(self, path: str | Path, /) -> None:
+        self.data = ttnn.load_tensor(path, device=None if self.on_host else self.device)
+
+    @property
+    def data(self) -> ttnn.Tensor:
+        if self._data is None:
+            msg = "parameter has no data"
+            raise RuntimeError(msg)
+        return self._data
+
+    @data.setter
+    def data(self, value: ttnn.Tensor) -> None:
+        self._check_data(value)
+        self._data = value
+
+    def _check_data(self, value: ttnn.Tensor) -> None:
+        if self.on_host:
+            if value.device() is not None:
+                msg = "expected host tensor, got device tensor"
+                raise ParameterLoadingError(msg)
+        elif value.device() != self.device:
+            msg = "device mismatch"
+            raise ParameterLoadingError(msg)
+
+        if value.dtype != self.dtype:
+            msg = f"dtype mismatch: expected {self.dtype}, got {value.dtype}"
+            raise ParameterLoadingError(msg)
+
+        if value.layout != self.layout:
+            msg = f"layout mismatch: expected {self.layout}, got {value.layout}"
+            raise ParameterLoadingError(msg)
+
+        if value.memory_config() != self.memory_config:
+            msg = f"memory config mismatch: expected {self.memory_config}, got {value.memory_config()}"
+            raise ParameterLoadingError(msg)
+
+        if value.shape != self.local_shape:
+            msg = f"shape mismatch: expected {self.local_shape}, got {tuple(value.shape)}"
+            raise ParameterLoadingError(msg)

--- a/models/experimental/tt_dit/layers/module.py
+++ b/models/experimental/tt_dit/layers/module.py
@@ -214,6 +214,10 @@ class ModuleList(Module):
         for i, m in enumerate(modules):
             self._children[str(i)] = m
 
+    def forward(self) -> None:
+        msg = "forward() should not be called on ModuleList. Iterate over the modules instead."
+        raise RuntimeError(msg)
+
     def __len__(self) -> int:
         return len(self._children)
 

--- a/models/experimental/tt_dit/layers/module.py
+++ b/models/experimental/tt_dit/layers/module.py
@@ -256,6 +256,25 @@ class Parameter:
         mesh_axes: Sequence[int | None] | None = None,
         on_host: bool = False,
     ) -> None:
+        """Initialize a Parameter for use in a Module.
+
+        The parameter is initially uninitialized. It is typically populated via the parent module's
+        `load_torch_state_dict()`. Alternatively, call `load_torch_tensor()` or assign the `data`
+        property directly with a correctly shaped and distributed `ttnn.Tensor`.
+
+        Args:
+            total_shape: The global shape of the parameter tensor across all mesh devices.
+            device: The mesh device on which the parameter is stored. If `on_host` is
+                `True`, this is used only to create the mesh mapper for distributing the tensor.
+            layout: See `ttnn.from_torch()`. Defaults to `ttnn.Layout.TILE`.
+            dtype: See `ttnn.from_torch()`. Defaults to `ttnn.bfloat16`.
+            memory_config: See `ttnn.from_torch()`. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+            pad_value: See `ttnn.from_torch()`. Defaults to `None`.
+            mesh_axes: Maps tensor dimensions to mesh device axes for distribution.
+                For a rank-3 tensor whose second and third dimensions are sharded on mesh axes 0 and
+                1, respectively, use `[None, 0, 1]`.
+            on_host: If `True`, keep the tensor in host memory instead of device memory.
+        """
         total_shape = tuple(total_shape)
         mesh_axes = tuple(mesh_axes) if mesh_axes is not None else (None,) * len(total_shape)
 

--- a/models/experimental/tt_dit/layers/normalization.py
+++ b/models/experimental/tt_dit/layers/normalization.py
@@ -2,58 +2,50 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+
+import math
+
 import torch
 import ttnn
 
-from ..utils.tensor import bf16_tensor
+from .module import Module, Parameter
 
 
-class RMSNorm:
+class RMSNorm(Module):
     def __init__(self, embedding_dim, norm_eps=1e-5, norm_elementwise_affine=True, bias=True, mesh_device=None):
+        super().__init__()
+
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
         self.mesh_device = mesh_device
-        self.use_bias = bias
-        self.weight = None
-        self.bias = None
+        self.use_bias = norm_elementwise_affine and bias
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+        if norm_elementwise_affine:
+            self.weight = Parameter(total_shape=[1, embedding_dim], device=mesh_device)
+            self.bias = Parameter(total_shape=[1, embedding_dim], device=mesh_device) if bias else None
+        else:
+            self.weight = None
+            self.bias = None
 
-        # Cache weight
-        if self.weight is not None:
-            weight_path = path_prefix + "weight" + path_suffix
-            ttnn.dump_tensor(weight_path, self.weight)
-            cache_dict["weight"] = weight_path
-
-        # Cache bias if it exists
-        if self.bias is not None:
-            bias_path = path_prefix + "bias" + path_suffix
-            ttnn.dump_tensor(bias_path, self.bias)
-            cache_dict["bias"] = bias_path
-
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        if "weight" in cache_dict:
-            self.weight = ttnn.load_tensor(cache_dict["weight"], device=self.mesh_device)
-        if "bias" in cache_dict:
-            self.bias = ttnn.load_tensor(cache_dict["bias"], device=self.mesh_device)
-
-    def load_state_dict(self, state_dict):
-        if self.norm_elementwise_affine:
-            self.weight = bf16_tensor(state_dict["weight"].unsqueeze(0), device=self.mesh_device)
-            if self.use_bias:
-                self.bias = bf16_tensor(state_dict["bias"].unsqueeze(0), device=self.mesh_device)
-
-    def __call__(self, x, compute_kernel_config=None):
+    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
         return ttnn.rms_norm(
-            x, weight=self.weight, bias=self.bias, epsilon=self.norm_eps, compute_kernel_config=compute_kernel_config
+            x,
+            weight=self.weight.data if self.weight is not None else None,
+            bias=self.bias.data if self.bias is not None else None,
+            epsilon=self.norm_eps,
+            compute_kernel_config=compute_kernel_config,
         )
 
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "weight" in state:
+            state["weight"] = state["weight"].unsqueeze(0)
 
-class LayerNorm:
+        if "bias" in state:
+            state["bias"] = state["bias"].unsqueeze(0)
+
+
+class LayerNorm(Module):
     def __init__(
         self,
         embedding_dim,
@@ -63,31 +55,14 @@ class LayerNorm:
         mesh_device=None,
         use_row_major_workaround=False,  # Issue #20789
     ):
+        super().__init__()
+
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
         self.mesh_device = mesh_device
-        self.use_bias = bias
+        self.use_bias = norm_elementwise_affine and bias
         self.use_row_major_workaround = use_row_major_workaround
-        self.weight = None
-        self.bias = None
-        # When using the row-major workaround, ensure that dummy weight/bias are created
-        if use_row_major_workaround:
-            if use_row_major_workaround:
-                self.weight = bf16_tensor(
-                    torch.ones(1, embedding_dim).reshape(-1, 32), device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT
-                )
-            else:
-                self.weight = bf16_tensor(torch.ones(1, embedding_dim), device=self.mesh_device)
-            if bias:
-                if use_row_major_workaround:
-                    self.bias = bf16_tensor(
-                        torch.zeros(1, embedding_dim).reshape(-1, 32),
-                        device=self.mesh_device,
-                        layout=ttnn.ROW_MAJOR_LAYOUT,
-                    )
-                else:
-                    self.bias = bf16_tensor(torch.zeros(1, embedding_dim), device=self.mesh_device)
 
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
@@ -97,56 +72,47 @@ class LayerNorm:
             packer_l1_acc=False,
         )
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+        shape = [embedding_dim // 32, 32] if use_row_major_workaround else [1, embedding_dim]
+        layout = ttnn.ROW_MAJOR_LAYOUT if self.use_row_major_workaround else ttnn.TILE_LAYOUT
 
-        if self.weight is not None:
-            # Cache weight
-            weight_path = path_prefix + "weight" + path_suffix
-            ttnn.dump_tensor(weight_path, self.weight)
-            cache_dict["weight"] = weight_path
+        self.weight = (
+            Parameter(total_shape=shape, layout=layout, device=mesh_device)
+            if norm_elementwise_affine or self.use_row_major_workaround
+            else None
+        )
+        self.bias = Parameter(total_shape=shape, layout=layout, device=mesh_device) if self.use_bias else None
 
-        if self.bias is not None:
-            # Cache bias
-            bias_path = path_prefix + "bias" + path_suffix
-            ttnn.dump_tensor(bias_path, self.bias)
-            cache_dict["bias"] = bias_path
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        weight = state.pop("weight", None)
+        bias = state.pop("bias", None)
 
-        return cache_dict
+        # When using the row-major workaround, ensure that dummy weight/bias are created
+        if self.use_row_major_workaround:
+            assert self.norm_elementwise_affine == (weight is not None)
+            assert self.use_bias == (bias is not None)
 
-    def from_cached_state_dict(self, cache_dict):
-        if "weight" in cache_dict:
-            self.weight = ttnn.load_tensor(cache_dict["weight"], device=self.mesh_device)
-        if "bias" in cache_dict:
-            self.bias = ttnn.load_tensor(cache_dict["bias"], device=self.mesh_device)
+            if weight is None:
+                weight = torch.ones(self.embedding_dim)
+            if self.use_bias and bias is None:
+                bias = torch.zeros(self.embedding_dim)
 
-    def load_state_dict(self, state_dict):
-        if self.norm_elementwise_affine:
-            if self.use_row_major_workaround:
-                self.weight = bf16_tensor(
-                    state_dict["weight"].reshape(-1, 32), device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT
-                )
-            else:
-                self.weight = bf16_tensor(state_dict["weight"].unsqueeze(0), device=self.mesh_device)
-            if self.use_bias:
-                if self.use_row_major_workaround:
-                    self.bias = bf16_tensor(
-                        state_dict["bias"].reshape(-1, 32), device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT
-                    )
-                else:
-                    self.bias = bf16_tensor(state_dict["bias"].unsqueeze(0), device=self.mesh_device)
+        if weight is not None:
+            state["weight"] = weight.reshape(-1, 32) if self.use_row_major_workaround else weight.unsqueeze(0)
 
-    def __call__(self, x):
+        if bias is not None:
+            state["bias"] = bias.reshape(-1, 32) if self.use_row_major_workaround else bias.unsqueeze(0)
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         return ttnn.layer_norm(
             x,
-            weight=self.weight,
-            bias=self.bias,
+            weight=self.weight.data if self.weight is not None else None,
+            bias=self.bias.data if self.bias is not None else None,
             epsilon=self.norm_eps,
             compute_kernel_config=self.compute_kernel_config,
         )
 
 
-class DistributedRMSNorm:
+class DistributedRMSNorm(Module):
     """
     Implements RMSNorm on an activation sharded on the reduction dimension.
     """
@@ -161,6 +127,8 @@ class DistributedRMSNorm:
         mesh_device=None,
         ccl_manager=None,
     ):
+        super().__init__()
+
         assert not bias, "bias is not supported for DistributedRMSNorm"
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
@@ -168,7 +136,6 @@ class DistributedRMSNorm:
         self.mesh_axis = mesh_axis
         self.mesh_device = mesh_device
         self.ccl_manager = ccl_manager
-        self.weight = None
         self.mesh_width = tuple(mesh_device.shape)[mesh_axis]
         self.TILE_SIZE = 32
 
@@ -180,34 +147,29 @@ class DistributedRMSNorm:
             packer_l1_acc=False,
         )
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+        n = self.TILE_SIZE * self.mesh_width
 
-        # Cache weight
-        if self.weight is not None:
-            weight_path = path_prefix + "weight" + path_suffix
-            ttnn.dump_tensor(weight_path, self.weight)
-            cache_dict["weight"] = weight_path
+        self.weight = (
+            Parameter(
+                total_shape=[embedding_dim // n, n],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh_device,
+                mesh_axes=[None, mesh_axis],
+            )
+            if norm_elementwise_affine
+            else None
+        )
 
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict):
-        if "weight" in cache_dict:
-            self.weight = ttnn.load_tensor(cache_dict["weight"], device=self.mesh_device)
-
-    def load_state_dict(self, state_dict):
-        if self.norm_elementwise_affine:
-            weight = state_dict["weight"]
-            weight = (
-                weight.reshape(self.mesh_width, -1, self.TILE_SIZE)
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "weight" in state:
+            state["weight"] = (
+                state["weight"]
+                .reshape(self.mesh_width, -1, self.TILE_SIZE)
                 .permute(1, 0, 2)
                 .reshape(-1, self.TILE_SIZE * self.mesh_width)
             )
-            self.weight = bf16_tensor(
-                weight, device=self.mesh_device, mesh_axis=self.mesh_axis, shard_dim=-1, layout=ttnn.ROW_MAJOR_LAYOUT
-            )
 
-    def __call__(self, x, compute_kernel_config=None):
+    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
         stats = ttnn.rms_norm_pre_all_gather(x)
 
         if tuple(self.mesh_device.shape)[self.mesh_axis] > 1:
@@ -227,14 +189,14 @@ class DistributedRMSNorm:
         x = ttnn.rms_norm_post_all_gather(
             x,
             stats,
-            weight=self.weight,
+            weight=self.weight.data if self.weight is not None else None,
             epsilon=self.norm_eps,
             compute_kernel_config=compute_kernel_config or self.compute_kernel_config,
         )
         return x
 
 
-class DistributedLayerNorm:
+class DistributedLayerNorm(Module):
     """
     Implements LayerNorm on an activation sharded on the reduction dimension.
 
@@ -251,33 +213,18 @@ class DistributedLayerNorm:
         mesh_device=None,
         ccl_manager=None,
     ):
+        super().__init__()
+
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
-        self.use_bias = bias
+        self.use_bias = norm_elementwise_affine and bias
         self.mesh_axis = mesh_axis
         self.mesh_device = mesh_device
         self.ccl_manager = ccl_manager
-        self.weight = None
-        self.bias = None
         self.mesh_width = tuple(mesh_device.shape)[mesh_axis]
         self.TILE_SIZE = 32
-        if not (norm_elementwise_affine and bias):
-            if not (norm_elementwise_affine and bias):
-                pass  # TODO: make logging less noisy
-                # logger.debug(
-                #     "DistributedLayerNorm initialized with norm_elementwise_affine=False. Creating gamma and beta tensors to meet op requirements."
-                # )
-            weight = torch.ones(1, embedding_dim)
-            weight = weight.reshape([-1, self.TILE_SIZE * self.mesh_width])
-            bias = torch.zeros(1, embedding_dim)
-            bias = bias.reshape([-1, self.TILE_SIZE * self.mesh_width])
-            self.weight = bf16_tensor(
-                weight, device=self.mesh_device, mesh_axis=mesh_axis, shard_dim=-1, layout=ttnn.ROW_MAJOR_LAYOUT
-            )
-            self.bias = bf16_tensor(
-                bias, device=self.mesh_device, mesh_axis=mesh_axis, shard_dim=-1, layout=ttnn.ROW_MAJOR_LAYOUT
-            )
+        self.workaround = not (norm_elementwise_affine and bias)
 
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
@@ -287,55 +234,56 @@ class DistributedLayerNorm:
             packer_l1_acc=False,
         )
 
-    def to_cached_state_dict(self, path_prefix, path_suffix=".tensorbin"):
-        cache_dict = {}
+        n = self.TILE_SIZE * self.mesh_width
+        shape = [embedding_dim // n, n]
 
-        # Cache weight
-        if self.weight is not None:
-            weight_path = path_prefix + "weight" + path_suffix
-            ttnn.dump_tensor(weight_path, self.weight)
-            cache_dict["weight"] = weight_path
+        self.weight = (
+            Parameter(total_shape=shape, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_axes=[None, mesh_axis], device=mesh_device)
+            if norm_elementwise_affine or self.workaround
+            else None
+        )
+        self.bias = (
+            Parameter(total_shape=shape, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_axes=[None, mesh_axis], device=mesh_device)
+            if (norm_elementwise_affine and bias) or self.workaround
+            else None
+        )
 
-        # Cache bias
-        if self.bias is not None:
-            bias_path = path_prefix + "bias" + path_suffix
-            ttnn.dump_tensor(bias_path, self.bias)
-            cache_dict["bias"] = bias_path
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        weight = state.pop("weight", None)
+        bias = state.pop("bias", None)
 
-        return cache_dict
+        if self.workaround:
+            # TODO: make logging less noisy
+            # logger.debug(
+            #     "DistributedLayerNorm initialized with norm_elementwise_affine=False. Creating gamma and beta tensors to meet op requirements."
+            # )
 
-    def from_cached_state_dict(self, cache_dict):
-        if "weight" in cache_dict:
-            self.weight = ttnn.load_tensor(cache_dict["weight"], device=self.mesh_device)
-        if "bias" in cache_dict:
-            self.bias = ttnn.load_tensor(cache_dict["bias"], device=self.mesh_device)
+            assert self.norm_elementwise_affine == (weight is not None)
+            assert self.use_bias == (bias is not None)
 
-    def load_state_dict(self, state_dict):
-        if self.norm_elementwise_affine:
-            weight = state_dict["weight"]
-            weight = (
+            if weight is None:
+                weight = torch.ones(self.embedding_dim)
+            if bias is None:
+                bias = torch.zeros(self.embedding_dim)
+
+        if weight is not None:
+            state["weight"] = (
                 weight.reshape(self.mesh_width, -1, self.TILE_SIZE)
                 .permute(1, 0, 2)
                 .reshape(-1, self.TILE_SIZE * self.mesh_width)
             )
-            self.weight = bf16_tensor(
-                weight, device=self.mesh_device, mesh_axis=self.mesh_axis, shard_dim=-1, layout=ttnn.ROW_MAJOR_LAYOUT
-            )
-            if self.use_bias:
-                bias = state_dict["bias"]
-                bias = (
-                    bias.reshape(self.mesh_width, -1, self.TILE_SIZE)
-                    .permute(1, 0, 2)
-                    .reshape(-1, self.TILE_SIZE * self.mesh_width)
-                )
-                self.bias = bf16_tensor(
-                    bias, device=self.mesh_device, mesh_axis=self.mesh_axis, shard_dim=-1, layout=ttnn.ROW_MAJOR_LAYOUT
-                )
 
-    def __call__(self, x, compute_kernel_config=None):
+        if bias is not None:
+            state["bias"] = (
+                bias.reshape(self.mesh_width, -1, self.TILE_SIZE)
+                .permute(1, 0, 2)
+                .reshape(-1, self.TILE_SIZE * self.mesh_width)
+            )
+
+    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
         assert (
             self.weight is not None and self.bias is not None
-        ), "weight and bias must be initialized before calling __call__"
+        ), "weight and bias must be initialized before calling forward"
         stats = ttnn.layer_norm_pre_all_gather(x)
 
         if tuple(self.mesh_device.shape)[self.mesh_axis] > 1:
@@ -355,8 +303,8 @@ class DistributedLayerNorm:
         x = ttnn.layer_norm_post_all_gather(
             x,
             stats,
-            weight=self.weight,
-            bias=self.bias,
+            weight=self.weight.data if self.weight is not None else None,
+            bias=self.bias.data if self.bias is not None else None,
             epsilon=self.norm_eps,
             compute_kernel_config=compute_kernel_config or self.compute_kernel_config,
         )
@@ -371,7 +319,7 @@ Set mesh_axis to None to disable data parallelism.
 
 
 # TODO: Add helper to assert torch reference
-class GroupNorm:
+class GroupNorm(Module):
     default_num_out_blocks = {
         # (Batch, Height, Width, Channels): num_out_blocks
     }  # used to overrride the num_out_blocks computed based on the input shape.
@@ -386,24 +334,51 @@ class GroupNorm:
         core_grid=None,
         torch_ref=None,
     ):
+        super().__init__()
+
         self.eps = eps or torch_ref.eps
         self.mesh_device = mesh_device
         self.mesh_axis = mesh_axis
         self.num_devices = tuple(mesh_device.shape)[mesh_axis] if mesh_axis is not None else 1
         self.num_channels = (num_channels or torch_ref.num_channels) // self.num_devices
         self.num_groups = (num_groups or torch_ref.num_groups) // self.num_devices
-        self.weight = None
-        self.bias = None
-        self.mask = None
         self.core_grid = core_grid or ttnn.CoreGrid(x=8, y=8)  # self.mesh_device.core_grid # Issue on 6U 8x9 grid
+        self.num_virtual_cols = ttnn.operations.normalization.dram_group_norm_virtual_columns(
+            self.mesh_device.core_grid, self.num_channels, self.num_groups
+        )
 
         # Assert group norm parameters
         assert (
             self.num_channels % 32 == 0 == self.num_channels % self.num_groups
         ), f"num_channels must be divisible by 32 and num_groups"
 
+        weight_shape = [
+            self.num_devices,
+            1,
+            math.ceil(self.num_channels // self.num_virtual_cols / 32) * self.num_virtual_cols,
+            32,
+        ]
+        block_wt = ttnn.operations.normalization.find_max_tile_span(
+            self.num_channels, self.num_channels // self.num_groups, 32
+        )
+        mask_shape = [1, self.num_groups, 32, 32 * block_wt]
+
+        self.weight = Parameter(
+            total_shape=weight_shape,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_axes=[mesh_axis, None, None, None],
+            device=self.mesh_device,
+        )
+        self.bias = Parameter(
+            total_shape=weight_shape,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_axes=[mesh_axis, None, None, None],
+            device=self.mesh_device,
+        )
+        self.mask = Parameter(total_shape=mask_shape, device=self.mesh_device)
+
         if torch_ref is not None:
-            self.load_state_dict(torch_ref.state_dict())
+            self.load_torch_state_dict(torch_ref.state_dict())
 
     @classmethod
     def from_torch(cls, torch_ref, mesh_device=None, mesh_axis=None, core_grid=None):
@@ -415,25 +390,33 @@ class GroupNorm:
         )
         return layer
 
-    def load_state_dict(self, state_dict):
-        [self.weight, self.bias], self.mask = ttnn.dram_group_norm_params_from_torch(
-            torch_params=[state_dict["weight"], state_dict["bias"]],
-            channels_per_device=self.num_channels,
-            groups_per_device=self.num_groups,
-            device=self.mesh_device,
-            mesh_axis=self.mesh_axis,
-            return_mask=True,
-        )
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "weight" in state:
+            state["weight"] = self._prepare_param(state["weight"])
+        if "bias" in state:
+            state["bias"] = self._prepare_param(state["bias"])
 
-    def __call__(self, x, num_out_blocks=-1):
+        state["mask"] = ttnn.create_group_norm_input_mask(self.num_channels, self.num_groups, self.num_virtual_cols)
+
+    def _prepare_param(self, param: torch.Tensor) -> torch.Tensor:
+        expected_shape = (self.num_channels * self.num_devices,)
+        assert param.shape == expected_shape, f"expected shape {expected_shape}, got {param.shape}"
+
+        torch_sharded_lst = [
+            ttnn.create_group_norm_weight_bias_rm(t, self.num_channels, self.num_virtual_cols)
+            for t in param.chunk(self.num_devices)
+        ]
+        return torch.cat(torch_sharded_lst, dim=0)
+
+    def forward(self, x: ttnn.Tensor, num_out_blocks=-1) -> ttnn.Tensor:
         self.num_out_blocks = num_out_blocks
         batch_size, height, width, channels = x.shape
         x = x.reshape([batch_size, 1, width * height, channels])
         x = ttnn.group_norm(
             x,
-            weight=self.weight,
-            bias=self.bias,
-            input_mask=self.mask,
+            weight=self.weight.data,
+            bias=self.bias.data,
+            input_mask=self.mask.data,
             num_groups=self.num_groups,
             epsilon=self.eps,
             core_grid=self.core_grid,

--- a/models/experimental/tt_dit/tests/unit/test_embeddings.py
+++ b/models/experimental/tt_dit/tests/unit/test_embeddings.py
@@ -191,7 +191,7 @@ def test_timestep_embedding(
         time_embed_dim=time_embed_dim,
         mesh_device=mesh_device,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     # Create input tensors
     torch.manual_seed(0)
@@ -244,7 +244,7 @@ def test_pixart_alpha_text_projection(
         hidden_size=hidden_size,
         mesh_device=mesh_device,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     # Create input tensors
     torch.manual_seed(0)
@@ -297,7 +297,7 @@ def test_combined_timestep_text_proj_embeddings(
         pooled_projection_dim=pooled_projection_dim,
         mesh_device=mesh_device,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     # Create input tensors
     torch.manual_seed(0)
@@ -381,7 +381,7 @@ def test_patch_embed_sd35(
         tp_mesh_axis=tp_mesh_axis,
         sp_mesh_axis=sp_mesh_axis,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     # Create input tensors - NHWC format for TT model
     torch.manual_seed(0)
@@ -463,7 +463,7 @@ def test_patch_embed_mochi(
         embed_dim=embed_dim,
         mesh_device=mesh_device,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     # Create input tensors - NHWC format for TT model
     torch.manual_seed(0)
@@ -546,7 +546,7 @@ def test_wan_patch_embed(
         embed_dim=embed_dim,
         mesh_device=mesh_device,
     )
-    tt_model.load_state_dict(substate(torch_model.state_dict(), "proj"))
+    tt_model.load_torch_state_dict(substate(torch_model.state_dict(), "proj"))
 
     # Create input tensors
     torch.manual_seed(0)

--- a/models/experimental/tt_dit/tests/unit/test_embeddings.py
+++ b/models/experimental/tt_dit/tests/unit/test_embeddings.py
@@ -190,7 +190,6 @@ def test_timestep_embedding(
         in_channels=in_channels,
         time_embed_dim=time_embed_dim,
         mesh_device=mesh_device,
-        init=True,
     )
     tt_model.load_state_dict(torch_model.state_dict())
 
@@ -244,7 +243,6 @@ def test_pixart_alpha_text_projection(
         in_features=in_features,
         hidden_size=hidden_size,
         mesh_device=mesh_device,
-        init=True,
     )
     tt_model.load_state_dict(torch_model.state_dict())
 
@@ -298,7 +296,6 @@ def test_combined_timestep_text_proj_embeddings(
         embedding_dim=embedding_dim,
         pooled_projection_dim=pooled_projection_dim,
         mesh_device=mesh_device,
-        init=True,
     )
     tt_model.load_state_dict(torch_model.state_dict())
 
@@ -383,7 +380,6 @@ def test_patch_embed_sd35(
         mesh_device=mesh_device,
         tp_mesh_axis=tp_mesh_axis,
         sp_mesh_axis=sp_mesh_axis,
-        init=False,
     )
     tt_model.load_state_dict(torch_model.state_dict())
 
@@ -466,7 +462,6 @@ def test_patch_embed_mochi(
         in_channels=in_channels,
         embed_dim=embed_dim,
         mesh_device=mesh_device,
-        init=False,
     )
     tt_model.load_state_dict(torch_model.state_dict())
 
@@ -550,7 +545,6 @@ def test_wan_patch_embed(
         in_channels=in_channels,
         embed_dim=embed_dim,
         mesh_device=mesh_device,
-        init=False,
     )
     tt_model.load_state_dict(substate(torch_model.state_dict(), "proj"))
 

--- a/models/experimental/tt_dit/tests/unit/test_feedforward.py
+++ b/models/experimental/tt_dit/tests/unit/test_feedforward.py
@@ -78,7 +78,7 @@ def test_feedforward(
     tt_model = FeedForward(
         dim, dim_out, inner_dim=inner_dim, bias=bias, activation_fn=activation_fn, mesh_device=mesh_device
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn((1, B, seq, dim), dtype=torch_dtype)
 
@@ -162,7 +162,7 @@ def test_parallel_feedforward(
         fsdp_mesh_axis=fsdp_mesh_axis,
         ccl_manager=ccl_manager,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn((1, B, seq, dim), dtype=torch_dtype)
 

--- a/models/experimental/tt_dit/tests/unit/test_linear.py
+++ b/models/experimental/tt_dit/tests/unit/test_linear.py
@@ -58,7 +58,7 @@ def test_linear(
     torch_model.eval()
 
     tt_model = Linear(K, N, bias=bias, mesh_device=mesh_device)
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn((1, B, M, K), dtype=torch_dtype)
 
@@ -168,7 +168,7 @@ def test_col_parallel_linear(
         )
     else:
         tt_model = ColParallelLinear(K, N, bias=bias, mesh_device=mesh_device, mesh_axis=tp_mesh_axis)
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn((1, B, M, K), dtype=torch_dtype)
 
@@ -255,7 +255,7 @@ def test_row_parallel_linear(
         fsdp_mesh_axis=fsdp_mesh_axis,
         ccl_manager=ccl_manager,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn((1, B, M, K), dtype=torch_dtype)
 

--- a/models/experimental/tt_dit/tests/unit/test_module.py
+++ b/models/experimental/tt_dit/tests/unit/test_module.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from tempfile import TemporaryDirectory
+
+import pytest
+import torch
+import ttnn
+
+from ...layers.module import Module, Parameter
+
+
+class TinyLinear(Module):
+    def __init__(self, in_dim: int, out_dim: int, *, bias: bool, device: ttnn.MeshDevice) -> None:
+        super().__init__()
+
+        self.weight = Parameter(total_shape=[in_dim, out_dim], device=device)
+        self.bias = Parameter(total_shape=[out_dim], device=device) if bias else None
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.linear(x, self.weight.data, bias=self.bias.data if self.bias is not None else None)
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        if "weight" in state:
+            state["weight"].transpose_(0, 1)
+
+
+class TinyFeedForward(Module):
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int, *, device: ttnn.MeshDevice) -> None:
+        super().__init__()
+
+        self.linear1 = TinyLinear(in_dim, hidden_dim, device=device, bias=True)
+        self.linear2 = TinyLinear(hidden_dim, out_dim, device=device, bias=True)
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = self.linear1.forward(x)
+        x = ttnn.silu(x)
+        return self.linear2.forward(x)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_load_torch_state(mesh_device: ttnn.MeshDevice) -> None:
+    model = TinyFeedForward(10, 20, 30, device=mesh_device)
+
+    state_dict = {
+        "linear1.weight": torch.randn([20, 10]),
+        "linear1.bias": torch.randn([20]),
+        "linear2.weight": torch.randn([30, 20]),
+        "something.unexpected": torch.randn([1]),
+    }
+
+    missing, unexpected = model.load_torch_state_dict(state_dict, strict=False)
+
+    assert missing == ["linear2.bias"]
+    assert unexpected == ["something.unexpected"]
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_save_and_load(mesh_device: ttnn.MeshDevice) -> None:
+    model1 = TinyFeedForward(10, 20, 30, device=mesh_device)
+    model2 = TinyFeedForward(10, 20, 30, device=mesh_device)
+
+    state_dict = {
+        "linear1.weight": torch.randn([20, 10]),
+        "linear1.bias": torch.randn([20]),
+        "linear2.weight": torch.randn([30, 20]),
+        "linear2.bias": torch.randn([30]),
+    }
+
+    model1.load_torch_state_dict(state_dict)
+
+    with TemporaryDirectory() as dirname:
+        model1.save(dirname)
+        model2.load(dirname)
+
+    x = ttnn.from_torch(torch.randn([10]), device=mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    y1 = ttnn.to_torch(model1.forward(x))
+    y2 = ttnn.to_torch(model2.forward(x))
+
+    assert torch.equal(y1, y2)

--- a/models/experimental/tt_dit/tests/unit/test_normalization.py
+++ b/models/experimental/tt_dit/tests/unit/test_normalization.py
@@ -20,9 +20,10 @@ class TorchRMSNorm(torch.nn.Module):
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
         self.use_bias = bias
-        self.weight = torch.nn.Parameter(torch.randn(embedding_dim))
-        if bias:
-            self.bias = torch.nn.Parameter(torch.randn(embedding_dim))
+        if norm_elementwise_affine:
+            self.weight = torch.nn.Parameter(torch.randn(embedding_dim))
+            if bias:
+                self.bias = torch.nn.Parameter(torch.randn(embedding_dim))
 
     def forward(self, x):
         x = x / torch.sqrt(torch.mean(x**2, dim=-1, keepdim=True) + self.norm_eps)
@@ -39,9 +40,10 @@ class TorchLayerNorm(torch.nn.Module):
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
         self.use_bias = bias
-        self.weight = torch.nn.Parameter(torch.randn(embedding_dim))
-        if bias:
-            self.bias = torch.nn.Parameter(torch.randn(embedding_dim))
+        if norm_elementwise_affine:
+            self.weight = torch.nn.Parameter(torch.randn(embedding_dim))
+            if bias:
+                self.bias = torch.nn.Parameter(torch.randn(embedding_dim))
 
     def forward(self, x):
         mean = torch.mean(x, dim=-1, keepdim=True)
@@ -87,7 +89,7 @@ def test_rmsnorm(
     tt_model = RMSNorm(
         embedding_dim=input_shape[-1], norm_elementwise_affine=norm_eltwise_affine, bias=bias, mesh_device=mesh_device
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype) * 2 + 4
 
@@ -143,7 +145,7 @@ def test_layernorm(
         mesh_device=mesh_device,
         use_row_major_workaround=use_row_major_workaround,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype) * 2 + 4
 
@@ -211,7 +213,7 @@ def test_distributed_rms_norm(
         mesh_axis=mesh_axis,
         ccl_manager=ccl_manager,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype) * 2 + 4
 
@@ -284,7 +286,7 @@ def test_distributed_layernorm(
         mesh_axis=mesh_axis,
         ccl_manager=ccl_manager,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype) * 2 + 4
 

--- a/models/experimental/tt_dit/utils/substate.py
+++ b/models/experimental/tt_dit/utils/substate.py
@@ -8,6 +8,8 @@ import itertools
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     import torch
 
 
@@ -22,6 +24,20 @@ def has_substate(state: dict[str, torch.Tensor], key: str) -> bool:
     prefix = f"{key}."
 
     return any(k.startswith(prefix) for k in state)
+
+
+def pop_substate(state: MutableMapping[str, torch.Tensor], key: str) -> dict[str, torch.Tensor]:
+    prefix = f"{key}."
+    return {k.removeprefix(prefix): state.pop(k) for k in list(state) if k.startswith(prefix)}
+
+
+def rename_substate(state: MutableMapping[str, torch.Tensor], key_from: str, key_to: str) -> None:
+    src_prefix = f"{key_from}."
+    dst_prefix = f"{key_to}."
+
+    for k in list(state):
+        if k.startswith(src_prefix):
+            state[dst_prefix + k.removeprefix(src_prefix)] = state.pop(k)
 
 
 def indexed_substates(state: dict[str, torch.Tensor], key: str) -> list[dict[str, torch.Tensor]]:


### PR DESCRIPTION
### What's changed

Every module in `layers` is now derived from `Module`, except `ContextParallelConv3d` whose tests do currently not succeed.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes