### PR TITLE
Fold operation for unaligned input channels.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from tests.ttnn.unit_tests.operations.conv.data_movement.test_fold_op import run_fold_sharded_test
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "act_shape,stride_h,stride_w,padding, core_grid",
+    [
+        ((8, 18, 12, 8), 3, 2, (3, 2), None),
+        ((2, 30, 30, 32), 5, 5, (0, 0), None),
+        ((1, 24, 32, 16), 3, 4, (3, 0), None),
+        ((1, 20, 20, 8), 2, 2, (1, 3, 0, 2), None),
+        ((2, 16, 16, 16), 4, 4, (2, 2, 1, 3), None),
+        ((1, 6, 6, 3), 1, 1, (3, 3), (1, 4)),
+        ((2, 6, 6, 5), 2, 2, (1, 1), (2, 4)),
+        ((4, 8, 8, 7), 2, 2, (4, 4), (4, 4)),
+        ((8, 6, 6, 11), 2, 2, (1, 1), (4, 4)),
+        ((16, 6, 6, 13), 2, 2, (5, 5), (8, 2)),
+        ((4, 8, 8, 17), 1, 2, (2, 2), (6, 2)),
+        ((8, 4, 8, 19), 2, 1, (3, 1), (2, 5)),
+        ((8, 10, 6, 23), 1, 2, (0, 2), (2, 5)),
+        ((10, 4, 8, 29), 2, 1, (1, 1), (2, 5)),
+        ((4, 16, 16, 15), 3, 3, (1, 1), (4, 6)),
+        ((16, 16, 16, 63), 3, 3, (1, 1), (8, 6)),
+        ((16, 224, 224, 8), 2, 2, (4, 4), (8, 8)),
+    ],
+)
+def test_fold_sharded(device, act_shape, stride_h, stride_w, padding, core_grid):
+    run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import ttnn
 import pytest
 from tests.ttnn.unit_tests.operations.conv.data_movement.test_fold_op import run_fold_sharded_test
 
@@ -31,3 +32,16 @@ from tests.ttnn.unit_tests.operations.conv.data_movement.test_fold_op import run
 )
 def test_fold_sharded(device, act_shape, stride_h, stride_w, padding, core_grid):
     run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "act_shape,stride_h,stride_w,padding, core_grid",
+    [
+        ((1, 32, 32, 32), 2, 2, (0, 0), (2, 2)),
+        ((2, 32, 32, 32), 4, 4, (0, 0), (4, 4)),
+        ((1, 256, 256, 64), 8, 8, (0, 0), (8, 8)),
+    ],
+)
+def test_fold_sharded_tile_layout(device, act_shape, stride_h, stride_w, padding, core_grid):
+    run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid, ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -395,7 +395,7 @@ def test_fold(act_shape, stride_h, stride_w, device):
     torch.testing.assert_close(actual, expected)
 
 
-def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid):
+def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_grid, layout=ttnn.ROW_MAJOR_LAYOUT):
     torch.manual_seed(0)
 
     N, H, W, C = act_shape
@@ -444,7 +444,7 @@ def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_g
         tt_input = torch2tt_tensor(
             torch_input,
             device,
-            ttnn.ROW_MAJOR_LAYOUT,
+            layout,
             tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
         )
         tt_out = ttnn.fold(tt_input, stride_h=stride_h, stride_w=stride_w, padding=list(padding))

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -38,9 +38,6 @@ void validate_fold(
             shard_shape[0] % (input_shape[2] * stride_h) == 0,
             "Fold: Shard height must be divisible by input width times stride_h for proper folding operation.");
         TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Fold: Expect sharded input tensor in row-major layout.");
-        TT_FATAL(
-            (input_shape[-1] * input_tensor.element_size()) % 16 == 0,
-            "Fold: Expect input tensor's pages to be multiples of 16 bytes.");
     } else if (is_dram_interleaved) {
         TT_FATAL(input_shape[1] % stride_h == 0, "Fold: Input height must be divisible by stride_h.");
         TT_FATAL(input_shape[2] % stride_w == 0, "Fold: Input width must be divisible by stride_w.");

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -65,6 +65,7 @@ Fold::MultiCore::cached_program_t fold_multi_core(
         num_dst_rows,
         width / stride_w,
         pixels_per_dst_row * aligned_pixel_size,
+        input.element_size(),
         true,
     };
     // Setup kernel
@@ -75,7 +76,7 @@ Fold::MultiCore::cached_program_t fold_multi_core(
         all_cores,
         WriterDataMovementConfig(compile_time_args, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
-    compile_time_args[12] = false;  // is_reader = false for writer
+    compile_time_args[13] = false;  // is_reader = false for writer
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
@@ -18,7 +18,8 @@ void kernel_main() {
     constexpr uint32_t num_dst_rows = get_compile_time_arg_val(9);
     constexpr uint32_t num_dst_cols = get_compile_time_arg_val(10);
     constexpr uint32_t dst_row_offset = get_compile_time_arg_val(11);
-    constexpr uint32_t is_reader = get_compile_time_arg_val(12);
+    constexpr uint32_t element_size = get_compile_time_arg_val(12);
+    constexpr uint32_t is_reader = get_compile_time_arg_val(13);
 
     constexpr uint32_t dst_row_size = num_dst_cols * aligned_dst_pixel_size;
     constexpr uint32_t cols_per_core = num_dst_cols / 2;
@@ -27,8 +28,8 @@ void kernel_main() {
     constexpr uint32_t core_dst_offset = is_reader ? 0 : aligned_dst_pixel_size;
 
     constexpr bool is_aligned = (pixel_size == aligned_pixel_size);
-    constexpr uint32_t num_pixels = pixel_size / 2;
-    constexpr uint32_t aligned_pixels = aligned_pixel_size / 2;
+    constexpr uint32_t num_pixels = pixel_size / element_size;
+    constexpr uint32_t aligned_pixels = aligned_pixel_size / element_size;
 
     uint64_t src_noc_addr = get_noc_addr(get_read_ptr(src_cb));
     const uint32_t dst_addr_base = get_write_ptr(dst_cb);
@@ -38,23 +39,31 @@ void kernel_main() {
         noc_async_read_one_packet_set_state(src_noc_addr, aligned_chunk_size);
     }
 
+    // Process each destination row
     for (uint32_t row = 0; row < num_dst_rows; ++row) {
         uint64_t src_col_offset = core_col_offset;
         uint32_t dst_addr = dst_addr_base + (row * dst_row_size) + core_dst_offset;
 
+        // Process columns assigned to this core
         for (uint32_t col = 0; col < process_cols; ++col) {
             uint32_t dst_pixel_addr = dst_addr;
+            // Gather pixels along stride_h dimension
             for (uint32_t h = 0; h < stride_h; ++h) {
                 const uint32_t h_offset = h * aligned_row_size;
                 if constexpr (is_aligned) {
+                    // Fast path: aligned NOC read
                     noc_async_read_one_packet_with_state<true>(
                         src_noc_addr + src_col_offset + h_offset, dst_pixel_addr);
                     dst_pixel_addr += aligned_chunk_size;
                 } else {
+                    // Slow path: element-wise copy for unaligned data
+                    // Cast to uint16_t* for element-level access to pixel data
                     uint16_t* src_ptr = (uint16_t*)(src_addr_base + src_col_offset + h_offset);
                     uint16_t* dst_ptr = (uint16_t*)dst_pixel_addr;
 
+                    // Gather pixels along stride_w dimension
                     for (uint32_t w = 0; w < stride_w; ++w) {
+                        // Copy num_pixels (half-words) from source to destination
                         for (uint32_t i = 0; i < num_pixels; ++i) {
                             dst_ptr[i] = src_ptr[i];
                         }
@@ -64,9 +73,11 @@ void kernel_main() {
                     dst_pixel_addr += pixel_size * stride_w;
                 }
             }
+            // Move to next column (2 cores interleaved)
             src_col_offset += aligned_chunk_size * 2;
             dst_addr += aligned_dst_pixel_size * 2;
         }
+        // Move to next row
         src_noc_addr += dst_row_offset;
         src_addr_base += dst_row_offset;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
@@ -28,8 +28,8 @@ void kernel_main() {
     constexpr uint32_t core_dst_offset = is_reader ? 0 : aligned_dst_pixel_size;
 
     constexpr bool is_aligned = (pixel_size == aligned_pixel_size);
-    constexpr uint32_t num_pixels = pixel_size / element_size;
-    constexpr uint32_t aligned_pixels = aligned_pixel_size / element_size;
+    constexpr uint32_t elements_per_pixel = pixel_size / element_size;
+    constexpr uint32_t elements_per_aligned_pixel = aligned_pixel_size / element_size;
 
     uint64_t src_noc_addr = get_noc_addr(get_read_ptr(src_cb));
     const uint32_t dst_addr_base = get_write_ptr(dst_cb);
@@ -63,12 +63,12 @@ void kernel_main() {
 
                     // Gather pixels along stride_w dimension
                     for (uint32_t w = 0; w < stride_w; ++w) {
-                        // Copy num_pixels (half-words) from source to destination
-                        for (uint32_t i = 0; i < num_pixels; ++i) {
+                        // Copy elements_per_pixel (half-words) from source to destination
+                        for (uint32_t i = 0; i < elements_per_pixel; ++i) {
                             dst_ptr[i] = src_ptr[i];
                         }
-                        src_ptr += aligned_pixels;
-                        dst_ptr += num_pixels;
+                        src_ptr += elements_per_aligned_pixel;
+                        dst_ptr += elements_per_pixel;
                     }
                     dst_pixel_addr += pixel_size * stride_w;
                 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp
@@ -3,24 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include <cstdint>
 #include "dataflow_api.h"
-
-#define dump(a)                                               \
-    do {                                                      \
-        DPRINT << "Activations: " << #a " = " << a << ENDL(); \
-    } while (false)
-
-inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
-    for (uint32_t page = 0; page < npages; ++page) {
-        DPRINT << start + page << ": ";
-        for (uint32_t j = 0; j < elts_per_page; ++j, ++ptr) {
-            DPRINT << BF16(*ptr) << " ";
-        }
-        DPRINT << ENDL();
-    }
-}
 
 void kernel_main() {
     constexpr uint32_t src_cb = get_compile_time_arg_val(0);
@@ -45,6 +28,8 @@ void kernel_main() {
 
     constexpr bool is_aligned = (pixel_size == aligned_pixel_size);
     constexpr uint32_t read_size = is_aligned ? aligned_chunk_size : pixel_size;
+    constexpr uint32_t num_pixels = pixel_size / 2;
+    constexpr uint32_t pixel_skip_u16 = (aligned_pixel_size - pixel_size) / 2;
 
     uint64_t src_noc_addr = get_noc_addr(get_read_ptr(src_cb));
     const uint32_t dst_addr_base = get_write_ptr(dst_cb);
@@ -60,22 +45,24 @@ void kernel_main() {
 
         for (uint32_t col = 0; col < process_cols; ++col) {
             uint32_t dst_pixel_addr = dst_addr;
-            volatile tt_l1_ptr uint16_t* dst_h_addr = (volatile uint16_t*)dst_pixel_addr;
             for (uint32_t h = 0; h < stride_h; ++h) {
                 const uint32_t h_offset = h * aligned_row_size;
-                volatile tt_l1_ptr uint16_t* src_h_addr =
-                    (volatile uint16_t*)(src_addr_base + src_col_offset + h_offset);
                 if constexpr (is_aligned) {
                     noc_async_read_one_packet_with_state<true>(
                         src_noc_addr + src_col_offset + h_offset, dst_pixel_addr);
                     dst_pixel_addr += aligned_chunk_size;
                 } else {
+                    volatile tt_l1_ptr uint16_t* src_h_addr =
+                        (volatile tt_l1_ptr uint16_t*)(src_addr_base + src_col_offset + h_offset);
+                    volatile tt_l1_ptr uint16_t* dst_h_addr = (volatile tt_l1_ptr uint16_t*)dst_pixel_addr;
+
                     for (uint32_t w = 0; w < stride_w; ++w) {
-                        for (uint32_t i = 0; i < pixel_size / 2; ++i) {
-                            *(dst_h_addr++) = *(src_h_addr++);
+                        for (uint32_t i = 0; i < num_pixels; ++i) {
+                            *dst_h_addr++ = *src_h_addr++;
                         }
-                        src_h_addr += ((aligned_pixel_size - pixel_size) / 2);
+                        src_h_addr += pixel_skip_u16;
                     }
+                    dst_pixel_addr += pixel_size * stride_w;
                 }
             }
             src_col_offset += aligned_chunk_size * 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include <tt-metalium/constants.hpp>
@@ -452,6 +453,10 @@ Tensor FoldOperation::invoke(
                 ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
         }
 
+        // Convert to row-major if tiled since fold supports only row-major layout
+        if (processed_tensor.layout() == Layout::TILE) {
+            processed_tensor = ttnn::untilize(processed_tensor, std::nullopt, true, true);
+        }
         // Reshard if needed for optimal fold computation
         processed_tensor = reshard_if_needed(processed_tensor, stride_h, stride_w);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -261,13 +261,13 @@ void kernel_main() {
     constexpr bool enable_blocking = !skip_untilize;
 
 #ifdef CONFIG_TENSOR_IN_DRAM
-    constexpr uint32_t padding_config_dram_addr = get_compile_time_arg_val(19);
-    constexpr uint32_t padding_config_page_size = get_compile_time_arg_val(20);
-    constexpr uint32_t gather_config_dram_addr = get_compile_time_arg_val(21);
-    constexpr uint32_t gather_config_page_size = get_compile_time_arg_val(22);
+    constexpr uint32_t padding_config_dram_addr = get_compile_time_arg_val(18);
+    constexpr uint32_t padding_config_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t gather_config_dram_addr = get_compile_time_arg_val(20);
+    constexpr uint32_t gather_config_page_size = get_compile_time_arg_val(21);
 
-    constexpr auto padding_config_tensor_args = TensorAccessorArgs<23>();
-    constexpr auto gather_config_tensor_args = TensorAccessorArgs<24>();
+    constexpr auto padding_config_tensor_args = TensorAccessorArgs<22>();
+    constexpr auto gather_config_tensor_args = TensorAccessorArgs<23>();
 
     const auto padding_config_accessor =
         TensorAccessor(padding_config_tensor_args, padding_config_dram_addr, padding_config_page_size);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -133,7 +133,7 @@ static inline uint64_t get_remote_core_l1_noc_addr(
     return get_noc_addr(noc_x, noc_y, out_base_l1_addr);
 }
 
-template <uint32_t StickSizeBytes, uint32_t PageSize, bool EnableBlocking, uint32_t BlockHeightSticks>
+template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightSticks>
 static inline void write_stick_async(
     uint32_t in_base_l1_addr,
     uint64_t out_base_l1_addr,
@@ -142,14 +142,14 @@ static inline void write_stick_async(
     uint16_t transfer_size) {
     if constexpr (EnableBlocking) {
         const uint32_t src_offset = (src_offset_id % BlockHeightSticks) *
-                                    PageSize;  // Convert from global stick offset to local block stick offset
+                                    StickSizeBytes;  // Convert from global stick offset to local block stick offset
         const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
         const uint32_t size = transfer_size * StickSizeBytes;
         const uint32_t src_addr = in_base_l1_addr + src_offset;
         const uint64_t dst_addr = out_base_l1_addr + dst_offset;
         noc_async_write(src_addr, dst_addr, size);
     } else {
-        const uint32_t src_offset = src_offset_id * PageSize;
+        const uint32_t src_offset = src_offset_id * StickSizeBytes;
         const uint32_t dst_offset = dst_offset_id * StickSizeBytes;
         const uint32_t size = transfer_size * StickSizeBytes;
         const uint32_t src_addr = in_base_l1_addr + src_offset;
@@ -162,7 +162,6 @@ template <
     uint32_t InputCBIndex,
     uint32_t OutputCBIndex,
     uint32_t StickSizeBytes,
-    uint32_t InputPageSizeAligned,
     uint32_t BlockSizeHeight,
     uint32_t BlockSizeWidthTiles,
     uint32_t BlockStride,
@@ -224,7 +223,7 @@ static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my
                     in_base_l1_addr = get_read_ptr(InputCBIndex);  // Ensure base address is at front of input CB
                 }
             }
-            write_stick_async<StickSizeBytes, InputPageSizeAligned, EnableBlocking, BlockSizeHeight>(
+            write_stick_async<StickSizeBytes, EnableBlocking, BlockSizeHeight>(
                 in_base_l1_addr, out_l1_addr, src_offset, dst_offset, transfer_size);
             transfers_remaining--;
         }
@@ -245,17 +244,16 @@ void kernel_main() {
     constexpr uint32_t pad_cb_id = get_compile_time_arg_val(5);
     constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(6);
     constexpr uint32_t in_nsticks = get_compile_time_arg_val(7);
-    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(8);
+    constexpr uint32_t aligned_stick_nbytes = get_compile_time_arg_val(8);
     constexpr bool is_block_sharded = get_compile_time_arg_val(9) == 1;
     constexpr bool remote_read = get_compile_time_arg_val(10) == 1;
     constexpr bool is_col_major = get_compile_time_arg_val(11) == 1;
     constexpr bool is_width_sharded = get_compile_time_arg_val(12) == 1;
-    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(13);
-    constexpr bool skip_untilize = get_compile_time_arg_val(14) == 1;
-    constexpr uint32_t block_size_height = get_compile_time_arg_val(15);
-    constexpr uint32_t block_size_width_tiles = get_compile_time_arg_val(16);
-    constexpr uint32_t block_start_offset = get_compile_time_arg_val(17);
-    constexpr uint32_t block_stride = get_compile_time_arg_val(18);
+    constexpr bool skip_untilize = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t block_size_height = get_compile_time_arg_val(14);
+    constexpr uint32_t block_size_width_tiles = get_compile_time_arg_val(15);
+    constexpr uint32_t block_start_offset = get_compile_time_arg_val(16);
+    constexpr uint32_t block_stride = get_compile_time_arg_val(17);
 
     static_assert(!remote_read, "Remote read is not supported in this kernel");
 
@@ -300,15 +298,15 @@ void kernel_main() {
             // Use MEM_ZEROS_BASE if we are zero padded
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, MEM_ZEROS_BASE);
             constexpr uint32_t padding_region_size = MEM_ZEROS_SIZE;
-            copy_padding<padding_config_cb_id, out_cb_id, stick_nbytes, padding_region_size>(padding_l1_addr);
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
         } else {
             constexpr uint16_t pad_val = static_cast<uint16_t>(pad_val_u32);
-            constexpr uint32_t num_elements_to_fill = stick_nbytes / elem_nbytes;
+            constexpr uint32_t num_elements_to_fill = aligned_stick_nbytes / elem_nbytes;
             fill_with_val<num_elements_to_fill, pad_val>(get_write_ptr(pad_cb_id));
 
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
-            constexpr uint32_t padding_region_size = stick_nbytes / elem_nbytes;
-            copy_padding<padding_config_cb_id, out_cb_id, stick_nbytes, padding_region_size>(padding_l1_addr);
+            constexpr uint32_t padding_region_size = aligned_stick_nbytes / elem_nbytes;
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
         }
     }
 
@@ -321,8 +319,7 @@ void kernel_main() {
     run_halo_gather<
         in_cb_id,
         out_cb_id,
-        stick_nbytes,
-        input_aligned_page_size,
+        aligned_stick_nbytes,
         block_size_height,
         block_size_width_tiles,
         block_stride,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -89,9 +89,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     const CoreRangeSet all_cores = output_tensor.shard_spec().value().grid;
 
     const ShardOrientation shard_orientation = output_tensor.shard_spec().value().orientation;
-    const auto input_shard_shape = output_tensor.shard_spec().value().shape;
+    const auto input_shard_shape = input_tensor.shard_spec().value().shape;
     const auto output_shard_shape = output_tensor.shard_spec().value().shape;
-    TT_ASSERT(input_shard_shape[1] == output_shard_shape[1], "Expected input and output shard shapes to match");
+    TT_ASSERT(input_shard_shape[1] == output_shard_shape[1], "Expected input and output shard widths to match");
 
     const uint32_t input_nhw_height = input_shape[0] * input_shape[1] * input_shape[2];
     const uint32_t remapped_input_shard_shape_for_output_grid = tt::div_up(input_nhw_height, ncores_nhw);
@@ -107,7 +107,12 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         input_npages = remapped_input_shard_shape_for_output_grid;
     }
 
-    const uint32_t out_stick_nbytes = output_shard_shape[1] * out_nbytes;
+    // Calculate aligned stick size - used for both input and output since channels don't change
+    const uint32_t stick_nbytes = output_shard_shape[1] * out_nbytes;
+    uint32_t aligned_stick_nbytes = stick_nbytes;
+    if (stick_nbytes % input_tensor.buffer()->alignment() != 0) {
+        aligned_stick_nbytes = tt::round_up(stick_nbytes, input_tensor.buffer()->alignment());
+    }
     const uint32_t out_tile_size = tt::tile_size(out_df);
 
     CBIndices cb_indices = CBIndices();
@@ -126,14 +131,14 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         "Block size must be a multiple of tile height (was {})",
         clamped_block_size_height);
 
-    uint32_t out_cb_pagesize = out_stick_nbytes;
+    uint32_t out_cb_pagesize = aligned_stick_nbytes;
     uint32_t out_cb_npages = max_out_nsticks_per_core;
     cb_indices.out_cb_id = cb_indices.get_next_cb_id();
     auto out_cb = create_circular_buffer(
         program, all_cores, cb_indices.out_cb_id, out_df, out_cb_npages, out_cb_pagesize, dst_buffer);
 
     // Used for storing padding immediate values (only used if not zero padding)
-    uint32_t pad_cb_pagesize = out_stick_nbytes;
+    uint32_t pad_cb_pagesize = aligned_stick_nbytes;
     uint32_t pad_cb_npages = 1;
     cb_indices.pad_cb_id0 = cb_indices.get_next_cb_id();
     create_circular_buffer(program, all_cores, cb_indices.pad_cb_id0, out_df, pad_cb_npages, pad_cb_pagesize);
@@ -234,11 +239,6 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
-    auto aligned_input_nstick_nbytes = out_stick_nbytes;
-    if (out_stick_nbytes % input_tensor.buffer()->alignment() != 0) {
-        aligned_input_nstick_nbytes = tt::round_up(out_stick_nbytes, input_tensor.buffer()->alignment());
-    }
-
     const uint32_t block_stride = 2;  // Skip every 2nd block because of split reader
     const std::string reader_kernel_name =
         "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp";
@@ -251,12 +251,12 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         0,  // padding value cb
         pad_val,
         input_npages,
-        out_stick_nbytes,
+        aligned_stick_nbytes,
         is_block_sharded,
         remote_read,
         (uint32_t)(transpose_mcast ? 1 : 0),
         is_width_sharded,
-        aligned_input_nstick_nbytes,
+        aligned_stick_nbytes,
         skip_untilize,
         clamped_block_size_height,  // Block size in sticks
         ntiles_per_block,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -256,7 +256,6 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
         remote_read,
         (uint32_t)(transpose_mcast ? 1 : 0),
         is_width_sharded,
-        aligned_stick_nbytes,
         skip_untilize,
         clamped_block_size_height,  // Block size in sticks
         ntiles_per_block,
@@ -300,7 +299,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     core_1_reader_ct_args[1] = cb_indices.gather_config1;
     core_1_reader_ct_args[3] = input_to_writer_cb_id1;
     core_1_reader_ct_args[5] = cb_indices.pad_cb_id1;
-    core_1_reader_ct_args[17] = 1;  // Block start offset
+    core_1_reader_ct_args[16] = 1;  // Block start offset
 
     auto reader_0_kernel_id = CreateKernel(
         program,


### PR DESCRIPTION
### Ticket
#22378

### Problem description

1. Fold operation kernel is not handling unaligned reads properly.
2. Halo kernel has 2 variables for input and output sticks where as halo never changes stick size. This was causing problem in unaligned copy.

### What's changed

- Updated fold kernel to handle unaligned data.
- Removed redundant variable from halo.
- Added test cases for fold which uses halo for padding with unaligned channels.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834121093)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834165447)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834142179) same as main
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834146561)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834149809) same as main.
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/18834154395)