### PR TITLE
Slightly adjust Falcon7b t3k CI perf targets (mostly minor increases)

### DIFF
--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -11,8 +11,8 @@ from models.demos.falcon7b_common.demo.demo import run_falcon_demo_kv
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 10900, "decode_t/s": 3630, "decode_t/s/u": 14.1}, False, None),
-        (True, 1024, {"prefill_t/s": 12200, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
+        (True, 128, {"prefill_t/s": 10900, "decode_t/s": 3737, "decode_t/s/u": 14.6}, False, None),
+        (True, 1024, {"prefill_t/s": 13300, "decode_t/s": 3379, "decode_t/s/u": 13.2}, False, None),
         (True, 2048, {"prefill_t/s": 11600, "decode_t/s": 3174, "decode_t/s/u": 12.4}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Perf has slightly improved overall (except for very small decrease for decode-1k) for Falcon7b-t3k, resulting in some CI demo test failures

### What's changed
- Adjusted Falcon7b-t3k targets for CI

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
