### PR TITLE
[skip ci] Add job id to the slack ping msg with job.check_run_id 

### DIFF
--- a/.github/actions/slack-report/action.yaml
+++ b/.github/actions/slack-report/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Report Github Pipeline Status Slack Action
-      if: ${{ github.ref == 'refs/heads/main' }}
+      # if: ${{ github.ref == 'refs/heads/main' }}
       uses: slackapi/slack-github-action@v1.26.0
       with:
         payload: |

--- a/.github/actions/slack-report/action.yaml
+++ b/.github/actions/slack-report/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Report Github Pipeline Status Slack Action
-      # if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: slackapi/slack-github-action@v1.26.0
       with:
         payload: |

--- a/.github/actions/slack-report/action.yaml
+++ b/.github/actions/slack-report/action.yaml
@@ -16,7 +16,7 @@ runs:
       with:
         payload: |
           {
-            "text": "<@${{ inputs.owner }}> just so you know `${{ github.event.sender.login }}` broke ${{ github.workflow }} with https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }} at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "text": "<@${{ inputs.owner }}> just so you know `${{ github.event.sender.login }}` broke ${{ github.workflow }} with https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }} at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -24,55 +24,55 @@ jobs:
       fail-fast: false
       matrix:
         runner-group:
-          # - name: LLMBox unit tests
-          #   runner-label: BH-LLMBox
-          # - name: DeskBox unit tests
-          #   runner-label: BH-DeskBox
-          # - name: LoudBox unit tests
-          #   runner-label: BH-LoudBox
+          - name: LLMBox unit tests
+            runner-label: BH-LLMBox
+          - name: DeskBox unit tests
+            runner-label: BH-DeskBox
+          - name: LoudBox unit tests
+            runner-label: BH-LoudBox
           - name: P300 unit tests
             runner-label: P300-viommu
         test-group:
           - name: fabric 1D unit tests
             cmd: |
-              exit 1
+              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
             timeout: 15
-          # - name: fabric 2D fixture unit tests
-          #   cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-          #   timeout: 15
-          # - name: fabric system health tests
-          #   cmd: ./build/test/tt_metal/tt_fabric/test_system_health
-          #   timeout: 15
-          # - name: fabric stability nightly tests
-          #   cmd: TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ./tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml
-          #   timeout: 30
-          # - name: cpp unit tests eth
-          #   cmd: |
-          #     ./build/test/tt_metal/unit_tests_eth
-          #     ./build/test/tt_metal/unit_tests_tunneling
-          #     TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
-          #   timeout: 15
-          # - name: multi erisc tests
-          #   cmd: |
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_eth
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=DPrintMeshFixture.ActiveEthTestPrint
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TensixTestWatcherPause
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TestWatcherAssert
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=MeshWatcherFixture.ActiveEthTestWatcherSanitizeEth
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramFixture.ActiveEthTestPrograms
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramTraceFixture.ActiveEthTestProgramsTrace
-          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQFixture.ActiveEthTwoRiscsHandshake
-          #   timeout: 60
-          # - name: ccl nightly tests
-          #   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly
-          #   timeout: 60
-          # - name: fabric infra unit tests
-          #   cmd: |
-          #     TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
-          #     TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
-          #   timeout: 15
-          # # - name: t3000 fast fabric tests
-          # #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
+          - name: fabric 2D fixture unit tests
+            cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+            timeout: 15
+          - name: fabric system health tests
+            cmd: ./build/test/tt_metal/tt_fabric/test_system_health
+            timeout: 15
+          - name: fabric stability nightly tests
+            cmd: TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ./tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml
+            timeout: 30
+          - name: cpp unit tests eth
+            cmd: |
+              ./build/test/tt_metal/unit_tests_eth
+              ./build/test/tt_metal/unit_tests_tunneling
+              TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
+            timeout: 15
+          - name: multi erisc tests
+            cmd: |
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_eth
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=DPrintMeshFixture.ActiveEthTestPrint
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TensixTestWatcherPause
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TestWatcherAssert
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=MeshWatcherFixture.ActiveEthTestWatcherSanitizeEth
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramFixture.ActiveEthTestPrograms
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramTraceFixture.ActiveEthTestProgramsTrace
+              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQFixture.ActiveEthTwoRiscsHandshake
+            timeout: 60
+          - name: ccl nightly tests
+            cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly
+            timeout: 60
+          - name: fabric infra unit tests
+            cmd: |
+              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+            timeout: 15
+          # - name: t3000 fast fabric tests
+          #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
     name: ${{ inputs.arch }} ${{ matrix.runner-group.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service
@@ -117,7 +117,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           tt-smi -s
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@williamly/slack-ping-job
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -24,55 +24,55 @@ jobs:
       fail-fast: false
       matrix:
         runner-group:
-          - name: LLMBox unit tests
-            runner-label: BH-LLMBox
-          - name: DeskBox unit tests
-            runner-label: BH-DeskBox
-          - name: LoudBox unit tests
-            runner-label: BH-LoudBox
+          # - name: LLMBox unit tests
+          #   runner-label: BH-LLMBox
+          # - name: DeskBox unit tests
+          #   runner-label: BH-DeskBox
+          # - name: LoudBox unit tests
+          #   runner-label: BH-LoudBox
           - name: P300 unit tests
             runner-label: P300-viommu
         test-group:
           - name: fabric 1D unit tests
             cmd: |
-              TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+              exit 1
             timeout: 15
-          - name: fabric 2D fixture unit tests
-            cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-            timeout: 15
-          - name: fabric system health tests
-            cmd: ./build/test/tt_metal/tt_fabric/test_system_health
-            timeout: 15
-          - name: fabric stability nightly tests
-            cmd: TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ./tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml
-            timeout: 30
-          - name: cpp unit tests eth
-            cmd: |
-              ./build/test/tt_metal/unit_tests_eth
-              ./build/test/tt_metal/unit_tests_tunneling
-              TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
-            timeout: 15
-          - name: multi erisc tests
-            cmd: |
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_eth
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=DPrintMeshFixture.ActiveEthTestPrint
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TensixTestWatcherPause
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TestWatcherAssert
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=MeshWatcherFixture.ActiveEthTestWatcherSanitizeEth
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramFixture.ActiveEthTestPrograms
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramTraceFixture.ActiveEthTestProgramsTrace
-              TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQFixture.ActiveEthTwoRiscsHandshake
-            timeout: 60
-          - name: ccl nightly tests
-            cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly
-            timeout: 60
-          - name: fabric infra unit tests
-            cmd: |
-              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
-              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
-            timeout: 15
-          # - name: t3000 fast fabric tests
-          #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
+          # - name: fabric 2D fixture unit tests
+          #   cmd: TT_METAL_USE_MGD_2_0=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+          #   timeout: 15
+          # - name: fabric system health tests
+          #   cmd: ./build/test/tt_metal/tt_fabric/test_system_health
+          #   timeout: 15
+          # - name: fabric stability nightly tests
+          #   cmd: TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ./tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml
+          #   timeout: 30
+          # - name: cpp unit tests eth
+          #   cmd: |
+          #     ./build/test/tt_metal/unit_tests_eth
+          #     ./build/test/tt_metal/unit_tests_tunneling
+          #     TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
+          #   timeout: 15
+          # - name: multi erisc tests
+          #   cmd: |
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_eth
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=DPrintMeshFixture.ActiveEthTestPrint
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TensixTestWatcherPause
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=WatcherAssertTest.TestWatcherAssert
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_debug_tools --gtest_filter=MeshWatcherFixture.ActiveEthTestWatcherSanitizeEth
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramFixture.ActiveEthTestPrograms
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshRandomProgramTraceFixture.ActiveEthTestProgramsTrace
+          #     TT_METAL_MULTI_AERISC=1 build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQFixture.ActiveEthTwoRiscsHandshake
+          #   timeout: 60
+          # - name: ccl nightly tests
+          #   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/nightly
+          #   timeout: 60
+          # - name: fabric infra unit tests
+          #   cmd: |
+          #     TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+          #     TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+          #   timeout: 15
+          # # - name: t3000 fast fabric tests
+          # #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
     name: ${{ inputs.arch }} ${{ matrix.runner-group.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service
@@ -117,7 +117,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           tt-smi -s
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@williamly/slack-ping-job
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}


### PR DESCRIPTION
### Ticket
Slightly related to https://github.com/tenstorrent/tt-metal/issues/11711

### Problem description
Github finally has job id in the GH context with job.check_run_id

### What's changed
Try it out in the slack ping msg action

### Checklist
- [x] Ping works https://github.com/tenstorrent/tt-metal/actions/runs/18540689652/job/52847724915#step:8:9