### PR TITLE
[DM] Add DRAM sharded read tests and deprecate tile_dram_sharded_*_state APIs

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -17,6 +17,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/one_packet/test_one_packet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multi_interleaved/test_multi_interleaved.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dram_sharded/test_dram_sharded.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -29,6 +29,7 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 | Conv Hardcoded              | 21-23                | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
 | Interleaved Page Read/Write | 61-69, 71-75         | Reads and writes pages between interleaved buffers and a Tensix core.                   |
 | One Packet Read/Write       | 80-83                | Reads or writes packets between two Tensix cores.                                       |
+| DRAM Sharded Read           | 84-86                | Reads from sharded DRAM into one core.                                                  |
 | Multi Interleaved           | 110-127              | Reads and writes pages between interleaved DRAM buffers and multiple Tensix cores.      |
 | Core Bidrectional           | 140-148              | Tensix core reads from and writes to another Tensix core simultaneously.                |
 | Deinterleave                | 200-201              | Tests deinterleaving. **(Slow Dispatch)**                                               |

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
@@ -1,0 +1,41 @@
+# DRAM Sharded Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement reads from sharded DRAM buffer into a Tensix core using the stateful one_packet APIs.
+
+## Mesh Device API Support
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+**Note**: The Mesh Device API only supports fast dispatch mode internally and does not support slow dispatch mode. This provides optimal performance for data movement operations.
+
+## Test Flow
+Runs the reader kernel on a Tensix core. After initializing a sharded DRAM buffer with data, the kernel issues NOC instructions to read this data into L1 memory using the stateful one_packet APIs. A read barrier is placed after these transactions to ensure data validity.
+
+Test attributes such as number of DRAM banks to shard into and number of tiles per bank, as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Running the Tests
+The tests use the Mesh Device API with fast dispatch mode:
+```
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*TensixDataMovementDRAMShardedRead*"
+```
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions       | uint32_t              | Number of NOC transactions. |
+| num_banks                 | uint32_t              | Number of DRAM banks to shard. |
+| pages_per_bank            | uint32_t              | Number of pages of data per bank. |
+| page_size_bytes           | uint32_t              | Size of a page in bytes. |
+| l1_data_format            | DataFormat            | Type of data in transaction. |
+| cores                     | CoreRangeSet          | Tensix core that the kernel is run on. |
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format.
+Each test case uses a 32 x 32 datum tile as a page.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. DRAM Sharded Read Directed Ideal: Tests the most optimal transactions for reading packets by maximizing the number of pages, banks, and transactions to amortize initialization overhead and saturate the bandwidth.
+2. DRAM Sharded Read Tile Numbers: Tests reading over varying number of pages per DRAM bank.
+3. DRAM Sharded Read Bank Numbers: Tests reading over varying numbers of DRAM banks.

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+#include "dataflow_api.h"
+#include "tensix_types.h"
+
+#include "debug/dprint.h"
+#include "debug/dprint_pages.h"
+
+template <uint32_t num_of_transactions, uint32_t num_pages, uint32_t page_size_bytes, typename AddrGen>
+FORCE_INLINE void noc_read_helper(const uint32_t l1_write_addr, const AddrGen& s) {
+    for (uint32_t i = 0; i < num_of_transactions; i++) {
+        for (uint32_t p = 0; p < num_pages; p++) {
+            noc_async_read_page(p, s, l1_write_addr + p * page_size_bytes);
+        }
+    }
+    noc_async_read_barrier();
+}
+
+// DRAM to L1 read
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+
+    constexpr uint32_t transaction_size_bytes = page_size_bytes;
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    uint32_t offset = 0;
+    uint32_t tile_size_bytes = 32 * 32 * 2;
+
+    uint32_t total_size_bytes = 64 * 64 * 2;
+    uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(0, src_addr);  // bank 0, offset 0, noc 0 (default)
+    noc_async_read_set_state(src_noc_addr);
+    // uint32_t dram_addr = noc_async_read_tile_dram_sharded_set_state<false>(src_addr, tile_size_bytes, 0);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        // do i ever need to iterate over bank ids? one set state per bank id?
+        // run kernel multiple times with different bank ids?
+
+        for (uint32_t bank_id = 0; bank_id < 4; bank_id++) {
+            // how does local l1 src and dst addr work here? and how about size
+            noc_async_read_with_state(src_addr, l1_addr, tile_size_bytes);
+            // noc_async_read_tile_dram_sharded_with_state(dram_addr, offset, l1_addr);
+            // DPRINT << bank_id << " " << src_noc_addr << " " << src_addr << " " << l1_addr << ENDL();
+            DPRINT << bank_id << " " << src_noc_addr << " " << offset << " " << l1_addr << ENDL();
+            // tt::data_movement::common::print_bf16_pages(l1_addr, 32 * 32, 1);
+            src_addr += tile_size_bytes;
+            offset += tile_size_bytes;
+            l1_addr += tile_size_bytes;
+            noc_async_read_barrier();
+        }
+        /*
+        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(0, src_addr); // bank 0, offset 0, noc 0 (default)
+        noc_async_read_set_state(src_noc_addr);
+        //how does local l1 src and dst addr work here? and how about size
+        noc_async_read_with_state(l1_addr, l1_addr, total_size_bytes);
+        noc_async_read_barrier();
+        */
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -52,7 +52,10 @@ void kernel_main() {
                     uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
                     noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
                     for (uint32_t i = 0; i < pages_per_bank; i++) {
-                        noc_async_read_one_packet_with_state(src_addr + i * page_size_bytes, dst_addr);
+                        noc_async_read_one_packet_with_state(src_noc_addr + i * page_size_bytes, dst_addr);
+                        // noc_async_read_tile_dram_sharded_set_trid(1);
+                        // noc_async_read_tile_dram_sharded_with_state_with_trid(src_noc_addr, i * page_size_bytes,
+                        // dst_addr, 1);
                         dst_addr += page_size_bytes;
                     }
                 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -16,63 +16,48 @@ void kernel_main() {
     uint32_t l1_addr = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
-    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(2);
-    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(1);
+    constexpr uint32_t pages_per_bank = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
 
-    constexpr uint32_t transaction_size_bytes = page_size_bytes;
     DeviceTimestampedData("Number of transactions", num_of_transactions);
-    DeviceTimestampedData("Transaction size in bytes", num_pages * transaction_size_bytes);
+    DeviceTimestampedData("Transaction size in bytes", num_banks * pages_per_bank * page_size_bytes);
     DeviceTimestampedData("Test id", test_id);
 
-    uint32_t offset = 0;
-    uint32_t tile_size_bytes = page_size_bytes;
+    constexpr bool use_tds = false;  // for testing regular stateful read vs tile dram sharded stateful read
 
-    uint32_t total_size_bytes = page_size_bytes * num_pages;
-    // uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(0, src_addr);  // bank 0, offset 0, noc 0 (default)
-    // noc_async_read_set_state(src_noc_addr);
-    // uint32_t dram_addr = noc_async_read_tile_dram_sharded_set_state<false>(src_addr, tile_size_bytes, 0);
+    uint32_t dst_addr = l1_addr;
+
     {
         DeviceZoneScopedN("RISCV0");
-        // do i ever need to iterate over bank ids? one set state per bank id?
-        // run kernel multiple times with different bank ids?
-
-        /*
-        for (uint32_t i = 0; i < num_of_transactions; i++) {
-            for (uint32_t j = 0; j < num_pages; j++) {
-                noc_async_read_with_state(src_addr + j * tile_size_bytes, l1_addr + j * tile_size_bytes,
-        tile_size_bytes);
+        if constexpr (use_tds) {
+            for (uint32_t i = 0; i < num_of_transactions; i++) {
+                dst_addr = l1_addr;
+                for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
+                    uint32_t dram_base_addr =
+                        noc_async_read_tile_dram_sharded_set_state<true>(src_addr, page_size_bytes, bank_id);
+                    for (uint32_t page_id = 0; page_id < pages_per_bank; page_id++) {
+                        noc_async_read_tile_dram_sharded_with_state(
+                            dram_base_addr, page_id * page_size_bytes, dst_addr);
+                        dst_addr += page_size_bytes;
+                    }
+                }
             }
-        }
-        noc_async_read_barrier();
-        */
-
-        for (uint32_t bank_id = 0; bank_id < 6; bank_id++) {
-            // how does local l1 src and dst addr work here? and how about size
-            uint64_t src_noc_addr =
-                get_noc_addr_from_bank_id<true>(bank_id, src_addr);  // bank 0, offset 0, noc 0 (default)
-            noc_async_read_set_state(src_noc_addr);
-            for (uint32_t i = 0; i < 4; i++) {
-                noc_async_read_with_state(
-                    src_addr + i * tile_size_bytes, l1_addr + i * tile_size_bytes, tile_size_bytes);
+            noc_async_read_barrier();
+        } else {
+            for (uint32_t i = 0; i < num_of_transactions; i++) {
+                dst_addr = l1_addr;
+                for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
+                    uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+                    noc_async_read_set_state(src_noc_addr);
+                    for (uint32_t i = 0; i < pages_per_bank; i++) {
+                        noc_async_read_with_state(src_addr + i * page_size_bytes, dst_addr, page_size_bytes);
+                        dst_addr += page_size_bytes;
+                    }
+                }
             }
-            // noc_async_read_with_state(src_addr, l1_addr, tile_size_bytes * 4);
-            //  noc_async_read_tile_dram_sharded_with_state(dram_addr, offset, l1_addr);
-            //  DPRINT << bank_id << " " << src_noc_addr << " " << src_addr << " " << l1_addr << ENDL();
-            //  DPRINT << bank_id << " " << src_noc_addr << " " << offset << " " << l1_addr << ENDL();
-            //  tt::data_movement::common::print_bf16_pages(l1_addr, 32 * 32, 1);
-            //  src_addr += tile_size_bytes * 4;
-            //  offset += tile_size_bytes;
-            l1_addr += tile_size_bytes * 4;
             noc_async_read_barrier();
         }
-
-        /*
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(0, src_addr); // bank 0, offset 0, noc 0 (default)
-        noc_async_read_set_state(src_noc_addr);
-        //how does local l1 src and dst addr work here? and how about size
-        noc_async_read_with_state(l1_addr, l1_addr, total_size_bytes);
-        noc_async_read_barrier();
-        */
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -50,9 +50,9 @@ void kernel_main() {
                 dst_addr = l1_addr;
                 for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                     uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
-                    noc_async_read_set_state(src_noc_addr);
+                    noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
                     for (uint32_t i = 0; i < pages_per_bank; i++) {
-                        noc_async_read_with_state(src_addr + i * page_size_bytes, dst_addr, page_size_bytes);
+                        noc_async_read_one_packet_with_state(src_addr + i * page_size_bytes, dst_addr);
                         dst_addr += page_size_bytes;
                     }
                 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -7,8 +7,8 @@
 #include "dataflow_api.h"
 #include "tensix_types.h"
 
-#include "debug/dprint.h"
-#include "debug/dprint_pages.h"
+// #include "debug/dprint.h"
+// #include "debug/dprint_pages.h"
 
 // DRAM to L1 read
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -71,7 +71,6 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     uint32_t input_buffer_address = mesh_buffer->address();
 
     // Input
-    // vector<uint32_t> packed_input = create_arange_vector_of_bfloat16(total_size_bytes, true);
     vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -100.0f, 100.0f, total_size_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -27,7 +27,7 @@ struct DramShardedConfig {
     uint32_t pages_per_bank = 0;
     uint32_t page_size_bytes = 0;
     DataFormat l1_data_format = DataFormat::Invalid;
-    CoreRangeSet cores = CoreRangeSet();
+    CoreRangeSet cores;
 };
 
 /// @brief Reads from Sharded DRAM to L1 using stateful API

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -203,8 +203,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBaseCase) {
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
         .test_id = 1000,
         .num_of_transactions = num_of_transactions,
-        .num_banks = 4,
-        .pages_per_bank = 1,
+        .num_banks = mesh_device->num_dram_channels(),
+        .pages_per_bank = 2,
         .page_size_bytes = page_size_bytes,
         .l1_data_format = l1_data_format,
         .cores = core_range_set};

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -154,7 +154,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal)
 
     // Test config
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-        .test_id = 1000,
+        .test_id = 84,
         .num_of_transactions = num_of_transactions,
         .num_banks = mesh_device->num_dram_channels(),
         .pages_per_bank = 32,
@@ -185,7 +185,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers) {
         for (uint32_t num_pages = 1; num_pages <= max_num_pages; num_pages *= 2) {
             // Test config
             unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-                .test_id = 1001,
+                .test_id = 85,
                 .num_of_transactions = num_of_transactions,
                 .num_banks = num_banks,
                 .pages_per_bank = num_pages,
@@ -218,7 +218,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
         for (uint32_t num_banks = 1; num_banks <= max_num_banks; num_banks++) {
             // Test config
             unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-                .test_id = 1002,
+                .test_id = 86,
                 .num_of_transactions = num_of_transactions,
                 .num_banks = num_banks,
                 .pages_per_bank = num_pages,

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -207,7 +207,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
     DataFormat l1_data_format = DataFormat::Float16_b;
     uint32_t page_size_bytes = tt::tile_size(l1_data_format);
     uint32_t max_num_banks = mesh_device->num_dram_channels();
-    uint32_t num_pages = 16;
+    uint32_t num_pages = 32;
     uint32_t max_transactions = 256;
 
     // Cores

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::dram_sharded {
+// Test config, i.e. test parameters
+struct DramShardedConfig {
+    uint32_t test_id = 0;
+    uint32_t num_of_transactions = 0;
+    uint32_t num_pages = 0;
+    uint32_t page_size_bytes = 0;
+    DataFormat l1_data_format = DataFormat::Invalid;
+    CoreRangeSet cores = CoreRangeSet();
+};
+
+/// @brief Does Interleaved buffer --> Reader --> L1 --> Writer --> Interleaved buffer
+/// @param mesh_device - MeshDevice to run the test on
+/// @param test_config - Configuration of the test -- see struct
+/// @return
+bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramShardedConfig& test_config) {
+    // Get the actual device for this single-device test
+    IDevice* device = mesh_device->get_device(0);
+
+    // Program
+    Program program = CreateProgram();
+
+    // Shape tensor_pages_shape = {2, 2};
+    // Shape shard_pages_shape = {1, 1};
+    BufferDistributionSpec shard_spec = BufferDistributionSpec(
+        Shape{2, 2},  // tensor shape in pages
+        Shape{1, 1},  // shard shape in pages
+        corerange_to_cores(test_config.cores));
+
+    uint32_t single_tile_size = tt::tile_size(test_config.l1_data_format);
+    distributed::DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size,
+        .buffer_type = BufferType::DRAM,
+        .sharding_args = BufferShardingArgs(shard_spec),
+        .bottom_up = true};  // idk what bottom up does
+    // const size_t total_size_bytes = test_config.num_pages * test_config.page_size_bytes;
+    Shape2D global_shape = {64, 64};
+    const size_t total_size_bytes = global_shape.height() * global_shape.width() * sizeof(bfloat16);
+    distributed::ShardedBufferConfig sharded_buffer_config{
+        .global_size = total_size_bytes,
+        .global_buffer_shape = global_shape,
+        .shard_shape = global_shape,  // equal to global buffer shape since only one chip?
+        .shard_orientation = ShardOrientation::ROW_MAJOR,
+    };
+
+    auto mesh_buffer =
+        distributed::MeshBuffer::create(sharded_buffer_config, per_device_buffer_config, mesh_device.get());
+    uint32_t input_buffer_address = mesh_buffer->address();
+    // ShardSpecBuffer(
+    //     const CoreRangeSet& core_sets_,
+    //     const std::array<uint32_t, 2>& shard_shape_,
+    //     const ShardOrientation& shard_orientation_,
+    //     const std::array<uint32_t, 2>& page_shape,
+    //     const std::array<uint32_t, 2>& tensor2d_shape_in_pages)
+
+    // struct ShardedBufferConfig {
+    //     IDevice* device{};
+    //     DeviceAddr size{};       // Size in bytes
+    //     DeviceAddr page_size{};  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    //     BufferType buffer_type = BufferType::L1;
+    //     TensorMemoryLayout buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    //     ShardSpecBuffer shard_parameters;
+    // };
+
+    // ShardSpecBuffer shard_spec = ShardSpecBuffer(
+    //     test_config.cores,
+    //     {total_size_bytes / test_config.page_size_bytes, 1},
+    //     ShardOrientation::ROW_MAJOR,
+    //     {test_config.page_size_bytes, 1},
+    //     {total_size_bytes / test_config.page_size_bytes, 1});
+
+    // InterleavedBufferConfig interleaved_buffer_config{
+    //     .device = device,
+    //     .size = total_size_bytes,
+    //     .page_size = test_config.page_size_bytes,
+    //     .buffer_type = test_config.is_dram ? BufferType::DRAM : BufferType::L1};
+    // std::shared_ptr<Buffer> input_buffer;
+    // input_buffer = CreateBuffer(interleaved_buffer_config);
+    // uint32_t input_buffer_address = input_buffer->address();
+
+    // auto output_buffer = CreateBuffer(interleaved_buffer_config);
+    // uint32_t output_buffer_address = output_buffer->address();
+
+    // Input
+    // vector<uint32_t> packed_input = create_arange_vector_of_bfloat16(total_size_bytes, true);
+    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, total_size_bytes / sizeof(bfloat16), chrono::system_clock::now().time_since_epoch().count());
+
+    // Golden output
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    vector<uint32_t> packed_golden = packed_input;
+
+    // Compile-time arguments for kernels
+    vector<uint32_t> reader_compile_args = {
+        (uint32_t)test_config.num_of_transactions,
+        (uint32_t)test_config.num_pages,
+        (uint32_t)test_config.page_size_bytes,
+        (uint32_t)test_config.test_id};
+    // tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(reader_compile_args);
+
+    // Kernels
+    auto reader_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp",
+        test_config.cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = reader_compile_args});
+
+    uint32_t l1_addr = get_l1_address_and_size(mesh_device, corerange_to_cores(test_config.cores)[0]).base_address;
+    std::vector<uint32_t> reader_run_time_args = {input_buffer_address, l1_addr};
+    tt::tt_metal::SetRuntimeArgs(program, reader_kernel, test_config.cores, reader_run_time_args);
+
+    // log_info(tt::LogTest, "Input buffer addr: {}, Output buffer addr: {}", input_buffer_address,
+    // output_buffer_address);
+
+    // Assign unique id
+    log_info(tt::LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    // Launch program and record outputs
+    vector<uint32_t> packed_output;
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, mesh_buffer, packed_input);
+
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    detail::ReadFromDeviceL1(
+        device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
+
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
+        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error(tt::LogTest, "PCC Check failed");
+        log_info(tt::LogTest, "Golden vector");
+        print_vector(unpack_vector<bfloat16, uint32_t>(packed_golden));
+        log_info(tt::LogTest, "Output vector");
+        print_vector(unpack_vector<bfloat16, uint32_t>(packed_output));
+    }
+
+    return pcc;
+}
+}  // namespace unit_tests::dm::dram_sharded
+
+/* ========== INTERLEAVED DRAM TESTS ========== */
+
+/* ========== Directed Ideal Test Case; Test id = 65 ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedRead) {
+    auto mesh_device = get_mesh_device();
+    // Physical Constraints
+    // auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
+    //     tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+    // Parameters
+    uint32_t page_size_bytes = 64 * 64 * 2;
+    uint32_t num_pages = 1;
+    uint32_t num_of_transactions = 1;
+
+    // Cores
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+
+    // Test config
+    unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
+        .test_id = 1000,
+        .num_of_transactions = num_of_transactions,
+        .num_pages = num_pages,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = DataFormat::Float16_b,
+        .cores = core_range_set};
+
+    // Run
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -100,6 +100,14 @@
     riscv_0:
       bandwidth: 61
 
+"DRAM Sharded Read Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 30
+  blackhole:
+    riscv_0:
+      bandwidth: 60
+
 "Multi Interleaved Directed Ideal":
   wormhole_b0:
     riscv_1:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -191,6 +191,15 @@ tests:
   83:
     name: "One Packet Write Directed Ideal"
 
+  84:
+    name: "DRAM Sharded Read Directed Ideal"
+
+  85:
+    name: "DRAM Sharded Read Tile Numbers"
+
+  86:
+    name: "DRAM Sharded Read Bank Numbers"
+
   100:
     name: "Multicast Schemes (Loopback Enabled)"
 
@@ -320,53 +329,6 @@ tests:
       Performance fluctuates because the flush disturbs the steady state and will randomly create
       traffic that sometimes has head of line blocking, and sometimes does not.
 
-  400:
-    name: "I2S - DRAM Sharded Row Major Writer"
-    comment: |
-      Here, we are getting ~4B/cycle. There are multiple reasons for such BW.
-      The first one is the large number of get_noc_addr(stick_id, s0) calls, without them the BW
-      would be ~6.7B/cycle.
-      The second reason is two additional operations inside the for loop.
-      The third and the main reason that also applies for other tests in the Interleaved to Sharded test suite is
-      that in our ideal tests we are mostly using compile time arguments. This significantly speeds up the runtime since the
-      compiler can introduce a lot of optimizations because of that. In this example we have 6 runtime arguments in the loop,
-      which slows things a lot. Because of this, this performance is expected.
-      Another note is that the more transactions we have, the more BW will be degraded, because of the additional operations inside the loop.
-
-  401:
-    name: "I2S - DRAM Sharded Tile Writer"
-    comment: |
-      Here, we are getting ~16.7B/cycle which is the expected BW, for the config: num of transactions = 8, transaction size = 4096B
-
-  402:
-    name: "I2S - DRAM Interleaved Tile Reader"
-    comment: |
-      Here, we are getting ~11.5B/cycle when reading from DRAM, with the num of transactions = 4, and
-      transaction size = 2048B. Compared to our DRAM Interleaved Page Read Numbers, we can see that
-      that is the expected performance.
-
-  403:
-    name: "I2S - L1 Interleaved Tile Reader"
-    comment: |
-      When reading from L1 we are getting ~14B/cycle, which is also expected
-      compared to our L1 Interleaved Page Read Numbers
-
-  404:
-    name: "I2S - DRAM Interleaved Row Major Reader"
-    comment: |
-      Here, we are getting ~11B/cycle when reading from DRAM, with the num of transactions = 128,
-      and transaction size = 512B. Compared to our DRAM Interleaved Page Read Numbers, we can see that
-      that is a bit below expected performance, but when we take into account the runtime arguments overhead,
-      this is expected.
-
-  405:
-    name: "I2S - L1 Interleaved Row Major Reader"
-    comment: |
-      When reading from L1 with the same config we are also getting ~11.5B/cycle, which is ~60%
-      of the performance when compared to our L1 Interleaved Page Read Numbers. The reason for this is the
-      large number of get_noc_addr(stick_id, s0) calls. Without them, we get ~14.3B/cycle, compared
-      to the expected ~18B/cycle. The same reasoning as in the previous test applies here.
-
   300:
     name: "All to All Directed Ideal"
 
@@ -420,3 +382,50 @@ tests:
 
   318:
     name: "All from All Custom"
+
+  400:
+    name: "I2S - DRAM Sharded Row Major Writer"
+    comment: |
+      Here, we are getting ~4B/cycle. There are multiple reasons for such BW.
+      The first one is the large number of get_noc_addr(stick_id, s0) calls, without them the BW
+      would be ~6.7B/cycle.
+      The second reason is two additional operations inside the for loop.
+      The third and the main reason that also applies for other tests in the Interleaved to Sharded test suite is
+      that in our ideal tests we are mostly using compile time arguments. This significantly speeds up the runtime since the
+      compiler can introduce a lot of optimizations because of that. In this example we have 6 runtime arguments in the loop,
+      which slows things a lot. Because of this, this performance is expected.
+      Another note is that the more transactions we have, the more BW will be degraded, because of the additional operations inside the loop.
+
+  401:
+    name: "I2S - DRAM Sharded Tile Writer"
+    comment: |
+      Here, we are getting ~16.7B/cycle which is the expected BW, for the config: num of transactions = 8, transaction size = 4096B
+
+  402:
+    name: "I2S - DRAM Interleaved Tile Reader"
+    comment: |
+      Here, we are getting ~11.5B/cycle when reading from DRAM, with the num of transactions = 4, and
+      transaction size = 2048B. Compared to our DRAM Interleaved Page Read Numbers, we can see that
+      that is the expected performance.
+
+  403:
+    name: "I2S - L1 Interleaved Tile Reader"
+    comment: |
+      When reading from L1 we are getting ~14B/cycle, which is also expected
+      compared to our L1 Interleaved Page Read Numbers
+
+  404:
+    name: "I2S - DRAM Interleaved Row Major Reader"
+    comment: |
+      Here, we are getting ~11B/cycle when reading from DRAM, with the num of transactions = 128,
+      and transaction size = 512B. Compared to our DRAM Interleaved Page Read Numbers, we can see that
+      that is a bit below expected performance, but when we take into account the runtime arguments overhead,
+      this is expected.
+
+  405:
+    name: "I2S - L1 Interleaved Row Major Reader"
+    comment: |
+      When reading from L1 with the same config we are also getting ~11.5B/cycle, which is ~60%
+      of the performance when compared to our L1 Interleaved Page Read Numbers. The reason for this is the
+      large number of get_noc_addr(stick_id, s0) calls. Without them, we get ~14.3B/cycle, compared
+      to the expected ~18B/cycle. The same reasoning as in the previous test applies here.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -71,7 +71,7 @@ void kernel_main() {
             // noc_async_read_tile_dram_sharded_with_state_with_trid(
             //     src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                input_addr, l1_read_addr, l1_write_addr, curr_block_trid);
+                src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
 
     // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
     uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
-    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc = vc);
+    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc);
     uint32_t l1_read_addr = 0;
 
     constexpr uint32_t total_num_blocks_in_buffer = 3;
@@ -71,7 +71,7 @@ void kernel_main() {
             // noc_async_read_tile_dram_sharded_with_state_with_trid(
             //     src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                src_addr, l1_read_addr, l1_write_addr, curr_block_trid);
+                input_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -8,35 +8,6 @@
 
 #include "debug/dprint.h"
 
-template <uint32_t bank_base_address, uint32_t page_size, bool use_vc>
-FORCE_INLINE void noc_async_read_tile_dram_sharded(
-    uint32_t src_addr, uint32_t dest_addr, uint32_t bank_id = 0, const uint32_t vc = 0) {
-    uint32_t src_addr_;
-    uint32_t src_noc_xy;
-
-    src_addr_ = src_addr + bank_base_address;
-    src_addr_ += bank_to_dram_offset[bank_id];
-    src_noc_xy = dram_bank_to_noc_xy[noc_index][bank_id];
-
-    WAYPOINT("NRTW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr_), dest_addr, page_size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    WAYPOINT("NRTD");
-
-    if constexpr (use_vc) {
-        uint32_t noc_rd_cmd_field =
-            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CTRL, noc_rd_cmd_field);
-    }
-
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr_);           // (uint32_t)src_addr
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE, page_size);              // len_bytes
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    noc_reads_num_issued[noc_index] += 1;
-}
-
 void kernel_main() {
     constexpr uint32_t input_addr = get_compile_time_arg_val(0);
     constexpr uint32_t input_start_tile_id = get_compile_time_arg_val(1);
@@ -50,7 +21,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_id = 0;
 
-    // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
     uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
     noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc);
     uint32_t l1_read_addr = 0;
@@ -68,8 +38,6 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            // noc_async_read_tile_dram_sharded_with_state_with_trid(
-            //     src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
                 src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -50,7 +50,9 @@ void kernel_main() {
 
     constexpr uint32_t cb_id = 0;
 
-    uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
+    // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
+    uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
+    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc = vc);
     uint32_t l1_read_addr = 0;
 
     constexpr uint32_t total_num_blocks_in_buffer = 3;
@@ -66,8 +68,10 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
+            // noc_async_read_tile_dram_sharded_with_state_with_trid(
+            //     src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
+                src_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -65,7 +65,7 @@ void kernel_main() {
 
         for (uint32_t h = 0; h < num_pages; ++h) {
             // noc_async_read_tile_dram_sharded_with_state(src_base_addr, src_read_addr, l1_write_addr);
-            noc_async_read_one_packet_with_state<use_vc = true>(src_base_addr + src_read_addr, l1_write_addr, vc);
+            noc_async_read_one_packet_with_state<true, true>(src_base_addr + src_read_addr, l1_write_addr, vc);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -91,7 +91,7 @@ void kernel_main() {
             // noc_async_read_tile_dram_sharded_with_state_with_trid(
             //     src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                input_addr, src_read_addr, l1_write_addr, curr_block_trid);
+                src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
 
     // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
     uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
-    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc = vc);
+    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc);
     uint32_t src_read_addr = 0;
 
 #ifdef ARCH_GRAYSKULL
@@ -65,7 +65,7 @@ void kernel_main() {
 
         for (uint32_t h = 0; h < num_pages; ++h) {
             // noc_async_read_tile_dram_sharded_with_state(src_base_addr, src_read_addr, l1_write_addr);
-            noc_async_read_one_packet_with_state<use_vc = true>(src_base_addr + src_read_addr, l1_write_addr, vc = vc);
+            noc_async_read_one_packet_with_state<use_vc = true>(src_base_addr + src_read_addr, l1_write_addr, vc);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -8,35 +8,6 @@
 
 #include "debug/dprint.h"
 
-template <uint32_t bank_base_address, uint32_t page_size, bool use_vc>
-FORCE_INLINE void noc_async_read_tile_dram_sharded(
-    uint32_t src_addr, uint32_t dest_addr, uint32_t bank_id = 0, const uint32_t vc = 0) {
-    uint32_t src_addr_;
-    uint32_t src_noc_xy;
-
-    src_addr_ = src_addr + bank_base_address;
-    src_addr_ += bank_to_dram_offset[bank_id];
-    src_noc_xy = dram_bank_to_noc_xy[noc_index][bank_id];
-
-    WAYPOINT("NRTW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr_), dest_addr, page_size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    WAYPOINT("NRTD");
-
-    if constexpr (use_vc) {
-        uint32_t noc_rd_cmd_field =
-            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CTRL, noc_rd_cmd_field);
-    }
-
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr_);           // (uint32_t)src_addr
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE, page_size);              // len_bytes
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    noc_reads_num_issued[noc_index] += 1;
-}
-
 void kernel_main() {
     constexpr uint32_t input_addr = get_compile_time_arg_val(0);
     constexpr uint32_t input_start_tile_id = get_compile_time_arg_val(1);
@@ -52,7 +23,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_id = 0;
 
-    // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
     uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
     noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc);
     uint32_t src_read_addr = 0;
@@ -64,7 +34,6 @@ void kernel_main() {
         auto l1_write_addr = get_write_ptr(cb_id);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            // noc_async_read_tile_dram_sharded_with_state(src_base_addr, src_read_addr, l1_write_addr);
             noc_async_read_one_packet_with_state<true, true>(src_base_addr + src_read_addr, l1_write_addr, vc);
             src_read_addr += page_size;
             l1_write_addr += page_size;
@@ -88,8 +57,6 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            // noc_async_read_tile_dram_sharded_with_state_with_trid(
-            //     src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
                 src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             src_read_addr += page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -52,7 +52,9 @@ void kernel_main() {
 
     constexpr uint32_t cb_id = 0;
 
-    uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
+    // uint32_t src_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(input_addr, page_size, bank_id, vc);
+    uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
+    noc_async_read_one_packet_set_state<true>(src_base_addr, page_size, vc = vc);
     uint32_t src_read_addr = 0;
 
 #ifdef ARCH_GRAYSKULL
@@ -62,7 +64,8 @@ void kernel_main() {
         auto l1_write_addr = get_write_ptr(cb_id);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            noc_async_read_tile_dram_sharded_with_state(src_base_addr, src_read_addr, l1_write_addr);
+            // noc_async_read_tile_dram_sharded_with_state(src_base_addr, src_read_addr, l1_write_addr);
+            noc_async_read_one_packet_with_state<use_vc = true>(src_base_addr + src_read_addr, l1_write_addr, vc = vc);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }
@@ -85,8 +88,10 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
+            // noc_async_read_tile_dram_sharded_with_state_with_trid(
+            //     src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
+                input_addr, src_read_addr, l1_write_addr, curr_block_trid);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
@@ -75,7 +75,7 @@ void kernel_main() {
         // uint32_t src_base_addr =
         //     noc_async_read_tile_dram_sharded_set_state<true>(input_addr, curr_page_size, bank_id, vc);
         uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
-        noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc = vc);
+        noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc);
         src_read_addr = src_read_addr_offset_bytes;
 
         // For debug purpose, use trivial DRAM read method

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
@@ -114,7 +114,7 @@ void kernel_main() {
                 // noc_async_read_tile_dram_sharded_with_state_with_trid(
                 //     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 noc_async_read_tile_dram_sharded_with_state_with_trid(
-                    input_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
+                    src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 src_read_addr += curr_page_size;
                 temp_l1_write_addr += curr_page_size;
             }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
@@ -72,8 +72,10 @@ void kernel_main() {
         uint32_t curr_block_size_bytes = curr_num_pages * curr_page_size;
         uint32_t curr_layer_size_bytes = curr_num_blocks * curr_block_size_bytes;
 
-        uint32_t src_base_addr =
-            noc_async_read_tile_dram_sharded_set_state<true>(input_addr, curr_page_size, bank_id, vc);
+        // uint32_t src_base_addr =
+        //     noc_async_read_tile_dram_sharded_set_state<true>(input_addr, curr_page_size, bank_id, vc);
+        uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, input_addr);
+        noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc = vc);
         src_read_addr = src_read_addr_offset_bytes;
 
         // For debug purpose, use trivial DRAM read method
@@ -109,8 +111,10 @@ void kernel_main() {
 
             uint32_t temp_l1_write_addr = l1_write_addr;
             for (uint32_t h = 0; h < curr_num_pages; ++h) {
+                // noc_async_read_tile_dram_sharded_with_state_with_trid(
+                //     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 noc_async_read_tile_dram_sharded_with_state_with_trid(
-                    src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
+                    input_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 src_read_addr += curr_page_size;
                 temp_l1_write_addr += curr_page_size;
             }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -107,7 +107,7 @@ void kernel_main() {
 
     // DRAM sharded read API
     uint64_t src_addr = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
-    noc_async_read_one_packet_set_state<true>(src_addr, page_size, 0, noc_index);
+    noc_async_read_one_packet_set_state<true>(src_addr, page_size, vc, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -105,15 +105,16 @@ void kernel_main() {
     reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
 
     // DRAM sharded read API
-    uint32_t src_addr = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
-    for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
-    }
+    // uint32_t src_addr = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
+    // for (uint32_t i = 0; i < iteration; i++) {
+    //     uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
+    //     noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid,
+    //     noc_index);
+    // }
 
-    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
-        noc_async_read_barrier_with_trid(i, noc_index);
-    }
+    // for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
+    //     noc_async_read_barrier_with_trid(i, noc_index);
+    // }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -43,9 +43,10 @@ void kernel_main() {
     }
 
     // Test stateful read one packet API
-    noc_async_read_one_packet_set_state(addr_self_noc, page_size, 0, noc_index);
+    constexpr uint32_t vc = 0;
+    noc_async_read_one_packet_set_state(addr_self_noc, page_size, vc, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, vc, noc_index);
     }
 
     // Test stateful write one packet API

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -105,16 +105,16 @@ void kernel_main() {
     reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
 
     // DRAM sharded read API
-    // uint32_t src_addr = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
-    // for (uint32_t i = 0; i < iteration; i++) {
-    //     uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-    //     noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid,
-    //     noc_index);
-    // }
+    uint64_t src_addr = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
+    noc_async_read_one_packet_set_state<true>(src_addr, page_size, 0, noc_index);
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
+        noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+    }
 
-    // for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
-    //     noc_async_read_barrier_with_trid(i, noc_index);
-    // }
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
+        noc_async_read_barrier_with_trid(i, noc_index);
+    }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -43,9 +43,9 @@ void kernel_main() {
     }
 
     // Test stateful read one packet API
-    noc_async_read_one_packet_set_state(addr_self_noc, page_size, noc_index);
+    noc_async_read_one_packet_set_state(addr_self_noc, page_size, 0, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, noc_index);
     }
 
     // Test stateful write one packet API

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -59,11 +59,11 @@ void kernel_main() {
     }
 
     // Test stateful read one packet API
-    noc_async_read_one_packet_set_state(addr_self_noc, page_size, noc_index);
-    noc_async_read_one_packet_set_state(addr_other_noc, page_size, 1 - noc_index);
+    noc_async_read_one_packet_set_state(addr_self_noc, page_size, 0, noc_index);
+    noc_async_read_one_packet_set_state(addr_other_noc, page_size, 0, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, noc_index);
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 1 - noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, 1 - noc_index);
     }
 
     // Test stateful write one packet API

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -159,20 +159,20 @@ void kernel_main() {
     }
 
     // DRAM sharded read API
-    uint32_t src_addr_0 = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, noc_index);
-    uint32_t src_addr_1 =
-        noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, 1 - noc_index);
-    for (uint32_t i = 0; i < iteration; i++) {
-        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(
-            src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(
-            src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
-    }
-    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
-        noc_async_read_barrier_with_trid(i, noc_index);
-        noc_async_read_barrier_with_trid(i, 1 - noc_index);
-    }
+    // uint32_t src_addr_0 = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0,
+    // noc_index); uint32_t src_addr_1 =
+    //     noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, 1 - noc_index);
+    // for (uint32_t i = 0; i < iteration; i++) {
+    //     uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
+    //     noc_async_read_tile_dram_sharded_with_state_with_trid(
+    //         src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+    //     noc_async_read_tile_dram_sharded_with_state_with_trid(
+    //         src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
+    // }
+    // for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
+    //     noc_async_read_barrier_with_trid(i, noc_index);
+    //     noc_async_read_barrier_with_trid(i, 1 - noc_index);
+    // }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -59,11 +59,12 @@ void kernel_main() {
     }
 
     // Test stateful read one packet API
-    noc_async_read_one_packet_set_state(addr_self_noc, page_size, 0, noc_index);
-    noc_async_read_one_packet_set_state(addr_other_noc, page_size, 0, 1 - noc_index);
+    constexpr uint32_t vc = 0;
+    noc_async_read_one_packet_set_state(addr_self_noc, page_size, vc, noc_index);
+    noc_async_read_one_packet_set_state(addr_other_noc, page_size, vc, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, noc_index);
-        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, 0, 1 - noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, vc, noc_index);
+        noc_async_read_one_packet_with_state(l1_read_addr, l1_read_addr, vc, 1 - noc_index);
     }
 
     // Test stateful write one packet API
@@ -161,8 +162,8 @@ void kernel_main() {
     // DRAM sharded read API
     uint64_t src_addr_0 = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
     uint64_t src_addr_1 = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
-    noc_async_read_one_packet_set_state<true>(src_addr_0, page_size, 0, noc_index);
-    noc_async_read_one_packet_set_state<true>(src_addr_1, page_size, 0, 1 - noc_index);
+    noc_async_read_one_packet_set_state<true>(src_addr_0, page_size, vc, noc_index);
+    noc_async_read_one_packet_set_state<true>(src_addr_1, page_size, vc, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
         noc_async_read_tile_dram_sharded_with_state_with_trid(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -159,20 +159,21 @@ void kernel_main() {
     }
 
     // DRAM sharded read API
-    // uint32_t src_addr_0 = noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0,
-    // noc_index); uint32_t src_addr_1 =
-    //     noc_async_read_tile_dram_sharded_set_state<true>(DRAM_ALIGNMENT, page_size, 0, 0, 1 - noc_index);
-    // for (uint32_t i = 0; i < iteration; i++) {
-    //     uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-    //     noc_async_read_tile_dram_sharded_with_state_with_trid(
-    //         src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
-    //     noc_async_read_tile_dram_sharded_with_state_with_trid(
-    //         src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
-    // }
-    // for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
-    //     noc_async_read_barrier_with_trid(i, noc_index);
-    //     noc_async_read_barrier_with_trid(i, 1 - noc_index);
-    // }
+    uint64_t src_addr_0 = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
+    uint64_t src_addr_1 = get_noc_addr_from_bank_id<true>(0, DRAM_ALIGNMENT);
+    noc_async_read_one_packet_set_state<true>(src_addr_0, page_size, 0, noc_index);
+    noc_async_read_one_packet_set_state<true>(src_addr_1, page_size, 0, 1 - noc_index);
+    for (uint32_t i = 0; i < iteration; i++) {
+        uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
+        noc_async_read_tile_dram_sharded_with_state_with_trid(
+            src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_tile_dram_sharded_with_state_with_trid(
+            src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
+    }
+    for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
+        noc_async_read_barrier_with_trid(i, noc_index);
+        noc_async_read_barrier_with_trid(i, 1 - noc_index);
+    }
 
     // L1 sharded write API
     for (uint32_t i = 0; i < iteration; i++) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2030,78 +2030,9 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
 
 // clang-format off
 /**
- * Sets the stateful registers for an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * This is similar to \a noc_async_read_set_state, except that the source location is determined by the bank_base_address and bank_id.
- * In addition, the VC used for the transactions can also be configured.
- *
- * Return value: source address
- *
- * | Argument                   | Description                               | Data type | Valid range                                            | required |
- * |----------------------------|-------------------------------------------|-----------|--------------------------------------------------------|----------|
- * | bank_base_address          | Base address where DRAM banks are located | uint32_t  | 0..1MB                                                 | True     |
- * | page_size                  | Size of data transfer in bytes            | uint32_t  | 0..1MB                                                 | True     |
- * | bank_id                    | DRAM bank id                              | uint32_t  | Refer to relevant yaml in "tt_metal/soc_descriptors"   | False    |
- * | vc                         | Which VC to use for the transaction       | uint32_t  | 0-3 (Unicast VCs)                                      | False    |
- * | noc                        | Which NOC to use for the transaction      | uint8_t   | 0 or 1                                                 | False    |
- * | use_vc (template argument) | Enable custom VC usage                    | bool      | True or False                                          | False    |
- */
-// clang-format on
-template <bool use_vc>
-FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
-    uint32_t bank_base_address,
-    uint32_t page_size,
-    uint32_t bank_id = 0,
-    const uint32_t vc = 0,
-    uint8_t noc = noc_index) {
-    uint32_t src_addr_ = bank_base_address + bank_to_dram_offset[bank_id];
-    uint32_t src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
-    uint64_t src_noc_addr = get_noc_addr_helper(src_noc_xy, src_addr_);
-
-    DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ_DRAM_SHARDED_SET_STATE, uint64_t(src_noc_xy) << 32, page_size, (use_vc) ? vc : -1);
-
-    WAYPOINT("NRTW");
-    ncrisc_noc_read_set_state<DM_DEDICATED_NOC, true /* one_packet */, use_vc>(
-        noc, read_cmd_buf, src_noc_addr, page_size, vc);
-    WAYPOINT("NRTD");
-
-    return src_addr_;
-}
-
-// clang-format off
-/**
  * Initiates an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * This is similar to \a noc_async_read_with_state, except that the source location is determined by the src_base_addr and src_addr.
- *
- * Return value: None
- *
- * | Argument      | Description                                    | Data type | Valid range         | required |
- * |---------------|------------------------------------------------|-----------|-------------------- |----------|
- * | src_base_addr | Base address of source location                | uint32_t  | 0..1MB              | True     |
- * | src_addr      | Address in local L1 memory on source core      | uint32_t  | 0..1MB              | True     |
- * | dest_addr     | Address in local L1 memory on destination core | uint32_t  | 0..1MB              | True     |
- * | noc           | Which NOC to use for the transaction           | uint8_t   | 0 or 1              | False    |
- */
-// clang-format on
-FORCE_INLINE
-void noc_async_read_tile_dram_sharded_with_state(
-    uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_DRAM_SHARDED_WITH_STATE);
-
-    uint32_t src_local_addr = src_base_addr + src_addr;
-
-    WAYPOINT("NRTW");
-    ncrisc_noc_read_with_state<noc_mode, true /* inc_num_issued */, true /* one_packet */>(
-        noc, read_cmd_buf, src_local_addr, dest_addr);
-    WAYPOINT("NRTD");
-}
-
-// clang-format off
-/**
- * Initiates an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * This is similar to \a noc_async_read_tile_dram_sharded_with_state, except that this is used when the transaction
- * id is set.
+ * This is similar to \a noc_async_read_tile_dram_sharded_with_state (now deprecated; see \a noc_async_read_one_packet_with_state),
+ * except that this is used when the transaction id is set.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -565,17 +565,18 @@ inline void noc_async_read(
  * | max_page_size (template argument) | Maximum size of a single transaction in bytes      | uint32_t  | Any uint32_t number                      | False    |
  */
 // clang-format on
