### PR TITLE
Make SDXL support parameters available in torch

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -277,17 +277,8 @@ def prepare_device(mesh_device, use_cfg_parallel):
     "prompt_2, negative_prompt_2, crop_coords_top_left, guidance_rescale, timesteps, sigmas",
     [
         (None, None, (0, 0), 0.0, None, None),
-        # TODO: Remove once this is tested properly
-        (
-            "highly detailed, photorealistic, 8k",  # prompt_2
-            "blurry, low quality",  # negative_prompt_2
-            (64, 64),  # crop_coords_top_left - slight offset
-            0.7,  # guidance_rescale - fixes overexposure
-            None,  # timesteps
-            None,  # sigmas
-        ),
     ],
-    ids=["baseline", "test_crop_offset"],
+    ids=["default_additional_parameters"],
 )
 def test_demo(
     validate_fabric_compatibility,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -180,15 +180,17 @@ def batch_encode_prompt_on_device(
             the output of the pre-final layer will be used for computing the prompt embeddings.
     """
     prompt = [prompt] if isinstance(prompt, str) else prompt
+    prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
 
     num_devices = ttnn_device.get_num_devices()
     num_prompts = len(prompt)
     if use_cfg_parallel and num_prompts < num_devices:
         # Pad prompts by appending empty strings to match num_devices
         prompt = prompt + [""] * (num_devices - len(prompt))
+        if prompt_2 is not None:
+            prompt_2 = prompt_2 + [""] * (num_devices - len(prompt_2))
 
     assert len(prompt) == num_devices, "Prompt length must be equal to number of devices"
-    assert prompt_2 is None, "Prompt 2 is not supported currently"
     assert lora_scale is None, "Lora scale is not supported currently with on device text encoders"
     assert clip_skip is None, "Clip skip is not supported currently with on device text encoders"
     assert prompt_embeds is None, "Prompt embeds is not supported currently with on device text encoders"
@@ -212,7 +214,6 @@ def batch_encode_prompt_on_device(
 
     if prompt_embeds is None:
         prompt_2 = prompt_2 or prompt
-        prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
 
         # textual inversion: process multi-vector tokens if necessary
         prompt_embeds_list = []
@@ -515,6 +516,7 @@ def run_tt_image_gen(
     tid_vae=None,
     capture_trace=False,
     use_cfg_parallel=False,
+    guidance_rescale=0.0,
 ):
     assert not (capture_trace and len(tt_timesteps) != 1), "Trace should capture only 1 iteration"
     profiler.start("image_gen")
@@ -560,15 +562,46 @@ def run_tt_image_gen(
             else:
                 noise_pred_uncond, noise_pred_text = unet_outputs
 
+            if guidance_rescale > 0.0:
+                # ttnn.clone doesn't work with L1 sharded tensors
+                noise_pred_text_new = ttnn.to_memory_config(noise_pred_text, ttnn.L1_MEMORY_CONFIG)
+                ttnn.deallocate(noise_pred_text)
+                noise_pred_text = noise_pred_text_new
+                noise_pred_text_orig = ttnn.clone(noise_pred_text)
+
             # perform guidance
             noise_pred_text = ttnn.sub_(noise_pred_text, noise_pred_uncond)
             noise_pred_text = ttnn.mul_(noise_pred_text, guidance_scale)
-            noise_pred = ttnn.add_(noise_pred_uncond, noise_pred_text)
-
-            tt_latents = tt_scheduler.step(noise_pred, None, tt_latents, **tt_extra_step_kwargs, return_dict=False)[0]
+            noise_pred = ttnn.add(noise_pred_uncond, noise_pred_text)
 
             ttnn.deallocate(noise_pred_uncond)
             ttnn.deallocate(noise_pred_text)
+
+            if guidance_rescale > 0.0:
+                noise_pred_new = ttnn.to_memory_config(noise_pred, ttnn.L1_MEMORY_CONFIG)
+                ttnn.deallocate(noise_pred)
+                noise_pred = noise_pred_new
+                std_text = ttnn.std(noise_pred_text_orig, dim=[1, 2, 3], keepdim=True)
+                std_cfg = ttnn.std(noise_pred, dim=[1, 2, 3], keepdim=True)
+
+                std_ratio = ttnn.div(std_text, std_cfg)
+
+                noise_pred_rescaled = ttnn.mul(noise_pred, std_ratio)
+
+                rescaled_term = ttnn.mul(noise_pred_rescaled, guidance_rescale)
+                original_term = ttnn.mul(noise_pred, (1.0 - guidance_rescale))
+                ttnn.deallocate(noise_pred)
+                noise_pred = ttnn.add(rescaled_term, original_term)
+                ttnn.deallocate(std_text)
+                ttnn.deallocate(std_cfg)
+                ttnn.deallocate(std_ratio)
+                ttnn.deallocate(noise_pred_rescaled)
+                ttnn.deallocate(rescaled_term)
+                ttnn.deallocate(original_term)
+                ttnn.deallocate(noise_pred_text_orig)
+                noise_pred = ttnn.move(noise_pred)
+
+            tt_latents = tt_scheduler.step(noise_pred, None, tt_latents, **tt_extra_step_kwargs, return_dict=False)[0]
 
             if capture_trace:
                 ttnn.end_trace_capture(ttnn_device, tid, cq_id=0)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -130,6 +130,12 @@ def test_accuracy_sdxl(
         guidance_scale,
         use_cfg_parallel=use_cfg_parallel,
         fixed_seed_for_batch=True,
+        prompt_2=None,
+        negative_prompt_2=None,
+        crop_coords_top_left=(0, 0),
+        guidance_rescale=0.0,
+        timesteps=None,
+        sigmas=None,
     )
 
     clip = CLIPEncoder()

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -157,6 +157,9 @@ class TtSDXLPipeline(LightweightModule):
         )
         ttnn.copy_host_to_device_tensor(host_guidance_rescale, self.guidance_rescale)
 
+    def set_crop_coords_top_left(self, crop_coords_top_left: tuple):
+        self.pipeline_config.crop_coords_top_left = crop_coords_top_left
+
     def __validate_config(self):
         """
         Validates pipeline configuration parameters.

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -35,6 +35,8 @@ class TtSDXLPipelineConfig:
     vae_on_device: bool = True
     encoders_on_device: bool = True
     use_cfg_parallel: bool = False
+    crop_coords_top_left: tuple = (0, 0)
+    guidance_rescale: float = 0.0
 
 
 class TtSDXLPipeline(LightweightModule):
@@ -62,6 +64,9 @@ class TtSDXLPipeline(LightweightModule):
         )
         self.torch_pipeline = torch_pipeline
         self.pipeline_config = pipeline_config
+
+        # Validate config parameters once at initialization
+        self.__validate_config()
 
         self.encoders_compiled = False
         self.image_processing_compiled = False
@@ -133,6 +138,116 @@ class TtSDXLPipeline(LightweightModule):
         )
         ttnn.copy_host_to_device_tensor(host_guidance_scale, self.guidance_scale)
 
