### PR TITLE
#23166: Fix sqrt and rsqrt for negative inputs

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -77,7 +77,7 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
 
     if constexpr (unary_op_type == UnaryOpType::SQRT) {
         auto host_output = host_function<::detail::sqrt>(input_tensor);
-        auto device_output = ttnn::sqrt(input_tensor.to_device(device)).cpu();
+        auto device_output = ttnn::sqrt(input_tensor.to_device(device), /*fast_and_approximate_mode=*/false).cpu();
         return ttnn::allclose<bfloat16>(host_output, device_output, args...);
     } else if constexpr (unary_op_type == UnaryOpType::EXP) {
         auto host_output = host_function<::detail::exp>(input_tensor);

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -236,7 +236,7 @@ TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
         auto* device = device_;
         const auto& output_spec = input_spec;
         auto query = ttnn::graph::query_op_constraints(
-            ttnn::sqrt, device, input_spec, output_spec.tensor_layout().get_memory_config());
+            ttnn::sqrt, device, input_spec, false, output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         // Ensure some real usage is reported

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -236,7 +236,11 @@ TEST_P(EltwiseUnaryOpIfTest, Sqrt) {
         auto* device = device_;
         const auto& output_spec = input_spec;
         auto query = ttnn::graph::query_op_constraints(
-            ttnn::sqrt, device, input_spec, false, output_spec.tensor_layout().get_memory_config());
+            ttnn::sqrt,
+            device,
+            input_spec,
+            /*fast_and_approximate_mode=*/false,
+            output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         // Ensure some real usage is reported

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -168,7 +168,10 @@ def test_hypot_multi_dtype(device, dtype):
     y_tt = ttnn.from_torch(y_torch, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     z_tt_hypot = ttnn.hypot(x_tt, y_tt)
 
-    assert_with_ulp(z_tt_hypot, z_torch, ulp_threshold=1)
+    if dtype == ttnn.float32:
+        assert_allclose(z_torch, z_tt_hypot, rtol=1e-05, atol=1e-05)
+    else:
+        assert_with_ulp(z_torch, z_tt_hypot, ulp_threshold=1)
 
 
 def test_add_fp32_activ(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1839,19 +1839,13 @@ def test_hardmish_bfloat16_allclose(device):
     tt_result = ttnn.hardmish(tt_in)
     result = ttnn.to_torch(tt_result)
     assert_allclose(golden, result, rtol=1e-05, atol=1e-35)
-        (torch.float32, ttnn.float32),
-        (torch.bfloat16, ttnn.bfloat16),
-    
-    
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
-        (torch.Size([100])),
-        (torch.Size([10, 10])),
         (torch.Size([3, 128, 32])),
-        (torch.Size([1, 1, 102400, 32])),
-        (torch.Size([1, 1, 102400, 64])),
-        (torch.Size([1, 1, 400, 512])),
+        (torch.Size([1, 1, 3, 64, 12])),
     ),
 )
 @pytest.mark.parametrize(
@@ -1870,7 +1864,7 @@ def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fas
         in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_op(input_tensor, fast_approx_mode=fast_approx_mode)
+    output_tensor = ttnn_op(input_tensor, fast_and_approximate_mode=fast_approx_mode)
     golden_function = ttnn.get_golden_function(ttnn_op)
     golden_tensor = golden_function(in_data)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -226,20 +226,8 @@ def test_relu(device, h, w):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rsqrt(device, h, w):
-    run_unary_test(device, h, w, ttnn.rsqrt)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
 def test_silu(device, h, w):
     run_unary_test(device, h, w, ttnn.silu)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_rsqrt(device, h, w):
-    run_unary_test(device, h, w, ttnn.rsqrt)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -1851,3 +1839,47 @@ def test_hardmish_bfloat16_allclose(device):
     tt_result = ttnn.hardmish(tt_in)
     result = ttnn.to_torch(tt_result)
     assert_allclose(golden, result, rtol=1e-05, atol=1e-35)
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+    
+    
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([10, 10])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 1, 102400, 32])),
+        (torch.Size([1, 1, 102400, 64])),
+        (torch.Size([1, 1, 400, 512])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+@pytest.mark.parametrize("ttnn_op", [ttnn.rsqrt, ttnn.sqrt])
+@pytest.mark.parametrize("fast_approx_mode", [True, False])
+def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device):
+    if fast_approx_mode:
+        in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(1, 100)
+    else:
+        in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_op(input_tensor, fast_approx_mode=fast_approx_mode)
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    golden_tensor = golden_function(in_data)
+
+    if fast_approx_mode:
+        assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=2)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor, dtype=torch_dtype)
+        if torch_dtype == torch.bfloat16:
+            output_tensor = torch.where(
+                torch.isinf(output_tensor), torch.tensor(float("nan"), dtype=output_tensor.dtype), output_tensor
+            )
+        torch.isclose(output_tensor, golden_tensor, equal_nan=True)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -699,26 +699,6 @@ def test_unary_log_sigmoid_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_rsqrt_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 100, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.rsqrt(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.rsqrt(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 @pytest.mark.parametrize(
     "approx_mode",
     (False, True),
@@ -813,26 +793,6 @@ def test_unary_log10_ttnn(input_shapes, device):
     cq_id = 0
     ttnn.log10(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.log10(in_data)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-def test_unary_sqrt_ttnn(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 100, device)
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.sqrt(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    golden_tensor = torch.sqrt(in_data)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -12,9 +12,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -12,9 +12,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -15,10 +15,12 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt, APPROXIMATE>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
 }
 
-template <bool APPROXIMATE, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, legacy_compat>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index,
+        vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sqrt.h
@@ -10,10 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_sqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sqrt<APPROXIMATE, 8, fp32_dest_acc_en, legacy_compat>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_sqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index,
+        vector_mode);
 }
 
 template <bool APPROXIMATE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -12,9 +12,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -12,9 +12,9 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -15,10 +15,12 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt, APPROXIMATE>(sfpu::rsqrt_init<APPROXIMATE, legacy_compat>);
 }
 
-template <bool APPROXIMATE, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, legacy_compat>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index,
+        vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sqrt.h
@@ -10,10 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool fp32_dest_acc_en, bool legacy_compat>
+template <bool APPROXIMATE, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
 inline void llk_math_eltwise_unary_sfpu_sqrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sqrt<APPROXIMATE, 8, fp32_dest_acc_en, legacy_compat>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_sqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
+        dst_index,
+        vector_mode);
 }
 
 template <bool APPROXIMATE, bool legacy_compat>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/rsqrt.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/rsqrt.h
@@ -33,9 +33,9 @@ ALWI void rsqrt_tile_init() {
  * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-template <bool legacy_compat = false>
+template <bool legacy_compat = false, bool FAST_APPROX = false>
 ALWI void rsqrt_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_rsqrt<APPROX, DST_ACCUM_MODE, legacy_compat>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_rsqrt<APPROX, DST_ACCUM_MODE, FAST_APPROX, legacy_compat>(idst)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sqrt.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sqrt.h
@@ -33,9 +33,9 @@ ALWI void sqrt_tile_init() {
  * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-template <bool legacy_compat = true>
+template <bool legacy_compat = true, bool FAST_APPROX = false>
 ALWI void sqrt_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_sqrt<APPROX, DST_ACCUM_MODE, legacy_compat>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_sqrt<APPROX, DST_ACCUM_MODE, FAST_APPROX, legacy_compat>(idst)));
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_op_utils.hpp"
 
+#include <cstdint>
 #include <optional>
 #include <tt_stl/assert.hpp>
 #include "ttnn/tensor/types.hpp"
@@ -551,7 +552,16 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 fmt::format("hardmish_tile<{1}u>({0});", idst, (uint32_t)param0)};
             break;
         }
-
+        case UnaryOpType::RSQRT:{
+            op_init_and_name = {
+                "rsqrt_tile_init<false>();", fmt::format("rsqrt_tile<false, {1}>({0});", idst, param0_raw)};
+            break;
+        }
+        case UnaryOpType::SQRT:{
+            op_init_and_name = {
+                "sqrt_tile_init<false>();", fmt::format("sqrt_tile<false, {1}>({0});", idst, param0_raw)};
+            break;
+        }
         default: TT_THROW("unexpected parameterized op type {}", op_type);
     };
     return op_init_and_name;
@@ -568,12 +578,6 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
             op_init_and_name = {"recip_tile_init<false>();", fmt::format("recip_tile<false>({});", idst)};
             break;
         case UnaryOpType::GELU: op_init_and_name = {"gelu_tile_init();", fmt::format("gelu_tile({});", idst)}; break;
-        case UnaryOpType::RSQRT:
-            op_init_and_name = {"rsqrt_tile_init<false>();", fmt::format("rsqrt_tile<false>({});", idst)};
-            break;
-        case UnaryOpType::SQRT:
-            op_init_and_name = {"sqrt_tile_init<false>();", fmt::format("sqrt_tile<false>({});", idst)};
-            break;
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::LOG1P: op_init_and_name = {"log1p_tile_init();", fmt::format("log1p_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
@@ -844,9 +848,9 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
     } else if (name == "sigmoid_approx") {
         return UnaryWithParam(UnaryOpType::SIGMOID, {static_cast<float>(VecMode::RC), static_cast<float>(true)});
     } else if (name == "sqrt") {
-        return UnaryWithParam(UnaryOpType::SQRT);
+        return UnaryWithParam(UnaryOpType::SQRT, {static_cast<float>(false)});
     } else if (name == "rsqrt") {
-        return UnaryWithParam(UnaryOpType::RSQRT);
+        return UnaryWithParam(UnaryOpType::RSQRT, {static_cast<float>(false)});
     } else if (name == "exp") {
         return UnaryWithParam(UnaryOpType::EXP, static_cast<float>(true));
     } else if (name == "recip") {
@@ -905,6 +909,7 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
             }
             return "sigmoid";
         case UnaryOpType::SQRT: return "sqrt";
+        case UnaryOpType::RSQRT: return "rsqrt";
         case UnaryOpType::EXP: return "exp";
         case UnaryOpType::RECIP: return "recip";
         case UnaryOpType::LOG: return "log";

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -4,7 +4,6 @@
 
 #include "unary_op_utils.hpp"
 
-#include <cstdint>
 #include <optional>
 #include <tt_stl/assert.hpp>
 #include "ttnn/tensor/types.hpp"
@@ -729,6 +728,8 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile({});", idst)};
             }
             break;
+        case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;
+        case UnaryOpType::RSQRT: op_init_and_name = {"rsqrt_tile_init();", fmt::format("rsqrt_tile({});", idst)}; break;
         case UnaryOpType::EXP2: op_init_and_name = {"exp2_tile_init();", fmt::format("exp2_tile({});", idst)}; break;
         case UnaryOpType::EXPM1: op_init_and_name = {"expm1_tile_init();", fmt::format("expm1_tile({});", idst)}; break;
         case UnaryOpType::ASIN: op_init_and_name = {"asin_tile_init();", fmt::format("asin_tile({});", idst)}; break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -52,6 +52,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::ELU:
         case UnaryOpType::GELU:
         case UnaryOpType::RSQRT:
+        case UnaryOpType::SQRT:
         case UnaryOpType::HEAVISIDE:
         case UnaryOpType::ERF:
         case UnaryOpType::ERFC:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -140,6 +140,8 @@ template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG10>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG2>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG1P>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::RSQRT>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::SQRT>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithVectorAndFastAndApproximateMode<unary_op_type>::invoke(
@@ -236,24 +238,6 @@ Tensor Sigmoid_accurate::invoke(
          UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,
         optional_output_tensor);
-}
-
-Tensor Sqrt::invoke(
-    const Tensor& input_tensor,
-    const bool fast_approx_mode,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    return detail::unary_impl(
-        input_tensor, {UnaryWithParam{UnaryOpType::SQRT, fast_approx_mode}}, memory_config, optional_output_tensor);
-}
-
-Tensor Rsqrt::invoke(
-    const Tensor& input_tensor,
-    const bool fast_approx_mode,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    return detail::unary_impl(
-        input_tensor, {UnaryWithParam{UnaryOpType::RSQRT, fast_approx_mode}}, memory_config, optional_output_tensor);
 }
 
 template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -105,8 +105,6 @@ template struct ExecuteUnary<UnaryOpType::SIGN>;
 template struct ExecuteUnary<UnaryOpType::SIGNBIT>;
 template struct ExecuteUnary<UnaryOpType::SILU>;
 template struct ExecuteUnary<UnaryOpType::SIN>;
-template struct ExecuteUnary<UnaryOpType::SQRT>;
-template struct ExecuteUnary<UnaryOpType::RSQRT>;
 template struct ExecuteUnary<UnaryOpType::SQUARE>;
 template struct ExecuteUnary<UnaryOpType::TAN>;
 template struct ExecuteUnary<UnaryOpType::TILED_PROD>;
@@ -238,6 +236,24 @@ Tensor Sigmoid_accurate::invoke(
          UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,
         optional_output_tensor);
+}
+
+Tensor Sqrt::invoke(
+    const Tensor& input_tensor,
+    const bool fast_approx_mode,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return detail::unary_impl(
+        input_tensor, {UnaryWithParam{UnaryOpType::SQRT, fast_approx_mode}}, memory_config, optional_output_tensor);
+}
+
+Tensor Rsqrt::invoke(
+    const Tensor& input_tensor,
+    const bool fast_approx_mode,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return detail::unary_impl(
+        input_tensor, {UnaryWithParam{UnaryOpType::RSQRT, fast_approx_mode}}, memory_config, optional_output_tensor);
 }
 
 template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -326,6 +326,22 @@ struct Rsub {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Rsqrt {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        bool fast_approx_mode = false,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
+struct Sqrt {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        bool fast_approx_mode = false,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 }  // namespace operations::unary
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
@@ -405,8 +421,6 @@ REGISTER_UNARY_OPERATION(sign, SIGN);
 REGISTER_UNARY_OPERATION(signbit, SIGNBIT);
 REGISTER_UNARY_OPERATION(silu, SILU);
 REGISTER_UNARY_OPERATION(sin, SIN);
-REGISTER_UNARY_OPERATION(sqrt, SQRT);
-REGISTER_UNARY_OPERATION(rsqrt, RSQRT);
 REGISTER_UNARY_OPERATION(square, SQUARE);
 REGISTER_UNARY_OPERATION(tan, TAN);
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
@@ -469,7 +483,8 @@ constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::opera
 constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
-
+constexpr auto sqrt = ttnn::register_operation<"ttnn::sqrt", ttnn::operations::unary::Sqrt>();
+constexpr auto rsqrt = ttnn::register_operation<"ttnn::rsqrt", ttnn::operations::unary::Rsqrt>();
 constexpr auto selu = ttnn::register_operation<"ttnn::selu", ttnn::operations::unary::Selu>();
 constexpr auto fill = ttnn::register_operation<
     "ttnn::fill",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -326,22 +326,6 @@ struct Rsub {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
-struct Rsqrt {
-    static Tensor invoke(
-        const Tensor& input_tensor,
-        bool fast_approx_mode = false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
-struct Sqrt {
-    static Tensor invoke(
-        const Tensor& input_tensor,
-        bool fast_approx_mode = false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
 }  // namespace operations::unary
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
@@ -444,6 +428,8 @@ REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log, LOG);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log10, LOG10);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log2, LOG2);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(log1p, LOG1P);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(rsqrt, RSQRT);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(sqrt, SQRT);
 
 // Unaries with vector mode and fast and approximate mode
 REGISTER_UNARY_OPERATION_WITH_VECTOR_AND_FAST_AND_APPROXIMATE_MODE(sigmoid, SIGMOID);
@@ -483,8 +469,6 @@ constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::opera
 constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
-constexpr auto sqrt = ttnn::register_operation<"ttnn::sqrt", ttnn::operations::unary::Sqrt>();
-constexpr auto rsqrt = ttnn::register_operation<"ttnn::rsqrt", ttnn::operations::unary::Rsqrt>();
 constexpr auto selu = ttnn::register_operation<"ttnn::selu", ttnn::operations::unary::Selu>();
 constexpr auto fill = ttnn::register_operation<
     "ttnn::fill",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -273,6 +273,73 @@ void bind_unary_operation(
 }
 
 template <typename unary_operation_t>
+void bind_unary_sqrt_operation(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& info_doc = "") {
+    auto doc = fmt::format(
+        R"doc(
+        Applies {0} to :attr:`input_tensor` element-wise.
+
+        .. math::
+            \mathrm{{output\_tensor}}_i = \verb|{0}|(\mathrm{{input\_tensor}}_i)
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+        Keyword Args:
+            fast_approx_mode (bool, optional): use the fast and approximate mode. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {2}
+                 - TILE
+                 - 2, 3, 4
+
+            {3}
+
+        Example:
+            >>> tensor = ttnn.from_torch(torch.rand([2, 2], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        supported_dtype,
+        info_doc);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const Tensor& input_tensor,
+               const bool fast_approx_mode,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
+                return self(input_tensor, fast_approx_mode, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg("fast_approx_mode") = false,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
+}
+
+template <typename unary_operation_t>
 void bind_unary_operation_overload_complex(
     py::module& module,
     const unary_operation_t& operation,
@@ -2120,18 +2187,8 @@ void py_module(py::module& module) {
         R"doc(\mathrm{{output\_tensor}}_i = \verb|sin|(\mathrm{{input\_tensor}}_i))doc",
         "",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
-    bind_unary_operation(
-        module,
-        ttnn::sqrt,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|sqrt|(\mathrm{{input\_tensor}}_i))doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
-    bind_unary_operation(
-        module,
-        ttnn::rsqrt,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|rsqrt|(\mathrm{{input\_tensor}}_i))doc",
-        "",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+    bind_unary_sqrt_operation(module, ttnn::sqrt, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc", "");
+    bind_unary_sqrt_operation(module, ttnn::rsqrt, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc", "");
     bind_unary_operation(
         module,
         ttnn::square,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -2187,8 +2187,7 @@ void py_module(py::module& module) {
         R"doc(\mathrm{{output\_tensor}}_i = \verb|sin|(\mathrm{{input\_tensor}}_i))doc",
         "",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
-    bind_unary_sqrt_operation(module, ttnn::sqrt, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc", "");
-    bind_unary_sqrt_operation(module, ttnn::rsqrt, R"doc(FLOAT32, BFLOAT16, BFLOAT8_B)doc", "");
+
     bind_unary_operation(
         module,
         ttnn::square,
@@ -2265,6 +2264,10 @@ void py_module(py::module& module) {
         R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
 
     //  Unaries with fast_and_approximate_mode
+    bind_unary_operation_with_fast_and_approximate_mode(
+        module, ttnn::sqrt, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
+    bind_unary_operation_with_fast_and_approximate_mode(
+        module, ttnn::rsqrt, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erf, "", R"doc(BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erfc, "", R"doc(BFLOAT16, BFLOAT8_B)doc");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -308,7 +308,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSqrt::invoke(
     float t_inf = std::numeric_limits<float>::infinity();
 
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    ttnn::sqrt(input, output_mem_config, input_grad);
+    ttnn::sqrt(input, false, output_mem_config, input_grad);
     ttnn::multiply(
         grad,
         ttnn::reciprocal(ttnn::multiply(input_grad.value(), 2.0, std::nullopt, output_mem_config), output_mem_config),
@@ -472,7 +472,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
 
-    ttnn::rsqrt(input, output_mem_config, input_grad);
+    ttnn::rsqrt(input, false, output_mem_config, input_grad);
     ttnn::power(input_grad.value(), 3, output_mem_config, input_grad);
     ttnn::multiply(
         ttnn::multiply(grad, input_grad.value(), std::nullopt, output_mem_config),
@@ -564,7 +564,8 @@ std::vector<Tensor> ExecuteUnaryBackwardAcosh::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor in_sq = ttnn::square(input, output_mem_config);
-    Tensor in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_sq, 1.0, std::nullopt, output_mem_config), output_mem_config);
+    Tensor in_rsqrt =
+        ttnn::rsqrt(ttnn::subtract(in_sq, 1.0, std::nullopt, output_mem_config), false, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
     float t_nan = tt::tt_metal::hal::get_nan();
     float t_inf = tt::tt_metal::hal::get_inf();
@@ -611,6 +612,7 @@ std::vector<Tensor> ExecuteUnaryBackwardAcos::invoke(
     Tensor in_rsqrt = ttnn::rsqrt(
         ttnn::add(
             ttnn::multiply(neg_in, input, std::nullopt, output_mem_config), 1.0f, std::nullopt, output_mem_config),
+        false,
         output_mem_config);
     in_rsqrt = ttnn::neg(in_rsqrt, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -376,7 +376,7 @@ static Tensor std_var_impl(
     Tensor output_tensor =
         ttnn::subtract(mean_square_tensor, ttnn::pow(mean_tensor, 2.0f, memory_config), std::nullopt, memory_config);
     if constexpr (reduce_type == ReduceType::Std) {
-        output_tensor = ttnn::sqrt(output_tensor, memory_config);
+        output_tensor = ttnn::sqrt(output_tensor, false, memory_config);
     }
     return output_tensor;
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #23166

### Problem description
Both sqrt and rsqrt doesn't not returns nan for negative inputs.

### What's changed
Added a check to return NaN for negative inputs. Also introduced a fast_and_approx flag, so NaN handling occurs only when the flag is set to false.

### Perf results:
Op | Version | Config | Time (ns) | Notes
-- | -- | -- | -- | --
Rsqrt | Main | 1 tile | 2535 | —
  | Updated (approx = false) | 1 tile | 2624 | ~3% slower
  | Updated (approx = true) | 1 tile | 2537 | Nearly same as main
Sqrt | Main | 1 tile | 2410 | —
  | Updated (approx = false) | 1 tile | 2587 | ~7% slower
  | Updated (approx = true) | 1 tile | 2428 | Nearly same as main


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19034959773)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19034964929)