### PR TITLE
Fix clearing devices from profiler sync map

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -461,6 +461,9 @@ def test_profiler_host_device_sync():
 
     syncinfoDF = pd.read_csv(syncInfoFile)
     devices = sorted(syncinfoDF["device id"].unique())
+    available_devices = sorted(int(device_id) for device_id in deviceData["data"]["devices"].keys())
+    missing_devices = [device_id for device_id in available_devices if device_id not in devices]
+    assert len(missing_devices) == 0, f"Missing sync info for devices {missing_devices}"
     for device in devices:
         deviceFreq = syncinfoDF[syncinfoDF["device id"] == device].iloc[-1]["frequency"]
         if not np.isnan(deviceFreq):  # host sync entry
@@ -485,6 +488,9 @@ def test_profiler_host_device_sync():
 
     syncinfoDF = pd.read_csv(syncInfoFile)
     devices = sorted(syncinfoDF["device id"].unique())
+    available_devices = sorted(int(device_id) for device_id in deviceData["data"]["devices"].keys())
+    missing_devices = [device_id for device_id in available_devices if device_id not in devices]
+    assert len(missing_devices) == 0, f"Missing sync info for devices {missing_devices}"
     for device in devices:
         deviceFreq = syncinfoDF[syncinfoDF["device id"] == device].iloc[-1]["frequency"]
         if not np.isnan(deviceFreq):  # host sync entry

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -536,11 +536,11 @@ void syncAllDevices(chip_id_t host_connected_device) {
 
             uint64_t shift = ((double)(senderSum - (freqScale * (double)receiverSum)) / accumulateSampleCount) +
                              (senderBase - freqScale * receiverBase);
-            deviceDeviceSyncInfo.insert_or_assign(sender.first, (std::unordered_map<chip_id_t, std::pair<double, int64_t>>){});
+            deviceDeviceSyncInfo.try_emplace(sender.first);
             deviceDeviceSyncInfo.at(sender.first)
                 .insert_or_assign(receiver.first, (std::pair<double, int64_t>){freqScale, shift});
 
-            deviceDeviceSyncInfo.insert_or_assign(receiver.first, (std::unordered_map<chip_id_t, std::pair<double, int64_t>>){});
+            deviceDeviceSyncInfo.try_emplace(receiver.first);
             deviceDeviceSyncInfo.at(receiver.first)
                 .insert_or_assign(sender.first, (std::pair<double, int64_t>){1.0 / freqScale, -1 * shift});
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30406

### Problem description
Device sync on T3K is broken 

### What's changed
Do not refresh the maps keys and only append the values

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18538004084)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/18572009957)
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18572004114)