### PR TITLE
generalize EdmChannelWorkerInterface to support different channel types

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_mux_ubench_drainer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_mux_ubench_drainer.cpp
@@ -26,7 +26,8 @@ constexpr size_t my_eth_channel_id = get_compile_time_arg_val(8);
 namespace tt::tt_fabric {
 using DrainerChannelBuffer = EthChannelBuffer<PACKET_HEADER_TYPE, NUM_BUFFERS>;
 using DrainerChannelClientLocationInfo = EDMChannelWorkerLocationInfo;
-using DrainerChannelWorkerInterface = EdmChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, NUM_BUFFERS>;
+using DrainerChannelWorkerInterface =
+    StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, NUM_BUFFERS>;
 using DrainerStatus = EDMStatus;
 }  // namespace tt::tt_fabric
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -208,6 +208,11 @@ struct OutboundReceiverChannelPointers {
     }
 
     FORCE_INLINE bool has_space_for_packet() const { return num_free_slots; }
+
+    FORCE_INLINE void advance_remote_receiver_buffer_index() {
+        remote_receiver_buffer_index =
+            BufferIndex{wrap_increment<RECEIVER_NUM_BUFFERS>(remote_receiver_buffer_index.get())};
+    }
 };
 
 /*

--- a/tt_metal/fabric/hw/inc/tt_fabric_mux.hpp
+++ b/tt_metal/fabric/hw/inc/tt_fabric_mux.hpp
@@ -21,8 +21,8 @@ template <uint8_t FABRIC_MUX_CHANNEL_NUM_BUFFERS>
 using FabricMuxChannelBuffer = EthChannelBuffer<PACKET_HEADER_TYPE, FABRIC_MUX_CHANNEL_NUM_BUFFERS>;
 
 template <uint8_t FABRIC_MUX_CHANNEL_NUM_BUFFERS>
-using FabricMuxChannelWorkerInterface =
-    EdmChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, FABRIC_MUX_CHANNEL_NUM_BUFFERS>;
+using FabricMuxStaticSizedChannelWorkerInterface =
+    StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, FABRIC_MUX_CHANNEL_NUM_BUFFERS>;
 
 using FabricMuxChannelClientLocationInfo = EDMChannelWorkerLocationInfo;
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -35,7 +35,7 @@ FORCE_INLINE bool connect_is_requested(uint32_t cached) {
 
 template <uint8_t MY_ETH_CHANNEL, uint8_t SENDER_NUM_BUFFERS>
 FORCE_INLINE void establish_worker_connection(
-    tt::tt_fabric::EdmChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS>&
+    tt::tt_fabric::StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS>&
         local_sender_channel_worker_interface) {
     local_sender_channel_worker_interface.template cache_producer_noc_addr<MY_ETH_CHANNEL>();
     local_sender_channel_worker_interface.notify_worker_of_read_counter_update();
@@ -43,7 +43,7 @@ FORCE_INLINE void establish_worker_connection(
 
 template <uint8_t MY_ETH_CHANNEL, uint8_t SENDER_NUM_BUFFERS>
 FORCE_INLINE void check_worker_connections(
-    tt::tt_fabric::EdmChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS>&
+    tt::tt_fabric::StaticSizedSenderChannelWorkerInterface<tt::tt_fabric::worker_handshake_noc, SENDER_NUM_BUFFERS>&
         local_sender_channel_worker_interface,
     bool& channel_connection_established,
     uint32_t stream_id) {

--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -49,7 +49,7 @@ using FabricMuxToEdmSender = WorkerToFabricEdmSenderImpl<false, NUM_EDM_BUFFERS>
 
 template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
-    tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {
+    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {
     while (!connect_is_requested(*worker_interface.connection_live_semaphore)) {
         invalidate_l1_cache();
     }
@@ -60,7 +60,7 @@ void wait_for_static_connection_to_ready(
 template <uint8_t NUM_BUFFERS>
 void setup_channel(
     tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS>* channel_ptr,
-    tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS>* worker_interface_ptr,
+    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>* worker_interface_ptr,
     bool& channel_connection_established,
     uint8_t channel_id,
     size_t buffer_size_bytes,
@@ -78,7 +78,7 @@ void setup_channel(
         reinterpret_cast<volatile tt::tt_fabric::FabricMuxChannelClientLocationInfo*>(connection_info_address);
     connection_info_address += sizeof(tt::tt_fabric::FabricMuxChannelClientLocationInfo);
 
-    new (worker_interface_ptr) tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS>(
+    new (worker_interface_ptr) tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>(
         connection_worker_info_ptr,
         reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(sender_flow_control_address),
         reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_handshake_address),
@@ -93,7 +93,7 @@ void setup_channel(
 template <uint8_t NUM_BUFFERS>
 void forward_data(
     tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS>& channel,
-    tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
+    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     tt::tt_fabric::FabricMuxToEdmSender& fabric_connection,
     bool& channel_connection_established,
     StreamId my_channel_free_slots_stream_id,
@@ -151,15 +151,18 @@ void kernel_main() {
 
     std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_FULL_SIZE_CHANNEL>, NUM_FULL_SIZE_CHANNELS>
         full_size_channels;
-    std::array<tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS_FULL_SIZE_CHANNEL>, NUM_FULL_SIZE_CHANNELS>
+    std::array<
+        tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_FULL_SIZE_CHANNEL>,
+        NUM_FULL_SIZE_CHANNELS>
         full_size_channel_worker_interfaces;
     std::array<bool, NUM_FULL_SIZE_CHANNELS> full_size_channel_connection_established;
 
     std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_HEADER_ONLY_CHANNEL>, NUM_HEADER_ONLY_CHANNELS>
         header_only_channels;
-    std::
-        array<tt::tt_fabric::FabricMuxChannelWorkerInterface<NUM_BUFFERS_HEADER_ONLY_CHANNEL>, NUM_HEADER_ONLY_CHANNELS>
-            header_only_channel_worker_interfaces;
+    std::array<
+        tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_HEADER_ONLY_CHANNEL>,
+        NUM_HEADER_ONLY_CHANNELS>
+        header_only_channel_worker_interfaces;
     std::array<bool, NUM_HEADER_ONLY_CHANNELS> header_only_channel_connection_established;
 
     // Stream IDs


### PR DESCRIPTION
abstract out SenderEthChannel to stop passing SENDER/RECEIVER_NUM_BUFFERS around

incremental refactor towards elastic channel enablement

### Ticket
#26311 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/18582104948 (rerun of profiler jobs after rebase https://github.com/tenstorrent/tt-metal/actions/runs/18594891447, those failures looked completely unrelated to the changes here)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18582104948
- [x] BH Multicard Tests: https://github.com/tenstorrent/tt-metal/actions/runs/18582112968 -- failures look the same as other runs (e.g. https://github.com/tenstorrent/tt-metal/actions/runs/18390429001/job/52400333144 and https://github.com/tenstorrent/tt-metal/actions/runs/18577324648/job/52967164108 -- hard to tell due to infrequent runs on main)