+    def __validate_config(self):
+        """
+        Validates pipeline configuration parameters.
+        Called once during initialization.
+        """
+        # Validate guidance_rescale
+        guidance_rescale = self.pipeline_config.guidance_rescale
+        assert isinstance(
+            guidance_rescale, (int, float)
+        ), f"`guidance_rescale` must be numeric but is {type(guidance_rescale)}"
+        assert 0.0 <= guidance_rescale <= 1.0, (
+            f"`guidance_rescale` must be in range [0.0, 1.0] but is {guidance_rescale}. "
+            "Typical values are 0.0 (no rescale) to 0.7."
+        )
+
+        # Validate crop_coords_top_left
+        crop_coords_top_left = self.pipeline_config.crop_coords_top_left
+        assert isinstance(
+            crop_coords_top_left, (tuple, list)
+        ), f"`crop_coords_top_left` must be a tuple or list but is {type(crop_coords_top_left)}"
+        assert (
+            len(crop_coords_top_left) == 2
+        ), f"`crop_coords_top_left` must have exactly 2 elements (y, x) but has {len(crop_coords_top_left)}"
+        y, x = crop_coords_top_left
+        assert isinstance(y, (int, float)) and isinstance(
+            x, (int, float)
+        ), f"`crop_coords_top_left` values must be numeric but got ({type(y)}, {type(x)})"
+        assert (
+            y >= 0 and x >= 0
+        ), f"`crop_coords_top_left` = ({y}, {x}) has negative values. Both coordinates must be non-negative."
+        assert (
+            y <= 2048 and x <= 2048
+        ), f"`crop_coords_top_left` = ({y}, {x}) is unreasonably large. Coordinates should typically be within [0, 1024] for SDXL."
+
+    def __validate_timesteps_sigmas(self, timesteps=None, sigmas=None):
+        """
+        Validates timesteps and sigmas parameters.
+        """
+        assert not (
+            timesteps is not None and sigmas is not None
+        ), "Only one of `timesteps` or `sigmas` can be passed. Please choose one to set custom values"
+
+        # Validate timesteps
+        if timesteps is not None:
+            assert isinstance(timesteps, (list, tuple)), f"`timesteps` must be a list or tuple but is {type(timesteps)}"
+            assert len(timesteps) > 0, "`timesteps` cannot be empty"
+            assert (
+                len(timesteps) <= 1000
+            ), f"`timesteps` has {len(timesteps)} steps which is too many. Maximum recommended is 1000 steps."
+
+            # Check all timesteps are non-negative and within reasonable range
+            num_train_timesteps = getattr(self.torch_pipeline.scheduler, "num_train_timesteps", 1000)
+            for i, ts in enumerate(timesteps):
+                assert isinstance(ts, (int, float)), f"`timesteps[{i}]` must be numeric but is {type(ts)}"
+                assert ts >= 0, f"`timesteps[{i}]` = {ts} is negative. All timesteps must be non-negative."
+                assert (
+                    ts <= num_train_timesteps
+                ), f"`timesteps[{i}]` = {ts} exceeds num_train_timesteps ({num_train_timesteps})"
+
+        # Validate sigmas
+        if sigmas is not None:
+            assert isinstance(sigmas, (list, tuple)), f"`sigmas` must be a list or tuple but is {type(sigmas)}"
+            assert len(sigmas) > 0, "`sigmas` cannot be empty"
+            assert (
+                len(sigmas) <= 1000
+            ), f"`sigmas` has {len(sigmas)} steps which is too many. Maximum recommended is 1000 steps."
+
+            # Check all sigmas are non-negative
+            for i, sigma in enumerate(sigmas):
+                assert isinstance(sigma, (int, float)), f"`sigmas[{i}]` must be numeric but is {type(sigma)}"
+                assert sigma >= 0, f"`sigmas[{i}]` = {sigma} is negative. All sigmas must be non-negative."
+                assert (
+                    sigma <= 1000
+                ), f"`sigmas[{i}]` = {sigma} is unreasonably large. Sigmas should typically be in range [0, ~20]."
+
+    def check_inputs(
+        self,
+        prompts,
+        negative_prompts,
+        prompt_2=None,
+        negative_prompt_2=None,
+    ):
+        """
+        Validates prompt-related input parameters before generation.
+        Raises ValueError if any parameter is invalid.
+        """
+        assert prompts is not None, "Provide `prompts`. Cannot be None."
+
+        if prompt_2 is not None:
+            assert isinstance(
+                prompt_2, (str, list)
+            ), f"`prompt_2` has to be of type `str` or `list` but is {type(prompt_2)}"
+
+        # Validate negative prompts
+        if negative_prompts is not None:
+            if isinstance(negative_prompts, list):
+                assert len(negative_prompts) == len(prompts), (
+                    f"`negative_prompts` list length ({len(negative_prompts)}) must match "
+                    f"`prompts` list length ({len(prompts)})"
+                )
+            else:
+                assert isinstance(
+                    negative_prompts, str
+                ), f"`negative_prompts` has to be of type `str` or `list` but is {type(negative_prompts)}"
+
+        if negative_prompt_2 is not None:
+            assert isinstance(
+                negative_prompt_2, (str, list)
+            ), f"`negative_prompt_2` has to be of type `str` or `list` but is {type(negative_prompt_2)}"
+
     def compile_text_encoding(self):
         # Compilation of text encoders on the device.
         if not self.encoders_compiled:
@@ -177,6 +292,7 @@ class TtSDXLPipeline(LightweightModule):
                 self.ag_semaphores,
                 capture_trace=False,
                 use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
+                guidance_rescale=self.pipeline_config.guidance_rescale,
             )
             ttnn.synchronize_device(self.ttnn_device)
             profiler.end("warmup_run")
@@ -186,8 +302,16 @@ class TtSDXLPipeline(LightweightModule):
 
             self.image_processing_compiled = True
 
-    def encode_prompts(self, prompts, negative_prompts):
+    def encode_prompts(self, prompts, negative_prompts, prompt_2=None, negative_prompt_2=None):
         # Encode prompts using the text encoders.
+
+        # Validate prompt inputs at the beginning of execution
+        self.check_inputs(
+            prompts=prompts,
+            negative_prompts=negative_prompts,
+            prompt_2=prompt_2,
+            negative_prompt_2=negative_prompt_2,
+        )
 
         if self.pipeline_config.encoders_on_device:
             # Prompt encode on device
@@ -203,18 +327,24 @@ class TtSDXLPipeline(LightweightModule):
                     if isinstance(negative_prompts, list)
                     else negative_prompts
                 )
+                batch_prompts_2 = prompt_2[i : i + self.batch_size] if isinstance(prompt_2, list) else prompt_2
+                current_negative_prompts_2 = (
+                    negative_prompt_2[i : i + self.batch_size]
+                    if isinstance(negative_prompt_2, list)
+                    else negative_prompt_2
+                )
                 batch_embeds = batch_encode_prompt_on_device(
                     self.torch_pipeline,
                     self.tt_text_encoder,
                     self.tt_text_encoder_2,
                     self.ttnn_device,
                     prompt=batch_prompts,  # Pass the entire batch
-                    prompt_2=None,
+                    prompt_2=batch_prompts_2,
                     device=self.cpu_device,
                     num_images_per_prompt=1,
                     do_classifier_free_guidance=True,
                     negative_prompt=current_negative_prompts,
-                    negative_prompt_2=None,
+                    negative_prompt_2=current_negative_prompts_2,
                     prompt_embeds=None,
                     negative_prompt_embeds=None,
                     pooled_prompt_embeds=None,
@@ -251,12 +381,12 @@ class TtSDXLPipeline(LightweightModule):
             profiler.start("encode_prompts")
             all_embeds = self.torch_pipeline.encode_prompt(
                 prompt=prompts,  # Pass the entire list at once
-                prompt_2=None,
+                prompt_2=prompt_2,
                 device=self.cpu_device,
                 num_images_per_prompt=1,
                 do_classifier_free_guidance=True,
                 negative_prompt=negative_prompts,
-                negative_prompt_2=None,
+                negative_prompt_2=negative_prompt_2,
                 prompt_embeds=None,
                 negative_prompt_embeds=None,
                 pooled_prompt_embeds=None,
@@ -300,12 +430,18 @@ class TtSDXLPipeline(LightweightModule):
         torch_add_text_embeds,
         start_latent_seed=None,
         fixed_seed_for_batch=False,
+        timesteps=None,
+        sigmas=None,
     ):
         # Generate user input tensors for the TT model.
 
+        # Validate timesteps/sigmas at the beginning if custom values are provided
+        if timesteps is not None or sigmas is not None:
+            self.__validate_timesteps_sigmas(timesteps, sigmas)
+
         logger.info("Generating input tensors...")
         profiler.start("prepare_latents")
-        self.__prepare_timesteps()
+        self.__prepare_timesteps(timesteps, sigmas)
 
         num_channels_latents = self.torch_pipeline.unet.config.in_channels
         height = width = 1024
@@ -342,7 +478,7 @@ class TtSDXLPipeline(LightweightModule):
 
         original_size = (height, width)
         target_size = (height, width)
-        crops_coords_top_left = (0, 0)
+        crops_coords_top_left = self.pipeline_config.crop_coords_top_left
         add_time_ids = self.torch_pipeline._get_add_time_ids(
             original_size,
             crops_coords_top_left,
@@ -415,6 +551,7 @@ class TtSDXLPipeline(LightweightModule):
             output_shape=self.output_shape,
             tid_vae=self.tid_vae if hasattr(self, "tid_vae") else None,
             use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
+            guidance_rescale=self.pipeline_config.guidance_rescale,
         )
         return imgs
 
@@ -556,11 +693,11 @@ class TtSDXLPipeline(LightweightModule):
         profiler.end("create_user_tensors")
         return tt_latents, tt_prompt_embeds, tt_add_text_embeds
 
-    def __prepare_timesteps(self):
+    def __prepare_timesteps(self, timesteps=None, sigmas=None):
         # Helper method for timestep preparation.
 
         self.ttnn_timesteps, self.pipeline_config.num_inference_steps = retrieve_timesteps(
-            self.torch_pipeline.scheduler, self.pipeline_config.num_inference_steps, self.cpu_device, None, None
+            self.torch_pipeline.scheduler, self.pipeline_config.num_inference_steps, self.cpu_device, timesteps, sigmas
         )
 
     def __trace_image_processing(self):
@@ -590,6 +727,7 @@ class TtSDXLPipeline(LightweightModule):
             self.ag_semaphores,
             capture_trace=True,
             use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
+            guidance_rescale=self.pipeline_config.guidance_rescale,
         )
         ttnn.synchronize_device(self.ttnn_device)
         profiler.end("capture_model_trace")


