### PR TITLE
#30280: Add uint32 support for where llk

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -501,6 +501,7 @@ def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, d
         (9999, -9999),
         (-24567, 16777216),
         (-16777216, 56789),
+        (-2147483647, 2147483647),
     ],
 )
 @pytest.mark.parametrize(
@@ -521,6 +522,39 @@ def test_where_TSS_int_types(scalars, input_shapes, device):
 
     tt_result = ttnn.to_torch(ttnn_result)
 
+    assert torch.equal(tt_result, torch_result)
+
+
+@pytest.mark.parametrize(
+    "scalars",
+    [
+        (3, 7),
+        (10, 42),
+        (0, 1),
+        (24567, 16777216),
+        (16777216, 56789),
+        (2147483647, 3294967295),
+        (4274947110, 3264965225),
+        (3294967295, 4294967295),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([64, 128]),
+    ],
+)
+def test_where_TSS_uint32_types(scalars, input_shapes, device):
+    scalar_true, scalar_false = scalars
+    condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch.uint32)
+
+    torch_result = torch.where(condition.bool(), scalar_true, scalar_false)
+
+    ttnn_condition = ttnn.from_torch(condition, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_result = ttnn.where(ttnn_condition, scalar_true, scalar_false)
+
+    tt_result = ttnn.to_torch(ttnn_result, dtype=torch.uint32)
+    torch_result = torch_result.to(torch.uint32)
     assert torch.equal(tt_result, torch_result)
 
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -8,47 +8,11 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Int32, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_uint32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::UInt32, 8>,
+        ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,
         dst_index1,
         dst_index2,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -45,6 +45,18 @@ inline void llk_math_eltwise_ternary_sfpu_where_int32(
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_where_uint32(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::UInt32, 8>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -8,47 +8,11 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, DataFormat data_format>
 inline void llk_math_eltwise_ternary_sfpu_where(
     uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Int32, 8>,
-        dst_index0,
-        dst_index1,
-        dst_index2,
-        odst,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_ternary_sfpu_where_uint32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::UInt32, 8>,
+        ckernel::sfpu::_calculate_where_<APPROXIMATE, data_format, 8>,
         dst_index0,
         dst_index1,
         dst_index2,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -45,6 +45,18 @@ inline void llk_math_eltwise_ternary_sfpu_where_int32(
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_where_uint32(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::UInt32, 8>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
 }

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
@@ -28,19 +28,19 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void where_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX>(idst0, idst1, idst2, odst)));
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX, DataFormat::Float16_b>(idst0, idst1, idst2, odst)));
 }
 
 ALWI void where_fp32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_fp32<APPROX>(idst0, idst1, idst2, odst)));
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX, DataFormat::Float32>(idst0, idst1, idst2, odst)));
 }
 
 ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2, odst)));
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX, DataFormat::Int32>(idst0, idst1, idst2, odst)));
 }
 
 ALWI void where_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_uint32<APPROX>(idst0, idst1, idst2, odst)));
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX, DataFormat::UInt32>(idst0, idst1, idst2, odst)));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
@@ -39,6 +39,10 @@ ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint3
     MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2, odst)));
 }
 
+ALWI void where_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
+    MATH((llk_math_eltwise_ternary_sfpu_where_uint32<APPROX>(idst0, idst1, idst2, odst)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -206,12 +206,7 @@ Tensor invoke_impl(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
     log_debug(tt::LogOp, "Where LLK - TSS");
-    unary::UnaryOpType op_type = unary::UnaryOpType::WHERE_TSS;
-    return ttnn::operations::unary::Unary_chain::invoke(
-        condition,
-        {unary::UnaryWithParam{op_type, {static_cast<float>(t_true), static_cast<float>(t_false)}}},
-        memory_config,
-        output);
+    return ttnn::where_tss(condition, t_true, t_false, memory_config, output);
 }
 
 }  // namespace
@@ -229,6 +224,21 @@ Tensor WhereOperation::invoke(
         value_true,
         value_false);
 }
+template <typename T>
+    requires std::same_as<T, int32_t> || std::same_as<T, uint32_t>
+Tensor WhereOperation::invoke(
+    const Tensor& predicate,
+    const T& value_true,
+    const T& value_false,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    return ttnn::where_tss(predicate, value_true, value_false, memory_config, output);
+}
+
+template Tensor WhereOperation::invoke<int32_t>(
+    const Tensor&, const int32_t&, const int32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+template Tensor WhereOperation::invoke<uint32_t>(
+    const Tensor&, const uint32_t&, const uint32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 
 }  // namespace ternary
 }  // namespace operations

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
@@ -24,6 +24,15 @@ struct WhereOperation {
         const TensorScalarVariant& value_false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt);
+
+    template <typename T>
+        requires std::same_as<T, int32_t> || std::same_as<T, uint32_t>
+    static Tensor invoke(
+        const Tensor& predicate,
+        const T& value_true,
+        const T& value_false,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt);
 };
 
 }  // namespace ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.cpp
@@ -150,6 +150,38 @@ void bind_ternary_where(py::module& module, const ternary_operation_t& operation
             py::arg("false_value"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const ternary_operation_t& self,
+               const Tensor& predicate,
+               const int32_t& true_value,
+               const int32_t& false_value,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<Tensor> output_tensor) {
+                return self(predicate, true_value, false_value, memory_config, output_tensor);
+            },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const ternary_operation_t& self,
+               const Tensor& predicate,
+               const uint32_t& true_value,
+               const uint32_t& false_value,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<Tensor> output_tensor) {
+                return self(predicate, true_value, false_value, memory_config, output_tensor);
+            },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt});
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -107,6 +107,5 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
 std::string get_compute_kernel_path(
     UnaryOpType op_type, const std::string& compute_root, std::optional<DataType> input_dtype = std::nullopt);
 
