### PR TITLE
re-enable fabric in 2-erisc mode on BH as experimental

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_test_2erisc_quick.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_test_2erisc_quick.yaml
@@ -1,0 +1,35 @@
+Tests:
+  - name: "LinearMulticastUbench"
+    benchmark_mode: true
+    sync: true
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1]
+      ntype: [unicast_write]
+      size: [16, 2048, 4096]
+
+    defaults:
+      ftype: mcast
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 3
+
+  - name: "LinearMulticast"
+    fabric_setup:
+      topology: Linear
+
+    parametrization_params:
+      num_links: [1]
+      ntype: [unicast_write]
+
+    defaults:
+      ftype: mcast
+      size: 1024
+      num_packets: 100
+
+    patterns:
+      - type: all_to_all

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -217,11 +217,12 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     // used by fabric router, while other sender channels are skipped and have 0 buffer slots.
     static const std::vector<std::vector<std::pair<size_t, size_t>>> default_with_tensix_buffer_slot_options = {
         {{16, 16}, {8, 16}, {8, 8}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
-        {{16, 16}, {8, 16}, {8, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
+        {{16, 32}, {16, 16}, {8, 16}, {8, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
     };
 
     static const std::vector<std::vector<std::pair<size_t, size_t>>> ring_buffer_slot_options = {
-        {{8, 8}, {4, 8}}, {{8, 8}, {4, 8}}};
+        {{8, 8}, {4, 8}},
+        {{16, 32}, {16, 16}, {8, 16}, {8, 8}, {4, 8}}};
 
     static const std::vector<std::vector<std::pair<size_t, size_t>>> torus_buffer_slot_options = {
         {{4, 8}, {4, 8}}, {{4, 8}, {4, 8}}};
@@ -246,11 +247,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         // Architecture-specific buffer slot configurations
         static const std::vector<std::vector<std::pair<size_t, size_t>>> mesh_buffer_slot_options = {
             {{7, 11}, {4, 8}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
-            {{8, 16}, {4, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
+            {{8, 16}, {8, 8}, {4, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
         };
         static const std::vector<std::vector<std::pair<size_t, size_t>>> other_buffer_slot_options = {
             {{8, 16}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
-            {{8, 16}}   // BLACKHOLE: {sender_slots, receiver_slots}
+            {{16, 16}, {8, 16}, {8, 8}, {4, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
         };
 
         static tt::stl::Indestructible<std::vector<std::vector<std::pair<size_t, size_t>>>> mesh_slots(

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -234,9 +234,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
 
     // issue: https://github.com/tenstorrent/tt-metal/issues/29073. TODO: Re-enable after hang is resolved.
     // Ethernet txq IDs on WH are 0,1 and on BH are 0,1,2.
-    // if (tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE) {
-    //     this->receiver_txq_id = 1;
-    // }
+    if (tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE && tt::tt_metal::MetalContext::instance().rtoptions().get_is_fabric_2_erisc_mode_enabled()) {
+        this->receiver_txq_id = 1;
+    }
     this->num_riscv_cores = get_num_riscv_cores();
     for (uint32_t risc_id = 0; risc_id < this->num_riscv_cores; risc_id++) {
         this->risc_configs.emplace_back(risc_id);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2886,6 +2886,10 @@ void kernel_main() {
         }
     }
 
+    if constexpr (NUM_ACTIVE_ERISCS > 1) {
+        wait_for_other_local_erisc();
+    }
+
     // if enable the tensix extension, then before open downstream connection, need to wait for downstream tensix ready
     // for connection.
     if constexpr (num_downstream_tensix_connections) {
@@ -2933,6 +2937,10 @@ void kernel_main() {
                     DOWNSTREAM_SENDER_NUM_BUFFERS_VC1);
             }
         }
+    }
+
+    if constexpr (NUM_ACTIVE_ERISCS > 1) {
+        wait_for_other_local_erisc();
     }
 
     if constexpr (is_receiver_channel_serviced[0] and NUM_ACTIVE_ERISCS > 1) {


### PR DESCRIPTION
This conditionally enables 2-erisc mode for TT-Fabric for improved performance. The enabled mode adopts a simple, interim parallelization scheme where erisc0 services sender channels and erisc1 services receiver channels.

Observed up to 60% link utilization with these changes, @ 4k packet size on BH QB.

To run with this mode, enable `TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC=1 TT_METAL_MULTI_AERISC=1`.

To enable this mode, multiple Ethernet TXQs must be programmed. This has an issue when re-initializing fabric as a different topology. This is likely due to a bug with the txq/rxq reprogramming sequence and some messages being directed to the incorrect rxq on fabric reinits.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/18549461977
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18549463143