### PR TITLE
Remove -fstack-usage due to ccache issues

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -165,7 +165,7 @@ void JitBuildEnv::init(
     string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
-        common_flags += "-g -fstack-usage ";
+        common_flags += "-g ";
     }
 
     this->cflags_ = common_flags;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Kernel ccache reporting the .su file not found. get_riscv_debug_info_enabled is actually enabled by default due to inspector

### What's changed
This flag is only used for debug purposes. Remove it for now to unblock ccache functionality.

### Checklist
N/A - Trivial revert