-uint32_t pack_scalar_runtime_arg(float scalar, DataType dtype);
-
+uint32_t pack_scalar_runtime_arg(const EltwiseUnaryWithParam& op, size_t index, DataType dtype);
 }  // namespace ttnn::operations::unary::utils

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -493,6 +493,29 @@ Tensor Rad2Deg::invoke(
         std::nullopt);
 }
 
+template <typename T>
+Tensor Where::invoke(
+    const Tensor& condition,
+    const T& value_true,
+    const T& value_false,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    Tensor input = condition;
+    if ((condition.dtype() == DataType::INT32 || condition.dtype() == DataType::UINT32) && (std::is_same_v<T, float>)) {
+        input = ttnn::typecast(condition, DataType::FLOAT32);
+    }
+    UnaryOpType op_type = UnaryOpType::WHERE_TSS;
+    return detail::unary_impl(
+        input, {EltwiseUnaryWithParam{op_type, {value_true, value_false}}}, memory_config, optional_output_tensor);
+}
+
+template Tensor Where::invoke<float>(
+    const Tensor&, const float&, const float&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+template Tensor Where::invoke<int32_t>(
+    const Tensor&, const int32_t&, const int32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+template Tensor Where::invoke<uint32_t>(
+    const Tensor&, const uint32_t&, const uint32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+
 template <UnaryOpType unary_op_type, typename T>
 Tensor ExecuteUnaryWithIntegerParameter<unary_op_type, T>::invoke(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/ternary/ternary.hpp"
 #include "ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 
 namespace ttnn::operations::unary {
 
@@ -493,28 +494,31 @@ Tensor Rad2Deg::invoke(
         std::nullopt);
 }
 
-template <typename T>
 Tensor Where::invoke(
     const Tensor& condition,
-    const T& value_true,
-    const T& value_false,
+    const ScalarVariant& value_true,
+    const ScalarVariant& value_false,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     Tensor input = condition;
-    if ((condition.dtype() == DataType::INT32 || condition.dtype() == DataType::UINT32) && (std::is_same_v<T, float>)) {
+    // Check if we have any float scalars
+    bool has_float_scalar = std::holds_alternative<float>(value_true) || std::holds_alternative<float>(value_false);
+
+    // Convert input tensor to float32 only if input is INT32/UINT32 and scalars are float
+    if ((condition.dtype() == DataType::INT32 || condition.dtype() == DataType::UINT32) && has_float_scalar) {
         input = ttnn::typecast(condition, DataType::FLOAT32);
     }
     UnaryOpType op_type = UnaryOpType::WHERE_TSS;
-    return detail::unary_impl(
-        input, {EltwiseUnaryWithParam{op_type, {value_true, value_false}}}, memory_config, optional_output_tensor);
-}
+    auto param = std::visit(
+        [op_type](const auto& val_true, const auto& val_false) {
+            using T = std::decay_t<decltype(val_true)>;
+            return EltwiseUnaryWithParam{op_type, std::vector<T>{val_true, val_false}};
+        },
+        value_true,
+        value_false);
 
-template Tensor Where::invoke<float>(
-    const Tensor&, const float&, const float&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
-template Tensor Where::invoke<int32_t>(
-    const Tensor&, const int32_t&, const int32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
-template Tensor Where::invoke<uint32_t>(
-    const Tensor&, const uint32_t&, const uint32_t&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+    return detail::unary_impl(input, {param}, memory_config, optional_output_tensor);
+}
 
 template <UnaryOpType unary_op_type, typename T>
 Tensor ExecuteUnaryWithIntegerParameter<unary_op_type, T>::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -7,7 +7,6 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/eltwise/complex/complex.hpp"
-#include "ttnn/operations/copy/typecast/typecast.hpp"
 
 namespace ttnn {
 namespace operations::unary {
@@ -329,11 +328,10 @@ struct Rsub {
 };
 
 struct Where {
-    template <typename T>
     static Tensor invoke(
         const Tensor& condition,
-        const T& value_true,
-        const T& value_false,
+        const ScalarVariant& value_true,
+        const ScalarVariant& value_false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -7,6 +7,8 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/eltwise/complex/complex.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+
 namespace ttnn {
 namespace operations::unary {
 
@@ -326,6 +328,16 @@ struct Rsub {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Where {
+    template <typename T>
+    static Tensor invoke(
+        const Tensor& condition,
+        const T& value_true,
+        const T& value_false,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 }  // namespace operations::unary
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
@@ -469,6 +481,7 @@ constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::opera
 constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
 constexpr auto tanhshrink = ttnn::register_operation<"ttnn::tanhshrink", ttnn::operations::unary::Tanhshrink>();
 constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
+constexpr auto where_tss = ttnn::register_operation<"ttnn::where_tss", ttnn::operations::unary::Where>();
 constexpr auto selu = ttnn::register_operation<"ttnn::selu", ttnn::operations::unary::Selu>();
 constexpr auto fill = ttnn::register_operation<
     "ttnn::fill",


### PR DESCRIPTION
### Ticket
Link to Github Issue #30280 

### Problem description
ttnn.where doesn't support uint32 type

### What's changed
Added uint32 support for TSS variant.
Follow up: 
To add uint32 support for other variants once ternary refactoring is complete #31028


Results for the case mentioned in the issue after updating where to support uint32:

<img width="699" height="75" alt="Screenshot 2025-10-27 at 4 59 28 PM" src="https://github.com/user-attachments/assets/54c43d5e-c28c-4f0e-a4db-93aa1d8c776a" />

### Checklist
- [x] [All post commit]
- [x] [Blackhole Post commit]