### PR TITLE
[skip ci] adding support for detecting ND failures to git bisect tool

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -14,6 +14,11 @@ on:
         type: boolean
         default: false
         description: "Build with tracy enabled"
+      nd-mode:
+        required: true
+        type: boolean
+        default: false
+        description: "Enable non-deterministic detection mode"
       runner-label:
         required: true
         type: choice
@@ -117,4 +122,4 @@ jobs:
           mkdir -p ./build_bisect
           cp ./tests/scripts/tt_bisect.sh ./build_bisect/
           chmod +x ./build_bisect/tt_bisect.sh
-          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }}
+          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -112,4 +112,9 @@ jobs:
           GIT_COMMITTER_NAME: "GitHub Actions"
           GIT_COMMITTER_EMAIL: "actions@github.com"
         run: |
-          ./tests/scripts/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }}
+          set -euo pipefail
+          trap 'rm -rf ./build_bisect' EXIT
+          mkdir -p ./build_bisect
+          cp ./tests/scripts/tt_bisect.sh ./build_bisect/
+          chmod +x ./build_bisect/tt_bisect.sh
+          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }}

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -125,7 +125,7 @@ jobs:
           ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f '${{ inputs.command }}' -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}
 
       - name: Upload ND results CSV
-        if: ${{ inputs.nd-mode == 'true' }}
+        if: ${{ hashFiles('bisect_nd_results.csv') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: bisect-nd-results

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -125,15 +125,15 @@ jobs:
           ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f '${{ inputs.command }}' -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}
 
       - name: Upload ND results CSV
-        if: ${{ hashFiles('bisect_nd_results.csv') != '' }}
+        if: ${{ hashFiles('docker-job/bisect_nd_results.csv') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: bisect-nd-results
-          path: bisect_nd_results.csv
+          path: docker-job/bisect_nd_results.csv
           if-no-files-found: ignore
 
       - name: ND results CSV not found (debug)
-        if: ${{ hashFiles('bisect_nd_results.csv') == '' }}
+        if: ${{ hashFiles('docker-job/bisect_nd_results.csv') == '' }}
         run: |
           echo "bisect_nd_results.csv not found in $(pwd)"
           echo "Listing current directory:"

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -131,12 +131,3 @@ jobs:
           name: bisect-nd-results
           path: docker-job/bisect_nd_results.csv
           if-no-files-found: ignore
-
-      - name: ND results CSV not found (debug)
-        if: ${{ hashFiles('docker-job/bisect_nd_results.csv') == '' }}
-        run: |
-          echo "bisect_nd_results.csv not found in $(pwd)"
-          echo "Listing current directory:"
-          ls -la
-          echo "Searching for CSV files nearby:"
-          find . -maxdepth 3 -type f -name "bisect_nd_results*.csv" -print || true

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -129,5 +129,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bisect-nd-results
-          path: docker-job/bisect_nd_results.csv
+          path: bisect_nd_results.csv
           if-no-files-found: ignore

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -131,3 +131,12 @@ jobs:
           name: bisect-nd-results
           path: bisect_nd_results.csv
           if-no-files-found: ignore
+
+      - name: ND results CSV not found (debug)
+        if: ${{ hashFiles('bisect_nd_results.csv') == '' }}
+        run: |
+          echo "bisect_nd_results.csv not found in $(pwd)"
+          echo "Listing current directory:"
+          ls -la
+          echo "Searching for CSV files nearby:"
+          find . -maxdepth 3 -type f -name "bisect_nd_results*.csv" -print || true

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -122,7 +122,7 @@ jobs:
           mkdir -p ./build_bisect
           cp ./tests/scripts/tt_bisect.sh ./build_bisect/
           chmod +x ./build_bisect/tt_bisect.sh
-          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}
+          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f '${{ inputs.command }}' -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}
 
       - name: Upload ND results CSV
         if: ${{ inputs.nd-mode == 'true' }}

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -123,3 +123,11 @@ jobs:
           cp ./tests/scripts/tt_bisect.sh ./build_bisect/
           chmod +x ./build_bisect/tt_bisect.sh
           ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f "${{ inputs.command }}" -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == 'true' && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == 'true' && '-n' || '' }}
