### PR TITLE
Verify eth firmware version

### DIFF
--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -18,6 +18,8 @@
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <umd/device/types/xy_pair.hpp>
+#include <umd/device/types/cluster_types.hpp>
 #include <unordered_set>
 #include <utility>
 #include <variant>
@@ -253,6 +255,7 @@ public:
     using DispatchFeatureQueryFunc = std::function<bool(DispatchFeature)>;
     using SetIRAMTextSizeFunc = std::function<void(
         dev_msgs::launch_msg_t::View, HalProgrammableCoreType, HalProcessorClassType, uint32_t, uint32_t)>;
+    using VerifyFwVersionFunc = std::function<void(tt::umd::tt_version)>;
 
 private:
     tt::ARCH arch_;
@@ -313,6 +316,7 @@ private:
     DispatchFeatureQueryFunc device_features_func_;
     std::unique_ptr<HalJitBuildQueryInterface> jit_build_query_;
     SetIRAMTextSizeFunc set_iram_text_size_func_;
+    VerifyFwVersionFunc verify_eth_fw_version_func_;
 
 public:
     Hal(tt::ARCH arch, bool is_base_routing_fw_enabled);
@@ -474,6 +478,12 @@ public:
     uint64_t get_pcie_addr_lower_bound() const;
     // Inclusive upper bound
     uint64_t get_pcie_addr_upper_bound() const;
