### PR TITLE
Fix missing test call in run_t3000_ccl_tests in T3K fast

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -520,8 +520,8 @@ run_t3000_ccl_tests() {
   # all gather: 1 ring, 1 line, 1 2d, 1 sharded should be covered
   # width sharded to interleaved case using linear
   pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_sharded_to_interleaved[wormhole_b0-fabric_linear-check-i2s_shape0-1-layout0-ag_input_dtype0-mesh_device0]
-  # 10 iteration trace test with fabric ring
-  pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async[wormhole_b0-fabric_ring-barrier_without_persistent_buffers-perf-mem_config_input0-mem_config_ag0-dit_shape-1link-mesh_device0]
+  # 10 iteration trace test with fabric ring (dit_shape now in test_ttnn_all_gather, no barrier parameters)
+  pytest -n auto tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_ttnn_all_gather[wormhole_b0-fabric_ring-perf-mem_config_input0-mem_config_ag0-dit_shape-1link-mesh_device0]
   # 2D fabric case – hanging on main? tracking with issue #30250
   # pytest -n auto tests/nightly/t3000/2d_ccl/test_minimal_all_gather_async.py::test_all_gather_async_training_shapes[wormhole_b0-fabric_2d_dynamic_linear-check-mem_config_input0-mem_config_ag0-tt_training_test_one-mesh_device0-1link]
   # training shapes


### PR DESCRIPTION
Renamed test and didn't run APC after, causing a failure.


APC: https://github.com/tenstorrent/tt-metal/actions/runs/18510933822
Just the T3K APC fast suite: https://github.com/tenstorrent/tt-metal/actions/runs/18510955537