-FORCE_INLINE
-void noc_async_read_one_packet_set_state(uint64_t src_noc_addr, uint32_t size, uint8_t noc = noc_index) {
+template <bool use_vc = false>
+FORCE_INLINE void noc_async_read_one_packet_set_state(
+    uint64_t src_noc_addr, uint32_t size, uint8_t noc = noc_index, const uint32_t vc = 0) {
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, size, -1);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, size, (use_vc) ? vc : -1);
 
     WAYPOINT("NASW");
-    ncrisc_noc_read_set_state<noc_mode, true /* one_packet */>(noc, read_cmd_buf, src_noc_addr, size);
+    ncrisc_noc_read_set_state<noc_mode, true /* one_packet */, use_vc>(noc, read_cmd_buf, src_noc_addr, size, vc);
     WAYPOINT("NASD");
 }
 
@@ -594,14 +595,15 @@ void noc_async_read_one_packet_set_state(uint64_t src_noc_addr, uint32_t size, u
  * | inc_num_issued (template argument)| Whether issued read counter should be increment    | uint32_t  | Any uint32_t number | False    |
  */
 // clang-format on
-template <bool inc_num_issued = true>
+template <bool inc_num_issued = true, bool use_vc = false>
 FORCE_INLINE void noc_async_read_one_packet_with_state(
-    uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
+    uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index, const uint32_t vc = 0) {
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_WITH_STATE, static_cast<uint64_t>(src_local_l1_addr), 0, -1);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::READ_WITH_STATE, static_cast<uint64_t>(src_local_l1_addr), 0, (use_vc) ? vc : -1);
 
     WAYPOINT("NATW");
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2035,8 +2035,8 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
 // clang-format off
 /**
  * Initiates an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * This is similar to \a noc_async_read_tile_dram_sharded_with_state (now deprecated; see \a noc_async_read_one_packet_with_state),
- * except that this is used when the transaction id is set.
+ * Must first set the transaction id using \a noc_async_read_tile_dram_sharded_set_trid and the stateful registers
+ * using an API such as \a noc_async_read_one_packet_set_state.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -567,7 +567,7 @@ inline void noc_async_read(
 // clang-format on
 template <bool use_vc = false>
 FORCE_INLINE void noc_async_read_one_packet_set_state(
-    uint64_t src_noc_addr, uint32_t size, uint8_t noc = noc_index, const uint32_t vc = 0) {
+    uint64_t src_noc_addr, uint32_t size, const uint32_t vc = 0, uint8_t noc = noc_index) {
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically
@@ -597,7 +597,7 @@ FORCE_INLINE void noc_async_read_one_packet_set_state(
 // clang-format on
 template <bool inc_num_issued = true, bool use_vc = false>
 FORCE_INLINE void noc_async_read_one_packet_with_state(
-    uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index, const uint32_t vc = 0) {
+    uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, const uint32_t vc = 0, uint8_t noc = noc_index) {
     /*
         Read requests - use static VC
         Read responses - assigned VCs dynamically

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -561,8 +561,10 @@ inline void noc_async_read(
  * |-----------------------------------|----------------------------------------------------|-----------|------------------------------------------|----------|
  * | src_noc_addr                      | Encoding of the source NOC location (x,y)+address  | uint64_t  | Results of \a get_noc_addr calls         | True     |
  * | size                              | Size of data transfer in bytes                     | uint32_t  | 0..1MB                                   | True     |
+ * | vc                                | Which VC to use for the transaction                | uint32_t  | 0-3 (Unicast VCs)                        | False    |
  * | noc                               | Which NOC to use for the transaction               | uint8_t   | 0 or 1                                   | False    |
  * | max_page_size (template argument) | Maximum size of a single transaction in bytes      | uint32_t  | Any uint32_t number                      | False    |
+ * | use_vc (template argument)        | Enable custom VC usage                             | bool      | True or False                            | False    |
  */
 // clang-format on
 template <bool use_vc = false>
