### PR TITLE
Increase upper bound on number of windows that sdpa_windowed supports

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -23,24 +23,24 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 40, owner_id: ULMEPM2MA}, #Sean Nijjar
-          { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
-          { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 15, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
-          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          { name: "t3k llama3.2-11b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          { name: "t3k llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          { name: "t3k n300 mesh llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_unit_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          #{ name: "t3k llama3.1-70b tests", arch: wormhole_b0, cmd: run_t3000_llama3.1-70b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          { name: "t3k llama3.2-90b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, # Harry Zhou
-          { name: "t3k grok tests", arch: wormhole_b0, cmd: run_t3000_grok_tests, timeout: 30, owner_id: U03HY7MK4BT}, #Mark O'Connor
-          { name: "t3k unet shallow tests", arch: wormhole_b0, cmd: run_t3000_unet_shallow_tests, timeout: 30, owner_id: U06ECNVR0EN}, #Evan Smal
-          { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 30, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 40, owner_id: ULMEPM2MA}, #Sean Nijjar
+          # { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
+          # { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 15, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          # { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
+          # { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          # { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          # { name: "t3k llama3.2-11b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          # { name: "t3k llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          # { name: "t3k n300 mesh llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          # { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_unit_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # #{ name: "t3k llama3.1-70b tests", arch: wormhole_b0, cmd: run_t3000_llama3.1-70b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          # { name: "t3k llama3.2-90b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, # Harry Zhou
+          # { name: "t3k grok tests", arch: wormhole_b0, cmd: run_t3000_grok_tests, timeout: 30, owner_id: U03HY7MK4BT}, #Mark O'Connor
+          # { name: "t3k unet shallow tests", arch: wormhole_b0, cmd: run_t3000_unet_shallow_tests, timeout: 30, owner_id: U06ECNVR0EN}, #Evan Smal
+          # { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 30, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
           { name: "t3k qwen25_vl tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_unit_tests, timeout: 20, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          { name: "t3k gemma3-small tests", arch: wormhole_b0, cmd: run_t3000_gemma3-small_tests, timeout: 30, owner_id: U08E1JCDVNX},  #Pavle Petrovic
+          # { name: "t3k gemma3-small tests", arch: wormhole_b0, cmd: run_t3000_gemma3-small_tests, timeout: 30, owner_id: U08E1JCDVNX},  #Pavle Petrovic
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -23,24 +23,24 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 40, owner_id: ULMEPM2MA}, #Sean Nijjar
-          # { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
-          # { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 15, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          # { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
-          # { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          # { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          # { name: "t3k llama3.2-11b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          # { name: "t3k llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          # { name: "t3k n300 mesh llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          # { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_unit_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # #{ name: "t3k llama3.1-70b tests", arch: wormhole_b0, cmd: run_t3000_llama3.1-70b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
-          # { name: "t3k llama3.2-90b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, # Harry Zhou
-          # { name: "t3k grok tests", arch: wormhole_b0, cmd: run_t3000_grok_tests, timeout: 30, owner_id: U03HY7MK4BT}, #Mark O'Connor
-          # { name: "t3k unet shallow tests", arch: wormhole_b0, cmd: run_t3000_unet_shallow_tests, timeout: 30, owner_id: U06ECNVR0EN}, #Evan Smal
-          # { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 30, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 40, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 45, owner_id: UBHPP2NDP}, #Joseph Chu
+          { name: "t3k tt_metal multiprocess tests", arch: wormhole_b0, cmd: run_t3000_tt_metal_multiprocess_tests, timeout: 15, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, owner_id: UBHPP2NDP}, #Joseph Chu
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          { name: "t3k llama3.2-11b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          { name: "t3k llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          { name: "t3k n300 mesh llama3.2-11b-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_unit_tests, timeout: 30, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_unit_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          #{ name: "t3k llama3.1-70b tests", arch: wormhole_b0, cmd: run_t3000_llama3.1-70b_tests, timeout: 30, owner_id: U03PUAKE719},  #Miguel Tairum Cruz
+          { name: "t3k llama3.2-90b tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b_tests, timeout: 30, label: pipeline-functional, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, # Harry Zhou
+          { name: "t3k grok tests", arch: wormhole_b0, cmd: run_t3000_grok_tests, timeout: 30, owner_id: U03HY7MK4BT}, #Mark O'Connor
+          { name: "t3k unet shallow tests", arch: wormhole_b0, cmd: run_t3000_unet_shallow_tests, timeout: 30, owner_id: U06ECNVR0EN}, #Evan Smal
+          { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 30, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
           { name: "t3k qwen25_vl tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_unit_tests, timeout: 20, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          # { name: "t3k gemma3-small tests", arch: wormhole_b0, cmd: run_t3000_gemma3-small_tests, timeout: 30, owner_id: U08E1JCDVNX},  #Pavle Petrovic
+          { name: "t3k gemma3-small tests", arch: wormhole_b0, cmd: run_t3000_gemma3-small_tests, timeout: 30, owner_id: U08E1JCDVNX},  #Pavle Petrovic
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_op.hpp
@@ -14,9 +14,10 @@
 
 namespace ttnn::operations::transformer {
 
-constexpr uint32_t cu_window_seqlens_nelements = 1024;
-// [INFO] 1024 is large enough for 300DPI images but can be increased if needed
-static_assert(cu_window_seqlens_nelements == 1024, "cu_window_seqlens_nelements must be 1024");
+constexpr uint32_t cu_window_seqlens_nelements = 4096;
+// [INFO] 1024 is large enough for 300DPI images and it was increased to 4096 to support larger images.
+//        Even larger number of elements can be supported if needed.
+static_assert(cu_window_seqlens_nelements == 4096, "cu_window_seqlens_nelements must be 4096");
 
 struct WindowedScaledDotProductAttention {
     const std::optional<float> scale;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
In Customer Success Team (CST)'s testing of Qwen2.5-VL-3B model, some test images required more than the current maximum number of windows (`1037`). The upper bound on the number of windows were experimentally chosen to support 300DPI images when `sdpa_windowed` was created. The kernel could support larger numbers of windows. However, we still want to put an upper bound on that as the performance benefits that `sdpa_windowed` provides decreases as the number of windows increases.

### What's changed
Change the upper bound number of windows to 4096 (to provide a little buffer room to grow into). Thanks, @ssanjayTT, for testing and confirming that this code change works for CST's testing flow.

### Checklist
- [x] T3K unit test CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/18502265182
- [x] revert [0079d70](https://github.com/tenstorrent/tt-metal/pull/30540/commits/0079d7054175f29e493cf75291ac3129fa5656a1)
  - through [11ebd2d](https://github.com/tenstorrent/tt-metal/pull/30540/commits/11ebd2d341aa17c2e49d4739ee17c3d116fb49a8) 