### PR TITLE
RS AG Line Zero Hop Fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -176,7 +176,9 @@ void kernel_main() {
                     32});
 
             if (topology == Topology::Linear) {
-                // multicast to both the forward and backward worker on all devices that you write to
+                // multicast to both the forward and backward worker on all devices that you write to.
+                // this only executes if the worker actually sends something over fabric (i.e. the writers
+                // on the end of the line pointing outward don't issue sem incs)
 
                 // device going in the same direction
                 uint64_t same_direction_barrier_sem_noc_addr_in_pkt =


### PR DESCRIPTION
### Problem description
The line implementations of RS and AG were making fabric setup calls when they wouldn't actually be sending anything over fabric (the end devices with their direction pointing outside of the line). This would then trigger an assert on watcher.

### What's changed
Only do the fabric setup logic in the writer kernel if that core is going to be sending anything over fabric.

### Pipelines
APC https://github.com/tenstorrent/tt-metal/actions/runs/18516610436
BH APC https://github.com/tenstorrent/tt-metal/actions/runs/18516616352
T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/18516620121
GLX Frequent https://github.com/tenstorrent/tt-metal/actions/runs/18516617962

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes