### PR TITLE
Move hlk_desc out of API

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -61,7 +61,6 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/graph_tracking.hpp
     api/tt-metalium/hal.hpp
     api/tt-metalium/hal_types.hpp
-    api/tt-metalium/hlk_desc.hpp
     api/tt-metalium/host_api.hpp
     api/tt-metalium/host_buffer.hpp
     api/tt-metalium/kernel_types.hpp

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -149,7 +149,7 @@ inline void hash_hlk_args(size_t& seed, void* hlk_args, size_t hlk_args_size) {
 
 template <>
 struct std::hash<tt::tt_hlk_desc> {
-    std::size_t operator()(tt::tt_hlk_desc const& obj) const {
+    std::size_t operator()(const tt::tt_hlk_desc& obj) const {
         std::size_t hash_value = 0;
         for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
             ttsl::hash::hash_combine(hash_value, hash<tt::DataFormat>{}(obj.get_buf_dataformat(i)));

--- a/tt_metal/jit_build/jit_build_options.hpp
+++ b/tt_metal/jit_build/jit_build_options.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <tt-metalium/hlk_desc.hpp>
+#include "hlk_desc.hpp"
 #include <hostdevcommon/kernel_structs.h>
 
 enum class MathFidelity : uint8_t;


### PR DESCRIPTION
### Ticket
Close #30582

### Problem description
`hlk_desc.hpp` is used for jit build system, it is an internal concept for the Runtime team, not suitable for public consumption.

### What's changed
Moved it to internal jitbuild directory.

### Checklist
- Being able to pass compile should give high confidence on wellness of this PR.
- Merge gate should be sufficient for testing.
- [ ] [?? All post commit ??](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) Maybe let's not clog APC