@@ -591,8 +593,10 @@ FORCE_INLINE void noc_async_read_one_packet_set_state(
  * |-----------------------------------|----------------------------------------------------|-----------|-------------------- |----------|
  * | src_local_l1_addr                 | Address in local L1 memory on source core          | uint32_t  | 0..1MB              | True     |
  * | dst_local_l1_addr                 | Address in local L1 memory on destination core     | uint32_t  | 0..1MB              | True     |
+ * | vc                                | Which VC to use for the transaction                | uint32_t  | 0-3 (Unicast VCs)   | False    |
  * | noc                               | Which NOC to use for the transaction               | uint8_t   | 0 or 1              | False    |
  * | inc_num_issued (template argument)| Whether issued read counter should be increment    | uint32_t  | Any uint32_t number | False    |
+ * | use_vc (template argument)        | Enable custom VC usage                             | bool      | True or False       | False    |
  */
 // clang-format on
 template <bool inc_num_issued = true, bool use_vc = false>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -168,7 +168,7 @@ void kernel_main() {
                         noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
-                        noc_async_read_one_packet_with_state<use_vc = true>(
+                        noc_async_read_one_packet_with_state<true, true>(
                             in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -169,7 +169,7 @@ void kernel_main() {
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<true, true>(
-                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
+                            in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -116,7 +116,6 @@ void kernel_main() {
     uint32_t dram_read_offset_bytes = 0;
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
-    // uint32_t in1_base_addr = 0;
 
     if constexpr (in1_is_dram_sharded) {
         in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -162,12 +162,8 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                        //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
                         uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
                         noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
-                        // noc_async_read_tile_dram_sharded_with_state(
-                        //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<true, true>(
                             in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -116,7 +116,7 @@ void kernel_main() {
     uint32_t dram_read_offset_bytes = 0;
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
-    uint32_t in1_base_addr = 0;
+    // uint32_t in1_base_addr = 0;
 
     if constexpr (in1_is_dram_sharded) {
         in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;
@@ -162,10 +162,14 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                            in1_tensor_addr, curr_page_size, dram_bank_id, vc);
-                        noc_async_read_tile_dram_sharded_with_state(
-                            in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
+                        // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
+                        //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
+                        uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
+                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc = vc);
+                        // noc_async_read_tile_dram_sharded_with_state(
+                        //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
+                        noc_async_read_one_packet_with_state<use_vc = true>(
+                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc = vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -165,11 +165,11 @@ void kernel_main() {
                         // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
                         //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
                         uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc = vc);
+                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<use_vc = true>(
-                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc = vc);
+                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -168,7 +168,7 @@ void kernel_main() {
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<true, true>(
-                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
+                            in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -167,7 +167,7 @@ void kernel_main() {
                         noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
-                        noc_async_read_one_packet_with_state<use_vc = true>(
+                        noc_async_read_one_packet_with_state<true, true>(
                             in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -161,12 +161,8 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                        //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
                         uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
                         noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
-                        // noc_async_read_tile_dram_sharded_with_state(
-                        //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<true, true>(
                             in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -164,11 +164,11 @@ void kernel_main() {
                         // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
                         //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
                         uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc = vc);
+                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
                         // noc_async_read_tile_dram_sharded_with_state(
                         //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
                         noc_async_read_one_packet_with_state<use_vc = true>(
-                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc = vc);
+                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -115,7 +115,6 @@ void kernel_main() {
     uint32_t dram_read_offset_bytes = 0;
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
-    // uint32_t in1_base_addr = 0;
 
     if constexpr (in1_is_dram_sharded) {
         in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -115,7 +115,7 @@ void kernel_main() {
     uint32_t dram_read_offset_bytes = 0;
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
-    uint32_t in1_base_addr = 0;
+    // uint32_t in1_base_addr = 0;
 
     if constexpr (in1_is_dram_sharded) {
         in1_shard_width_offset_bytes = in1_shard_width_in_dram * in1_single_tile_size_bytes;
@@ -161,10 +161,14 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                            in1_tensor_addr, curr_page_size, dram_bank_id, vc);
-                        noc_async_read_tile_dram_sharded_with_state(
-                            in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
+                        // in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
+                        //     in1_tensor_addr, curr_page_size, dram_bank_id, vc);
+                        uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
+                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc = vc);
+                        // noc_async_read_tile_dram_sharded_with_state(
+                        //     in1_base_addr, curr_l1_read_addr_in1, l1_write_addr_in1);
+                        noc_async_read_one_packet_with_state<use_vc = true>(
+                            in1_tensor_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc = vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -73,7 +73,7 @@ void kernel_main() {
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
             // noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
-            noc_async_read_one_packet_with_state<true, true>(in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
+            noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -99,7 +99,7 @@ void kernel_main() {
             // noc_async_read_tile_dram_sharded_with_state_with_trid(
             //     in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                in1_tensor_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
+                in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -142,7 +142,7 @@ void kernel_main() {
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
         // noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
-        noc_async_read_one_packet_with_state<true, true>(in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+        noc_async_read_one_packet_with_state<true, true>(in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -73,8 +73,7 @@ void kernel_main() {
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
             // noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
-            noc_async_read_one_packet_with_state<use_vc = true>(
-                in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
+            noc_async_read_one_packet_with_state<true, true>(in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -143,7 +142,7 @@ void kernel_main() {
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
         // noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
-        noc_async_read_one_packet_with_state<use_vc = true>(in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+        noc_async_read_one_packet_with_state<true, true>(in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -60,8 +60,6 @@ void kernel_main() {
     uint32_t l1_read_addr_in1 = 0;
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    // uint32_t in1_base_addr =
-    //     noc_async_read_tile_dram_sharded_set_state<true>(in1_tensor_addr, in1_page_size, dram_bank_id, vc);
     uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
     noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc);
 
@@ -72,7 +70,6 @@ void kernel_main() {
         l1_write_addr_in1 = get_write_ptr(cb_id_in1);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            // noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
             noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
@@ -96,8 +93,6 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            // noc_async_read_tile_dram_sharded_with_state_with_trid(
-            //     in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
                 in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
@@ -135,13 +130,10 @@ void kernel_main() {
     uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
     uint32_t l1_read_addr_in3 = 0;
 
-    // uint32_t in3_base_addr =
-    //     noc_async_read_tile_dram_sharded_set_state<true>(in3_tensor_addr, in3_page_size, dram_bank_id, vc);
     uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
     noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc);
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        // noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
         noc_async_read_one_packet_with_state<true, true>(in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -60,8 +60,10 @@ void kernel_main() {
     uint32_t l1_read_addr_in1 = 0;
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    uint32_t in1_base_addr =
-        noc_async_read_tile_dram_sharded_set_state<true>(in1_tensor_addr, in1_page_size, dram_bank_id, vc);
+    // uint32_t in1_base_addr =
+    //     noc_async_read_tile_dram_sharded_set_state<true>(in1_tensor_addr, in1_page_size, dram_bank_id, vc);
+    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
+    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc = vc);
 
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -70,7 +72,9 @@ void kernel_main() {
         l1_write_addr_in1 = get_write_ptr(cb_id_in1);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
+            // noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
+            noc_async_read_one_packet_with_state<use_vc = true>(
+                in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc = vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -93,8 +97,10 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
+            // noc_async_read_tile_dram_sharded_with_state_with_trid(
+            //     in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             noc_async_read_tile_dram_sharded_with_state_with_trid(
-                in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
+                in1_tensor_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -130,11 +136,15 @@ void kernel_main() {
     uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
     uint32_t l1_read_addr_in3 = 0;
 
-    uint32_t in3_base_addr =
-        noc_async_read_tile_dram_sharded_set_state<true>(in3_tensor_addr, in3_page_size, dram_bank_id, vc);
+    // uint32_t in3_base_addr =
+    //     noc_async_read_tile_dram_sharded_set_state<true>(in3_tensor_addr, in3_page_size, dram_bank_id, vc);
+    uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
+    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc = vc);
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
+        // noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
+        noc_async_read_one_packet_with_state<use_vc = true>(
+            in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc = vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -63,7 +63,7 @@ void kernel_main() {
     // uint32_t in1_base_addr =
     //     noc_async_read_tile_dram_sharded_set_state<true>(in1_tensor_addr, in1_page_size, dram_bank_id, vc);
     uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc = vc);
+    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc);
 
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -74,7 +74,7 @@ void kernel_main() {
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
             // noc_async_read_tile_dram_sharded_with_state(in1_base_addr, l1_read_addr_in1, l1_write_addr_in1);
             noc_async_read_one_packet_with_state<use_vc = true>(
-                in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc = vc);
+                in1_tensor_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -139,12 +139,11 @@ void kernel_main() {
     // uint32_t in3_base_addr =
     //     noc_async_read_tile_dram_sharded_set_state<true>(in3_tensor_addr, in3_page_size, dram_bank_id, vc);
     uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc = vc);
+    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc);
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
         // noc_async_read_tile_dram_sharded_with_state(in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
-        noc_async_read_one_packet_with_state<use_vc = true>(
-            in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc = vc);
+        noc_async_read_one_packet_with_state<use_vc = true>(in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -263,15 +263,19 @@ void kernel_main() {
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint32_t in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                                in1_tensor_addr,
-                                in1_single_tile_size_bytes,
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index],
-                                vc);
+                            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(
+                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in1_tensor_addr);
+                            // uint32_t in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
+                            //     in1_tensor_addr,
+                            //     in1_single_tile_size_bytes,
+                            //     current_dram_bank_id[next_bank_id_and_dram_stride_index],
+                            //     vc);
 
                             if (i == 0) {
                                 in1_base_addr += dram_tensor_start_offset;
                             }
+                            noc_async_read_one_packet_set_state<true>(
+                                in1_base_addr, in1_single_tile_size_bytes, vc = vc);
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
                             uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1) + l1_write_addr_in1_offset;
@@ -283,8 +287,10 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc_async_read_tile_dram_sharded_with_state(
-                                        in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
+                                    // noc_async_read_tile_dram_sharded_with_state(
+                                    //     in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
+                                    noc_async_read_one_packet_with_state<use_vc = true>(
+                                        in1_tensor_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc = vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -402,15 +408,20 @@ void kernel_main() {
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint32_t in3_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                                in3_tensor_addr,
-                                bias_single_tile_size_bytes,
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index],
-                                vc);
+                            uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(
+                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
+                            // uint32_t in3_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
+                            //     in3_tensor_addr,
+                            //     bias_single_tile_size_bytes,
+                            //     current_dram_bank_id[next_bank_id_and_dram_stride_index],
+                            //     vc);
 
                             if (i == 0) {
                                 in3_base_addr += dram_tensor_start_offset;
                             }
+
+                            noc_async_read_one_packet_set_state<true>(
+                                in3_base_addr, bias_single_tile_size_bytes, vc = vc);
 
                             uint32_t l1_read_addr_in3 = 0;
                             uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3) + l1_write_addr_in3_offset;
@@ -419,8 +430,10 @@ void kernel_main() {
                                 bias_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc_async_read_tile_dram_sharded_with_state(
-                                    in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
+                                noc_async_read_one_packet_with_state<use_vc = true>(
+                                    in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc = vc);
+                                // noc_async_read_tile_dram_sharded_with_state(
+                                //     in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -289,7 +289,7 @@ void kernel_main() {
                                     // noc_async_read_tile_dram_sharded_with_state(
                                     //     in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
                                     noc_async_read_one_packet_with_state<true, true>(
-                                        in1_tensor_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
+                                        in1_base_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -429,7 +429,7 @@ void kernel_main() {
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
                                 noc_async_read_one_packet_with_state<true, true>(
-                                    in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+                                    in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
                                 // noc_async_read_tile_dram_sharded_with_state(
                                 //     in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -274,8 +274,7 @@ void kernel_main() {
                             if (i == 0) {
                                 in1_base_addr += dram_tensor_start_offset;
                             }
-                            noc_async_read_one_packet_set_state<true>(
-                                in1_base_addr, in1_single_tile_size_bytes, vc = vc);
+                            noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_single_tile_size_bytes, vc);
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
                             uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1) + l1_write_addr_in1_offset;
@@ -290,7 +289,7 @@ void kernel_main() {
                                     // noc_async_read_tile_dram_sharded_with_state(
                                     //     in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
                                     noc_async_read_one_packet_with_state<use_vc = true>(
-                                        in1_tensor_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc = vc);
+                                        in1_tensor_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -420,8 +419,7 @@ void kernel_main() {
                                 in3_base_addr += dram_tensor_start_offset;
                             }
 
-                            noc_async_read_one_packet_set_state<true>(
-                                in3_base_addr, bias_single_tile_size_bytes, vc = vc);
+                            noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
 
                             uint32_t l1_read_addr_in3 = 0;
                             uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3) + l1_write_addr_in3_offset;
@@ -431,7 +429,7 @@ void kernel_main() {
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
                                 noc_async_read_one_packet_with_state<use_vc = true>(
-                                    in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc = vc);
+                                    in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
                                 // noc_async_read_tile_dram_sharded_with_state(
                                 //     in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -288,7 +288,7 @@ void kernel_main() {
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
                                     // noc_async_read_tile_dram_sharded_with_state(
                                     //     in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
-                                    noc_async_read_one_packet_with_state<use_vc = true>(
+                                    noc_async_read_one_packet_with_state<true, true>(
                                         in1_tensor_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
@@ -428,7 +428,7 @@ void kernel_main() {
                                 bias_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc_async_read_one_packet_with_state<use_vc = true>(
+                                noc_async_read_one_packet_with_state<true, true>(
                                     in3_tensor_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
                                 // noc_async_read_tile_dram_sharded_with_state(
                                 //     in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -265,11 +265,6 @@ void kernel_main() {
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
                             uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(
                                 current_dram_bank_id[next_bank_id_and_dram_stride_index], in1_tensor_addr);
-                            // uint32_t in1_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                            //     in1_tensor_addr,
-                            //     in1_single_tile_size_bytes,
-                            //     current_dram_bank_id[next_bank_id_and_dram_stride_index],
-                            //     vc);
 
                             if (i == 0) {
                                 in1_base_addr += dram_tensor_start_offset;
@@ -286,8 +281,6 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    // noc_async_read_tile_dram_sharded_with_state(
-                                    //     in1_base_addr, l1_read_addr_in1_temp, l1_write_addr_in1_temp);
                                     noc_async_read_one_packet_with_state<true, true>(
                                         in1_base_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
@@ -409,11 +402,6 @@ void kernel_main() {
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
                             uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(
                                 current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
-                            // uint32_t in3_base_addr = noc_async_read_tile_dram_sharded_set_state<true>(
-                            //     in3_tensor_addr,
-                            //     bias_single_tile_size_bytes,
-                            //     current_dram_bank_id[next_bank_id_and_dram_stride_index],
-                            //     vc);
 
                             if (i == 0) {
                                 in3_base_addr += dram_tensor_start_offset;
@@ -430,8 +418,6 @@ void kernel_main() {
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
                                 noc_async_read_one_packet_with_state<true, true>(
                                     in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
-                                // noc_async_read_tile_dram_sharded_with_state(
-                                //     in3_base_addr, l1_read_addr_in3, l1_write_addr_in3);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
             // uint32_t src_base_addr =
             //     noc_async_read_tile_dram_sharded_set_state<true>(tensor_base_address, curr_page_size, bank_id, vc);
             uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, tensor_base_address);
-            noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc = vc);
+            noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc);
 
             uint32_t src_read_addr = 0;
 

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -45,8 +45,6 @@ void kernel_main() {
 
             // Address setup
             uint32_t tensor_base_address = tensor_addrs_l1[layer * num_tensors + t];
-            // uint32_t src_base_addr =
-            //     noc_async_read_tile_dram_sharded_set_state<true>(tensor_base_address, curr_page_size, bank_id, vc);
             uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, tensor_base_address);
             noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc);
 
@@ -73,8 +71,6 @@ void kernel_main() {
                 // Issue noc async read commands for current block
                 uint32_t temp_l1_write_addr = l1_write_addr;
                 for (uint32_t h = 0; h < curr_block_num_pages; ++h) {
-                    // noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
-                    //     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
                         src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     src_read_addr += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -45,8 +45,11 @@ void kernel_main() {
 
             // Address setup
             uint32_t tensor_base_address = tensor_addrs_l1[layer * num_tensors + t];
-            uint32_t src_base_addr =
-                noc_async_read_tile_dram_sharded_set_state<true>(tensor_base_address, curr_page_size, bank_id, vc);
+            // uint32_t src_base_addr =
+            //     noc_async_read_tile_dram_sharded_set_state<true>(tensor_base_address, curr_page_size, bank_id, vc);
+            uint64_t src_base_addr = get_noc_addr_from_bank_id<true>(bank_id, tensor_base_address);
+            noc_async_read_one_packet_set_state<true>(src_base_addr, curr_page_size, vc = vc);
+
             uint32_t src_read_addr = 0;
 
             uint32_t num_free_blocks_in_buffer = total_num_blocks_in_buffer;
@@ -70,8 +73,10 @@ void kernel_main() {
                 // Issue noc async read commands for current block
                 uint32_t temp_l1_write_addr = l1_write_addr;
                 for (uint32_t h = 0; h < curr_block_num_pages; ++h) {
+                    // noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
+                    //     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
-                        src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
+                        tensor_base_address, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     src_read_addr += curr_page_size;
                     temp_l1_write_addr += curr_page_size;
                 }

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
                     // noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
                     //     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
-                        tensor_base_address, src_read_addr, temp_l1_write_addr, curr_block_trid);
+                        src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     src_read_addr += curr_page_size;
                     temp_l1_write_addr += curr_page_size;
                 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29739)

### Problem description
`noc_async_read_tile_dram_sharded` stateful APIs are redundant with other stateful APIs and rarely used.
Data movement test suite does not have coverage for reading from multiple sharded DRAM banks.

### What's changed
`noc_async_read_tile_dram_sharded_set_state()` and `noc_async_read_tile_dram_sharded_with_state()` have been deprecated and replaced by the `noc_async_read_one_packet_*_state` APIs already in place. 
Tests have been added for functional and performance analysis of reading from sharded DRAM banks:
- Directed Ideal
- Sweep over number of DRAM banks utilized
- Sweep over number of tiles in each DRAM bank

Further testing is still required for `noc_async_read_tile_dram_sharded_with_state_with_trid()`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes