### PR TITLE
Added Fabric test results upload to metal-run-microbenchmarks

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -105,9 +105,16 @@ jobs:
         timeout-minutes: 45
         run: ${{ matrix.test-group.cmd }}
       - name: Upload microbenchmark report csvs
-        uses: actions/upload-artifact@v4
+        uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
+        if: ${{ !cancelled() }}
         with:
-          name: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
+          prefix: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
           path: /work/generated/profiler/.logs
+      - name: Upload generated test reports
+        uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30404

### Problem description
Fabric test results in the `metal-run-microbenchmarks` workflow were not being uploaded after a test.

### What's changed
- Modified `metal-run-microbenchmarks-impl.yaml` so that all artifacts in `generated/test_reports` will be uploaded upon test completion, enabling Fabric CSVs to be uploaded.
- Updated the existing `upload-artifact` command to upload with UUID, for consistency.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18501579213
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18501602372
- [x] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18501611357
- [x] [Metal Run Microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/workflows/metal-run-microbenchmarks.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/18417366764/job/52484796158
