### PR TITLE
[skip ci] Updated SD perf numbers on README

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -49,8 +49,8 @@
 ## Diffusion Models
 | Model                                                                       | Batch | Hardware                                                 | Sec/Image     | Target Sec/Image | Release     |
 |-----------------------------------------------------------------------------|-------|----------------------------------------------------------|---------|------------|-------------|
-| [Stable Diffusion 1.4 (512x512)](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/wormhole/stable_diffusion)               | 1     | [n150 (Wormhole)](https://tenstorrent.com/hardware/wormhole)        | 6.25   | 3        |           |
-| [Stable Diffusion 1.4 (512x512)](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/blackhole/stable_diffusion)              | 1     | [p150 (Blackhole)](https://tenstorrent.com/hardware/blackhole)      | 3.50   |          |           |
+| [Stable Diffusion 1.4 (512x512)](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/wormhole/stable_diffusion)               | 1     | [n150 (Wormhole)](https://tenstorrent.com/hardware/wormhole)        | 4.83   | 3        |           |
+| [Stable Diffusion 1.4 (512x512)](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/blackhole/stable_diffusion)              | 1     | [p150 (Blackhole)](https://tenstorrent.com/hardware/blackhole)      | 3.15   |          |           |
 | [Stable Diffusion 3.5 Medium (512x512)](https://github.com/tenstorrent/tt-metal/tree/main/models/experimental/stable_diffusion_35_large) | 1     | [n150 (Wormhole)](https://tenstorrent.com/hardware/wormhole)        | 16     | 10       |           |
 
 **Notes:**

--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -5,6 +5,6 @@
 from models.common.utility_functions import is_blackhole
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 21056 if is_blackhole() else 20928
+SD_L1_SMALL_SIZE = 21184 if is_blackhole() else 20928
 # Trace Region Size Constants
 SD_TRACE_REGION_SIZE = 820000000 if is_blackhole() else 789835776

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -252,7 +252,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [
-        (1, 50, 3600, 5.10) if is_wormhole_b0() else (1, 50, 3600, 3.50),  # Wormhole B0 vs Blackhole performance
+        (1, 50, 3600, 4.85) if is_wormhole_b0() else (1, 50, 3600, 3.15),  # Wormhole B0 vs Blackhole performance
     ],
 )
 def test_stable_diffusion_perf(

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -252,7 +252,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [
-        (1, 50, 3600, 6.31) if is_wormhole_b0() else (1, 50, 3600, 3.50),  # Wormhole B0 vs Blackhole performance
+        (1, 50, 3600, 5.10) if is_wormhole_b0() else (1, 50, 3600, 3.50),  # Wormhole B0 vs Blackhole performance
     ],
 )
 def test_stable_diffusion_perf(


### PR DESCRIPTION
### Problem description
Currently the `Sec/Image` number for stable diffusion on BH was based on CI target

### What's changed
- updated README with relevant values
- set the `Sec/Image` values for SD on WH and BH to actual perf values
- bumped L1 small size for stable_diffusion on BH

### Checklist
- [X] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [cnn passes](https://github.com/tenstorrent/tt-metal/actions/runs/18837283550)