### PR TITLE
bump pytest timeout for `test_neighbor_pad` [skip ci]

### DIFF
--- a/tests/nightly/t3000/ccl/test_neighbor_pad_async.py
+++ b/tests/nightly/t3000/ccl/test_neighbor_pad_async.py
@@ -199,6 +199,7 @@ def run_neighbor_pad_impl(
 
 
 @skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.timeout(900)  # test is slow so bump up the default timeout
 @pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
NA

### Problem description
This test was timing out in CI and subsequently leaving the runner in a bad state.

### What's changed
Bump pytest timeout