### PR TITLE
TT-Train: clean up lambda captures

### DIFF
--- a/tt-train/CMakeLists.txt
+++ b/tt-train/CMakeLists.txt
@@ -65,9 +65,6 @@ else()
 endif()
 # ttml projects
 
-# FIXME: Many lambda functions in tt-train capture variables and don't use them.
-add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>")
-
 add_subdirectory(sources)
 include(CTest)
 enable_testing()

--- a/tt-train/sources/examples/linear_regression/main.cpp
+++ b/tt-train/sources/examples/linear_regression/main.cpp
@@ -46,7 +46,7 @@ int main() {
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [&num_features, &num_targets, device](std::vector<DatasetSample>&& samples) {
+        [device](std::vector<DatasetSample>&& samples) {
             const uint32_t batch_size = samples.size();
             std::vector<float> data;
             std::vector<float> targets;

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -47,7 +47,7 @@ int main() {
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [&num_features, &num_targets, device](std::vector<DatasetSample>&& samples) {
+        [device](std::vector<DatasetSample>&& samples) {
             const uint32_t batch_size = samples.size();
             std::vector<float> data;
             std::vector<float> targets;

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char **argv) {
     auto *device = &ttml::autograd::ctx().get_device();
     device->enable_program_cache();
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [num_features, num_targets, device](std::vector<DatasetSample> &&samples) {
+        [device](std::vector<DatasetSample> &&samples) {
             const uint32_t batch_size = samples.size();
             std::vector<float> data;
             std::vector<uint32_t> targets;
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     LossAverageMeter loss_meter;
     int training_step = 0;
 
-    auto get_loss_value = [device](const TensorPtr &loss) {
+    auto get_loss_value = [](const TensorPtr &loss) {
         auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});
         // sum of loss xtensors
         float loss_float =

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -655,7 +655,7 @@ int main(int argc, char **argv) {
         ttml::core::from_vector(mask, ttnn::Shape({1U, 1U, sequence_length, sequence_length}), device));
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [sequence_length, num_heads, device, &cached_data, &device_config](std::vector<DatasetSample> &&samples) {
+        [sequence_length, device, &cached_data, &device_config](std::vector<DatasetSample> &&samples) {
             auto start_timer = std::chrono::high_resolution_clock::now();
             const uint32_t batch_size = samples.size();
             std::vector<uint32_t> &data = cached_data.data;
@@ -877,7 +877,7 @@ int main(int argc, char **argv) {
         return global_step * config.batch_size * config.gradient_accumulation_steps;
     };
 
-    auto get_loss_value = [device](const TensorPtr &loss) {
+    auto get_loss_value = [](const TensorPtr &loss) {
         auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});
         // sum of loss xtensors
         float loss_float =

--- a/tt-train/sources/ttml/autograd/graph.cpp
+++ b/tt-train/sources/ttml/autograd/graph.cpp
@@ -31,7 +31,7 @@ NodeId Graph::add_node(GradFunction&& grad_function, std::span<NodeId> links) {
     size_t curr_id = m_graph_nodes.size();
     if (core::debug::Debug::enable_backward_performance_measurement()) {
         //  we are using this wrapper to measure the time taken by each node.
-        GradFunction wrapper = [grad_function = std::move(grad_function), curr_id, this]() {
+        GradFunction wrapper = [grad_function = std::move(grad_function), curr_id]() {
             const std::type_info& typeInfo = grad_function.target_type();
             auto demangled_name = core::demangle(typeInfo.name());
             auto time = std::chrono::high_resolution_clock::now();

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -218,7 +218,7 @@ void load_model_from_safetensors(const std::filesystem::path &path, serializatio
         return it->second;
     };
     serialization::SafetensorSerialization::TensorCallback loading_callback =
-        [&parameters, &get_parameter](
+        [&get_parameter](
             const serialization::SafetensorSerialization::TensorInfo &info, std::span<const std::byte> bytes) {
             fmt::print("Loading tensor: {}, shape:{}, format: {}\n", info.name, info.shape, info.dtype);
             auto float_vec = serialization::SafetensorSerialization::bytes_to_float_vec(bytes, info.dtype);

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -42,7 +42,7 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
     auto rms_a = rmsnorm_fw_result[1].value();
     auto out = autograd::create_tensor(rmsnorm_fw_result[0].value());
 
-    autograd::GradFunction grad = [B, S, C, tensor, gamma, out, rms_a, epsilon]() {
+    autograd::GradFunction grad = [tensor, gamma, out, rms_a]() {
         auto dL_dout = out->get_grad();
 
         auto grads = ttml::metal::rmsnorm_bw(tensor->get_value(), gamma->get_value(), rms_a, dL_dout);
@@ -78,7 +78,7 @@ autograd::TensorPtr rmsnorm_composite(
     // one gain parameter per channel
     assert((gamma->get_value().logical_shape().to_array_4D() == std::array<uint32_t, 4>{1, 1, 1, C}));
 
-    auto device = &autograd::ctx().get_device();
+    [[maybe_unused]] auto device = &autograd::ctx().get_device();
 
     ttnn::Tensor squares = ttnn::square(tensor->get_value());  // [B,1,S,C] -> [B,1,S,C]
 
@@ -124,7 +124,7 @@ autograd::TensorPtr rmsnorm_composite(
 
     auto out = autograd::create_tensor(out_tensor);
 
-    autograd::GradFunction grad = [B, S, C, tensor, gamma, out, rms_a, device]() {
+    autograd::GradFunction grad = [tensor, gamma, out, rms_a]() {
         auto a = tensor->get_value();  // [B,1,S,C]
         auto g = gamma->get_value();   // [1,1,1,C]
 

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -121,7 +121,7 @@ autograd::TensorPtr rope(const autograd::TensorPtr& input, const RotaryEmbedding
     auto seq_len = input_logical_shape[2];
     auto head_dim = input_logical_shape[3];
 
-    auto squish_batch = [num_batch, num_heads, seq_len, head_dim](const ttnn::Tensor& input) {
+    auto squish_batch = [num_batch, num_heads](const ttnn::Tensor& input) {
         auto shape = input.logical_shape();
         auto seq_len = shape[2];
         auto head_dim = shape[3];

--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -188,7 +188,7 @@ autograd::TensorPtr scaled_dot_product_attention(
     auto out = ttml::autograd::create_tensor(attention_qkv);
 
     ttml::autograd::GradFunction grad =
-        [scale, query, key, value, attention_weights, out, mask, batch_num, heads, seq_len, embedding_dim, groups]() {
+        [scale, query, key, value, attention_weights, out, mask, groups]() {
             constexpr auto none = ttsl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam>{};
             auto dL_dout = out->get_grad();  // (B, H, S, embedding_dim)
             // dL_d(softmax(σQK+mask)) = dL_dout @ value^T

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -73,7 +73,7 @@ TEST_F(LinearRegressionDDPTest, Full) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [&num_features, &num_targets, device](std::vector<DatasetSample>&& samples) {
+        [device](std::vector<DatasetSample>&& samples) {
             const uint32_t batch_size = samples.size();
             std::vector<float> data;
             std::vector<float> targets;

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -250,7 +250,7 @@ void train_test(bool use_tensor_parallel = false, bool use_ddp = false) {
 
     auto optimizer = std::make_shared<ttml::optimizers::MorehAdamW>(model->parameters(), adamw_params);
 
-    auto get_loss_value = [device](const TensorPtr &loss) {
+    auto get_loss_value = [](const TensorPtr &loss) {
         auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});
         // sum of loss xtensors
         float loss_float =


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TT-Train had some lambdas that were over-capturing.

### What's changed
Remove unused captures.
Remove warning supression.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes