### PR TITLE
Drop -fstack-usage from JIT build

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -165,7 +165,7 @@ void JitBuildEnv::init(
     string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
-        common_flags += "-g -fstack-usage ";
+        common_flags += "-g ";
     }
 
     this->cflags_ = common_flags;


### PR DESCRIPTION
### Ticket
n/a

### Problem description
This debugging flag is enabled by default due to inspector. It somehow interferes ccache, where ccache cannot find the .su file and unable to cache compilation results.

### What's changed
deleted

### Checklist
Trivial change, smoke test should be sufficient.