### PR TITLE
Bump t3k resnet50 perf

### DIFF
--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -12,7 +12,7 @@ PERF_EXPECTATIONS = {
         "test_perf": {"inference_time": 0.0125, "compile_time": 60},
         "test_perf_trace": {"inference_time": 0.0048, "compile_time": 60},
         "test_perf_2cqs": {"inference_time": 0.013, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.005, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0044, "compile_time": 60},
     },
     "tg": {
         "test_perf": {"inference_time": 0.025, "compile_time": 60},


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Resnet50 t3k perf test is failing: https://github.com/tenstorrent/tt-metal/actions/runs/18495788985/job/52700788208#step:9:741

### What's changed
Bumped perf

### Checklist
- [x] [T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/18509918175) CI passes :green_circle: 