### PR TITLE
all_gather composite codepath for fabric 2D

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -903,9 +903,11 @@ def test_all_gather_async_interleaved_to_sharded(
     "device_params, all_gather_topology",
     [
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D_DYNAMIC, "trace_region_size": 90112}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
-    ids=["fabric_linear"],
+    ids=["fabric_linear", "fabric2d_linear", "fabric2d_dynamic_linear"],
 )
 def test_all_gather_async_2x4(
     mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -27,16 +27,6 @@
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 
-namespace {
-inline bool is_fabric_2d() {
-    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
-
-    return (
-        fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D ||
-        fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
-}
-}  // namespace
-
 namespace ttnn::operations::experimental::ccl {
 
 uint32_t finding_scatter_dim(const ttnn::Shape& input_tensor_padded_shape, const Layout& layout, size_t num_workers) {
@@ -197,7 +187,8 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
         interleaved_tensor = ttnn::sharded_to_interleaved(padded_tensor, working_memory_config, std::nullopt);
     }
 
-    if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) || is_fabric_2d()) {
+    if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) ||
+        composite_common::is_fabric_2d()) {
         // All reduce = all gather + local reduce
         composite_dim = 0;
         auto reshaped_tensor = ttnn::reshape(
@@ -289,7 +280,8 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
         composite_common::use_composite_all_gather(padded_tensor, composite_dim, out_memory_config);
     bool composite_reduce_scatter =
         composite_common::use_composite_reduce_scatter(padded_tensor, composite_dim, cluster_axis);
-    if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) || is_fabric_2d()) {
+    if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) ||
+        composite_common::is_fabric_2d()) {
         // All reduce = all gather + local reduce
         composite_dim = 0;
         auto reshaped_tensor = ttnn::reshape(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -66,4 +66,6 @@ ttnn::Tensor composite_all_to_all(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id);
 
+bool is_fabric_2d();
+
 }  // namespace composite_common


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28530)

### Problem description
- all_gather fails for tile layout -the native code path- when a fabric 2D config was used.

### What's changed
- Switch to the composite codepath when Fabric 2D is used.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18544530906
- [x] T3K nightly (new test) https://github.com/tenstorrent/tt-metal/actions/runs/18544551154
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/18544543948
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/18544560671
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/18544565603
- [x] New/Existing tests provide coverage for changes