### PR TITLE
Conv2d Block Sharded split reader with CB overlap

### DIFF
--- a/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [MOBILENETV2_BATCH_SIZE, 3445],
+        [MOBILENETV2_BATCH_SIZE, 3595],
     ],
 )
 def test_perf_device_mobilenetv2(batch_size, expected_perf):

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -179,7 +179,6 @@ class resnet50Bottleneck:
                     ),
                     enable_weights_double_buffer=True if input_width < 56 else False,
                     full_inner_dim=True,
-                    force_split_reader=None if height_sharding else True,
                 ),
             }
 
@@ -246,7 +245,6 @@ class resnet50Bottleneck:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                force_split_reader=None if height_sharding else True,
             ),
         }
 
@@ -295,7 +293,6 @@ class resnet50Bottleneck:
                 enable_act_double_buffer=enable_act_double_buffer,
                 enable_weights_double_buffer=True,
                 full_inner_dim=True,
-                force_split_reader=None if height_sharding else True,
             ),
         }
 
@@ -341,7 +338,6 @@ class resnet50Bottleneck:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                force_split_reader=None if height_sharding else True,
             ),
         }
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -23,7 +23,7 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl impor
 # to having an extra VAE encode call, which increases it.
 # For simplicity, increase both to 29000 as there's enough
 # space left in base variant as well.
-SDXL_L1_SMALL_SIZE = 29000
+SDXL_L1_SMALL_SIZE = 30000
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 SDXL_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_1D

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -5139,24 +5139,23 @@ def test_resnet50_conv_p150(
     )
 
 
-@pytest.mark.parametrize("config_in_dram", [False,True])
-@pytest.mark.parametrize("full_inner_dim", [False,True])
 @pytest.mark.parametrize(
     "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, act_block_h_override",
     (
         (32, 32, 2, 32, 3, 3, 1, 1, 1, 1, 64),# single core
         (64, 64, 2, 32, 3, 3, 1, 1, 1, 1, 64),# multiple cores along C, single core along NHW
         (64, 32, 8, 32, 3, 3, 1, 1, 1, 1, 64),# output grid > input grid  ( output c > input c)
-        (32, 64, 2, 32, 3, 3, 1, 1, 1, 1, 64),# input grid > output grid ( input c > output c)
+        (32, 64, 4, 32, 3, 3, 1, 1, 1, 1, 64),# input grid > output grid ( input c > output c)
         (57, 24, 2, 32, 3, 3, 1, 1, 1, 1, 64),# weird shape example
     ),
 )
+@pytest.mark.parametrize("act_double_buffer", [True, False])
+@pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("force_split_reader", [True, False])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_conv_block_sharding(
     device,
     torch_tensor_map,
-    config_in_dram,
     output_channels,
     input_channels,
     input_height,
@@ -5168,15 +5167,16 @@ def test_conv_block_sharding(
     pad_h,
     pad_w,
     force_split_reader,
-    full_inner_dim,
+    output_dtype,
     act_block_h_override,
+    act_double_buffer
 ):
 
     run_conv(
         device,
         torch_tensor_map,
         ttnn.MathFidelity.LoFi, #math_fidelity
-        ttnn.bfloat8_b, #output_dtype
+        output_dtype, #output_dtype
         ttnn.bfloat8_b, #weights_dtype
         1, # batch_size
         output_channels,
@@ -5195,6 +5195,5 @@ def test_conv_block_sharding(
         groups=1,
         in_place=False,
         force_split_reader=force_split_reader,
-        config_tensors_in_dram=config_in_dram,
-        bs_full_inner_dim=full_inner_dim,
+        enable_act_double_buffer=act_double_buffer,
     )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -320,8 +320,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
             enable_activation_reuse));
     log_debug(
         tt::LogOp,
-        "force_split_reader: {}, enable_split_reader: {}, num_blocks_act_h: {}, per_core_out_matrix_height_ntiles: {}, "
-        "act_block_h_ntiles: {}",
+        "force_split_reader: {}, enable_split_reader: {}, num_blocks_act_h: {}, "
+        "per_core_out_matrix_height_ntiles: {}, act_block_h_ntiles: {}",
         force_split_reader,
         enable_split_reader,
         per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles,
@@ -569,60 +569,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
     }
     uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
 
-    const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
-    const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
-
-    const CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
-    const CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
-    const CoreCoord bottom_right_core = {(std::size_t)in_num_cores_x - 1, (std::size_t)in_num_cores_y - 1};
-    const CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
-    const CoreCoord top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
-    const CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
-
-    CoreRangeSet mcast_sender_cores =
-        CoreRangeSet(CoreRange(top_left_core, top_left_core));  // If single core, this kernel doesn't do mcasting
-    CoreRangeSet mcast_receiver_cores;
-    uint32_t weights_mcast_sender_semaphore_id{};
-    uint32_t weights_mcast_receiver_semaphore_id{};
-    uint32_t act_mcast_sender_semaphore_id = 0;
-    uint32_t act_mcast_receiver_semaphore_id = 0;
-
-    // Check if we should run BRISC kernels on cores that are not in the output grid ( when split reader is enabled and
-    // the output grid is smaller than the input grid)
-    const bool populate_skipped_work_cores =
-        enable_split_reader && block_sharded && input_cores.num_cores() > output_cores.num_cores();
-
-    if (block_sharded) {
-        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
-        // 2D mcast
-        if (transpose_mcast) {
-            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1)));
-            if (!skip_weights_mcast) {
-                mcast_receiver_cores = CoreRange(CoreCoord(1, 0), out_bottom_right_core);
-            }
-        } else {
-            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0)));
-            if (!skip_weights_mcast) {
-                mcast_receiver_cores = CoreRange(CoreCoord(0, 1), out_bottom_right_core);
-            }
-        }
-        if (populate_skipped_work_cores) {
-            mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
-        }
-        act_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-        act_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-
-        weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-        weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-    } else {
-        // 1D mcast
-        if (!skip_weights_mcast) {
-            mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
-            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
-        }
-    }
-
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
     uint32_t act_block_w_extra_align_bytes =
         !slice_inner_dim
@@ -695,6 +641,75 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
     // call function to allocate circular buffers
     allocate_cbs(cb_info, program, all_cores, a, output, conv_reader_indices_tensor);
 
+    const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
+    const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
+
+    const CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
+    const CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
+    const CoreCoord bottom_right_core = {(std::size_t)in_num_cores_x - 1, (std::size_t)in_num_cores_y - 1};
+    const CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    const CoreCoord top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
+    const CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    CoreRangeSet mcast_sender_cores =
+        CoreRangeSet(CoreRange(top_left_core, top_left_core));  // If single core, this kernel doesn't do mcasting
+    CoreRangeSet mcast_receiver_cores;
+    uint32_t weights_mcast_sender_semaphore_id{};
+    uint32_t weights_mcast_receiver_semaphore_id{};
+    uint32_t act_mcast_sender_semaphore_id = 0;
+    uint32_t act_mcast_receiver_semaphore_id = 0;
+    uint32_t act_split_reader_reserve_done_semaphore_id = 0;
+    uint32_t act_split_reader_write_done_semaphore_id = 0;
+
+    // Check if we should run BRISC kernels on cores that are not in the output grid ( when split reader is enabled and
+    // the output grid is smaller than the input grid)
+    const bool populate_skipped_work_cores =
+        enable_split_reader && block_sharded && input_cores.num_cores() > output_cores.num_cores();
+
+    const bool overlap_act_cb =
+        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).overlapped_by_cb.has_value();
+    // When split reader is enabled with overlapped CBs, both readers write to the same circular buffer.
+    // This requires synchronization between the main reader and the second reader to prevent race conditions.
+    const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
+
+    if (block_sharded) {
+        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
+        // 2D mcast
+        if (transpose_mcast) {
+            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1)));
+            if (!skip_weights_mcast) {
+                mcast_receiver_cores = CoreRange(CoreCoord(1, 0), out_bottom_right_core);
+            }
+        } else {
+            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0)));
+            if (!skip_weights_mcast) {
+                mcast_receiver_cores = CoreRange(CoreCoord(0, 1), out_bottom_right_core);
+            }
+        }
+        if (populate_skipped_work_cores) {
+            mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
+        }
+        act_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        act_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+        if (split_reader_cb_shared) {
+            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_split_reader_reserve_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_split_reader_write_done_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        } else {
+            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+        }
+    } else {
+        // 1D mcast
+        if (!skip_weights_mcast) {
+            mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
+            weights_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+            weights_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, output_cores, INVALID);
+        }
+    }
+
     const tt::tt_metal::CBHandle cb_sharded_act = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).handle;
     const tt::tt_metal::CBHandle cb_output = get_cb_info_by_name(cb_info, Conv2dCb::OUT).handle;
     const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
@@ -765,7 +780,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         (uint32_t)conv_act_c_read_bytes,
         (uint32_t)window_outer,
         (uint32_t)window_inner,
