### PR TITLE
[Gridsample] Watcher asserting with the invalid NOC transactions fixes

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
     constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
-    constexpr uint32_t input_batch = get_compile_time_arg_val(5);
+
     constexpr uint32_t input_height = get_compile_time_arg_val(6);
     constexpr uint32_t input_width = get_compile_time_arg_val(7);
     constexpr uint32_t grid_batches = get_compile_time_arg_val(8);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -26,14 +26,15 @@ void kernel_main() {
     constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
     constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
-    constexpr uint32_t input_height = get_compile_time_arg_val(5);
-    constexpr uint32_t input_width = get_compile_time_arg_val(6);
-    constexpr uint32_t grid_batches = get_compile_time_arg_val(7);
-    constexpr uint32_t grid_dtype = get_compile_time_arg_val(8);
-    constexpr uint32_t output_hw_size = get_compile_time_arg_val(9);
-    constexpr bool use_precomputed_grid = get_compile_time_arg_val(10);
+    constexpr uint32_t input_batch = get_compile_time_arg_val(5);
+    constexpr uint32_t input_height = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_batches = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(9);
+    constexpr uint32_t output_hw_size = get_compile_time_arg_val(10);
+    constexpr bool use_precomputed_grid = get_compile_time_arg_val(11);
 
-    constexpr auto src_args = TensorAccessorArgs<11>();
+    constexpr auto src_args = TensorAccessorArgs<12>();
     constexpr auto grid_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     const auto grid_tensor_accessor = TensorAccessor(grid_args, grid_addr, grid_stick_nbytes);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -14,7 +14,7 @@
 #include "debug/dprint.h"
 #endif
 
-ALWI void advance_grid_index(
+ALWI void advance_grid_index_bounded(
     uint32_t& in_grid_row_idx,
     uint32_t& grid_stick_idx,
     uint32_t& l1_grid_addr,
@@ -89,7 +89,7 @@ void kernel_main() {
 
     // Advance at start if needed
     if constexpr (split_reader && reader_id == 1) {
-        advance_grid_index(
+        advance_grid_index_bounded(
             in_grid_row_idx,
             grid_stick_idx,
             l1_grid_addr,
@@ -117,7 +117,7 @@ void kernel_main() {
             scalar_cb_index>(grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
 
         // Always advance once after processing
-        advance_grid_index(
+        advance_grid_index_bounded(
             in_grid_row_idx,
             grid_stick_idx,
             l1_grid_addr,
@@ -131,7 +131,7 @@ void kernel_main() {
 
         // For split reader, advance one more time to skip the coordinate that the other reader will process
         if constexpr (split_reader) {
-            advance_grid_index(
+            advance_grid_index_bounded(
                 in_grid_row_idx,
                 grid_stick_idx,
                 l1_grid_addr,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -48,18 +48,19 @@ void kernel_main() {
     constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
     constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
     constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
-    constexpr uint32_t input_height = get_compile_time_arg_val(5);
-    constexpr uint32_t input_width = get_compile_time_arg_val(6);
-    constexpr uint32_t grid_batching_factor = get_compile_time_arg_val(7);
-    constexpr uint32_t grid_dtype = get_compile_time_arg_val(8);
-    constexpr uint32_t grid_hw = get_compile_time_arg_val(9);
-    constexpr uint32_t use_precomputed_grid = get_compile_time_arg_val(10);
-    constexpr uint32_t split_reader = get_compile_time_arg_val(11);
-    constexpr uint32_t reader_id = get_compile_time_arg_val(12);
-    constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(13);
+    constexpr uint32_t input_batch = get_compile_time_arg_val(5);
+    constexpr uint32_t input_height = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_batching_factor = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(9);
+    constexpr uint32_t grid_hw = get_compile_time_arg_val(10);
+    constexpr uint32_t use_precomputed_grid = get_compile_time_arg_val(11);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(12);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(13);
+    constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(14);
 
     // Input tensor accessor for remote NOC reads (updated for new arg count)
-    constexpr auto input_tensor_args = TensorAccessorArgs<14>();
+    constexpr auto input_tensor_args = TensorAccessorArgs<15>();
     const auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_addr, input_stick_nbytes);
 
     // Calculate starting batch from global grid stick position

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -23,7 +23,8 @@ ALWI void advance_grid_index(
     const uint32_t grid_batching_factor,
     const uint32_t grid_stick_nbytes,
     const uint32_t grid_hw,
-    const uint32_t grid_nsticks_per_core) {
+    const uint32_t grid_nsticks_per_core,
+    const uint32_t input_batch) {
     ++in_grid_row_idx;
     if (in_grid_row_idx == grid_batching_factor) {
         in_grid_row_idx = 0;
@@ -32,7 +33,9 @@ ALWI void advance_grid_index(
         ++grid_points_processed;
         if (grid_points_processed == grid_hw) {
             grid_points_processed = 0;
-            ++curr_batch;
+            if (curr_batch + 1 < input_batch) {
+                ++curr_batch;
+            }
         }
     }
 }
@@ -95,7 +98,8 @@ void kernel_main() {
             grid_batching_factor,
             grid_stick_nbytes,
             grid_hw,
-            grid_nsticks_per_core);
+            grid_nsticks_per_core,
+            input_batch);
     }
 
     while (grid_stick_idx < grid_nsticks_per_core) {
@@ -122,7 +126,8 @@ void kernel_main() {
             grid_batching_factor,
             grid_stick_nbytes,
             grid_hw,
-            grid_nsticks_per_core);
+            grid_nsticks_per_core,
+            input_batch);
 
         // For split reader, advance one more time to skip the coordinate that the other reader will process
         if constexpr (split_reader) {
@@ -135,7 +140,8 @@ void kernel_main() {
                 grid_batching_factor,
                 grid_stick_nbytes,
                 grid_hw,
-                grid_nsticks_per_core);
+                grid_nsticks_per_core,
+                input_batch);
         }
     }
 }


### PR DESCRIPTION
### Ticket
[28904](https://github.com/tenstorrent/tt-metal/issues/28904)

### Problem description
There were two problems that caused asserts with watcher being enabled. First one was when last core ended up with lesser amount of work, the batch was incremented even though there were not that many batches in the input tensor. Second one was that the cores that didn't have work to do ended up having dispatched kernels and some random numbers for them to have "busy" work.

### What's changed
Compile time argument as input tensor batch size was added to the reader kernels checking whether or not they should increment the batch when they end up having lesser amount of sticks. They end up recalculating the last stick multiple times. The cores that have nothing to calculate are excluded from dispatching kernels to.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18619884495)
- [x] [(Blackhole) Blackhole nightly tests ](https://github.com/tenstorrent/tt-metal/actions/runs/18619877523)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18619862289)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18619853764)
- [ ] [(Single-card) Frequent model and ttnn tests ](https://github.com/tenstorrent/tt-metal/actions/runs/18619863557)