+
+      - name: Upload ND results CSV
+        if: ${{ inputs.nd-mode == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bisect-nd-results
+          path: docker-job/bisect_nd_results.csv
+          if-no-files-found: ignore

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import random
+
 import pytest
 
 from models.common.utility_functions import is_wormhole_b0
@@ -46,9 +49,10 @@ def test_demo(
     mesh_device,
     is_ci_env,
 ):
-    # randint = random.randint(0, 1000000)
-    # if randint % 2 == 0:
-    #     assert False
+    # raise AssertionError("Injected deterministic failure")
+    fail_rate = float(os.environ.get("ND_FAIL_RATE", "0.95"))  # tune as needed
+    if random.random() < fail_rate:
+        raise AssertionError("Injected nondeterministic failure")
 
     # comment 1
     # comment 2

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -52,6 +52,7 @@ def test_demo(
 
     # comment 1
     # comment 2
+    # comment 3
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -53,6 +53,7 @@ def test_demo(
     # comment 1
     # comment 2
     # comment 3
+    # comment 4
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -46,6 +46,12 @@ def test_demo(
     mesh_device,
     is_ci_env,
 ):
+    # randint = random.randint(0, 1000000)
+    # if randint % 2 == 0:
+    #     assert False
+
+    # comment 1
+
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:
             pytest.skip("Skipping test in CI since it provides redundant testing")

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -59,6 +59,7 @@ def test_demo(
     # comment 3
     # comment 4
     # comment 5
+    # comment 6
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -63,6 +63,7 @@ def test_demo(
     # comment 7
     # comment 8
     # comment 9
+    # comment 10
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -61,6 +61,7 @@ def test_demo(
     # comment 5
     # comment 6
     # comment 7
+    # comment 8
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -60,6 +60,7 @@ def test_demo(
     # comment 4
     # comment 5
     # comment 6
+    # comment 7
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -54,6 +54,7 @@ def test_demo(
     # comment 2
     # comment 3
     # comment 4
+    # comment 5
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -62,6 +62,7 @@ def test_demo(
     # comment 6
     # comment 7
     # comment 8
+    # comment 9
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -51,6 +51,7 @@ def test_demo(
     #     assert False
 
     # comment 1
+    # comment 2
 
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -2,9 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import random
-
 import pytest
 
 from models.common.utility_functions import is_wormhole_b0
@@ -49,22 +46,6 @@ def test_demo(
     mesh_device,
     is_ci_env,
 ):
-    # raise AssertionError("Injected deterministic failure")
-    fail_rate = float(os.environ.get("ND_FAIL_RATE", "0.95"))  # tune as needed
-    if random.random() < fail_rate:
-        raise AssertionError("Injected nondeterministic failure")
-
-    # comment 1
-    # comment 2
-    # comment 3
-    # comment 4
-    # comment 5
-    # comment 6
-    # comment 7
-    # comment 8
-    # comment 9
-    # comment 10
-
     if is_ci_env:
         if not expected_greedy_output_path and not expected_perf_metrics and not len(user_input) == 1:
             pytest.skip("Skipping test in CI since it provides redundant testing")

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -21,6 +21,8 @@ bad_commit=""
 tracy_enabled=0
 retries=3
 nd_mode=false
+run_idx=0
+timeout_rc=1
 
 while getopts ":f:g:b:t:pr:n" opt; do
   case "$opt" in
@@ -213,24 +215,24 @@ while [[ "$found" == "false" ]]; do
         ;;
     esac
   else
-    attempt=1
+    run_idx=1
     timeout_rc=1
-    while [ $attempt -le $retries ]; do
-      echo "Attempt $attempt/$retries on $(git rev-parse HEAD)"
+    while [ $run_idx -le $retries ]; do
+      echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
       echo "Run: $test"
       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
         timeout_rc=0
-        echo "--- Logs (attempt $attempt) ---"
+        echo "--- Logs (attempt $run_idx) ---"
         sed -n '1,200p' "$output_file" || true
         echo "------------------------------"
         break
       else
         timeout_rc=$?
         echo "Test failed (code $timeout_rc), retrying…"
-        echo "--- Logs (attempt $attempt) ---"
+        echo "--- Logs (attempt $run_idx) ---"
         sed -n '1,200p' "$output_file" || true
         echo "------------------------------"
-        attempt=$((attempt+1))
+        run_idx=$((run_idx+1))
       fi
     done
     echo "Final exit code: $timeout_rc"

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -125,45 +125,77 @@ while [[ "$found" == "false" ]]; do
   echo "::endgroup::"
 
   echo "::group::Testing $rev"
-  timeout_rc=1
-  max_retries=$retries
-  attempt=1
   output_file="bisect_test_output.log"
-  while [ $attempt -le $max_retries ]; do
-    echo "Attempt $attempt on $(git rev-parse HEAD)"
+  nd_runs=4
+  success_count=0
+  failure_count=0
+  skip_count=0
+  run_idx=1
+  while [ $run_idx -le $nd_runs ]; do
+    echo "Attempt $run_idx/$nd_runs on $(git rev-parse HEAD)"
     echo "Run: $test"
+    tt-smi -r
+    # Always run the test; classify the outcome after each run
     if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
-      timeout_rc=0
-      echo "--- Logs (attempt $attempt) ---"
-      sed -n '1,200p' "$output_file" || true
-      echo "------------------------------"
-      break
+      # Exit code 0; check if test indicates it was skipped in the output
+      if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
+        echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
+        skip_count=$((skip_count+1))
+      else
+        echo "Attempt $run_idx: success"
+        success_count=$((success_count+1))
+      fi
     else
-      timeout_rc=$?
-      echo "Test failed (code $timeout_rc), retrying…"
-      echo "--- Logs (attempt $attempt) ---"
-      sed -n '1,200p' "$output_file" || true
-      echo "------------------------------"
-      attempt=$((attempt+1))
+      rc=$?
+      if [ $rc -eq 124 ] || [ $rc -eq 137 ] || [ $rc -eq 143 ]; then
+        echo "Attempt $run_idx: timeout/kill (rc=$rc) -> counting as skipped"
+        skip_count=$((skip_count+1))
+      else
+        echo "Attempt $run_idx: failure (rc=$rc)"
+        failure_count=$((failure_count+1))
+      fi
     fi
+
+    echo "--- Logs (attempt $run_idx) ---"
+    sed -n '1,200p' "$output_file" || true
+    echo "------------------------------"
+    run_idx=$((run_idx+1))
   done
-  echo "Final exit code: $timeout_rc"
+
+  evaluated=$((success_count + failure_count))
+  if [ $evaluated -gt 0 ]; then
+    passrate=$(awk -v s=$success_count -v e=$evaluated 'BEGIN { printf "%.2f", (s*100.0)/e }')
+  else
+    passrate="NA"
+  fi
+
+  # External TSV logging
+  nd_log_file="bisect_nd_results.tsv"
+  if [ ! -f "$nd_log_file" ]; then
+    echo -e "timestamp\tcommit_sha\trev_short\tsuccesses\tfailures\tskips\tevaluated\tpassrate_percent" > "$nd_log_file"
+  fi
+  echo -e "$(date -Iseconds)\t$(git rev-parse HEAD)\t$rev\t$success_count\t$failure_count\t$skip_count\t$evaluated\t$passrate" >> "$nd_log_file"
+
+  echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
   echo "::endgroup::"
 
-  if [ $timeout_rc -eq 0 ]; then
-    out="$(git bisect good || true)"
-  elif [ $timeout_rc -eq 124 ] || [ $timeout_rc -eq 137 ] || [ $timeout_rc -eq 143 ]; then
-    echo "Timeout/kill detected; skipping this commit"
+  if [ $failure_count -ge 1 ]; then
+    out="$(git bisect bad || true)"
+  elif [ $evaluated -eq 0 ]; then
+    echo "All attempts were skipped; skipping this commit"
     git bisect skip
     continue
   else
-    out="$(git bisect bad || true)"
+    out="$(git bisect good || true)"
   fi
 
   first_line="$(printf '%s\n' "$out" | head -n1)"
   case "$first_line" in
     *"is the first bad commit"*)
+      bad_sha="$(git rev-parse HEAD)"
       echo "FOUND IT: $first_line"
+      echo "Commit: $bad_sha"
+      echo "Title : $(git log -1 --pretty=%s "$bad_sha")"
       found=true
       ;;
     *"There are only 'skip'ped commits left to test."*)

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -3,268 +3,279 @@ set -euo pipefail
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-: << 'END'
-Usage:
-  -f TEST        : test command to run (quote if it has spaces)
-  -g GOOD_SHA    : known good commit
-  -b BAD_SHA     : known bad commit
-  -t TIMEOUT     : per-iteration timeout (default 30m)
-  -p             : enable Tracy profiling
-  -r RETRIES     : number of retries (default 3)
-  -n             : enable non-deterministic detection mode (ND mode)
-END
+# : << 'END'
+# Usage:
+#   -f TEST        : test command to run (quote if it has spaces)
+#   -g GOOD_SHA    : known good commit
+#   -b BAD_SHA     : known bad commit
+#   -t TIMEOUT     : per-iteration timeout (default 30m)
+#   -p             : enable Tracy profiling
+#   -r RETRIES     : number of retries (default 3)
+#   -n             : enable non-deterministic detection mode (ND mode)
+# END
 
-timeout_duration_iteration="30m"
-test=""
-good_commit=""
-bad_commit=""
-tracy_enabled=0
-retries=3
-nd_mode=false
+# timeout_duration_iteration="30m"
+# test=""
+# good_commit=""
+# bad_commit=""
+# tracy_enabled=0
+# retries=3
+# nd_mode=false
 
-while getopts ":f:g:b:t:pr:n" opt; do
-  case "$opt" in
-    f) test="$OPTARG" ;;
-    g) good_commit="$OPTARG" ;;
-    b) bad_commit="$OPTARG" ;;
-    t) timeout_duration_iteration="$OPTARG" ;;
-    p) tracy_enabled=1 ;;
-    r) retries="$OPTARG" ;;
-    n) nd_mode=true ;;
-    \?) die "Invalid option: -$OPTARG" ;;
-    :)  die "Option -$OPTARG requires an argument." ;;
-  esac
-done
+# while getopts ":f:g:b:t:pr:n" opt; do
+#   case "$opt" in
+#     f) test="$OPTARG" ;;
+#     g) good_commit="$OPTARG" ;;
+#     b) bad_commit="$OPTARG" ;;
+#     t) timeout_duration_iteration="$OPTARG" ;;
+#     p) tracy_enabled=1 ;;
+#     r) retries="$OPTARG" ;;
+#     n) nd_mode=true ;;
+#     \?) die "Invalid option: -$OPTARG" ;;
+#     :)  die "Option -$OPTARG requires an argument." ;;
+#   esac
+# done
 
-[ -n "$test" ] || die "Please specify -f TEST."
-[ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."
-[ -n "$bad_commit" ] || die "Please specify -b BAD_SHA."
+# [ -n "$test" ] || die "Please specify -f TEST."
+# [ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."
+# [ -n "$bad_commit" ] || die "Please specify -b BAD_SHA."
 
 
-echo "TT_METAL_HOME: $TT_METAL_HOME"
-echo "PYTHONPATH: $PYTHONPATH"
-echo "ARCH_NAME: ${ARCH_NAME:-}"
-echo "pwd: $(pwd)"
-if [ "$tracy_enabled" -eq 1 ]; then
-  echo "Tracy profiling enabled for builds."
+# echo "TT_METAL_HOME: $TT_METAL_HOME"
+# echo "PYTHONPATH: $PYTHONPATH"
+# echo "ARCH_NAME: ${ARCH_NAME:-}"
+# echo "pwd: $(pwd)"
+# if [ "$tracy_enabled" -eq 1 ]; then
+#   echo "Tracy profiling enabled for builds."
+# fi
+
+# # Creating virtual environment where we can install ttnn
+# ./create_venv.sh
+# pip install -r models/tt_transformers/requirements.txt
+
+# git cat-file -e "$good_commit^{commit}" 2>/dev/null || die "Invalid good commit: $good_commit"
+# git cat-file -e "$bad_commit^{commit}" 2>/dev/null  || die "Invalid bad commit: $bad_commit"
+
+# echo "Good: $good_commit"
+# echo "Bad : $bad_commit"
+# echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+# echo "Commit: $(git rev-parse HEAD)"
+# echo "Status:"
+# git status --porcelain=v1
+
+# # Keep CPM cache across iterations for speed, but ensure it's in the workspace
+# export CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-$TT_METAL_HOME/.cpmcache}"
+# mkdir -p "$CPM_SOURCE_CACHE"
+# export CMAKE_ARGS="-DCPM_SOURCE_CACHE=$CPM_SOURCE_CACHE -DCPM_DOWNLOAD_ALL=ON -DCPM_USE_LOCAL_PACKAGES=OFF"
+
+# # Helper to ensure repo matches rev and all build products are fresh
+# fresh_clean() {
+#   # Match submodules exactly for current rev
+#   git submodule sync --recursive
+#   git submodule update --init --recursive --force
+
+#   # Nuke build outputs but keep venv/cache
+#   git reset --hard
+#   rm -rf build build_Release build_Debug || true
+# }
+
+# # After building, verify we import from the workspace
+# verify_import_path() {
+#   python - <<'PY'
+# import ttnn, sys
+# print(ttnn.get_arch_name())
+# print("ttnn imported from:", ttnn.__file__)
+# PY
+# }
+
+# echo "Starting git bisect…"
+# git bisect start "$bad_commit" "$good_commit"
+
+# found=false
+# while [[ "$found" == "false" ]]; do
+#   rev="$(git rev-parse --short=12 HEAD)"
+#   echo "::group::Building $rev"
+
+#   fresh_clean
+
+#   build_rc=0
+#   if [ "$tracy_enabled" -eq 1 ]; then
+#     ./build_metal.sh \
+#       --build-all \
+#       --enable-ccache \
+#       --enable-profiler || build_rc=$?
+#   else
+#     ./build_metal.sh \
+#       --build-all \
+#       --enable-ccache || build_rc=$?
+#   fi
+
+#   echo "::endgroup::"
+
+#   if [ $build_rc -ne 0 ]; then
+#     echo "Build failed (rc=$build_rc); skipping this commit"
+#     git bisect skip
+#     continue
+#   fi
+
+#   echo "::group::Import sanity ($rev)"
+#   if ! verify_import_path; then
+#     echo "Import path check failed; skipping this commit"
+#     git bisect skip
+#     echo "::endgroup::"
+#     continue
+#   fi
+#   echo "::endgroup::"
+
+#   echo "::group::Testing $rev"
+#   output_file="bisect_test_output.log"
+#   if [ "$nd_mode" = true ]; then
+#     success_count=0
+#     failure_count=0
+#     skip_count=0
+#     run_idx=1
+#     while [ $run_idx -le $retries ]; do
+#       echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
+#       echo "Resetting devices..."
+#       tt-smi -r >/dev/null 2>&1 || true
+#       echo "Devices reset"
+
+#       echo "Run: $test"
+#       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+#         if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
+#           echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
+#           skip_count=$((skip_count+1))
+#         else
+#           echo "Attempt $run_idx: success"
+#           success_count=$((success_count+1))
+#         fi
+#       else
+#         rc=$?
+#         if [ $rc -eq 124 ] || [ $rc -eq 137 ] || [ $rc -eq 143 ]; then
+#           echo "Attempt $run_idx: timeout/kill (rc=$rc) -> counting as skipped"
+#           skip_count=$((skip_count+1))
+#         else
+#           echo "Attempt $run_idx: failure (rc=$rc)"
+#           failure_count=$((failure_count+1))
+#         fi
+#       fi
+
+#       echo "--- Logs (attempt $run_idx) ---"
+#       sed -n '1,200p' "$output_file" || true
+#       echo "------------------------------"
+#       run_idx=$((run_idx+1))
+#     done
+
+#     evaluated=$((success_count + failure_count))
+#     if [ $evaluated -gt 0 ]; then
+#       passrate=$(awk -v s=$success_count -v e=$evaluated 'BEGIN { printf "%.2f", (s*100.0)/e }')
+#     else
+#       passrate="NA"
+#     fi
+
+#     nd_log_file="bisect_nd_results.csv"
+#     if [ ! -f "$nd_log_file" ]; then
+#       echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
+#     fi
+#     echo "$(date -Iseconds),$(git rev-parse HEAD),$rev,$success_count,$failure_count,$skip_count,$evaluated,$passrate" >> "$nd_log_file"
+
+#     echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
+#     echo "::endgroup::"
+
+#     if [ $failure_count -ge 1 ]; then
+#       out="$(git bisect bad || true)"
+#     elif [ $evaluated -eq 0 ]; then
+#       echo "All attempts were skipped; skipping this commit"
+#       git bisect skip
+#       continue
+#     else
+#       out="$(git bisect good || true)"
+#     fi
+
+#     first_line="$(printf '%s\n' "$out" | head -n1)"
+#     case "$first_line" in
+#       *"is the first bad commit"*)
+#         bad_sha="$(git rev-parse HEAD)"
+#         echo "FOUND IT: $first_line"
+#         echo "Commit: $bad_sha"
+#         echo "Title : $(git log -1 --pretty=%s "$bad_sha")"
+#         found=true
+#         ;;
+#       *"There are only 'skip'ped commits left to test."*)
+#         echo "Bisect inconclusive: only skipped commits left."
+#         echo "Last bisect output: $first_line"
+#         break
+#         ;;
+#       "")
+#         echo "git bisect produced no output; stopping to avoid an infinite loop."
+#         echo "Last bisect output: $first_line"
+#         break
+#         ;;
+#     esac
+#   else
+#     attempt=1
+#     timeout_rc=1
+#     while [ $attempt -le $retries ]; do
+#       echo "Attempt $attempt/$retries on $(git rev-parse HEAD)"
+#       echo "Run: $test"
+#       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+#         timeout_rc=0
+#         echo "--- Logs (attempt $attempt) ---"
+#         sed -n '1,200p' "$output_file" || true
+#         echo "------------------------------"
+#         break
+#       else
+#         timeout_rc=$?
+#         echo "Test failed (code $timeout_rc), retrying…"
+#         echo "--- Logs (attempt $attempt) ---"
+#         sed -n '1,200p' "$output_file" || true
+#         echo "------------------------------"
+#         attempt=$((attempt+1))
+#       fi
+#     done
+#     echo "Final exit code: $timeout_rc"
+#     echo "::endgroup::"
+
+#     if [ $timeout_rc -eq 0 ]; then
+#       out="$(git bisect good || true)"
+#     elif [ $timeout_rc -eq 124 ] || [ $timeout_rc -eq 137 ] || [ $timeout_rc -eq 143 ]; then
+#       echo "Timeout/kill detected; skipping this commit"
+#       git bisect skip
+#       continue
+#     else
+#       out="$(git bisect bad || true)"
+#     fi
+
+#     first_line="$(printf '%s\n' "$out" | head -n1)"
+#     case "$first_line" in
+#       *"is the first bad commit"*)
+#         echo "FOUND IT: $first_line"
+#         found=true
+#         ;;
+#       *"There are only 'skip'ped commits left to test."*)
+#         echo "Bisect inconclusive: only skipped commits left."
+#         echo "Last bisect output: $first_line"
+#         break
+#         ;;
+#       "")
+#         echo "git bisect produced no output; stopping to avoid an infinite loop."
+#         echo "Last bisect output: $first_line"
+#         break
+#         ;;
+#     esac
+#   fi
+
+# done
+
+# git bisect reset || true
+
+# Temporary: minimal CSV generation for artifact upload testing
+nd_log_file="bisect_nd_results.csv"
+if [ ! -f "$nd_log_file" ]; then
+  echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
 fi
-
-# Creating virtual environment where we can install ttnn
-./create_venv.sh
-pip install -r models/tt_transformers/requirements.txt
-
-git cat-file -e "$good_commit^{commit}" 2>/dev/null || die "Invalid good commit: $good_commit"
-git cat-file -e "$bad_commit^{commit}" 2>/dev/null  || die "Invalid bad commit: $bad_commit"
-
-echo "Good: $good_commit"
-echo "Bad : $bad_commit"
-echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
-echo "Commit: $(git rev-parse HEAD)"
-echo "Status:"
-git status --porcelain=v1
-
-# Keep CPM cache across iterations for speed, but ensure it's in the workspace
-export CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-$TT_METAL_HOME/.cpmcache}"
-mkdir -p "$CPM_SOURCE_CACHE"
-export CMAKE_ARGS="-DCPM_SOURCE_CACHE=$CPM_SOURCE_CACHE -DCPM_DOWNLOAD_ALL=ON -DCPM_USE_LOCAL_PACKAGES=OFF"
-
-# Helper to ensure repo matches rev and all build products are fresh
-fresh_clean() {
-  # Match submodules exactly for current rev
-  git submodule sync --recursive
-  git submodule update --init --recursive --force
-
-  # Nuke build outputs but keep venv/cache
-  git reset --hard
-  rm -rf build build_Release build_Debug || true
-}
-
-# After building, verify we import from the workspace
-verify_import_path() {
-  python - <<'PY'
-import ttnn, sys
-print(ttnn.get_arch_name())
-print("ttnn imported from:", ttnn.__file__)
-PY
-}
-
-echo "Starting git bisect…"
-git bisect start "$bad_commit" "$good_commit"
-
-found=false
-while [[ "$found" == "false" ]]; do
-  rev="$(git rev-parse --short=12 HEAD)"
-  echo "::group::Building $rev"
-
-  fresh_clean
-
-  build_rc=0
-  if [ "$tracy_enabled" -eq 1 ]; then
-    ./build_metal.sh \
-      --build-all \
-      --enable-ccache \
-      --enable-profiler || build_rc=$?
-  else
-    ./build_metal.sh \
-      --build-all \
-      --enable-ccache || build_rc=$?
-  fi
-
-  echo "::endgroup::"
-
-  if [ $build_rc -ne 0 ]; then
-    echo "Build failed (rc=$build_rc); skipping this commit"
-    git bisect skip
-    continue
-  fi
-
-  echo "::group::Import sanity ($rev)"
-  if ! verify_import_path; then
-    echo "Import path check failed; skipping this commit"
-    git bisect skip
-    echo "::endgroup::"
-    continue
-  fi
-  echo "::endgroup::"
-
-  echo "::group::Testing $rev"
-  output_file="bisect_test_output.log"
-  if [ "$nd_mode" = true ]; then
-    success_count=0
-    failure_count=0
-    skip_count=0
-    run_idx=1
-    while [ $run_idx -le $retries ]; do
-      echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
-      echo "Resetting devices..."
-      tt-smi -r >/dev/null 2>&1 || true
-      echo "Devices reset"
-
-      echo "Run: $test"
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
-        if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
-          echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
-          skip_count=$((skip_count+1))
-        else
-          echo "Attempt $run_idx: success"
-          success_count=$((success_count+1))
-        fi
-      else
-        rc=$?
-        if [ $rc -eq 124 ] || [ $rc -eq 137 ] || [ $rc -eq 143 ]; then
-          echo "Attempt $run_idx: timeout/kill (rc=$rc) -> counting as skipped"
-          skip_count=$((skip_count+1))
-        else
-          echo "Attempt $run_idx: failure (rc=$rc)"
-          failure_count=$((failure_count+1))
-        fi
-      fi
-
-      echo "--- Logs (attempt $run_idx) ---"
-      sed -n '1,200p' "$output_file" || true
-      echo "------------------------------"
-      run_idx=$((run_idx+1))
-    done
-
-    evaluated=$((success_count + failure_count))
-    if [ $evaluated -gt 0 ]; then
-      passrate=$(awk -v s=$success_count -v e=$evaluated 'BEGIN { printf "%.2f", (s*100.0)/e }')
-    else
-      passrate="NA"
-    fi
-
-    nd_log_file="bisect_nd_results.csv"
-    if [ ! -f "$nd_log_file" ]; then
-      echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
-    fi
-    echo "$(date -Iseconds),$(git rev-parse HEAD),$rev,$success_count,$failure_count,$skip_count,$evaluated,$passrate" >> "$nd_log_file"
-
-    echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
-    echo "::endgroup::"
-
-    if [ $failure_count -ge 1 ]; then
-      out="$(git bisect bad || true)"
-    elif [ $evaluated -eq 0 ]; then
-      echo "All attempts were skipped; skipping this commit"
-      git bisect skip
-      continue
-    else
-      out="$(git bisect good || true)"
-    fi
-
-    first_line="$(printf '%s\n' "$out" | head -n1)"
-    case "$first_line" in
-      *"is the first bad commit"*)
-        bad_sha="$(git rev-parse HEAD)"
-        echo "FOUND IT: $first_line"
-        echo "Commit: $bad_sha"
-        echo "Title : $(git log -1 --pretty=%s "$bad_sha")"
-        found=true
-        ;;
-      *"There are only 'skip'ped commits left to test."*)
-        echo "Bisect inconclusive: only skipped commits left."
-        echo "Last bisect output: $first_line"
-        break
-        ;;
-      "")
-        echo "git bisect produced no output; stopping to avoid an infinite loop."
-        echo "Last bisect output: $first_line"
-        break
-        ;;
-    esac
-  else
-    attempt=1
-    timeout_rc=1
-    while [ $attempt -le $retries ]; do
-      echo "Attempt $attempt/$retries on $(git rev-parse HEAD)"
-      echo "Run: $test"
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
-        timeout_rc=0
-        echo "--- Logs (attempt $attempt) ---"
-        sed -n '1,200p' "$output_file" || true
-        echo "------------------------------"
-        break
-      else
-        timeout_rc=$?
-        echo "Test failed (code $timeout_rc), retrying…"
-        echo "--- Logs (attempt $attempt) ---"
-        sed -n '1,200p' "$output_file" || true
-        echo "------------------------------"
-        attempt=$((attempt+1))
-      fi
-    done
-    echo "Final exit code: $timeout_rc"
-    echo "::endgroup::"
-
-    if [ $timeout_rc -eq 0 ]; then
-      out="$(git bisect good || true)"
-    elif [ $timeout_rc -eq 124 ] || [ $timeout_rc -eq 137 ] || [ $timeout_rc -eq 143 ]; then
-      echo "Timeout/kill detected; skipping this commit"
-      git bisect skip
-      continue
-    else
-      out="$(git bisect bad || true)"
-    fi
-
-    first_line="$(printf '%s\n' "$out" | head -n1)"
-    case "$first_line" in
-      *"is the first bad commit"*)
-        echo "FOUND IT: $first_line"
-        found=true
-        ;;
-      *"There are only 'skip'ped commits left to test."*)
-        echo "Bisect inconclusive: only skipped commits left."
-        echo "Last bisect output: $first_line"
-        break
-        ;;
-      "")
-        echo "git bisect produced no output; stopping to avoid an infinite loop."
-        echo "Last bisect output: $first_line"
-        break
-        ;;
-    esac
-  fi
-
-done
-
-git bisect reset || true
+ts="$(date -Iseconds)"
+rev_short="$(git rev-parse --short=12 HEAD 2>/dev/null || echo NA)"
+commit_sha="$(git rev-parse HEAD 2>/dev/null || echo NA)"
+echo "$ts,$commit_sha,$rev_short,0,0,0,0,0.00" >> "$nd_log_file"
+exit 0

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -173,11 +173,11 @@ while [[ "$found" == "false" ]]; do
       passrate="NA"
     fi
 
-    nd_log_file="bisect_nd_results.tsv"
+    nd_log_file="bisect_nd_results.csv"
     if [ ! -f "$nd_log_file" ]; then
-      echo -e "timestamp\tcommit_sha\trev_short\tsuccesses\tfailures\tskips\tevaluated\tpassrate_percent" > "$nd_log_file"
+      echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
     fi
-    echo -e "$(date -Iseconds)\t$(git rev-parse HEAD)\t$rev\t$success_count\t$failure_count\t$skip_count\t$evaluated\t$passrate" >> "$nd_log_file"
+    echo "$(date -Iseconds),$(git rev-parse HEAD),$rev,$success_count,$failure_count,$skip_count,$evaluated,$passrate" >> "$nd_log_file"
 
     echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
     echo "::endgroup::"

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -265,4 +265,6 @@ while [[ "$found" == "false" ]]; do
     esac
   fi
 
+done
+
 git bisect reset || true

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -14,13 +14,13 @@ Usage:
   -n             : enable non-deterministic detection mode (ND mode)
 END
 
-# timeout_duration_iteration="30m"
-# test=""
-# good_commit=""
-# bad_commit=""
-# tracy_enabled=0
-# retries=3
-# nd_mode=false
+timeout_duration_iteration="30m"
+test=""
+good_commit=""
+bad_commit=""
+tracy_enabled=0
+retries=3
+nd_mode=false
 
 while getopts ":f:g:b:t:pr:n" opt; do
   case "$opt" in
@@ -36,246 +36,235 @@ while getopts ":f:g:b:t:pr:n" opt; do
   esac
 done
 
-# [ -n "$test" ] || die "Please specify -f TEST."
-# [ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."
-# [ -n "$bad_commit" ] || die "Please specify -b BAD_SHA."
+[ -n "$test" ] || die "Please specify -f TEST."
+[ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."
+[ -n "$bad_commit" ] || die "Please specify -b BAD_SHA."
 
 
-# echo "TT_METAL_HOME: $TT_METAL_HOME"
-# echo "PYTHONPATH: $PYTHONPATH"
-# echo "ARCH_NAME: ${ARCH_NAME:-}"
-# echo "pwd: $(pwd)"
-# if [ "$tracy_enabled" -eq 1 ]; then
-#   echo "Tracy profiling enabled for builds."
-# fi
-
-# # Creating virtual environment where we can install ttnn
-# ./create_venv.sh
-# pip install -r models/tt_transformers/requirements.txt
-
-# git cat-file -e "$good_commit^{commit}" 2>/dev/null || die "Invalid good commit: $good_commit"
-# git cat-file -e "$bad_commit^{commit}" 2>/dev/null  || die "Invalid bad commit: $bad_commit"
-
-# echo "Good: $good_commit"
-# echo "Bad : $bad_commit"
-# echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
-# echo "Commit: $(git rev-parse HEAD)"
-# echo "Status:"
-# git status --porcelain=v1
-
-# # Keep CPM cache across iterations for speed, but ensure it's in the workspace
-# export CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-$TT_METAL_HOME/.cpmcache}"
-# mkdir -p "$CPM_SOURCE_CACHE"
-# export CMAKE_ARGS="-DCPM_SOURCE_CACHE=$CPM_SOURCE_CACHE -DCPM_DOWNLOAD_ALL=ON -DCPM_USE_LOCAL_PACKAGES=OFF"
-
-# # Helper to ensure repo matches rev and all build products are fresh
-# fresh_clean() {
-#   # Match submodules exactly for current rev
-#   git submodule sync --recursive
-#   git submodule update --init --recursive --force
-
-#   # Nuke build outputs but keep venv/cache
-#   git reset --hard
-#   rm -rf build build_Release build_Debug || true
-# }
-
-# # After building, verify we import from the workspace
-# verify_import_path() {
-#   python - <<'PY'
-# import ttnn, sys
-# print(ttnn.get_arch_name())
-# print("ttnn imported from:", ttnn.__file__)
-# PY
-# }
-
-# echo "Starting git bisect…"
-# git bisect start "$bad_commit" "$good_commit"
-
-# found=false
-# while [[ "$found" == "false" ]]; do
-#   rev="$(git rev-parse --short=12 HEAD)"
-#   echo "::group::Building $rev"
-
-#   fresh_clean
-
-#   build_rc=0
-#   if [ "$tracy_enabled" -eq 1 ]; then
-#     ./build_metal.sh \
-#       --build-all \
-#       --enable-ccache \
-#       --enable-profiler || build_rc=$?
-#   else
-#     ./build_metal.sh \
-#       --build-all \
-#       --enable-ccache || build_rc=$?
-#   fi
-
-#   echo "::endgroup::"
-
-#   if [ $build_rc -ne 0 ]; then
-#     echo "Build failed (rc=$build_rc); skipping this commit"
-#     git bisect skip
-#     continue
-#   fi
-
-#   echo "::group::Import sanity ($rev)"
-#   if ! verify_import_path; then
-#     echo "Import path check failed; skipping this commit"
-#     git bisect skip
-#     echo "::endgroup::"
-#     continue
-#   fi
-#   echo "::endgroup::"
-
-#   echo "::group::Testing $rev"
-#   output_file="bisect_test_output.log"
-#   if [ "$nd_mode" = true ]; then
-#     success_count=0
-#     failure_count=0
-#     skip_count=0
-#     run_idx=1
-#     while [ $run_idx -le $retries ]; do
-#       echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
-#       echo "Resetting devices..."
-#       tt-smi -r >/dev/null 2>&1 || true
-#       echo "Devices reset"
-
-#       echo "Run: $test"
-#       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
-#         if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
-#           echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
-#           skip_count=$((skip_count+1))
-#         else
-#           echo "Attempt $run_idx: success"
-#           success_count=$((success_count+1))
-#         fi
-#       else
-#         rc=$?
-#         if [ $rc -eq 124 ] || [ $rc -eq 137 ] || [ $rc -eq 143 ]; then
-#           echo "Attempt $run_idx: timeout/kill (rc=$rc) -> counting as skipped"
-#           skip_count=$((skip_count+1))
-#         else
-#           echo "Attempt $run_idx: failure (rc=$rc)"
-#           failure_count=$((failure_count+1))
-#         fi
-#       fi
-
-#       echo "--- Logs (attempt $run_idx) ---"
-#       sed -n '1,200p' "$output_file" || true
-#       echo "------------------------------"
-#       run_idx=$((run_idx+1))
-#     done
-
-#     evaluated=$((success_count + failure_count))
-#     if [ $evaluated -gt 0 ]; then
-#       passrate=$(awk -v s=$success_count -v e=$evaluated 'BEGIN { printf "%.2f", (s*100.0)/e }')
-#     else
-#       passrate="NA"
-#     fi
-
-#     nd_log_file="bisect_nd_results.csv"
-#     if [ ! -f "$nd_log_file" ]; then
-#       echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
-#     fi
-#     echo "$(date -Iseconds),$(git rev-parse HEAD),$rev,$success_count,$failure_count,$skip_count,$evaluated,$passrate" >> "$nd_log_file"
-
-#     echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
-#     echo "::endgroup::"
-
-#     if [ $failure_count -ge 1 ]; then
-#       out="$(git bisect bad || true)"
-#     elif [ $evaluated -eq 0 ]; then
-#       echo "All attempts were skipped; skipping this commit"
-#       git bisect skip
-#       continue
-#     else
-#       out="$(git bisect good || true)"
-#     fi
-
-#     first_line="$(printf '%s\n' "$out" | head -n1)"
-#     case "$first_line" in
-#       *"is the first bad commit"*)
-#         bad_sha="$(git rev-parse HEAD)"
-#         echo "FOUND IT: $first_line"
-#         echo "Commit: $bad_sha"
-#         echo "Title : $(git log -1 --pretty=%s "$bad_sha")"
-#         found=true
-#         ;;
-#       *"There are only 'skip'ped commits left to test."*)
-#         echo "Bisect inconclusive: only skipped commits left."
-#         echo "Last bisect output: $first_line"
-#         break
-#         ;;
-#       "")
-#         echo "git bisect produced no output; stopping to avoid an infinite loop."
-#         echo "Last bisect output: $first_line"
-#         break
-#         ;;
-#     esac
-#   else
-#     attempt=1
-#     timeout_rc=1
-#     while [ $attempt -le $retries ]; do
-#       echo "Attempt $attempt/$retries on $(git rev-parse HEAD)"
-#       echo "Run: $test"
-#       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
-#         timeout_rc=0
-#         echo "--- Logs (attempt $attempt) ---"
-#         sed -n '1,200p' "$output_file" || true
-#         echo "------------------------------"
-#         break
-#       else
-#         timeout_rc=$?
-#         echo "Test failed (code $timeout_rc), retrying…"
-#         echo "--- Logs (attempt $attempt) ---"
-#         sed -n '1,200p' "$output_file" || true
-#         echo "------------------------------"
-#         attempt=$((attempt+1))
-#       fi
-#     done
-#     echo "Final exit code: $timeout_rc"
-#     echo "::endgroup::"
-
-#     if [ $timeout_rc -eq 0 ]; then
-#       out="$(git bisect good || true)"
-#     elif [ $timeout_rc -eq 124 ] || [ $timeout_rc -eq 137 ] || [ $timeout_rc -eq 143 ]; then
-#       echo "Timeout/kill detected; skipping this commit"
-#       git bisect skip
-#       continue
-#     else
-#       out="$(git bisect bad || true)"
-#     fi
-
-#     first_line="$(printf '%s\n' "$out" | head -n1)"
-#     case "$first_line" in
-#       *"is the first bad commit"*)
-#         echo "FOUND IT: $first_line"
-#         found=true
-#         ;;
-#       *"There are only 'skip'ped commits left to test."*)
-#         echo "Bisect inconclusive: only skipped commits left."
-#         echo "Last bisect output: $first_line"
-#         break
-#         ;;
-#       "")
-#         echo "git bisect produced no output; stopping to avoid an infinite loop."
-#         echo "Last bisect output: $first_line"
-#         break
-#         ;;
-#     esac
-#   fi
-
-# done
-
-# git bisect reset || true
-
-# Temporary: minimal CSV generation for artifact upload testing
-nd_log_file="bisect_nd_results.csv"
-if [ ! -f "$nd_log_file" ]; then
-  echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
+echo "TT_METAL_HOME: $TT_METAL_HOME"
+echo "PYTHONPATH: $PYTHONPATH"
+echo "ARCH_NAME: ${ARCH_NAME:-}"
+echo "pwd: $(pwd)"
+if [ "$tracy_enabled" -eq 1 ]; then
+  echo "Tracy profiling enabled for builds."
 fi
-ts="$(date -Iseconds)"
-rev_short="$(git rev-parse --short=12 HEAD 2>/dev/null || echo NA)"
-commit_sha="$(git rev-parse HEAD 2>/dev/null || echo NA)"
-echo "$ts,$commit_sha,$rev_short,0,0,0,0,0.00" >> "$nd_log_file"
-exit 0
+
+# Creating virtual environment where we can install ttnn
+./create_venv.sh
+pip install -r models/tt_transformers/requirements.txt
+
+git cat-file -e "$good_commit^{commit}" 2>/dev/null || die "Invalid good commit: $good_commit"
+git cat-file -e "$bad_commit^{commit}" 2>/dev/null  || die "Invalid bad commit: $bad_commit"
+
+echo "Good: $good_commit"
+echo "Bad : $bad_commit"
+echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "Commit: $(git rev-parse HEAD)"
+echo "Status:"
+git status --porcelain=v1
+
+# Keep CPM cache across iterations for speed, but ensure it's in the workspace
+export CPM_SOURCE_CACHE="${CPM_SOURCE_CACHE:-$TT_METAL_HOME/.cpmcache}"
+mkdir -p "$CPM_SOURCE_CACHE"
+export CMAKE_ARGS="-DCPM_SOURCE_CACHE=$CPM_SOURCE_CACHE -DCPM_DOWNLOAD_ALL=ON -DCPM_USE_LOCAL_PACKAGES=OFF"
+
+# Helper to ensure repo matches rev and all build products are fresh
+fresh_clean() {
+  # Match submodules exactly for current rev
+  git submodule sync --recursive
+  git submodule update --init --recursive --force
+
+  # Nuke build outputs but keep venv/cache
+  git reset --hard
+  rm -rf build build_Release build_Debug || true
+}
+
+# After building, verify we import from the workspace
+verify_import_path() {
+  python - <<'PY'
+import ttnn, sys
+print(ttnn.get_arch_name())
+print("ttnn imported from:", ttnn.__file__)
+PY
+}
+
+echo "Starting git bisect…"
+git bisect start "$bad_commit" "$good_commit"
+
+found=false
+while [[ "$found" == "false" ]]; do
+  rev="$(git rev-parse --short=12 HEAD)"
+  echo "::group::Building $rev"
+
+  fresh_clean
+
+  build_rc=0
+  if [ "$tracy_enabled" -eq 1 ]; then
+    ./build_metal.sh \
+      --build-all \
+      --enable-ccache \
+      --enable-profiler || build_rc=$?
+  else
+    ./build_metal.sh \
+      --build-all \
+      --enable-ccache || build_rc=$?
+  fi
+
+  echo "::endgroup::"
+
+  if [ $build_rc -ne 0 ]; then
+    echo "Build failed (rc=$build_rc); skipping this commit"
+    git bisect skip
+    continue
+  fi
+
+  echo "::group::Import sanity ($rev)"
+  if ! verify_import_path; then
+    echo "Import path check failed; skipping this commit"
+    git bisect skip
+    echo "::endgroup::"
+    continue
+  fi
+  echo "::endgroup::"
+
+  echo "::group::Testing $rev"
+  output_file="bisect_test_output.log"
+  if [ "$nd_mode" = true ]; then
+    success_count=0
+    failure_count=0
+    skip_count=0
+    run_idx=1
+    while [ $run_idx -le $retries ]; do
+      echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
+      echo "Resetting devices..."
+      tt-smi -r >/dev/null 2>&1 || true
+      echo "Devices reset"
+
+      echo "Run: $test"
+      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+        if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
+          echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
+          skip_count=$((skip_count+1))
+        else
+          echo "Attempt $run_idx: success"
+          success_count=$((success_count+1))
+        fi
+      else
+        rc=$?
+        if [ $rc -eq 124 ] || [ $rc -eq 137 ] || [ $rc -eq 143 ]; then
+          echo "Attempt $run_idx: timeout/kill (rc=$rc) -> counting as skipped"
+          skip_count=$((skip_count+1))
+        else
+          echo "Attempt $run_idx: failure (rc=$rc)"
+          failure_count=$((failure_count+1))
+        fi
+      fi
+
+      echo "--- Logs (attempt $run_idx) ---"
+      sed -n '1,200p' "$output_file" || true
+      echo "------------------------------"
+      run_idx=$((run_idx+1))
+    done
+
+    evaluated=$((success_count + failure_count))
+    if [ $evaluated -gt 0 ]; then
+      passrate=$(awk -v s=$success_count -v e=$evaluated 'BEGIN { printf "%.2f", (s*100.0)/e }')
+    else
+      passrate="NA"
+    fi
+
+    nd_log_file="bisect_nd_results.csv"
+    if [ ! -f "$nd_log_file" ]; then
+      echo "timestamp,commit_sha,rev_short,successes,failures,skips,evaluated,passrate_percent" > "$nd_log_file"
+    fi
+    echo "$(date -Iseconds),$(git rev-parse HEAD),$rev,$success_count,$failure_count,$skip_count,$evaluated,$passrate" >> "$nd_log_file"
+
+    echo "ND summary for $rev: successes=$success_count failures=$failure_count skips=$skip_count evaluated=$evaluated passrate=$passrate%"
+    echo "::endgroup::"
+
+    if [ $failure_count -ge 1 ]; then
+      out="$(git bisect bad || true)"
+    elif [ $evaluated -eq 0 ]; then
+      echo "All attempts were skipped; skipping this commit"
+      git bisect skip
+      continue
+    else
+      out="$(git bisect good || true)"
+    fi
+
+    first_line="$(printf '%s\n' "$out" | head -n1)"
+    case "$first_line" in
+      *"is the first bad commit"*)
+        bad_sha="$(git rev-parse HEAD)"
+        echo "FOUND IT: $first_line"
+        echo "Commit: $bad_sha"
+        echo "Title : $(git log -1 --pretty=%s "$bad_sha")"
+        found=true
+        ;;
+      *"There are only 'skip'ped commits left to test."*)
+        echo "Bisect inconclusive: only skipped commits left."
+        echo "Last bisect output: $first_line"
+        break
+        ;;
+      "")
+        echo "git bisect produced no output; stopping to avoid an infinite loop."
+        echo "Last bisect output: $first_line"
+        break
+        ;;
+    esac
+  else
+    attempt=1
+    timeout_rc=1
+    while [ $attempt -le $retries ]; do
+      echo "Attempt $attempt/$retries on $(git rev-parse HEAD)"
+      echo "Run: $test"
+      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+        timeout_rc=0
+        echo "--- Logs (attempt $attempt) ---"
+        sed -n '1,200p' "$output_file" || true
+        echo "------------------------------"
+        break
+      else
+        timeout_rc=$?
+        echo "Test failed (code $timeout_rc), retrying…"
+        echo "--- Logs (attempt $attempt) ---"
+        sed -n '1,200p' "$output_file" || true
+        echo "------------------------------"
+        attempt=$((attempt+1))
+      fi
+    done
+    echo "Final exit code: $timeout_rc"
+    echo "::endgroup::"
+
+    if [ $timeout_rc -eq 0 ]; then
+      out="$(git bisect good || true)"
+    elif [ $timeout_rc -eq 124 ] || [ $timeout_rc -eq 137 ] || [ $timeout_rc -eq 143 ]; then
+      echo "Timeout/kill detected; skipping this commit"
+      git bisect skip
+      continue
+    else
+      out="$(git bisect bad || true)"
+    fi
+
+    first_line="$(printf '%s\n' "$out" | head -n1)"
+    case "$first_line" in
+      *"is the first bad commit"*)
+        echo "FOUND IT: $first_line"
+        found=true
+        ;;
+      *"There are only 'skip'ped commits left to test."*)
+        echo "Bisect inconclusive: only skipped commits left."
+        echo "Last bisect output: $first_line"
+        break
+        ;;
+      "")
+        echo "git bisect produced no output; stopping to avoid an infinite loop."
+        echo "Last bisect output: $first_line"
+        break
+        ;;
+    esac
+  fi
+
+done
+
+git bisect reset || true

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -3,16 +3,16 @@ set -euo pipefail
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-# : << 'END'
-# Usage:
-#   -f TEST        : test command to run (quote if it has spaces)
-#   -g GOOD_SHA    : known good commit
-#   -b BAD_SHA     : known bad commit
-#   -t TIMEOUT     : per-iteration timeout (default 30m)
-#   -p             : enable Tracy profiling
-#   -r RETRIES     : number of retries (default 3)
-#   -n             : enable non-deterministic detection mode (ND mode)
-# END
+: << 'END'
+Usage:
+  -f TEST        : test command to run (quote if it has spaces)
+  -g GOOD_SHA    : known good commit
+  -b BAD_SHA     : known bad commit
+  -t TIMEOUT     : per-iteration timeout (default 30m)
+  -p             : enable Tracy profiling
+  -r RETRIES     : number of retries (default 3)
+  -n             : enable non-deterministic detection mode (ND mode)
+END
 
 # timeout_duration_iteration="30m"
 # test=""
@@ -22,19 +22,19 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 # retries=3
 # nd_mode=false
 
-# while getopts ":f:g:b:t:pr:n" opt; do
-#   case "$opt" in
-#     f) test="$OPTARG" ;;
-#     g) good_commit="$OPTARG" ;;
-#     b) bad_commit="$OPTARG" ;;
-#     t) timeout_duration_iteration="$OPTARG" ;;
-#     p) tracy_enabled=1 ;;
-#     r) retries="$OPTARG" ;;
-#     n) nd_mode=true ;;
-#     \?) die "Invalid option: -$OPTARG" ;;
-#     :)  die "Option -$OPTARG requires an argument." ;;
-#   esac
-# done
+while getopts ":f:g:b:t:pr:n" opt; do
+  case "$opt" in
+    f) test="$OPTARG" ;;
+    g) good_commit="$OPTARG" ;;
+    b) bad_commit="$OPTARG" ;;
+    t) timeout_duration_iteration="$OPTARG" ;;
+    p) tracy_enabled=1 ;;
+    r) retries="$OPTARG" ;;
+    n) nd_mode=true ;;
+    \?) die "Invalid option: -$OPTARG" ;;
+    :)  die "Option -$OPTARG requires an argument." ;;
+  esac
+done
 
 # [ -n "$test" ] || die "Please specify -f TEST."
 # [ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30201

### Problem description
The current bisect tool only checks for deterministic failures that occur over repeated attempts. This provides no mechanism to search for PRs that cause various tests to begin failing non-deterministically, since the retry loop will overlook those failures.

### What's changed
This PR adds an option to enable non deterministic detection to the bisect workflow. If checked, this will cause each test to always run the inputted test "retries" number of times, and will record the data on how often it passes. The test will only be considered passing if it passes every time its run, so a single failure will call git bisect bad. This will identify which commits lead to the start of ND behavior.

A spreadsheet outlining the pass-rate statistics will be uploaded as an artifact when in "detect non-deterministic failures mode.

some example runs are as follows:

https://github.com/tenstorrent/tt-metal/actions/runs/18504875860/job/52731049223
https://github.com/tenstorrent/tt-metal/actions/runs/18506134360/workflow

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes