### PR TITLE
Remove unused constants from `constants.hpp` in API

### DIFF
--- a/tt_metal/api/tt-metalium/constants.hpp
+++ b/tt_metal/api/tt-metalium/constants.hpp
@@ -21,16 +21,5 @@ constexpr uint32_t BFLOAT8_B_TILE_HW = TILE_HW + 64;  // Value is in bytes - 1B 
 constexpr uint32_t BFLOAT4_B_TILE_HW =
     (TILE_HW / 2) + 64;  // Value is in bytes - 0.5B per BFP4 datum + 4x16B exponent section
 
-constexpr uint32_t MAX_DST_SIZE = 16;
-
-// Defaults configured to match numodel numpy tile-checks
-const double DEFAULT_RTOL = 1e-4;
-const double DEFAULT_ATOL = 1e-3;
-const double DEFAULT_PCT_MATCHED = 1.0;
-const double DEFAULT_PCC_THRESH = 0.999;
-
-constexpr uint32_t LF_MAN_PREC = 4;
-constexpr uint32_t FP16_MAN_PREC = 10;
-constexpr uint32_t FP16B_MAN_PREC = 7;
 }  // namespace constants
 }  // namespace tt


### PR DESCRIPTION
### Ticket
Close #30563

### Problem description
Runtime is cleaning up our API. These constants in the `constants.hpp` files under the API directories are unused and maybe out-dated.

### What's changed
Removed unused constants.

### Checklist
- Passing compile should indiciate well-formed-ness of this change.