### PR DESCRIPTION
### Ticket
Closes #30218

### Problem description
Currently, only a few key parameters from the TT side are supported in the SDXL model. The customer requested support for additional parameters.

### What's changed
Added support for: `prompt_2`, `negative_prompt_2`, `crop_coords_top_left`, `guidance_rescale`, `timesteps`, and `sigmas`.

### 1. `prompt_2`
An additional text prompt field.  
- Useful for providing extra description, style, or context in addition to the main `prompt`.
- In SDXL, `prompt` and `prompt_2` can be applied at different conditioning stages, improving detail or altering tone.

### 2. `negative_prompt_2`
A secondary negative prompt used to specify what should be excluded during the second conditioning stage.  
- Helps steer away from unwanted attributes without changing the main `negative_prompt`.
- Can be used for cleaning artifacts or enforcing style consistency.

### 3. `crop_coords_top_left`
Coordinates (x, y) for cropping based on the top-left corner of the image.  
- Useful in workflows with larger canvases or image-to-image tasks.
- Allows precise control over which part of the image is kept or re-rendered.

### 4. `guidance_rescale`
A scaling factor applied to classifier-free guidance (CFG) strength.  
- Helps balance prompt adherence against image naturalness.
- Prevents oversaturation or harsh contrast from overly strong guidance.
- This parameter should be in [0.0, 1.0] range.

### 5. `timesteps`
Specifies the number (or schedule) of denoising steps in the generation process.  
- More timesteps → better detail but longer render times.
- Fewer timesteps → faster results but potentially lower quality.
- An example of custom timesteps: `[999, 980, 960, 940, 920, 900, 850, 800, 700, 600, 500, 400, 300, 200, 150, 100, 70, 40, 20, 0]`.

### 6. `sigmas`
Values that define the noise schedule’s standard deviations at each denoising step.  
- Controls how noise reduction progresses during sampling.
- Allows advanced tweaking for custom generation curves or artistic effects.
- An example of custom sigmas: `[15.0, 12.0, 9.5, 7.5, 6.0, 4.8, 3.8, 3.0, 2.4, 1.9, 1.5, 1.2, 0.95, 0.75, 0.60, 0.47, 0.37, 0.29, 0.23, 0.18, 0.0]`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18510016659) CI has unrelated fails
- [x] [Single card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18524419707) CI passes 
- [x] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/18499460504) CI passes