### PR TITLE
[skip ci] Move t3k profiler tests to run on CIv2

### DIFF
--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: >
       ${{
         inputs.topology == 'config-t3000' &&
-        'tt-ubuntu-2204-N300-llmbox-stable' ||
+        'tt-ubuntu-2204-n300-llmbox-stable' ||
         fromJSON('["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}"]')
       }}
     container:

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -28,10 +28,12 @@ jobs:
     strategy:
       fail-fast: false
     name: "profiler tests"
-    runs-on:
-      - arch-wormhole_b0
-      - ${{ inputs.topology }}
-      - ${{ inputs.extra-tag }}
+    runs-on: >
+      ${{
+        inputs.topology == 'config-t3000' &&
+        'tt-ubuntu-2204-N300-llmbox-stable' ||
+        fromJSON('["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}"]')
+      }}
     container:
       image: ${{ inputs.docker-image }}
       env:


### PR DESCRIPTION
Move t3k profiler tests to run on CIv2. Moving VMs and other workflows will follow.

Testing: https://github.com/tenstorrent/tt-metal/actions/runs/18585926283