+
+    // Verify that the eth version is compatible with the HAL capabilities. Throws an exception if version is
+    // not compatible.
+    void verify_eth_fw_version(tt::umd::tt_version eth_fw_version) const {
+        this->verify_eth_fw_version_func_(eth_fw_version);
+    }
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -398,7 +398,7 @@ void Hal::initialize_bh() {
     this->verify_eth_fw_version_func_ = [](tt::umd::tt_version fw_version) {
         if (blackhole::is_2_erisc_mode()) {
             tt::umd::tt_version min_version(1, 6, 2);
-            if (min_version >= fw_version) {
+            if (!(fw_version >= min_version)) {
                 TT_THROW(
                     "In 2-erisc mode, the minimum supported ethernet firmware version is {}. Detected version is {}",
                     min_version.str(),

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -394,6 +394,18 @@ void Hal::initialize_bh() {
         NOC_CFG(NOC_Y_ID_TRANSLATE_TABLE_5)};
 
     this->jit_build_query_ = std::make_unique<HalJitBuildQueryBlackHole>();
+
+    this->verify_eth_fw_version_func_ = [](tt::umd::tt_version fw_version) {
+        if (blackhole::is_2_erisc_mode()) {
+            tt::umd::tt_version min_version(1, 6, 2);
+            if (min_version >= fw_version) {
+                TT_THROW(
+                    "In 2-erisc mode, the minimum supported ethernet firmware version is {}. Detected version is {}",
+                    min_version.str(),
+                    fw_version.str());
+            }
+        }
+    };
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <string>
 #include <string_view>
+#include <tt-logger/tt-logger.hpp>
 
 #include "blackhole/bh_hal.hpp"
 #include "dev_mem_map.h"
@@ -399,7 +400,8 @@ void Hal::initialize_bh() {
         if (blackhole::is_2_erisc_mode()) {
             tt::umd::tt_version min_version(1, 6, 2);
             if (!(fw_version >= min_version)) {
-                TT_THROW(
+                log_critical(
+                    tt::LogLLRuntime,
                     "In 2-erisc mode, the minimum supported ethernet firmware version is {}. Detected version is {}",
                     min_version.str(),
                     fw_version.str());

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -361,6 +361,10 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
             launch_msg.kernel_config().ncrisc_kernel_size16() = (iram_text_size + 15) >> 4;
         }
     };
+
+    this->verify_eth_fw_version_func_ = [](tt::umd::tt_version /*eth_fw_version*/) {
+        // No checks
+    };
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -329,6 +329,10 @@ void Hal::initialize_qa() {
     this->noc_y_id_translate_table_ = {};
 
     this->jit_build_query_ = std::make_unique<HalJitBuildQueryQuasar>();
+
+    this->verify_eth_fw_version_func_ = [](tt::umd::tt_version /*eth_fw_version*/) {
+        // No checks
+    };
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -310,6 +310,7 @@ void Cluster::initialize_device_drivers() {
     this->start_driver(default_params);
     this->generate_virtual_to_umd_coord_mapping();
     this->generate_virtual_to_profiler_flat_id_mapping();
+    this->verify_eth_fw_capability();
 }
 
 void Cluster::assert_risc_reset() {
@@ -852,6 +853,8 @@ void Cluster::verify_sw_fw_versions(
         TT_FATAL(sw.minor <= fw.minor, "SW version is newer than FW version");
     }
 }
+
+void Cluster::verify_eth_fw_capability() const { hal_.verify_eth_fw_version(this->driver_->get_ethernet_fw_version()); }
 
 // DRAM barrier is used to implement host-to-device synchronization and should be used when all previous writes to DRAM
 // need to be flushed This is needed because writes to device are not blocking unless strict TLB ordering is used

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -854,7 +854,13 @@ void Cluster::verify_sw_fw_versions(
     }
 }
 
-void Cluster::verify_eth_fw_capability() const { hal_.verify_eth_fw_version(this->driver_->get_ethernet_fw_version()); }
+void Cluster::verify_eth_fw_capability() const {
+    // get_ethernet_fw_version is not supported in the simulation environment
+    if (rtoptions_.get_simulator_enabled()) {
+        return;
+    }
+    hal_.verify_eth_fw_version(this->driver_->get_ethernet_fw_version());
+}
 
 // DRAM barrier is used to implement host-to-device synchronization and should be used when all previous writes to DRAM
 // need to be flushed This is needed because writes to device are not blocking unless strict TLB ordering is used

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -859,7 +859,10 @@ void Cluster::verify_eth_fw_capability() const {
     if (rtoptions_.get_simulator_enabled()) {
         return;
     }
-    hal_.verify_eth_fw_version(this->driver_->get_ethernet_fw_version());
+    const auto fw_version = this->driver_->get_ethernet_fw_version();
+    if (fw_version) {
+        hal_.verify_eth_fw_version(fw_version.value());
+    }
 }
 
 // DRAM barrier is used to implement host-to-device synchronization and should be used when all previous writes to DRAM

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -131,7 +131,6 @@ public:
 
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
-    void verify_eth_fw_capability() const;
 
     void deassert_risc_reset_at_core(
         const tt_cxy_pair& physical_chip_coord,
@@ -372,6 +371,8 @@ private:
     void set_tunnels_from_mmio_device();
 
     bool supports_dma_operations(ChipId chip_id, uint32_t sz_in_bytes) const;
+
+    void verify_eth_fw_capability() const;
 
     ARCH arch_{tt::ARCH::Invalid};
     TargetDevice target_type_{0};

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -131,6 +131,7 @@ public:
 
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
+    void verify_eth_fw_capability() const;
 
     void deassert_risc_reset_at_core(
         const tt_cxy_pair& physical_chip_coord,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30629

### Problem description
For 2 ERISC mode, we decided to not enable it by default to reduce the impact to customers because the latest Eth Fw is needed for stability.

There are three possible outcomes if you enable try to enable this feature on an older fw version,

- Things will work
- Initialization will fail. In this case, we already have a message to tell the user they need to update their tt-firmware version to at least x.x.x.x
- Something will hang inside the Op. This is the worst case and it's not easy to debug.

The prevent these undefined behaviors from happening it's important that we can query the firmware version from Metal and enable/disable/print an error message as required for this feature.

### What's changed
- Add a check for the eth firmware version

### Checklist
BH
https://github.com/tenstorrent/tt-metal/actions/runs/18724440213
BH Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/18724446395
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18724443005