### PR TITLE
#0: Add an assertion to not mix block floats and RM

### DIFF
--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -178,6 +178,9 @@ Tensor Tensor::from_vector(
     size_t volume = spec.logical_shape().volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
+    if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
+        TT_FATAL(spec.layout() == Layout::TILE, "Block float types are only supported in TILE layout");
+    }
 
     // Create host tensor with DataType matching buffer
     auto buffer_dtype = convert_to_data_type<T>();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fixes https://github.com/tenstorrent/tt-metal/actions/runs/18500715205/job/52717888640#step:5:8051 by re-introducing an assertion that block float tensors should not be created with row major layout.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18506809488)
- [X] New/Existing tests provide coverage for changes - tested locally