### PR TITLE
Hot fix for ttnn w/ new ENV

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -200,6 +200,7 @@ target_sources(
             soc_descriptors/wormhole_b0_80_arch.yaml
             tools/profiler/kernel_profiler.hpp
             tools/profiler/fabric_event_profiler.hpp
+            tools/profiler/noc_event_profiler.hpp
             # Kernel sources
             impl/dispatch/kernels/cq_dispatch.cpp
             impl/dispatch/kernels/cq_dispatch_subordinate.cpp

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -410,6 +410,24 @@ def get_arch_name():
 
 from ttnn._ttnn.operations.data_movement import TileReshapeMapMode
 
+import pathlib
+import importlib.util
+
+
+def _is_editable():
+    spec = importlib.util.find_spec(__package__)
+    if not spec or not spec.origin:
+        return False
+    path = pathlib.Path(spec.origin).resolve()
+    return "site-packages" not in str(path) and "dist-packages" not in str(path)
+
+
 if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-    this_dir = os.path.dirname(__file__)
-    SetRootDir(os.path.join(os.path.abspath(this_dir), "tt-metalium"))
+    this_dir = Path(__file__).resolve().parent
+
+    if _is_editable():
+        # Go two levels up from the package's __init__.py location
+        root_dir = this_dir.parent.parent
+    else:
+        # For installed packages, reference bundled data directory
+        root_dir = this_dir / "tt-metalium"

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -432,4 +432,4 @@ if "TT_METAL_RUNTIME_ROOT" not in os.environ:
         # For installed packages, reference bundled data directory
         root_dir = this_dir / "tt-metalium"
 
-    SetRootDir(root_dir)
+    SetRootDir(str(root_dir))

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -423,7 +423,7 @@ def _is_editable():
 
 
 if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-    this_dir = Path(__file__).resolve().parent
+    this_dir = pathlib.Path(__file__).resolve().parent
 
     if _is_editable():
         # Go two levels up from the package's __init__.py location
@@ -431,3 +431,5 @@ if "TT_METAL_RUNTIME_ROOT" not in os.environ:
     else:
         # For installed packages, reference bundled data directory
         root_dir = this_dir / "tt-metalium"
+
+    ttnn._ttnn.SetRootDir(root_dir)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -432,4 +432,4 @@ if "TT_METAL_RUNTIME_ROOT" not in os.environ:
         # For installed packages, reference bundled data directory
         root_dir = this_dir / "tt-metalium"
 
-    ttnn._ttnn.SetRootDir(root_dir)
+    SetRootDir(root_dir)


### PR DESCRIPTION
### Ticket
NA

### Problem description
Fix for:
```
>       request.node.pci_ids = [ttnn.GetPCIeDeviceID(device_id)]
E       RuntimeError: Error: device descriptor file /home/ubuntu/tt-metal/ttnn/ttnn/tt-metalium/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml does not exist!
```

reported by @Aswinmcw 

AND

```
/opt/venv/lib/python3.10/site-packages/ttnn/tt-metalium/tt_metal/tools/profiler/kernel_profiler.hpp:570:10: fatal error: noc_event_profiler.hpp: No such file or directory
  570 | #include "noc_event_profiler.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

### What's changed
Detect if we are running in editable install mode.
If we are, set the correct RootDir.

Also, package a file needed at runtime.

### Checklist
- [ ] [All post commit with 2nd hot fix](https://github.com/tenstorrent/tt-metal/actions/runs/18584818392)
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18583734691) CI passes
- [x] New/Existing tests provide coverage for changes