### PR TITLE
#0: [skip ci] upstream testing: Remove skips for UMD tests that were fixed on p300

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -22,20 +22,9 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 
 # Function test run BH UMD tests, should be any topology
 test_suite_bh_umd_unit_tests() {
-    # Can't find test SOC descs... we don't actually run this test in metal CI
-    # so makes sense we broke it
-    # ./build/test/umd/api/api_tests
     ./build/test/umd/blackhole/unit_tests
     # Filter out the test that is failing due to local YAML files, see: https://github.com/tenstorrent/tt-metal/issues/24359
     gtest_filter="-ApiClusterTest.DifferentConstructors"
-
-    # Add more tests to exclude if hw_topology is blackhole_p300
-    # Issue: https://github.com/tenstorrent/tt-umd/issues/1412
-    if [[ "$hw_topology" == "blackhole_p300" ]]; then
-        gtest_filter+=":ApiClusterDescriptorTest.VerifyStandardTopology"
-        gtest_filter+=":ApiClusterTest.OpenChipsByPciId"
-        gtest_filter+=":ApiClusterTest.OpenClusterByLogicalID"
-    fi
     ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Tests were previously skipped on p300 due to https://github.com/tenstorrent/tt-umd/issues/1412

### What's changed
Issue resolved and UMD bumped on latest tt-metal, removing skip

### Checklist
- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/18500789985