### PR TITLE
Refactor mesh descriptor maps to include FabricType layer

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -147,7 +147,10 @@ public:
 
     // Static functions for mesh graph descriptor management
     static std::filesystem::path get_mesh_graph_descriptor_path_for_cluster_type(
-        tt::tt_metal::ClusterType cluster_type, const std::string& root_dir, bool version_2 = true);
+        tt::tt_metal::ClusterType cluster_type,
+        const std::string& root_dir,
+        bool version_2 = true,
+        tt::tt_fabric::FabricType fabric_type = tt::tt_fabric::FabricType::MESH);
 
     // Get the number of active channels the user has requested between meshes
     const RequestedIntermeshConnections& get_requested_intermesh_connections() const;

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -86,7 +86,6 @@ const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mes
         {tt::tt_fabric::FabricType::TORUS_XY,
          ClusterToDescriptorMap{
              {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.yaml"},
-             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"}, // It may be here because of 1D ring
          }}});
 
 const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mesh_graph_descriptor_mgd2 =
@@ -122,7 +121,6 @@ const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mes
         {tt::tt_fabric::FabricType::TORUS_XY,
          ClusterToDescriptorMap{
              {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.textproto"},
-             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"}, // It may be here because of 1D ring
          }}});
 
 bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -49,52 +49,81 @@ RoutingDirection routing_direction_to_port_direction(const proto::RoutingDirecti
     }
 }
 
-const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>&
-    cluster_type_to_mesh_graph_descriptor =
-        tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>(
-            std::unordered_map<tt::tt_metal::ClusterType, std::string_view>{
-                {tt::tt_metal::ClusterType::N150, "n150_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::N300, "n300_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::TG, "tg_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P100, "p100_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P150, "p150_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P150_X2, "p150_x2_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P150_X4, "p150_x4_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P150_X8, "p150_x8_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "n150_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "p150_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::SIMULATOR_QUASAR,
-                 "p150_mesh_graph_descriptor.yaml"},  // TODO use quasar mesh
-                {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.yaml"},
-                {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.yaml"},
-            });
 
-const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>&
-    cluster_type_to_mesh_graph_descriptor_mgd2 =
-        tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>(
-            std::unordered_map<tt::tt_metal::ClusterType, std::string_view>{
-                {tt::tt_metal::ClusterType::N150, "n150_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::N300, "n300_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::TG, "tg_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P100, "p100_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P150, "p150_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P150_X2, "p150_x2_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P150_X4, "p150_x4_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P150_X8, "p150_x8_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "n150_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "p150_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::SIMULATOR_QUASAR, "p150_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.textproto"},
-                {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.textproto"},
-            });
+using ClusterToDescriptorMap = std::unordered_map<tt::tt_metal::ClusterType, std::string_view>;
+using FabricToClusterDescriptorMap = std::unordered_map<tt::tt_fabric::FabricType, ClusterToDescriptorMap>;
+
+const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mesh_graph_descriptor =
+    tt::stl::Indestructible<FabricToClusterDescriptorMap>(FabricToClusterDescriptorMap{
+        {tt::tt_fabric::FabricType::MESH,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::N150, "n150_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::N300, "n300_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::TG, "tg_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P100, "p100_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P150, "p150_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P150_X2, "p150_x2_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P150_X4, "p150_x4_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P150_X8, "p150_x8_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "n150_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "p150_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::SIMULATOR_QUASAR, "p150_mesh_graph_descriptor.yaml"},  // TODO use quasar mesh
+             {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.textproto"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_X,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_x_graph_descriptor.yaml"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_Y,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_y_graph_descriptor.yaml"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_XY,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.yaml"},
+             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"}, // It may be here because of 1D ring
+         }}});
+
+const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mesh_graph_descriptor_mgd2 =
+    tt::stl::Indestructible<FabricToClusterDescriptorMap>(FabricToClusterDescriptorMap{
+        {tt::tt_fabric::FabricType::MESH,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::N150, "n150_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::N300, "n300_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::TG, "tg_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P100, "p100_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P150, "p150_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P150_X2, "p150_x2_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P150_X4, "p150_x4_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P150_X8, "p150_x8_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::SIMULATOR_WORMHOLE_B0, "n150_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::SIMULATOR_BLACKHOLE, "p150_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::SIMULATOR_QUASAR, "p150_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.textproto"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_X,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_x_graph_descriptor.textproto"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_Y,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_y_graph_descriptor.textproto"},
+         }},
+        {tt::tt_fabric::FabricType::TORUS_XY,
+         ClusterToDescriptorMap{
+             {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.textproto"},
+             {tt::tt_metal::ClusterType::T3K, "t3k_mesh_graph_descriptor.yaml"}, // It may be here because of 1D ring
+         }}});
 
 bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
 
@@ -780,15 +809,21 @@ const MeshContainer<MeshHostRankId>& MeshGraph::get_host_ranks(MeshId mesh_id) c
 }
 
 std::filesystem::path MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