-        (uint32_t)(enable_split_reader ? act_block_num_tiles_split : act_block_num_tiles),
+        (uint32_t)(enable_split_reader && !split_reader_cb_shared ? act_block_num_tiles_split : act_block_num_tiles),
         (uint32_t)filter_h,
         (uint32_t)filter_w,
         (uint32_t)conv_act_size_w + (pad_w),
@@ -821,6 +836,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
             reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
     }
 
+    if (split_reader_cb_shared) {
+        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+        reader_compile_time_args.push_back(act_split_reader_reserve_done_semaphore_id);
+        reader_compile_time_args.push_back(act_split_reader_write_done_semaphore_id);
+    } else if (block_sharded) {
+        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+        reader_compile_time_args.push_back(0);
+        reader_compile_time_args.push_back(0);
+    }
     if (skip_activation_mcast) {
         reader_defines["SKIP_MCAST"] = "1";
     }
@@ -832,7 +856,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         compute_defines.merge(ttnn::operations::unary::utils::get_defines(
             fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
     }
-
     if (enable_split_reader) {
         compute_defines["SPLIT_READER"] = "1";
         reader_defines["SPLIT_READER"] = "1";
@@ -858,7 +881,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
         (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
+        get_cb_info_by_name(cb_info, (split_reader_cb_shared ? Conv2dCb::ACT : Conv2dCb::ACT_SECOND_READER)).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
         num_blocks_act_w,
@@ -890,6 +913,40 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
             (uint32_t)dilation_w,
             (uint32_t)stride_w,
             (uint32_t)filter_h};
+
+        if (block_sharded) {
+            split_reader_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
+        }
+        if (split_reader_cb_shared) {
+            const tt::DataFormat img2col_cb_df =
+                get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).data_format;
+
+            const uint32_t img2col_cb_tile_size = tt::tile_size(img2col_cb_df);
+            const uint32_t act_cb_id_stride =
+                skip_activation_mcast ? 1 : 1 + get_num_cores_channels_from_parallel_config(parallel_config);
+            // get total number of blocks in the ACT CB so that we can compute the loop around when moving write
+            // pointer in second reader
+            const uint32_t act_cb_block_cnt = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages /
+                                              (act_block_num_tiles_split + act_block_num_tiles_split_last);
+
+            // In cases where the overlapped buffer is double buffered and number of push_backs done on NCRISC is odd,
+            // there are two addresses that need to be written to on the BRISC side for the second reader.
+            const bool second_writer_two_addr = (act_cb_block_cnt > 1) && (act_cb_id_stride % 2 == 1);
+            const uint32_t act_write_offset = act_block_num_tiles_split * img2col_cb_tile_size;
+            const uint32_t act_write_offset_last =
+                second_writer_two_addr
+                    ? (act_block_num_tiles_split_last + 2 * act_block_num_tiles_split) * img2col_cb_tile_size
+                    : act_write_offset;
+            split_reader_args.push_back(act_split_reader_reserve_done_semaphore_id);
+            split_reader_args.push_back(act_split_reader_write_done_semaphore_id);
+            split_reader_args.push_back(act_write_offset);
+            split_reader_args.push_back(act_write_offset_last);
+        } else if (block_sharded) {
+            split_reader_args.push_back(0);
+            split_reader_args.push_back(0);
+            split_reader_args.push_back(0);
+            split_reader_args.push_back(0);
+        }
 
         if (enable_activation_reuse && height_sharded) {
             std::vector<uint32_t> activation_reuse_args = {
@@ -950,7 +1007,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         pack_relu,
         weight_block_w_ntiles <= 8,  // packer_untilize
         packer_l1_acc_en,
-        has_bias};
+        has_bias,
+        static_cast<uint32_t>(split_reader_cb_shared)};
 
     if (enable_activation_reuse) {
         compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
@@ -1103,6 +1161,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         for (const CoreCoord& core : core_range) {
             if (populate_skipped_work_cores && !output_cores.contains(core)) {
                 std::vector<uint32_t> args = std::vector<uint32_t>(14, 0);
+                args[10] = weights_mcast_sender_semaphore_id;
+                args[11] = weights_mcast_receiver_semaphore_id;
                 args[12] =
                     static_cast<uint32_t>(true);  // is_sender_core, is always true for cores that belong to input_cores
                 args[13] = static_cast<uint32_t>(true);  //  skip work

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -447,7 +447,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
         pack_relu,
         weight_block_w_ntiles <= 8,  // packer_untilize
         packer_l1_acc,
-        has_bias};
+        has_bias,
+        static_cast<uint32_t>(false)};
 
     std::vector<uint32_t> activation_kernel_compile_args = {
         (uint32_t)stride_w,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -454,3 +454,22 @@ FORCE_INLINE void read_activation_data(
     noc_async_read_barrier();
     reader_offset += window_outer_offset;
 }
+
+// Helper functions for split reader synchronization
+FORCE_INLINE void signal_reserve_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
+    noc_semaphore_set(semaphore_addr_ptr, VALID);
+}
+
+FORCE_INLINE void wait_reserve_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
+    noc_semaphore_wait(semaphore_addr_ptr, VALID);
+    noc_semaphore_set(semaphore_addr_ptr, INVALID);
+}
+
+FORCE_INLINE void signal_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
+    noc_semaphore_set(semaphore_addr_ptr, VALID);
+}
+
+FORCE_INLINE void wait_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
+    noc_semaphore_wait(semaphore_addr_ptr, VALID);
+    noc_semaphore_set(semaphore_addr_ptr, INVALID);
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -41,6 +41,23 @@ void kernel_main() {
     constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
     constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
 
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(30) == 1;
+    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr = nullptr;
+    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr = nullptr;
+    if constexpr (split_reader_cb_shared) {  // When the split reader CB is shared, both readers write to the same
+                                             // circular
+                                             // buffer.
+        // Synchronization is required: the main reader signals when CB space is reserved,
+        // and the second reader signals when it has finished writing its portion.
+        const uint32_t act_split_reader_reserve_done_semaphore_addr = get_semaphore(get_compile_time_arg_val(31));
+        const uint32_t act_split_reader_write_done_semaphore_addr = get_semaphore(get_compile_time_arg_val(32));
+
+        act_split_reader_reserve_done_semaphore_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
+        act_split_reader_write_done_semaphore_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
+    }
+
     if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act_row_major_bfloat16>();
     }
@@ -94,7 +111,9 @@ void kernel_main() {
     // set_state uses just x/y from the get_noc_addr, addr is ignored
     uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
 
-    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+    if constexpr (!split_reader_cb_shared) {
+        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+    }
 
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
@@ -111,7 +130,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_act_row_major_bfloat16, act_block_num_tiles_read);
             if (is_sender_core) {
                 uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
-
+                if constexpr (split_reader_cb_shared) {
+                    signal_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                }
                 read_activation_data<
                     sliced_inner_dim,
                     dilation_w,
@@ -129,6 +151,9 @@ void kernel_main() {
                     reader_idx,
                     act_l1_read_addr,
                     stride_h_bytes);
+                if constexpr (split_reader_cb_shared) {
+                    wait_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                }
             }
             cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles_read);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -44,6 +44,27 @@ void kernel_main() {
     constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
     constexpr uint32_t stride_w = get_compile_time_arg_val(27);
     constexpr uint32_t weight_size_h = get_compile_time_arg_val(28);  // Input filter window height
+
+    // When the split reader CB is shared, both readers write to the same circular buffer.
+    // Synchronization is required: the main reader signals when CB space is reserved,
+    // and the second reader signals when it has finished writing its portion.
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(29) == 1;
+    const uint32_t act_split_reader_reserve_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(30)) : 0;
+    const uint32_t act_split_reader_write_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(31)) : 0;
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(32);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(33);
+
+    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
+
+    const uint32_t split_reader_cb_write_addr = get_write_ptr(cb_id_act_second_reader) + act_write_offset;
+    // In case of double buffering the split reader can write to two different addresses
+    const uint32_t split_reader_cb_write_addr_last = get_write_ptr(cb_id_act_second_reader) + act_write_offset_last;
+    const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
+#else
+    const uint32_t split_reader_cb_write_addr = 0;
 #endif
 
     // mcast args
@@ -81,12 +102,15 @@ void kernel_main() {
 
     const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
 
+    uint32_t cb_ind_offset = 0;
 #endif
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
 
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     // Write out col major blocks in row major layout to output
+    uint32_t l1_write_addr_act = split_reader_cb_write_addr;
+    uint32_t prev_addr = 0;
     for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
         for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
 #ifdef SPLIT_READER
@@ -95,12 +119,19 @@ void kernel_main() {
 #endif
             for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
 #ifdef SPLIT_READER
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
                 reader_idx = start_reader_idx;
-                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                if constexpr (!split_reader_cb_shared) {
+                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                }
 
                 if (is_sender_core) {
-                    uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    if constexpr (split_reader_cb_shared) {
+                        wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                        prev_addr = l1_write_addr_act;
+                    } else {
+                        l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    }
+                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
                     read_activation_data<
                         sliced_inner_dim,
                         dilation_w,
@@ -118,8 +149,16 @@ void kernel_main() {
                         reader_idx,
                         act_l1_read_addr,
                         stride_h_bytes);
+                    if constexpr (split_reader_cb_shared) {
+                        // in case of shared cb we update the write address (it will remain the same if double buffering
+                        // is not enabled)
+                        l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                        signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                    }
                 }
-                cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                if constexpr (!split_reader_cb_shared) {
+                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                }
 #endif
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
                      weight_tile_h_outer_i++) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -51,10 +51,29 @@ void kernel_main() {
     constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
     constexpr uint32_t stride_w = get_compile_time_arg_val(27);
     constexpr uint32_t weight_size_h = get_compile_time_arg_val(28);  // Input filter window height
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(29) == 1;
 
-    constexpr uint32_t ct_arg_idx = 29;
+    // When the split reader CB is shared, both readers write to the same circular buffer.
+    // Synchronization is required: the main reader signals when CB space is reserved,
+    // and the second reader signals when it has finished writing its portion.
+    const uint32_t act_split_reader_reserve_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(30)) : 0;
+    const uint32_t act_split_reader_write_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(31)) : 0;
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(32);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(33);
+
+    volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
+
+    const uint32_t split_reader_cb_write_addr = get_write_ptr(cb_id_act_second_reader) + act_write_offset;
+    // In case of double buffering the split reader can write to two different addresses
+    const uint32_t split_reader_cb_write_addr_last = get_write_ptr(cb_id_act_second_reader) + act_write_offset_last;
+    const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
+    constexpr uint32_t ct_arg_idx = 34;
 #else
     constexpr bool split_reader_enabled = false;
+    const uint32_t split_reader_cb_write_addr = 0;
     constexpr uint32_t ct_arg_idx = 19;
 #endif
 
@@ -106,6 +125,8 @@ void kernel_main() {
 
     const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
 
+    uint32_t cb_ind_offset = 0;
+
 #endif
 
 #ifndef SKIP_MCAST
@@ -145,6 +166,8 @@ void kernel_main() {
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     // Write out col major blocks in row major layout to output
     uint32_t weight_start_tile_id = out_start_tile_id_w;
+    uint32_t l1_write_addr_act = split_reader_cb_write_addr;
+    uint32_t prev_addr = 0;
     for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
         for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
 #ifdef SPLIT_READER
@@ -152,11 +175,18 @@ void kernel_main() {
 #endif
             for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
 #ifdef SPLIT_READER
-                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
                 reader_idx = start_reader_idx;
-                cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                if constexpr (!split_reader_cb_shared) {
+                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                }
                 if (is_sender_core) {
-                    uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    if constexpr (split_reader_cb_shared) {
+                        wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                        prev_addr = l1_write_addr_act;
+                    } else {
+                        l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    }
+                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
                     read_activation_data<
                         sliced_inner_dim,
                         dilation_w,
@@ -174,12 +204,20 @@ void kernel_main() {
                         reader_idx,
                         act_l1_read_addr,
                         stride_h_bytes);
+                    if constexpr (split_reader_cb_shared) {
+                        // in case of shared cb we update the write address (it will remain the same if double buffering
+                        // is not enabled)
+                        l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                        signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                    }
                 }
-                cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
-#endif
+                if constexpr (!split_reader_cb_shared) {
+                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                }
                 if (skip_work) {
                     continue;
                 }
+#endif
                 // Compute height block offset once per outer loop iteration
                 const uint32_t height_block_offset = height_block_index * height_stride_factor;
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
@@ -246,6 +284,9 @@ void kernel_main() {
 #ifdef SPLIT_READER
             // Update reader index for next iteration (split reader increment)
             start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+            if (skip_work) {
+                continue;
+            }
 #endif
             if constexpr (fuse_bias) {
                 if (load_bias) {


### PR DESCRIPTION
### Problem description
Previously block sharded split reader disabled CB overlapping in conv2d
due to the fact that we can't overlap 2 cbs with 1 cb

### What's changed
- added synchronization logic which enables block sharded split readers in case of overlapped cbs write to 1 CB 
- enabled split reader on block sharded convolutions to be on by default (heuristic defaults to true, still can be overriden)

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18750598626)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18750602764)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18529090346)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18750832236)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18712369176)