### PR TITLE
Fix vLLM nightly test for Qwen2.5-VL

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -47,6 +47,7 @@ jobs:
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
             multimodal: true,
+            additional-args: "--max_model_len 2048",
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
           # {
@@ -208,6 +209,7 @@ jobs:
 
           python3 vllm/examples/server_example_tt.py \
             --model ${{ matrix.test-group.model }} \
+            ${{ matrix.test-group.additional-args }} \
             "${OVERRIDE_TT_CONFIG[@]}" \
             > "${FILE_SERVER_LOG}" 2>&1 &
 

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "[WH-T3K] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
+          # {
+          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -49,81 +49,81 @@ jobs:
             multimodal: true,
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          {
-            name: "[BH-DB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: BH-DeskBox,
-            mesh-device: P150x2,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 2}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-QB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: bh-LLMBox,
-            mesh-device: P150x4,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 4}",
-            multimodal: false,
-            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[BH-LB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: bh-rackbox,
-            mesh-device: P150x8,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 8}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[WH-GLX] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-GLX] Llama-8B DP=16",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
-          {
-            name: "[WH-T3K] Gemma3-27B",
-            model: "google/gemma-3-27b-it",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
+          # {
+          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: BH-DeskBox,
+          #   mesh-device: P150x2,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 2}",
+          #   multimodal: false,
+          #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # },
+          # {
+          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: bh-LLMBox,
+          #   mesh-device: P150x4,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 4}",
+          #   multimodal: false,
+          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[BH-LB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: bh-rackbox,
+          #   mesh-device: P150x8,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 8}",
+          #   multimodal: false,
+          #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
+          #   model: "meta-llama/Llama-3.3-70B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   tt-llama-text-ver: llama3_70b_galaxy,
+          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-8B DP=16",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
+          # {
+          #   name: "[WH-T3K] Gemma3-27B",
+          #   model: "google/gemma-3-27b-it",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
+          {
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -50,81 +50,81 @@ jobs:
             additional-args: "--max_model_len 2048",
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          # {
-          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: BH-DeskBox,
-          #   mesh-device: P150x2,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 2}",
-          #   multimodal: false,
-          #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # },
-          # {
-          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: bh-LLMBox,
-          #   mesh-device: P150x4,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 4}",
-          #   multimodal: false,
-          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[BH-LB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
-          #   multimodal: false,
-          #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
-          #   model: "meta-llama/Llama-3.3-70B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   tt-llama-text-ver: llama3_70b_galaxy,
-          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-8B DP=16",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
-          # {
-          #   name: "[WH-T3K] Gemma3-27B",
-          #   model: "google/gemma-3-27b-it",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
+          {
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: BH-DeskBox,
+            mesh-device: P150x2,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: bh-LLMBox,
+            mesh-device: P150x4,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
+            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[BH-LB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-rackbox,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 8}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 95693824}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-GLX] Llama-8B DP=16",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
+          {
+            name: "[WH-T3K] Gemma3-27B",
+            model: "google/gemma-3-27b-it",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -122,7 +122,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             hf_config,
             mesh_device,
             max_batch_size,
-            max_seq_len=max_seq_len,
+            max_seq_len=max_seq_len // max_batch_size,  # max_seq_len is for all users to share
             dtype=ttnn.bfloat8_b,
             optimizations=optimizations,
         )

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -122,7 +122,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             hf_config,
             mesh_device,
             max_batch_size,
-            max_seq_len=max_seq_len // max_batch_size,  # max_seq_len is for all users to share
+            max_seq_len=max_seq_len,
             dtype=ttnn.bfloat8_b,
             optimizations=optimizations,
         )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/30224)

### Problem description
> Older runs (e.g. https://github.com/tenstorrent/tt-metal/actions/runs/18209040777/job/51846300270#step:14:452) are failing with 2025-10-03 00:40:57.590 | critical |          Always | Out of Memory: Not enough space to allocate 536870912 B DRAM buffer across 12 banks, where each bank needs to store 44740608 B, but bank size is only 1045274592 B (assert.hpp:103)

The root cause is because each user has an individual copy of RoPE cos/sin tensors that are padded up to `max_seq_len`. This is proven by the change in this commit: [6e7f057](https://github.com/tenstorrent/tt-metal/pull/30584/commits/6e7f057b23d1338d0399d04c430063eecd267a27). 

However, the proper fix is to maintain a "pool" up to `max_seq_len` for storing cos/sin values on device. This is similar to the mechanism behind paged kv_cache.

### What's changed
- [x] prove that there is enough space in on-device DRAMs (through [6e7f057](https://github.com/tenstorrent/tt-metal/pull/30584/commits/6e7f057b23d1338d0399d04c430063eecd267a27))
- [x] ~~Properly fix the root cause by setting up and maintain cos/sin matrixes up to `max_seq_len` across all users; this should allow dynamic slicing in vLLM continuous batching usage.~~ Adopt suggested solution of supplying `--max_model_len 2048` to the server setup code in github workflow file.

### Checklist
- [x] vLLM nightly with proof-of-concept [6e7f057](https://github.com/tenstorrent/tt-metal/pull/30584/commits/6e7f057b23d1338d0399d04c430063eecd267a27): 
  - https://github.com/tenstorrent/tt-metal/actions/runs/18515517535
- [x] revert proof-of-concept commit: [6e7f057](https://github.com/tenstorrent/tt-metal/pull/30584/commits/6e7f057b23d1338d0399d04c430063eecd267a27)
  - through [e486d66](https://github.com/tenstorrent/tt-metal/pull/30584/commits/e486d668c8ad4a1a1d4578d8a461401d44961ee5) 
- [x] vLLM nightly with suggested fix of `--max_model_len 2048`: 
  - https://github.com/tenstorrent/tt-metal/actions/runs/18533792491
- [x] revert [1084d2b](https://github.com/tenstorrent/tt-metal/pull/30584/commits/1084d2b77a2aa0edf433490a0162170e72dc88a2)
  - through [5b0ea98](https://github.com/tenstorrent/tt-metal/pull/30584/commits/5b0ea98c028d16f0db0a765ee171aeea9f1ce746)
- [x] Run all vLLM nightly to make sure no regression
  - https://github.com/tenstorrent/tt-metal/actions/runs/18535164534 