### PR TITLE
Sequentially run t3k fast tests

### DIFF
--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run t3k fabric tests
         id: t3k-fabric-tests
         timeout-minutes: 10
-        if: ${{ inputs.run-fabric-tests }}
+        if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -90,7 +90,7 @@ jobs:
       - name: Run t3k ttnn multiprocess tests
         id: t3k-ttnn-multiprocess-tests
         timeout-minutes: 10
-        if: ${{ inputs.run-multiprocess-tests }}
+        if: ${{ inputs.run-multiprocess-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -104,7 +104,7 @@ jobs:
       - name: Run t3k ttnn ccl tests
         id: t3k-ttnn-ccl-tests
         timeout-minutes: 10
-        if: ${{ inputs.run-ccl-tests }}
+        if: ${{ inputs.run-ccl-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -37,11 +37,8 @@ on:
         description: "Run t3k ttnn ccl tests"
 
 jobs:
-  t3000-unit-tests:
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-    name: ${{ matrix.test-group.name }}
+  t3000-fast-tests:
+    name: T3000 fast tests
     runs-on:
       - tt-ubuntu-2204-N300-llmbox-stable
     container:
@@ -50,7 +47,7 @@ jobs:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
@@ -70,7 +67,7 @@ jobs:
           enable-watcher: ${{ inputs.enable-watcher || false }}
       - name: Run t3k fabric tests
         id: t3k-fabric-tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
@@ -83,7 +80,7 @@ jobs:
           owner: UJ45FEC7M #Allan Liu
       - name: Run t3k ttnn multiprocess tests
         id: t3k-ttnn-multiprocess-tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         if: ${{ inputs.run-multiprocess-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -22,18 +22,18 @@ on:
         default: 20
       run-fabric-tests:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
         description: "Run t3k fabric tests"
       run-multiprocess-tests:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
         description: "Run t3k ttnn multiprocess tests"
       run-ccl-tests:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
         description: "Run t3k ttnn ccl tests"
 
 jobs:

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -41,12 +41,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        test-group: [
-          { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 15, owner_id: UJ45FEC7M}, # Allan Liu
-          { name: "t3k ttnn multiprocess tests", arch: wormhole_b0, cmd: run_t3000_ttnn_multiprocess_tests, timeout: 6, owner_id: UBHPP2NDP}, # Joseph Chu
-          { name: "t3k ttnn ccl tests", arch: wormhole_b0, cmd: run_t3000_ccl_tests, timeout: 9, owner_id: U06LRK6JDGB}, #Saad Jameel
-        ]
     name: ${{ matrix.test-group.name }}
     runs-on:
       - tt-ubuntu-2204-N300-llmbox-stable

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -20,9 +20,25 @@ on:
         required: false
         type: number
         default: 20
+      run-fabric-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run t3k fabric tests"
+      run-multiprocess-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run t3k ttnn multiprocess tests"
+      run-ccl-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run t3k ttnn ccl tests"
 
 jobs:
   t3000-unit-tests:
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -58,17 +74,46 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
-      - name: Run unit regression tests
-        timeout-minutes: ${{ matrix.test-group.timeout }}
+      - name: Run t3k fabric tests
+        id: t3k-fabric-tests
+        timeout-minutes: 10
+        if: ${{ inputs.run-fabric-tests }}
         run: |
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
-          ${{ matrix.test-group.cmd }}
+          run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
+          owner: UJ45FEC7M #Allan Liu
+      - name: Run t3k ttnn multiprocess tests
+        id: t3k-ttnn-multiprocess-tests
+        timeout-minutes: 10
+        if: ${{ inputs.run-multiprocess-tests }}
+        run: |
+          mkdir -p generated/test_reports
+          source tests/scripts/t3000/run_t3000_unit_tests.sh
+          run_t3000_ttnn_multiprocess_tests
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() && steps.t3k-ttnn-multiprocess-tests.outcome == 'failure' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: UBHPP2NDP #Joseph Chu
+
+      - name: Run t3k ttnn ccl tests
+        id: t3k-ttnn-ccl-tests
+        timeout-minutes: 10
+        if: ${{ inputs.run-ccl-tests }}
+        run: |
+          mkdir -p generated/test_reports
+          source tests/scripts/t3000/run_t3000_unit_tests.sh
+          run_t3000_ccl_tests
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() && steps.t3k-ttnn-ccl-tests.outcome == 'failure' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: U06LRK6JDGB #Saad Jameel
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 17
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-fast-tests.yaml
+++ b/.github/workflows/t3000-fast-tests.yaml
@@ -2,6 +2,22 @@ name: "(T3K) T3000 fast tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      run-fabric-tests:
+        description: 'Run t3k fabric tests'
+        required: false
+        default: true
+        type: boolean
+      run-multiprocess-tests:
+        description: 'Run t3k ttnn multiprocess tests'
+        required: false
+        default: true
+        type: boolean
+      run-ccl-tests:
+        description: 'Run t3k ttnn ccl tests'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   build-artifact:
@@ -20,3 +36,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      run-fabric-tests: ${{ inputs.run-fabric-tests }}
+      run-multiprocess-tests: ${{ inputs.run-multiprocess-tests }}
+      run-ccl-tests: ${{ inputs.run-ccl-tests }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
T3k fast tests pipelines run too slow. We spend ~10 mins on machine setup.


### What's changed
Sequentially run tests instead of in parallel.
Add option to run select tests to preserve some level of parallelness



### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/18575884979
https://github.com/tenstorrent/tt-metal/actions/runs/18575853941
https://github.com/tenstorrent/tt-metal/actions/runs/18575856786

Merge when above tests pass