### PR TITLE
#30528 Use OP specified topology for A2A Dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
@@ -22,6 +22,83 @@ from tracy import signpost
 @pytest.mark.parametrize(
     "device_params",
     [
+        {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("trace_mode", [False])
+@pytest.mark.parametrize("num_devices,mesh_shape", [(2, (2, 2))])
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
+@pytest.mark.parametrize("cluster_axis", [0], ids=["cluster_row"])
+@pytest.mark.parametrize("experts_per_device", [8])
+@pytest.mark.parametrize("select_experts_k", [4])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize(
+    "batches_per_device, seq_len, num_iters, warmup_iters",
+    [
+        (16, 2, 2, 1),
+        (1, 3, 2, 1),
+    ],
+    ids=["b16s2", "b1s3"],
+)
+@pytest.mark.parametrize("num_links", ["MAX_LINKS"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("input_memory_config", [ttnn.L1_MEMORY_CONFIG], ids=["l1"])
+@pytest.mark.parametrize("output_memory_config", [ttnn.L1_MEMORY_CONFIG], ids=["l1"])
+def test_all_to_all_dispatch_broken(
+    mesh_device,
+    trace_mode,
+    mesh_shape,
+    num_devices,
+    cluster_axis,
+    batches_per_device,
+    experts_per_device,
+    select_experts_k,
+    hidden_size,
+    seq_len,
+    num_iters,
+    warmup_iters,
+    num_links,
+    dtype,
+    input_memory_config,
+    output_memory_config,
+    device_params,
+):
+    topology = ttnn.Topology.Linear
+    validate_test(num_devices, topology, mesh_device.shape, cluster_axis)
+    if cluster_axis is None:
+        dispatch_devices = mesh_shape[0] * mesh_shape[1]
+    else:
+        dispatch_devices = mesh_shape[cluster_axis]
+    validate_test(dispatch_devices, topology, mesh_device.shape, 0)
+    batch = batches_per_device * dispatch_devices
+    experts = experts_per_device * dispatch_devices
+
+    if num_links == "MAX_LINKS":
+        num_links = 1
+    run_all_to_all_dispatch_test(
+        mesh_device,
+        mesh_shape,
+        batch,
+        experts,
+        select_experts_k,
+        hidden_size,
+        seq_len,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme="random",
+        topology=topology,
+        input_memory_config=input_memory_config,
+        output_memory_config=output_memory_config,
+        dtype=dtype,
+        cluster_axis=cluster_axis,
+    )
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
         {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
     ],
     indirect=True,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly/test_all_to_all_dispatch_bh.py
@@ -96,6 +96,7 @@ def test_all_to_all_dispatch_broken(
         cluster_axis=cluster_axis,
     )
 
+
 @pytest.mark.parametrize(
     "device_params",
     [

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -33,7 +33,9 @@ std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, axis));
     log_debug(tt::LogOp, "num_links: {}", num_links_);
     tt::tt_fabric::Topology topology_ = topology.value_or(tt::tt_fabric::get_fabric_topology());
-    if (num_links_ == 2) {
+    auto mesh_view = mesh_device->get_view();
+
+    if (mesh_view.num_devices() == 2) {
         topology_ = tt::tt_fabric::Topology::Linear;
     }
     auto memory_config_ = memory_config.value_or(input_tensor.memory_config());

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -32,7 +32,8 @@ std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
 
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, axis));
     log_debug(tt::LogOp, "num_links: {}", num_links_);
-    tt::tt_fabric::Topology topology_ = topology.value_or(tt::tt_fabric::get_fabric_topology());
+    tt::tt_fabric::Topology topology_ =
+        topology.value_or(::ttnn::ccl::get_usable_topology(input_tensor, tt::tt_fabric::get_fabric_topology(), axis));
     auto mesh_view = mesh_device->get_view();
 
     if (mesh_view.num_devices() == 2) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -33,6 +33,10 @@ std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, axis));
     log_debug(tt::LogOp, "num_links: {}", num_links_);
     tt::tt_fabric::Topology topology_ = topology.value_or(tt::tt_fabric::get_fabric_topology());
+    if (num_links_ == 2)
+    {
+        topology_ = tt::tt_fabric::Topology::Linear;
+    }
     auto memory_config_ = memory_config.value_or(input_tensor.memory_config());
     uint32_t output_concat_dim_ = output_concat_dim.value_or(1);
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -33,8 +33,7 @@ std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, axis));
     log_debug(tt::LogOp, "num_links: {}", num_links_);
     tt::tt_fabric::Topology topology_ = topology.value_or(tt::tt_fabric::get_fabric_topology());
-    if (num_links_ == 2)
-    {
+    if (num_links_ == 2) {
         topology_ = tt::tt_fabric::Topology::Linear;
     }
     auto memory_config_ = memory_config.value_or(input_tensor.memory_config());

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/fabric.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
 
 namespace ttnn::operations::ccl {
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.cpp
@@ -34,11 +34,6 @@ std::array<ttnn::Tensor, 2> ExecuteAllToAllDispatch::invoke(
     log_debug(tt::LogOp, "num_links: {}", num_links_);
     tt::tt_fabric::Topology topology_ =
         topology.value_or(::ttnn::ccl::get_usable_topology(input_tensor, tt::tt_fabric::get_fabric_topology(), axis));
-    auto mesh_view = mesh_device->get_view();
-
-    if (mesh_view.num_devices() == 2) {
-        topology_ = tt::tt_fabric::Topology::Linear;
-    }
     auto memory_config_ = memory_config.value_or(input_tensor.memory_config());
     uint32_t output_concat_dim_ = output_concat_dim.value_or(1);
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -137,7 +137,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     const auto& output_tensor = tensor_return_value.at(0);
     const auto& metadata_tensor = tensor_return_value.at(1);
     auto num_links = operation_attributes.num_links;
-    auto topology = tt::tt_fabric::get_fabric_topology();
+    auto topology = operation_attributes.topology;
 
     auto mesh_device = input_tensor.device();
     const auto& mesh_view = mesh_device->get_view();

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -30,6 +30,9 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
     // ring is possible if device coordinates along our cluster axis are the same as the last coordinate in the mesh
     // shape first_index = 0 last index = mesh_shape[cluster_axis] - 1
     if (cluster_axis.has_value()) {
+        if (mesh_shape[cluster_axis.value()] == 2) {
+            return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
+        }
         bool first_index_is_0 = device_coords.at(0)[cluster_axis.value()] == 0;
         bool last_index_is_mesh_shape_minus_1 =
             device_coords.at(device_coords.size() - 1)[cluster_axis.value()] == mesh_shape[cluster_axis.value()] - 1;
@@ -39,6 +42,9 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
             return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
         }
     } else {
+        if (mesh_shape[0] == 2 || mesh_shape[1] == 2) {
+            return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
+        }
         TT_FATAL(!device_coords.empty(), "device_coords is empty");
         for (int i = 0; i < device_coords.front().dims(); i++) {
             if (device_coords.front()[i] != 0) {


### PR DESCRIPTION
### Ticket
#30528 

### Problem description
Use the specified topology rather than inferring it from fabric mode

All to all dispatch on 1D+1Dring goes from 55% to 99.7% with this PR

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18499284074 https://github.com/tenstorrent/tt-metal/actions/runs/18505401934
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes