### PR TITLE
Adding comprehensive Nightly Fabric tests for Wormhole Galaxy 6U

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_api.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_api.yaml
@@ -78,7 +78,7 @@ Tests:
             (optional) mcast_start_hops: 0
     # 2. High-level pattern
     (optional) patterns:
-      - type: all_to_all/one_to_all/full_device_random_pairing/unidirectional_linear/full_ring/half_ring/all_devices_uniform_pattern
+      - type: all_to_all/one_to_all/all_to_one/all_to_one_random/full_device_random_pairing/unidirectional_linear/full_ring/half_ring/all_devices_uniform_pattern
         (optional) iterations: 2 # How many times to run the pattern.
       - type: all_to_all
       - type: one_to_all

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_comprehensive_nightly.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_comprehensive_nightly.yaml
@@ -1,0 +1,219 @@
+allocation_policies:
+    receiver:
+      max_configs_per_core: 4
+
+Tests:
+  # Linear tests
+  - name: "LinearUnicast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: unicast
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3
+
+  - name: "LinearMulticast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3
+
+  - name: "UnidirLinearMulticast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: unidirectional_linear
+        iterations: 3
+
+  - name: "SingleSenderLinearUnicastAllDevices"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: unicast
+      num_packets: 20000
+
+    patterns:
+      - type: one_to_all
+        iterations: 3
+    
+  - name: "SingleSenderLinearMulticastAllDevices"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: one_to_all
+        iterations: 3
+
+  # Ring tests
+
+  # Mesh tests
+  - name: "MeshUnicast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: unicast
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3
+
+  - name: "MeshMulticast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3
+
+  - name: "UnidirMeshMulticast"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: unidirectional_linear
+        iterations: 3
+
+  - name: "SingleSenderMeshUnicastAllDevices"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: unicast
+      num_packets: 20000
+
+    patterns:
+      - type: one_to_all
+        iterations: 3
+
+  - name: "SingleSenderMeshMulticastAllDevices"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: one_to_all
+        iterations: 3
+
+  - name: "MeshMulticastDynamic"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
+
+    defaults:
+      ftype: mcast
+      ntype: unicast_write
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30136

### Problem description
We lack a comprehensive test bench that will sweep a large number of Fabric tests. Current tests are designed to run quickly, as part of APC/quick testing.

### What's changed
- Added `test_fabric_ubench_comprehensive_nightly.yaml`, which contains an exhaustive set of fabric tests to be run on TT hardware
- Designed to run nightly.

### Checklist
- [ ] Add Ring and Torus tests
- [ ] Add neighbour exchange and min/max links tests
- [ ] Add Galaxy golden values
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes