### PR TITLE
#29978 / #29457: [skip ci] Print smi data when BH multi-card demo or unit test jobs fail

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -98,6 +98,10 @@ jobs:
             pip install -r /work/models/tt_transformers/requirements.txt
           fi
           ${{ matrix.test-group.cmd }}
+      - name: Print tt-smi data on failure
+        if: failure()
+        run: |
+          tt-smi -s
       - name: Save environment data
         if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
         timeout-minutes: 15

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -99,7 +99,7 @@ jobs:
           fi
           ${{ matrix.test-group.cmd }}
       - name: Print tt-smi data on failure
-        if: failure()
+        if: ${{ failure() }}
         run: |
           tt-smi -s
       - name: Save environment data

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -112,6 +112,10 @@ jobs:
           else
             ${{ matrix.test-group.cmd }}
           fi
+      - name: Print tt-smi data on failure
+        if: failure()
+        run: |
+          tt-smi -s
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -113,7 +113,7 @@ jobs:
             ${{ matrix.test-group.cmd }}
           fi
       - name: Print tt-smi data on failure
-        if: failure()
+        if: ${{ failure() }}
         run: |
           tt-smi -s
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29978
https://github.com/tenstorrent/tt-metal/issues/29457

### What's changed
Print out additional data from tt-smi upon failure 
We're interested in system/board temp readings from smi for debugging the linked issues on deskbox

### Checklist
- [x] BH multicard unit tests https://github.com/tenstorrent/tt-metal/actions/runs/18502149488