### PR TITLE
#30661 Add sliding window support in SDPA prefill

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -807,7 +807,7 @@ def test_joint_sdpa_program_cache(device, b, nh, seq_len, joint_seq_len, d, q_ch
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
-# from tracy.process_model_log import run_device_profiler, get_latest_ops_log_filename
+from tracy.process_model_log import run_device_profiler, get_latest_ops_log_filename
 
 
 @pytest.mark.skip()

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include "dataflow_api.h"
 #include <tt-metalium/constants.hpp>
+#include "debug/assert.h"
 
 template <uint32_t tile_bytes, uint32_t num_readers>
 constexpr uint32_t get_barrier_read_threshold() {
@@ -214,7 +215,12 @@ void fill_neginf_tile_bfp4(uint32_t cb_id, uint32_t tile_id) {
 }
 
 template <uint32_t tile_bytes>
-inline void fill_diagonal_tile_bfp4(uint32_t cb_id, uint32_t tile_id) {
+inline void fill_custom_diagonal_tile_bfp4(
+    uint32_t cb_id, uint32_t tile_id, int32_t leading_diagonal_offset, int32_t trailing_diagonal_offset) {
+    // Assert that we're not in a case where the entire tile should be fully masked or fully allowed
+    // Those cases should be handled before calling this function
+    ASSERT(leading_diagonal_offset >= -32 && trailing_diagonal_offset >= -32);
+
     // Clear the tile first
     fill_tile_zeros<tile_bytes>(cb_id, tile_id);
 
@@ -224,6 +230,17 @@ inline void fill_diagonal_tile_bfp4(uint32_t cb_id, uint32_t tile_id) {
      * [face0 exp][face1 exp][face2 exp][face3 exp]
      * [face0 mant][face1 mant][face2 mant][face3 mant]
      * where each face's exp is 16 bytes and each face's mant is 16x16x.5B = 128B.
+     *
+     * Diagonal offsets:
+     * - leading_diagonal_offset: positive shifts upper triangle mask upward (allows more values)
+     * - trailing_diagonal_offset: positive enables lower triangle masking
+     * - A position (row, col) is masked if:
+     *   - col > row + leading_diagonal_offset (upper triangle), OR
+     *   - col < row - trailing_diagonal_offset (lower triangle)
+     *
+     * Tile face layout (32x32 tile divided into 4 16x16 faces):
+     *   Face 0 (rows 0-15, cols 0-15)  | Face 1 (rows 0-15, cols 16-31)
+     *   Face 2 (rows 16-31, cols 0-15) | Face 3 (rows 16-31, cols 16-31)
      */
 
     constexpr uint32_t NEG_INF_EXP = 0xFFFFFFFF;
@@ -249,37 +266,82 @@ inline void fill_diagonal_tile_bfp4(uint32_t cb_id, uint32_t tile_id) {
     constexpr uint32_t face2_offset = face1_offset + uint32_datums_per_face;
     constexpr uint32_t face3_offset = face2_offset + uint32_datums_per_face;
 
-    // Process face 0 and face 3 (diagonal faces)
-    for (uint32_t face_idx = 0; face_idx < 4; face_idx += 3) {
-        uint32_t face_offset = (face_idx == 0) ? face0_offset : face3_offset;
+    // Define face boundaries
+    struct FaceInfo {
+        uint32_t row_start;
+        uint32_t row_end;
+        uint32_t col_start;
+        uint32_t col_end;
+        uint32_t offset;
+    };
 
+    FaceInfo faces[4] = {
+        {0, 15, 0, 15, face0_offset},   // Face 0: top-left
+        {0, 15, 16, 31, face1_offset},  // Face 1: top-right
+        {16, 31, 0, 15, face2_offset},  // Face 2: bottom-left
+        {16, 31, 16, 31, face3_offset}  // Face 3: bottom-right
+    };
+
+    // Process each face
+    for (uint32_t face_idx = 0; face_idx < 4; face_idx++) {
+        FaceInfo& face = faces[face_idx];
+
+        // Check if face is fully masked by upper triangle: col_min > row_max + leading_diagonal_offset
+        bool fully_masked_upper = (leading_diagonal_offset < 32) &&
+                                  ((int32_t)face.col_start > (int32_t)face.row_end + leading_diagonal_offset);
+
+        // Check if face is fully masked by lower triangle: col_max < row_min - trailing_diagonal_offset
+        bool fully_masked_lower = (trailing_diagonal_offset < 32) &&
+                                  ((int32_t)face.col_end < (int32_t)face.row_start - trailing_diagonal_offset);
+
+        if (fully_masked_upper || fully_masked_lower) {
+            // Fully masked: fill entire face with -inf
+            for (uint32_t i = 0; i < uint32_datums_per_face; i++) {
+                uint32_ptr[face.offset + i] = NEG_INF_MANT;
+            }
+            continue;
+        }
+
+        // Check if face is fully allowed (not masked)
+        // All positions must satisfy: col <= row + leading_diagonal_offset AND col >= row - trailing_diagonal_offset
+        bool fully_allowed_upper = (leading_diagonal_offset >= 32) ||
+                                   ((int32_t)face.col_end <= (int32_t)face.row_start + leading_diagonal_offset);
+        bool fully_allowed_lower = (trailing_diagonal_offset >= 32) ||
+                                   ((int32_t)face.col_start >= (int32_t)face.row_end - trailing_diagonal_offset);
+
+        if (fully_allowed_upper && fully_allowed_lower) {
+            // Fully allowed: leave as zeros (already cleared)
+            continue;
+        }
+
+        // Partially masked: process row by row
         for (uint32_t row = 0; row < tt::constants::FACE_HEIGHT; row++) {
-            uint32_t diag_col = row;                                   // Diagonal position is at (row, row)
-            uint32_t diag_group_idx = diag_col / bf4_mant_per_uint32;  // Which uint32 group contains diagonal
-            uint32_t pos_in_group = diag_col % bf4_mant_per_uint32;    // Position within the group
+            uint32_t global_row = face.row_start + row;
             uint32_t row_offset = row * uint32_datums_per_face_row;
 
-            // Process the uint32 containing the diagonal element
-            // Create mask where positions after diagonal are -inf mantissa (upper triangle)
-            uint32_t diag_mask = 0;
-            for (uint32_t i = pos_in_group + 1; i < bf4_mant_per_uint32; i++) {
-                diag_mask |= 0xC << (i * 4);
-            }
-            uint32_ptr[face_offset + row_offset + diag_group_idx] = diag_mask;
+            for (uint32_t col_group = 0; col_group < uint32_datums_per_face_row; col_group++) {
+                uint32_t mask_value = 0;
 
-            // Fill all uint32s to the right of diagonal with -inf mantissa
-            for (uint32_t col_group = diag_group_idx + 1; col_group < uint32_datums_per_face_row; col_group++) {
-                uint32_ptr[face_offset + row_offset + col_group] = NEG_INF_MANT;
+                // Process each mantissa in this uint32
+                for (uint32_t i = 0; i < bf4_mant_per_uint32; i++) {
+                    uint32_t local_col = col_group * bf4_mant_per_uint32 + i;
+                    uint32_t global_col = face.col_start + local_col;
+
+                    // Check if this position should be masked
+                    bool masked_upper = (leading_diagonal_offset < 32) &&
+                                        ((int32_t)global_col > (int32_t)global_row + leading_diagonal_offset);
+                    bool masked_lower = (trailing_diagonal_offset < 32) &&
+                                        ((int32_t)global_col < (int32_t)global_row - trailing_diagonal_offset);
+
+                    if (masked_upper || masked_lower) {
+                        mask_value |= 0xC << (i * 4);  // Set mantissa to 0xC (-inf)
+                    }
+                }
+
+                uint32_ptr[face.offset + row_offset + col_group] = mask_value;
             }
         }
     }
-
-    // Fill face 1 completely with -inf
-    for (uint32_t i = 0; i < uint32_datums_per_face; i++) {
-        uint32_ptr[face1_offset + i] = NEG_INF_MANT;
-    }
-
-    // Face 2 is all zeros (already set by fill_tile at the beginning)
 }
 
 template <uint32_t tile_bytes>
@@ -376,8 +438,16 @@ void fill_vertical_tile_bfp4(uint32_t cb_id, uint32_t tile_id, uint32_t unpad_co
     }
 }
 
+enum class MaskType { FULLY_ALLOWED, FULLY_MASKED, PARTIAL_MASK };
+
 template <uint32_t cb_mask_in>
-void generate_causal_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, uint32_t q_chunk, uint32_t k_chunk) {
+void generate_mask(
+    uint32_t Sq_chunk_t,
+    uint32_t Sk_chunk_t,
+    uint32_t q_chunk,
+    uint32_t k_chunk,
+    bool is_causal = true,
+    uint32_t sliding_window_size = 0) {
     uint32_t mask_size_tiles = Sq_chunk_t * Sk_chunk_t;
     cb_reserve_back(cb_mask_in, mask_size_tiles);
 
@@ -387,35 +457,117 @@ void generate_causal_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, uint32_t q_c
 
     int zero_tile_idx = -1;
     int inf_tile_idx = -1;
-    int diag_tile_idx = -1;
+    int triu_diag_tile_idx = -1;
+    int tril_diag_tile_idx = -1;
 
+    int32_t min_window_start, max_window_start, min_window_end, max_window_end;
     for (uint32_t q_tile = 0; q_tile < Sq_chunk_t; ++q_tile) {
+        uint32_t global_q_tile = Sq_chunk_t * q_chunk + q_tile;
+        uint32_t q_tile_start = global_q_tile * tt::constants::TILE_HEIGHT;
+        uint32_t q_tile_end = q_tile_start + tt::constants::TILE_HEIGHT - 1;  // inclusive
+        if (sliding_window_size > 0) {
+            // Calculate the sliding window bounds for this Q tile
+            if (is_causal) {
+                // Causal sliding window: window spans [q_pos - sliding_window_size + 1, q_pos]
+                // For the entire Q tile, we need the union of all windows
+                min_window_start = (int32_t)q_tile_start - (int32_t)sliding_window_size + 1;
+                if (min_window_start < 0) {
+                    min_window_start = 0;
+                }
+                max_window_start = (int32_t)q_tile_end - (int32_t)sliding_window_size + 1;
+                if (max_window_start < 0) {
+                    max_window_start = 0;
+                }
+                max_window_end = (int32_t)q_tile_end + 1;    // exclusive
+                min_window_end = (int32_t)q_tile_start + 1;  // exclusive
+            } else {
+                // Non-causal sliding window: window spans [q_pos - sliding_window_size/2, q_pos +
+                // sliding_window_size/2]
+                int32_t half_window = (int32_t)sliding_window_size / 2;
+                min_window_start = (int32_t)q_tile_start - half_window;
+                if (min_window_start < 0) {
+                    min_window_start = 0;
+                }
+                max_window_start = (int32_t)q_tile_end - half_window;
+                if (max_window_start < 0) {
+                    max_window_start = 0;
+                }
+                max_window_end = (int32_t)q_tile_end + half_window + 1;    // exclusive
+                min_window_end = (int32_t)q_tile_start + half_window + 1;  // exclusive
+            }
+        }
         for (uint32_t k_tile = 0; k_tile < Sk_chunk_t; ++k_tile) {
             uint32_t in_mask_tile_id = q_tile * Sk_chunk_t + k_tile;
-            uint32_t global_q_tile = Sq_chunk_t * q_chunk + q_tile;
             uint32_t global_k_tile = Sk_chunk_t * k_chunk + k_tile;
 
-            if (global_k_tile < global_q_tile) {
-                if (zero_tile_idx == -1) {
-                    fill_tile_zeros<tile_bytes>(cb_mask_in, in_mask_tile_id);
-                    zero_tile_idx = in_mask_tile_id;
+            // Determine the masking pattern for this tile
+            MaskType mask_type = MaskType::FULLY_ALLOWED;
+            int32_t leading_diagonal_offset = 0;
+            int32_t trailing_diagonal_offset = 0;
+            if (sliding_window_size > 0) {
+                // Calculate tile boundaries in sequence positions
+                uint32_t k_tile_start = global_k_tile * tt::constants::TILE_HEIGHT;
+                uint32_t k_tile_end = k_tile_start + tt::constants::TILE_HEIGHT - 1;  // inclusive
+                // Check if K tile overlaps with the union of all sliding windows for this Q tile
+                bool k_tile_outside_window =
+                    ((int32_t)k_tile_end < min_window_start) ||
+                    ((int32_t)k_tile_start >=
+                     max_window_end);  // outside the start (bottom left) or end of the window (top right)
+                if (k_tile_outside_window) {
+                    // K tile is completely outside all sliding windows
+                    mask_type = MaskType::FULLY_MASKED;
                 } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
-                }
-            } else if (global_k_tile == global_q_tile) {
-                if (diag_tile_idx == -1) {
-                    fill_diagonal_tile_bfp4<tile_bytes>(cb_mask_in, in_mask_tile_id);
-                    diag_tile_idx = in_mask_tile_id;
-                } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, diag_tile_idx, in_mask_tile_id);
+                    // K tile overlaps with sliding windows, but we need to check if it's fully contained
+                    bool k_tile_fully_contained =
+                        ((int32_t)k_tile_start >= min_window_start) &&
+                        ((int32_t)k_tile_end < min_window_end);  // fully contained within the window
+                    if (k_tile_fully_contained) {
+                        mask_type = MaskType::FULLY_ALLOWED;
+                    } else {
+                        leading_diagonal_offset = (min_window_end - 1) - k_tile_start;
+                        trailing_diagonal_offset = k_tile_end - max_window_start;
+                        mask_type = MaskType::PARTIAL_MASK;
+                    }
                 }
             } else {
-                if (inf_tile_idx == -1) {
-                    fill_neginf_tile_bfp4<tile_bytes>(cb_mask_in, in_mask_tile_id);
-                    inf_tile_idx = in_mask_tile_id;
+                // No sliding window
+                if (is_causal) {
+                    if (global_k_tile < global_q_tile) {
+                        mask_type = MaskType::FULLY_ALLOWED;
+                    } else if (global_k_tile == global_q_tile) {
+                        leading_diagonal_offset = 0;
+                        trailing_diagonal_offset = 32;  // we won't apply any masking along the trailing diagonal when
+                                                        // no sliding window is applied
+                        mask_type = MaskType::PARTIAL_MASK;
+                    } else {
+                        mask_type = MaskType::FULLY_MASKED;
+                    }
                 } else {
-                    copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
+                    mask_type = MaskType::FULLY_ALLOWED;
                 }
+            }
+
+            // Apply the appropriate masking
+            switch (mask_type) {
+                case MaskType::FULLY_ALLOWED:
+                    if (zero_tile_idx == -1) {
+                        fill_tile_zeros<tile_bytes>(cb_mask_in, in_mask_tile_id);
+                        zero_tile_idx = in_mask_tile_id;
+                    } else {
+                        copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, zero_tile_idx, in_mask_tile_id);
+                    }
+                    break;
+                case MaskType::FULLY_MASKED:
+                    if (inf_tile_idx == -1) {
+                        fill_neginf_tile_bfp4<tile_bytes>(cb_mask_in, in_mask_tile_id);
+                        inf_tile_idx = in_mask_tile_id;
+                    } else {
+                        copy_tile<tile_bytes>(noc_write_addr_base, write_ptr_base, inf_tile_idx, in_mask_tile_id);
+                    }
+                    break;
+                case MaskType::PARTIAL_MASK:
+                    fill_custom_diagonal_tile_bfp4<tile_bytes>(
+                        cb_mask_in, in_mask_tile_id, leading_diagonal_offset, trailing_diagonal_offset);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -239,6 +239,7 @@ operation::ProgramWithCallbacks ring_sdpa_multi_core(
         false,  //(std::uint32_t)use_provided_mask,
         false,  //(std::uint32_t)use_padded_mask,
         true,   //(uint32_t)is_chunked,
+        0,      //(uint32_t)sliding_window_size,
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
@@ -272,6 +273,7 @@ operation::ProgramWithCallbacks ring_sdpa_multi_core(
         false,  //(std::uint32_t)use_padded_mask,
         true,   //(uint32_t)is_chunked,
         scale_union.u,
+        0,  //(uint32_t)sliding_window_size,
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -335,7 +335,8 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
         this->compute_kernel_config,
         this->program_config,
         this->use_mla.value_or(false),
-        this->head_dim_v.value_or(0));
+        this->head_dim_v.value_or(0),
+        this->sliding_window_size);
 }
 
 operation::OpPerformanceModel ScaledDotProductAttention::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
@@ -22,6 +22,7 @@ struct ScaledDotProductAttention {
     const DeviceComputeKernelConfig compute_kernel_config;
     const std::optional<bool> use_mla;
     const std::optional<uint32_t> head_dim_v;
+    const std::optional<uint32_t> sliding_window_size;
 
     void validate(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -38,7 +38,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     DeviceComputeKernelConfig compute_kernel_config,
     std::optional<SDPAProgramConfig> program_config,
     bool use_mla,
-    uint32_t head_dim_v) {
+    uint32_t head_dim_v,
+    std::optional<uint32_t> sliding_window_size) {
     /*
     Q: B x NQH x S x DH
     K: B x NKH x DH x S
@@ -111,6 +112,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     log_debug(tt::LogOp, "q_num_chunks: {}", q_num_chunks);
     log_debug(tt::LogOp, "k_num_chunks: {}", k_num_chunks);
     log_debug(tt::LogOp, "NKH: {}", NKH);
+    log_debug(tt::LogOp, "sliding_window_size: {}", sliding_window_size.has_value() ? sliding_window_size.value() : 0);
 
     // In chunked prefill mode, the offset of Q in terms of Q chunks
     uint32_t chunked_q_chunk_offset = 0;
@@ -372,6 +374,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         (std::uint32_t)use_provided_mask,
         (std::uint32_t)use_padded_mask,
         (uint32_t)is_chunked,
+        sliding_window_size.value_or(0),
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -406,6 +409,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         (std::uint32_t)use_padded_mask,
         (uint32_t)is_chunked,
         scale_union.u,
+        sliding_window_size.value_or(0),
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
@@ -25,6 +25,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sdpa_multi_core(
     DeviceComputeKernelConfig compute_kernel_config,
     std::optional<SDPAProgramConfig> program_config,
     bool use_mla,
-    uint32_t head_dim_v = 0);
+    uint32_t head_dim_v = 0,
+    std::optional<uint32_t> sliding_window_size = std::nullopt);
 
 }  // namespace ttnn::operations::transformer::detail

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -22,6 +22,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
     const std::optional<ttnn::Tensor>& attn_mask,
     bool is_causal,
     std::optional<float> scale,
+    std::optional<uint32_t> sliding_window_size,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
@@ -40,7 +41,9 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                    .is_causal = is_causal,
                    .chunk_start_idx = std::nullopt,
                    .compute_kernel_config = kernel_config_val,
-                   .use_mla = false},
+                   .use_mla = false,
+                   .head_dim_v = std::nullopt,
+                   .sliding_window_size = sliding_window_size},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {attn_mask},
                {})
@@ -72,7 +75,9 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
                    .is_causal = true,  // Always causal for chunked version
                    .chunk_start_idx = chunk_start_idx,
                    .compute_kernel_config = kernel_config_val,
-                   .use_mla = false},
+                   .use_mla = false,
+                   .head_dim_v = std::nullopt,
+                   .sliding_window_size = std::nullopt},  // Chunked version doesn't support sliding window yet
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
                {})
@@ -225,7 +230,8 @@ ttnn::Tensor ExecuteFlashMLAPrefill::invoke(
                    .chunk_start_idx = std::nullopt,
                    .compute_kernel_config = kernel_config_val,
                    .use_mla = true,
-                   .head_dim_v = head_dim_v},
+                   .head_dim_v = head_dim_v,
+                   .sliding_window_size = std::nullopt},  // MLA version doesn't support sliding window yet
                {input_tensor_q, input_tensor_k},
                {attn_mask},
                {})
@@ -258,7 +264,8 @@ ttnn::Tensor ExecuteChunkedFlashMLAPrefill::invoke(
                    .chunk_start_idx = chunk_start_idx,
                    .compute_kernel_config = kernel_config_val,
                    .use_mla = true,
-                   .head_dim_v = head_dim_v},
+                   .head_dim_v = head_dim_v,
+                   .sliding_window_size = std::nullopt},  // Chunked MLA version doesn't support sliding window yet
                {input_tensor_q, input_tensor_k},
                {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
                {})

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -20,6 +20,7 @@ struct ExecuteScaledDotProductAttention {
         const std::optional<ttnn::Tensor>& attn_mask = std::nullopt,
         bool is_causal = true,
         std::optional<float> scale = std::nullopt,
+        std::optional<uint32_t> sliding_window_size = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<SDPAProgramConfig> program_config = std::nullopt,
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -29,8 +29,9 @@ void py_bind_sdpa(py::module& module) {
         Keyword args:
             attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
             is_causal (bool): Defaults to `true`.
-            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             scale (float, optional): Defaults to `None`.
+            sliding_window_size (int, optional): Defaults to `None`. Size of sliding window for attention. If provided, only attends to the last `sliding_window_size` tokens.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
 
@@ -53,6 +54,7 @@ void py_bind_sdpa(py::module& module) {
                std::optional<ttnn::Tensor> attn_mask,
                bool is_causal,
                std::optional<float> scale,
+               std::optional<uint32_t> sliding_window_size,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
                std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
@@ -63,6 +65,7 @@ void py_bind_sdpa(py::module& module) {
                     attn_mask,
                     is_causal,
                     scale,
+                    sliding_window_size,
                     memory_config,
                     program_config,
                     compute_kernel_config);
@@ -74,6 +77,7 @@ void py_bind_sdpa(py::module& module) {
             py::arg("attn_mask").noconvert() = std::nullopt,
             py::arg("is_causal").noconvert() = true,
             py::arg("scale").noconvert() = std::nullopt,
+            py::arg("sliding_window_size").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
             py::arg("compute_kernel_config").noconvert() = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -30,7 +30,7 @@ void py_bind_sdpa(py::module& module) {
             attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
             is_causal (bool): Defaults to `true`.
             scale (float, optional): Defaults to `None`.
-            sliding_window_size (int, optional): Defaults to `None`. Size of sliding window for attention. If provided, only attends to the last `sliding_window_size` tokens.
+            sliding_window_size (int, optional): Defaults to `None`. Size of sliding window for attention. If provided && is_causal, only attends to the last `sliding_window_size` tokens. If provided && !is_causal, attends to a window of size `sliding_window_size` centered at the current position.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.


### PR DESCRIPTION
### Ticket
#30661

### Problem description
We need to support sliding window attention in our SDPA op for models that use this technique (Gemma-3, GPT-OSS etc.)

### What's changed
This PR changes the existing SDPA op we use for prefill `ttnn.transformers.scaled_dot_product_attention` by changing the mask generation logic. We make use of the existing circular buffer that was being used for causal masking and adapt the mask creation to work for causal, sliding window and causal+sliding window.

The `generate_mask` function will loop over all q and k tiles in the q and k chunk and make use of a new Enum `MaskType` to determine whether to fully mask, fully allow or partially mask a particular tile. Leading and trailing edge diagonal offsets are then determined based on the `is_causal` and `sliding_window` parameters for the partial fill case.

@tenstorrent/metalium-developers-infra llama 70b long context demo tests on galaxy are timing out on main: https://github.com/tenstorrent/tt-metal/actions/runs/18653634261/job/53177759713 - I've increased timeout to 1hr (we think this is an io bottleneck on loading model weights).

### Checklist
APC: https://github.com/tenstorrent/tt-metal/actions/runs/18592488562
APC2: https://github.com/tenstorrent/tt-metal/actions/runs/18595317229
Single card: https://github.com/tenstorrent/tt-metal/actions/runs/18564493520
T3K: https://github.com/tenstorrent/tt-metal/actions/runs/18564522440
Galaxy: https://github.com/tenstorrent/tt-metal/actions/runs/18649618856

After rebase + timeout increase:
Galaxy unit: https://github.com/tenstorrent/tt-metal/actions/runs/18681108088
Galaxy demo: https://github.com/tenstorrent/tt-metal/actions/runs/18681048747