### PR TITLE
Wrapper for multiple tensor concat

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_concat_issue.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_concat_issue.py
@@ -13,7 +13,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 def test_5d_concat_tile(device, layout):
-    torch_input_tensors = [torch.rand(1, 32, 56, 56, 1, dtype=torch.bfloat16) for _ in range(3)]
+    torch_input_tensors = [torch.rand(1, 32, 56, 56, 1, dtype=torch.bfloat16) for _ in range(500)]
     torch_result = torch.cat(torch_input_tensors, dim=-1)
 
     ttnn_input_tensors = [ttnn.from_torch(x, layout=layout, device=device) for x in torch_input_tensors]
@@ -24,7 +24,7 @@ def test_5d_concat_tile(device, layout):
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 def test_5d_concat_rm(device, layout):
-    torch_input_tensors = [torch.rand(1, 32, 56, 56, 1, dtype=torch.bfloat16) for _ in range(3)]
+    torch_input_tensors = [torch.rand(1, 32, 56, 56, 1, dtype=torch.bfloat16) for _ in range(500)]
     torch_result = torch.cat(torch_input_tensors, dim=-1)
 
     ttnn_input_tensors = [ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, device=device) for x in torch_input_tensors]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22845

### Problem description
The `ttnn.concat` operation fails when concatenating more than approximately 50 tensors with the error:
```
278 unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id
on (x=0,y=0) are too large. Max allowable is 256
```

**Root cause**: Each tensor being concatenated contributes runtime arguments to the kernel. When the total number of arguments (compile-time + runtime) exceeds the kernel's limit of 256 uint32_t values, the operation crashes.

**Reproduction**:
- Works: Concatenating 50 tensors
- Fails: Concatenating 55 tensors

This is a systemic limitation of the concat kernel's runtime argument capacity, not specific to tensor shapes or hardware architecture.


### What's changed
### 1. Added Adaptive Batch Size Calculation
**My implementation**: Dynamic calculation based on kernel runtime args formula

#### For Interleaved (non-sharded) Concat

The total runtime args consumed by concat_multi_core kernel follows this pattern:

**Compile-time args**:
```
- src0_cb_index: 1
- num_input_tensors: 1
- page_size_per_tensor[N]: N
- TensorAccessorArgs[N]: N (1 arg per tensor for interleaved buffers)
Total: 2 + 2N
```

**Runtime args per core**:
```
- num_pages_per_core: 1
- curr_tensor: 1
- curr_tensor_id: 1
- src_addr[N]: N
- num_pages_per_block[N]: N
- page_id_per_tensor[N]: N
Total: 3 + 3N
```

**Total args validated**: `(2 + 2N) + (3 + 3N) = 5 + 5N`

**Kernel limit**: 256 (empirically determined, though kernel_types.hpp defines max_runtime_args = 341, concat kernels are compiled with NUM_RUNTIME_ARGS=256)

**Formula**:
```
5 + 5N ≤ 256
N ≤ 50.2
N_max = 50
```

**Verification**:
- N=50: 5 + 250 = 255 ≤ 256 ✓
- N=55: 5 + 275 = 280 > 256 ✗

#### For Sharded Concat

Sharded concat uses `s2s_concat_multi_core` kernel with different arg pattern:
```
Compile-time: 4 args (cb_dst_id, page_size, output_stride, num_input_tensors)
Runtime: ~4N args (4 args per tensor for reader/writer kernels)
Total: ~4 + 4N
```

**Calculation**:
```
4 + 4N ≤ 256
N ≤ 63
With 10% safety margin: N_max = 56
```

### 2. Implementation Details

**File modified**: `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp`

**Function added**: `calculate_max_tensors_per_concat()`
- Takes input tensors and concat dimension as parameters
- Detects whether tensors are sharded or interleaved
- Applies appropriate formula based on memory layout
- Returns maximum safe batch size

**Batching logic** (already present, now uses adaptive limit):
- If `num_tensors > max_tensors_per_concat`:
  - Split tensors into batches of size ≤ `max_tensors_per_concat`
  - Recursively concat each batch
  - Final concat of intermediate results

**Key changes**:
1. Replaced hardcoded `50` with `calculate_max_tensors_per_concat(input_tensors, dim)`
2. Added detailed documentation explaining the args calculation
3. Added `log_debug` statements for troubleshooting
4. Added `TT_FATAL` assertion to verify calculation matches expected value (50 for interleaved)

### 3. What This Does NOT Change

**Factors that do NOT affect the limit**:
- Tensor shape/size (only the count matters)
- Tensor dtype (bfloat16, float32, etc.)
- Hardware architecture (Wormhole vs Blackhole use same limit)
- Concat dimension

**Factors that DO affect the limit**:
- Memory layout (sharded vs interleaved) - different kernels
- Number of input tensors

### 4. Benefits

1. **Correctness**: Prevents runtime failures by respecting kernel argument limits
2. **Clarity**: Explicit formula-based calculation instead of magic number
3. **Maintainability**: Comprehensive documentation of args breakdown
4. **Debuggability**: Added logging to track batch size decisions
5. **Slight optimization**: Sharded concat can now handle up to 56 tensors (was 50)

### 5. Testing

**Validated scenarios**:
- The script mentioned in the GitHub Issue: 55 tensors concatenated successfully (split into 2 batches: 50 + 5)
- `test_concat_issue.py`: 500 tensors concatenated successfully
- Both TILE_LAYOUT and ROW_MAJOR_LAYOUT

**Expected behavior**:
- Input: 55 tensors
- Batch 1: concat tensors [0:50] → intermediate_result_1
- Batch 2: concat tensors [50:55] → intermediate_result_2
- Final: concat [intermediate_result_1, intermediate_result_2] → output

## Verification

To verify the fix works:
```bash
source /proj_sw/user_dev/zfang/setup_env.sh
pytest tests/ttnn/unit_tests/base_functionality/test_concat_issue.py  # Should pass
pytest tests/ttnn/unit_tests/operations/data_movement/test_concat.py
```
And the script mentioned in the GitHub Issue is verified passed.

PS: You will need to change
```python
pt_tensor = torch.tensor([2.0], dtype=torch.bfloat16) 
```
to 
```python
pt_tensor = torch.tensor([[2.0]], dtype=torch.bfloat16) 
```
in the GitHub Issue's script, since 1D tensor will cause a separate issue here.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/18662260596