### PR TITLE
Reduce filling scalar cb in pool op

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -251,7 +251,7 @@ ALWI void fill_scalar(
     // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
     if (counter < scalar_end && (counter == scalar_start || counter == scalar_start + 1 ||
                                  (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
-        fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, scalar_value, false);
+        fill_with_val(get_write_ptr(in_scalar_cb_id), FACE_WIDTH, scalar_value, false);
     }
     cb_push_back(in_scalar_cb_id, 1);
     counter++;
@@ -356,7 +356,7 @@ void kernel_main() {
 
     // initialize the scalar CB
     if constexpr (reader_id == 0 && one_scalar_per_core) {
-        fill_with_val(get_write_ptr(in_scalar_cb_id_0), TILE_WIDTH, bf16_scalar >> 16);
+        fill_with_val(get_write_ptr(in_scalar_cb_id_0), FACE_WIDTH, bf16_scalar >> 16);
         cb_push_back(in_scalar_cb_id_0, 1);
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -251,6 +251,9 @@ ALWI void fill_scalar(
     // second half of the condition counter == scalar_start + 1 || counter == scalar_start + 3.
     if (counter < scalar_end && (counter == scalar_start || counter == scalar_start + 1 ||
                                  (split_reader && (counter == scalar_start + 2 || counter == scalar_start + 3)))) {
+        // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
+        // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
+        // between the first and second face.
         fill_with_val(get_write_ptr(in_scalar_cb_id), FACE_WIDTH, scalar_value, false);
     }
     cb_push_back(in_scalar_cb_id, 1);
@@ -356,6 +359,9 @@ void kernel_main() {
 
     // initialize the scalar CB
     if constexpr (reader_id == 0 && one_scalar_per_core) {
+        // Fill only the first FACE_WIDTH, since we set reload_srcB = true in unpack_tilizeA_B_block, meaning the values
+        // for the remaining faces will be reused from the first one. This is safe here because there’s no difference
+        // between the first and second face.
         fill_with_val(get_write_ptr(in_scalar_cb_id_0), FACE_WIDTH, bf16_scalar >> 16);
         cb_push_back(in_scalar_cb_id_0, 1);
     }


### PR DESCRIPTION
### What's changed
`unpack_tilizeA_B_block` has a `reload_srcB` parameter, which is used if data from other faces are same as data from face0, so filling face0 is enough. That is case with pool op, so there is no need to fill full row of scalar, but just half (first face) is enough. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18589420295)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18589431326)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/18589447256) (not related failure)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18589505707) (pipeline not in the best state, checked affected models and all should be ok)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18589529063)