-    tt::tt_metal::ClusterType cluster_type, const std::string& root_dir, const bool version_2) {
-    auto & descriptor_map = version_2
-        ? cluster_type_to_mesh_graph_descriptor_mgd2.get()
-        : cluster_type_to_mesh_graph_descriptor.get();
-    auto it = descriptor_map.find(cluster_type);
-    if (it != descriptor_map.end()) {
-        return std::filesystem::path(root_dir) / MESH_GRAPH_DESCRIPTOR_DIR / it->second;
+    const tt::tt_metal::ClusterType cluster_type,
+    const std::string& root_dir,
+    const bool version_2,
+    const tt::tt_fabric::FabricType fabric_type) {
+    auto& fabric_to_cluster_map =
+        version_2 ? cluster_type_to_mesh_graph_descriptor_mgd2.get() : cluster_type_to_mesh_graph_descriptor.get();
+    auto fabric_it = fabric_to_cluster_map.find(fabric_type);
+    if (fabric_it != fabric_to_cluster_map.end()) {
+        const auto& cluster_to_descriptor_map = fabric_it->second;
+        auto cluster_it = cluster_to_descriptor_map.find(cluster_type);
+        if (cluster_it != cluster_to_descriptor_map.end()) {
+            return std::filesystem::path(root_dir) / MESH_GRAPH_DESCRIPTOR_DIR / cluster_it->second;
+        }
     }
-    TT_THROW("Cannot find mesh graph descriptor for cluster type {}", cluster_type);
+    TT_THROW("Cannot find mesh graph descriptor for fabric type {} and cluster type {}", fabric_type, cluster_type);
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -823,6 +823,23 @@ std::filesystem::path MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type
             return std::filesystem::path(root_dir) / MESH_GRAPH_DESCRIPTOR_DIR / cluster_it->second;
         }
     }
+
+    // Fallback: if a torus fabric type was requested but not found, try MESH fabric type.
+    if (fabric_type != FabricType::MESH) {
+        auto mesh_fabric_it = fabric_to_cluster_map.find(FabricType::MESH);
+        const auto& cluster_to_descriptor_map = mesh_fabric_it->second;
+        auto cluster_it = cluster_to_descriptor_map.find(cluster_type);
+        if (cluster_it != cluster_to_descriptor_map.end()) {
+            log_warning(
+                tt::LogFabric,
+                "Mesh Graph Descriptor for fabric type {} and cluster type {} not found. Picking mesh graph descriptor "
+                "for MESH fabric type.",
+                enchantum::to_string(fabric_type),
+                enchantum::to_string(cluster_type));
+            return std::filesystem::path(root_dir) / MESH_GRAPH_DESCRIPTOR_DIR / cluster_it->second;
+        }
+    }
+
     TT_THROW("Cannot find mesh graph descriptor for fabric type {} and cluster type {}", fabric_type, cluster_type);
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -586,46 +586,20 @@ void MetalContext::initialize_control_plane() {
     }
     log_debug(tt::LogDistributed, "Using default mesh graph descriptor.");
 
+    if (!rtoptions_.get_use_mesh_graph_descriptor_1_0()) {
+        log_debug(tt::LogDistributed, "Using MGD 2.0 mesh graph descriptor.");
+    } else {
+        log_debug(tt::LogDistributed, "Using MGD 1.0 mesh graph descriptor.");
+    }
+
     auto cluster_type = cluster_->get_cluster_type();
+    auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_);
     std::filesystem::path mesh_graph_desc_path =
         tt::tt_fabric::MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
             cluster_type,
             std::filesystem::path(rtoptions_.get_root_dir()),
-            rtoptions_.get_use_mesh_graph_descriptor_1_0());
-
-    std::string suffix;
-    if (!rtoptions_.get_use_mesh_graph_descriptor_1_0()) {
-        suffix = ".textproto";
-        log_debug(tt::LogDistributed, "Using MGD 2.0 mesh graph descriptor.");
-    } else {
-        suffix = ".yaml";
-        log_debug(tt::LogDistributed, "Using MGD 1.0 mesh graph descriptor.");
-    }
-
-    // If the cluster is a GALAXY and the fabric type is TORUS_XY, override the mesh graph descriptor path
-    if (cluster_->is_ubb_galaxy()) {
-        std::string mesh_graph_descriptor;
-        if (cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY) {
-            // For Blackhole Galaxy, only use the default descriptor
-            mesh_graph_descriptor = "single_bh_galaxy_mesh_graph_descriptor" + suffix;
-        } else {
-            // For regular Galaxy, handle different fabric types
-            switch (tt::tt_fabric::get_fabric_type(this->fabric_config_)) {
-                case tt::tt_fabric::FabricType::TORUS_XY:
-                    mesh_graph_descriptor = "single_galaxy_torus_xy_graph_descriptor" + suffix;
-                    break;
-                case tt::tt_fabric::FabricType::TORUS_X:
-                    mesh_graph_descriptor = "single_galaxy_torus_x_graph_descriptor" + suffix;
-                    break;
-                case tt::tt_fabric::FabricType::TORUS_Y:
-                    mesh_graph_descriptor = "single_galaxy_torus_y_graph_descriptor" + suffix;
-                    break;
-                default: mesh_graph_descriptor = "single_galaxy_mesh_graph_descriptor" + suffix; break;
-            }
-        }
-        mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
-                               "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
-    }
+            !rtoptions_.get_use_mesh_graph_descriptor_1_0(),
+            fabric_type);
 
     log_debug(tt::LogMetal, "Using mesh graph descriptor: {}", mesh_graph_desc_path);
 


### PR DESCRIPTION
### Ticket
Current approach was not sustainable with more specializations of graph descriptors being added, I streamlined the process to include torus type in default graph descriptor maps.

### Problem description
Mesh graph descriptor maps only indexed by ClusterType, requiring ~40 lines of manual override logic to handle different fabric types, which was not scalable for new fabric/cluster combinations.

### What's changed
Refactored descriptor maps to use nested structure with FabricType as top-level key and updated get_mesh_graph_descriptor_path_for_cluster_type() to accept fabric_type parameter, centralizing all descriptor path resolution and eliminating manual override logic.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes