### PR TITLE
Hotfix: Wrong arguments to create_yolov4_model_parameters()

### DIFF
--- a/models/demos/yolov4/runner/performant_runner_infra.py
+++ b/models/demos/yolov4/runner/performant_runner_infra.py
@@ -62,6 +62,9 @@ class YOLOv4PerformanceRunnerInfra:
             self.input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, mesh_mapper=self.inputs_mesh_mapper)
             self.torch_input_tensor = torch_input_tensor.permute(0, 3, 1, 2)
 
+        torch_input_tensor_params = torch.randn(torch_input_shape, dtype=torch.float32)
+        self.torch_input_tensor_params = torch_input_tensor_params.permute(0, 3, 1, 2)
+
         parameters = create_yolov4_model_parameters(
             self.torch_model, self.torch_input_tensor_params, resolution, device
         )


### PR DESCRIPTION
### Problem description

(https://github.com/tenstorrent/tt-metal/actions/runs/18570540877/job/52944286573)
`Error: test_yolov4_dp[wormhole_b0-resolution0-1-act_dtype0-weight_dtype0-models/demos/yolov4/resources-device_params0]

AttributeError: 'YOLOv4PerformanceRunnerInfra' object has no attribute 'torch_input_tensor_params'. Did you mean: 'torch_input_tensor'?`


### What's changed
torch_input_tensor_params initialization must have been dropped during the merge - brought it back.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18589147718) CI with demo tests passes (if applicable) All relevant checks passed, but [Galaxy Llama3 demo tests](https://github.com/tenstorrent/tt-metal/pull/30735#logs) stalls waiting for the runner
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18589080895) CI passes

NOTE: Removed [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18589314372) and [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18589337505) since they aren't affected by this change, and they keep failing for unrelated reasons.
