### PR TITLE
#19801: [skip ci] Remove docker-run from custom test dispatch, containerize and support CIv2

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -86,6 +86,7 @@ jobs:
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
+        timeout-minutes: 10
         with:
           fetch-depth: 1
           submodules: recursive
@@ -93,19 +94,23 @@ jobs:
           ref: ${{ inputs.commit || github.sha }}
       - name: 📦 Download Build Artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
         with:
           name: ${{ needs.build-artifact.outputs.build-artifact-name }}
           path: docker-job
       - name: 📂 Extract Build Files
+        timeout-minutes: 10
         working-directory: docker-job
         run: tar --zstd -xf ttm_any.tar.zst
         shell: bash
       - name: 🧪 Download Python Wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
         with:
           name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
           path: docker-job
       - name: 💿 Install Wheel
+        timeout-minutes: 10
         working-directory: docker-job
         run: |
           echo "📂 In directory: $(pwd)"

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -99,7 +99,6 @@ jobs:
         working-directory: docker-job
         run: tar --zstd -xf ttm_any.tar.zst
         shell: bash
-
       - name: 🧪 Download Python Wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -50,17 +50,6 @@ on:
 
 run-name: ${{ inputs.description }}
 jobs:
-  # setup:
-  #   name: Setup runner labels for deploy
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     deployrunner: ${{ steps.step1.outputs.deployrunner }}
-  #   steps:
-  #     - name: Set runs-on for deploy
-  #       id: step1
-  #       run: |
-  #         # local_var="\'[\"${{ inputs.hw-config }}\", \"${{ inputs.runner-label }}\"]\'"
-  #         echo "deployrunner=${{ inputs.runner-label }}" >> $GITHUB_OUTPUT
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -73,19 +62,32 @@ jobs:
       build-wheel: true
       ref: ${{ inputs.commit || github.sha }}
   test-dispatch:
-    # needs: setup
     needs: build-artifact
     timeout-minutes: 120
     runs-on: ${{ fromJSON(inputs.runner-label) }}
+    container:
+      image: ${{ contains(inputs.runner-label, 'tt-ubuntu-2204') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved' }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        LD_LIBRARY_PATH: /work/build/lib
+        GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TT_METAL_HOME: /work
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - ${{ !contains(inputs.runner-label, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G' || '/nohugepages:/nohugepages' }}
+        - ${{ !contains(inputs.runner-label, 'tt-ubuntu-2204') && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{ inputs.commit || github.sha }}
-      - uses: ./.github/actions/ensure-active-weka-mount
-        timeout-minutes: 3
-        if: ${{ inputs.arch != 'blackhole' }}
       - name: ⬇️ Download Build
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         timeout-minutes: 10
@@ -98,18 +100,16 @@ jobs:
         timeout-minutes: 10
         with:
           name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: Run regression in loop in docker
-        uses: ./.github/actions/docker-run
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          install_wheel: true
-          docker_opts: |
-            -v /mnt/MLPerf:/mnt/MLPerf:ro
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=${{ inputs.arch }}
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/
-          run_args: |
-            pip3 install pytest-repeat
-            ${{ inputs.command }}
+      - name: 💿 Install Wheel
+        run: |
+          echo "📂 In directory: $(pwd)"
+          echo "📄 Files:"
+          ls -la
+          WHEEL_FILENAME=$(ls -1 *.whl)
+          echo "📦 Installing $WHEEL_FILENAME"
+          pip3 install "$WHEEL_FILENAME"
+        shell: bash
+      - name: Run regression in loop
+        run: |
+          pip3 install pytest-repeat
+          ${{ inputs.command }}

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ fromJSON(inputs.runner-label) }}
     container:
-      image: ${{ contains(inputs.runner-label, 'tt-ubuntu-2204') && 'harbor.ci.tenstorrent.net/' || '' }}${{ inputs.docker-image || 'docker-image-unresolved' }}
+      image: ${{ contains(inputs.runner-label, 'tt-ubuntu-2204') && 'harbor.ci.tenstorrent.net/' || '' }}${{ needs.build-artifact.outputs.dev-docker-image || 'docker-image-unresolved' }}
       env:
         ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -83,24 +83,30 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: ⬇️ Checkout
+      - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 1
           submodules: recursive
+          path: docker-job
           ref: ${{ inputs.commit || github.sha }}
-      - name: ⬇️ Download Build
+      - name: 📦 Download Build Artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
         with:
           name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      - name: Extract files
-        run: tar --zstd -xvf ttm_any.tar.zst
-      - name: ⬇️ Download Wheel
+          path: docker-job
+      - name: 📂 Extract Build Files
+        working-directory: docker-job
+        run: tar --zstd -xf ttm_any.tar.zst
+        shell: bash
+
+      - name: 🧪 Download Python Wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
         with:
           name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+          path: docker-job
       - name: 💿 Install Wheel
+        working-directory: docker-job
         run: |
           echo "📂 In directory: $(pwd)"
           echo "📄 Files:"
@@ -113,3 +119,6 @@ jobs:
         run: |
           pip3 install pytest-repeat
           ${{ inputs.command }}
+        shell: bash
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -70,6 +70,7 @@ jobs:
       env:
         ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TT_METAL_HOME: /work


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19801

### Problem description
Custom test dispatch still uses docker-run and has some extra steps that are CIv1-only (e.g. ensure-active-weka-mount that has been moved to reset.sh)

### What's changed
Containerize the workflow
Support CIv2

### Checklist
- [x] Test dispatch on CIv1: https://github.com/tenstorrent/tt-metal/actions/runs/18538963178
- [x] Test dispatch on CIv2: https://github.com/tenstorrent/tt-metal/actions/runs/18539535838