### PR TITLE
[skip ci] Bumped yolov12x expected perf

### DIFF
--- a/models/demos/yolov12x/tests/perf/test_perf.py
+++ b/models/demos/yolov12x/tests/perf/test_perf.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 14.54],
+        [1, 34.70],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Problem description
Device perf CI pipeline is red due to yolov12x increased perf coming from https://github.com/tenstorrent/tt-metal/pull/30186
https://github.com/tenstorrent/tt-metal/actions/runs/18515972303/job/52767139009#step:33:186
https://github.com/tenstorrent/tt-metal/actions/runs/18512496648/job/52756746945#step:33:186
https://github.com/tenstorrent/tt-metal/actions/runs/18508724109/job/52744982400#step:33:186

### What's changed
- bumped expected device perf