### PR TITLE
Fix for In Place Halo With New L1 Alignment

### DIFF
--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -14,7 +14,7 @@
 
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/common/constants.hpp"
-#include "ttnn/api/ttnn/types.hpp"
+#include "ttnn/types.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -533,7 +533,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
-    const auto delta = output_tensor.buffer()->aligned_size_per_bank() - input_tensor.buffer()->aligned_size_per_bank();
+    const auto delta = in_out_shard_size_delta * out_stick_nbytes;
     TT_ASSERT(
         src_buffer->address() == dst_buffer->address() + delta,
         "In-place halo requires input and output buffers to be sharded at the same address");

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -533,7 +533,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
 
-    bool is_in_tiled = input_tensor.layout() == ttnn::TILE_LAYOUT;
+    bool is_in_tiled = input_tensor.layout() == ttnn::types::TILE_LAYOUT;
     const auto stick_delta = in_out_shard_size_delta * out_stick_nbytes;
     const auto buffer_delta =
         output_tensor.buffer()->aligned_size_per_bank() - input_tensor.buffer()->aligned_size_per_bank();

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -14,6 +14,7 @@
 
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/api/ttnn/types.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
L1 alignment was recently differentiated from DRAM alignment causing a failure in the in place halo checks which ensure the output and input buffers overlap.

### What's changed
The alignment check has been updated to respect the new L1 alignment scheme.

### Checklist
WH Post Commit:
https://github.com/tenstorrent/tt-metal/actions/runs/18568803398
BH Post Commit:
https://github.com/tenstorrent/tt-metal/actions/runs/18568806487
WH Nightly:
https://github.com/tenstorrent/tt-metal/actions/runs/18568810902
BH Nightly:
https://github.com/tenstorrent/tt-metal/actions/runs/18568818221