### PR TITLE
Move `core_descriptor.hpp` from API to llrt

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <memory>
 #include <optional>

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <exception>

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <exception>

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -42,7 +42,6 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/constants.hpp
     api/tt-metalium/control_plane.hpp
     api/tt-metalium/core_coord.hpp
-    api/tt-metalium/core_descriptor.hpp
     api/tt-metalium/data_format.hpp
     api/tt-metalium/data_types.hpp
     api/tt-metalium/device.hpp

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -10,7 +10,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 #include "impl/context/metal_context.hpp"
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/device_pool.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/fabric.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include "tt_metal/fabric/erisc_datamover_builder.hpp"
 #include "core_coord.hpp"
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.hpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <cstdint>
 
 #include "impl/allocator/allocator_types.hpp"

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -8,7 +8,7 @@
 #include <tt_stl/indestructible.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/distributed_context.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/hal_types.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <llrt/hal.hpp>

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -7,7 +7,7 @@
 #include <set>
 
 #include <tt-metalium/control_plane.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
 #include "llrt.hpp"

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/core_descriptor.hpp>
+#include "llrt/core_descriptor.hpp"
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <umd/device/types/arch.hpp>                    // tt::ARCH
+#include <umd/device/types/arch.hpp>                      // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.hpp>  // chip_id_t
 #include <map>
 #include <optional>


### PR DESCRIPTION
### Ticket
Close #30565

### Problem description
Runtime is reducing it's API exposure. `core_descriptor.hpp` contains concepts that are too low level for genreral consumption, and is not used in anywhere besides llrt and fabric.

### What's changed
Move file into `tt_metal/llrt`.

### Checklist
- Compilation should indicate well-formness. 
- [x] No reference at mlir