### PR TITLE
Fix integer division bug in nlp_create_qkv_heads and decode variant f…

### DIFF
--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TT_EAGER_TESTS_OPS
     ops/test_bmm_op.cpp
     # ops/test_pad_op.cpp                     # <- not called in run_tt_eager.py
     ops/test_sfpu.cpp
+    ops/test_nlp_create_qkv_heads.cpp
 )
 
 set(TT_EAGER_TESTS_TENSORS

--- a/tests/tt_eager/ops/test_nlp_create_qkv_heads.cpp
+++ b/tests/tt_eager/ops/test_nlp_create_qkv_heads.cpp
@@ -1,0 +1,443 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/host_api.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/shape.hpp>
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace constants;
+
+/**
+ * Comprehensive test suite for nlp_create_qkv_heads operation
+ *
+ * This test was created to verify the fix for a bug where integer division
+ * caused incorrect output shapes when head_dim < TILE_WIDTH (32).
+ *
+ * BUG: q_num_tiles = num_heads * (head_dim / TILE_WIDTH) returns 0 when head_dim < 32
+ * FIX: q_num_tiles = (num_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH
+ */
+
+bool test_nlp_create_qkv_heads(
+    distributed::MeshDevice* device,
+    uint32_t batch_size,
+    uint32_t seq_len,
+    uint32_t head_dim,
+    uint32_t num_q_heads,
+    uint32_t num_kv_heads,
+    bool transpose_k_heads,
+    std::optional<ttnn::MemoryConfig> memory_config,
+    const std::string& test_name) {
+
+    log_info(LogTest, "Running test: {}", test_name);
+    log_info(LogTest, "  batch={}, seq_len={}, head_dim={}, num_q_heads={}, num_kv_heads={}, transpose_k={}",
+             batch_size, seq_len, head_dim, num_q_heads, num_kv_heads, transpose_k_heads);
+
+    uint32_t q_embedding_dim = num_q_heads * head_dim;
+    uint32_t kv_embedding_dim = num_kv_heads * head_dim;
+    uint32_t qkv_width = q_embedding_dim + 2 * kv_embedding_dim;  // Q + K + V concatenated
+
+    // Create fused QKV input tensor: [batch, 1, seq_len, qkv_width]
+    ttnn::Shape input_shape({batch_size, 1, seq_len, qkv_width});
+    Tensor input_tensor = ttnn::random::random(input_shape)
+        .to_layout(Layout::TILE)
+        .to_device(device);
+
+    // Call nlp_create_qkv_heads
+    auto [q, k, v] = ttnn::experimental::nlp_create_qkv_heads(
+        input_tensor,
+        /*input_tensor_kv=*/std::nullopt,
+        /*num_heads=*/num_q_heads,
+        /*num_kv_heads=*/num_kv_heads,
+        /*transpose_k_heads=*/transpose_k_heads,
+        /*memory_config=*/memory_config);
+
+    // Check output shapes
+    auto q_shape = q.padded_shape();
+    auto k_shape = k.padded_shape();
+    auto v_shape = v.padded_shape();
+
+    // Expected shapes
+    // Q: [batch, num_q_heads, seq_len, head_dim]
+    // K: [batch, num_kv_heads, seq_len, head_dim] or [batch, num_kv_heads, head_dim, seq_len] if transposed
+    // V: [batch, num_kv_heads, seq_len, head_dim]
+
+    log_info(LogTest, "  Q expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+             batch_size, num_q_heads, seq_len, head_dim,
+             q_shape[0], q_shape[1], q_shape[2], q_shape[3]);
+
+    if (transpose_k_heads) {
+        log_info(LogTest, "  K expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}] (transposed)",
+                 batch_size, num_kv_heads, head_dim, seq_len,
+                 k_shape[0], k_shape[1], k_shape[2], k_shape[3]);
+    } else {
+        log_info(LogTest, "  K expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+                 batch_size, num_kv_heads, seq_len, head_dim,
+                 k_shape[0], k_shape[1], k_shape[2], k_shape[3]);
+    }
+
+    log_info(LogTest, "  V expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+             batch_size, num_kv_heads, seq_len, head_dim,
+             v_shape[0], v_shape[1], v_shape[2], v_shape[3]);
+
+    // Verify Q shape
+    bool q_shape_correct = (q_shape[0] == batch_size &&
+                            q_shape[1] == num_q_heads &&
+                            q_shape[2] == seq_len &&
+                            q_shape[3] == head_dim);
+
+    // Verify K shape (depends on transpose_k_heads)
+    bool k_shape_correct;
+    if (transpose_k_heads) {
+        k_shape_correct = (k_shape[0] == batch_size &&
+                          k_shape[1] == num_kv_heads &&
+                          k_shape[2] == head_dim &&
+                          k_shape[3] == seq_len);
+    } else {
+        k_shape_correct = (k_shape[0] == batch_size &&
+                          k_shape[1] == num_kv_heads &&
+                          k_shape[2] == seq_len &&
+                          k_shape[3] == head_dim);
+    }
+
+    // Verify V shape
+    bool v_shape_correct = (v_shape[0] == batch_size &&
+                            v_shape[1] == num_kv_heads &&
+                            v_shape[2] == seq_len &&
+                            v_shape[3] == head_dim);
+
+    if (!q_shape_correct || !k_shape_correct || !v_shape_correct) {
+        if (!q_shape_correct) {
+            log_error(LogTest, "  Q shape mismatch");
+        }
+        if (!k_shape_correct) {
+            log_error(LogTest, "  K shape mismatch");
+        }
+        if (!v_shape_correct) {
+            log_error(LogTest, "  V shape mismatch");
+        }
+        return false;
+    }
+
+    log_info(LogTest, "  Test passed");
+    return true;
+}
+
+bool test_nlp_create_qkv_heads_with_separate_kv(
+    distributed::MeshDevice* device,
+    uint32_t batch_size,
+    uint32_t seq_len,
+    uint32_t head_dim,
+    uint32_t num_q_heads,
+    uint32_t num_kv_heads,
+    const std::string& test_name) {
+
+    log_info(LogTest, "Running test: {}", test_name);
+    log_info(LogTest, "  batch={}, seq_len={}, head_dim={}, num_q_heads={}, num_kv_heads={} (separate KV tensor)",
+             batch_size, seq_len, head_dim, num_q_heads, num_kv_heads);
+
+    uint32_t q_width = num_q_heads * head_dim;
+    uint32_t kv_width = 2 * num_kv_heads * head_dim;  // K + V concatenated
+
+    // Create separate Q and KV tensors
+    ttnn::Shape q_input_shape({batch_size, 1, seq_len, q_width});
+    ttnn::Shape kv_input_shape({batch_size, 1, seq_len, kv_width});
+
+    Tensor q_tensor = ttnn::random::random(q_input_shape)
+        .to_layout(Layout::TILE)
+        .to_device(device);
+
+    Tensor kv_tensor = ttnn::random::random(kv_input_shape)
+        .to_layout(Layout::TILE)
+        .to_device(device);
+
+    // Call nlp_create_qkv_heads with separate KV tensor
+    auto [q, k, v] = ttnn::experimental::nlp_create_qkv_heads(
+        q_tensor,
+        /*input_tensor_kv=*/kv_tensor,
+        /*num_heads=*/num_q_heads,
+        /*num_kv_heads=*/num_kv_heads,
+        /*transpose_k_heads=*/false,
+        /*memory_config=*/std::nullopt);
+
+    // Check output shapes
+    auto q_out_shape = q.padded_shape();
+    auto k_out_shape = k.padded_shape();
+    auto v_out_shape = v.padded_shape();
+
+    log_info(LogTest, "  Q expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+             batch_size, num_q_heads, seq_len, head_dim,
+             q_out_shape[0], q_out_shape[1], q_out_shape[2], q_out_shape[3]);
+    log_info(LogTest, "  K expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+             batch_size, num_kv_heads, seq_len, head_dim,
+             k_out_shape[0], k_out_shape[1], k_out_shape[2], k_out_shape[3]);
+    log_info(LogTest, "  V expected: [{}, {}, {}, {}], got: [{}, {}, {}, {}]",
+             batch_size, num_kv_heads, seq_len, head_dim,
+             v_out_shape[0], v_out_shape[1], v_out_shape[2], v_out_shape[3]);
+
+    // Verify shapes
+    bool shapes_correct =
+        (q_out_shape[0] == batch_size && q_out_shape[1] == num_q_heads &&
+         q_out_shape[2] == seq_len && q_out_shape[3] == head_dim) &&
+        (k_out_shape[0] == batch_size && k_out_shape[1] == num_kv_heads &&
+         k_out_shape[2] == seq_len && k_out_shape[3] == head_dim) &&
+        (v_out_shape[0] == batch_size && v_out_shape[1] == num_kv_heads &&
+         v_out_shape[2] == seq_len && v_out_shape[3] == head_dim);
+
+    if (!shapes_correct) {
+        log_error(LogTest, "  Shape mismatch with separate KV tensor");
+        return false;
+    }
+
+    log_info(LogTest, "  Test passed");
+    return true;
+}
+
+int main(int argc, char** argv) {
+    bool pass = true;
+
+    try {
+        ////////////////////////////////////////////////////////////////////////////
+        //                      Device Setup
+        ////////////////////////////////////////////////////////////////////////////
+        int device_id = 0;
+        auto device_owner = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+        auto device = device_owner.get();
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                Bug Regression Tests (head_dim < TILE_WIDTH)
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Critical: head_dim=16 triggers the original bug
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 16, 4, 4, false, std::nullopt,
+            "bug_regression_head_dim_16");
+
+        // Critical: head_dim=8 (even smaller)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 8, 8, 8, false, std::nullopt,
+            "bug_regression_head_dim_8");
+
+        // Different configurations with head_dim < 32
+        pass &= test_nlp_create_qkv_heads(
+            device, 2, 64, 16, 2, 2, false, std::nullopt,
+            "bug_regression_batch2_head_dim_16");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                      K-Head Transpose Tests
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Test transpose_k_heads=true with small head_dim
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 16, 4, 4, true, std::nullopt,
+            "transpose_k_small_head_dim");
+
+        // Test transpose_k_heads=true with normal head_dim
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 64, 64, 8, 8, true, std::nullopt,
+            "transpose_k_normal_head_dim");
+
+        // Test transpose_k_heads=true with large head_dim
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 128, 16, 16, true, std::nullopt,
+            "transpose_k_large_head_dim");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //            GQA (Grouped Query Attention) Tests
+        ////////////////////////////////////////////////////////////////////////////
+
+        // GQA with small head_dim (32 Q heads, 4 KV heads - 8x groups)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 16, 32, 4, false, std::nullopt,
+            "gqa_head_dim_16_q32_kv4");
+
+        // GQA typical case (16 Q heads, 2 KV heads - 8x groups)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 64, 16, 2, false, std::nullopt,
+            "gqa_head_dim_64_q16_kv2");
+
+        // GQA with single KV head (71 Q heads, 1 KV head - Falcon-like)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 64, 71, 1, false, std::nullopt,
+            "gqa_falcon_q71_kv1");
+
+        // GQA with small head_dim and transpose
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 64, 16, 8, 2, true, std::nullopt,
+            "gqa_transpose_head_dim_16_q8_kv2");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                   Separate KV Tensor Tests
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Separate KV with small head_dim
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 32, 16, 8, 8,
+            "separate_kv_head_dim_16");
+
+        // Separate KV with normal head_dim
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 64, 64, 16, 16,
+            "separate_kv_head_dim_64");
+
+        // Separate KV with GQA
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 128, 64, 32, 4,
+            "separate_kv_gqa_q32_kv4");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                  Memory Configuration Tests
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Test with DRAM memory config
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 16, 4, 4, false, ttnn::DRAM_MEMORY_CONFIG,
+            "memory_dram_head_dim_16");
+
+        // Test with L1 memory config
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 64, 8, 8, false, ttnn::L1_MEMORY_CONFIG,
+            "memory_l1_head_dim_64");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //             Large head_dim Tests (Modern Transformers)
+        ////////////////////////////////////////////////////////////////////////////
+
+        // head_dim=128 (Llama-style)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 128, 32, 32, false, std::nullopt,
+            "large_head_dim_128");
+
+        // head_dim=128 with GQA (Llama 2/3 style: 32 Q, 4 KV)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 1024, 128, 32, 4, false, std::nullopt,
+            "large_head_dim_128_gqa_llama");
+
+        // head_dim=256 (very large)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 64, 256, 16, 16, false, std::nullopt,
+            "large_head_dim_256");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                 Edge Cases and Stress Tests
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Edge: head_dim=32 (exactly TILE_WIDTH)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 32, 4, 4, false, std::nullopt,
+            "edge_head_dim_32");
+
+        // Large batch size
+        pass &= test_nlp_create_qkv_heads(
+            device, 8, 128, 64, 16, 16, false, std::nullopt,
+            "large_batch_8");
+
+        // Long sequence
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 2048, 64, 16, 16, false, std::nullopt,
+            "long_seq_2048");
+
+        // Minimal configuration
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 32, 8, 1, 1, false, std::nullopt,
+            "minimal_config");
+
+        ////////////////////////////////////////////////////////////////////////////
+        //          REGRESSION TESTS - Existing "Working" head_dims
+        //   These MUST pass both BEFORE and AFTER the bug fix
+        ////////////////////////////////////////////////////////////////////////////
+
+        // head_dim=64 regression tests (most common, MUST NOT BREAK)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 256, 64, 16, 2, true, std::nullopt,
+            "regression_head64_gqa_transpose");
+
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 256, 64, 16, 2,
+            "regression_head64_gqa_separate_kv");
+
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 256, 64, 16, 16, true, ttnn::L1_MEMORY_CONFIG,
+            "regression_head64_transpose_l1");
+
+        // head_dim=96 regression tests (from existing tests, MUST NOT BREAK)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 96, 8, 2, true, std::nullopt,
+            "regression_head96_gqa_transpose");
+
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 128, 96, 8, 2,
+            "regression_head96_gqa_separate_kv");
+
+        // head_dim=128 regression tests (Llama, MUST NOT BREAK)
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 512, 128, 32, 4, true, std::nullopt,
+            "regression_head128_llama_transpose");
+
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 512, 128, 32, 4,
+            "regression_head128_llama_separate_kv");
+
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 512, 128, 32, 8, true, ttnn::DRAM_MEMORY_CONFIG,
+            "regression_head128_gqa_transpose_dram");
+
+        // Boundary case: head_dim=32 (CRITICAL - boundary between bug and no-bug)
+        // This should work BOTH before and after the fix
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 32, 8, 8, false, std::nullopt,
+            "regression_boundary_head32_basic");
+
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 32, 8, 8, true, std::nullopt,
+            "regression_boundary_head32_transpose");
+
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 1, 128, 32, 8, 2,
+            "regression_boundary_head32_gqa_separate_kv");
+
+        pass &= test_nlp_create_qkv_heads(
+            device, 1, 128, 32, 16, 2, true, ttnn::L1_MEMORY_CONFIG,
+            "regression_boundary_head32_all_features");
+
+        // Stress test: All features combined with safe head_dims
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 2, 256, 64, 16, 2,
+            "regression_stress_head64_batch2_gqa");
+
+        pass &= test_nlp_create_qkv_heads(
+            device, 4, 128, 96, 8, 2, true, ttnn::DRAM_MEMORY_CONFIG,
+            "regression_stress_head96_batch4_transpose");
+
+        pass &= test_nlp_create_qkv_heads_with_separate_kv(
+            device, 2, 512, 128, 32, 4,
+            "regression_stress_head128_llama_batch2");
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_error(LogTest, "{}", e.what());
+        log_error(LogTest, "System error message: {}", std::strerror(errno));
+    }
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    TT_FATAL(pass, "Error");
+
+    return 0;
+}

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for nlp_create_qkv_heads_decode bug when head_dim < TILE_WIDTH (32)
+
+BUG: Integer division bug in nlp_create_qkv_heads_decode_program_factory.cpp causes
+incorrect output shapes when head_dim < 32.
+
+Root cause: head_tiles = head_dim / TILE_WIDTH
+When head_dim=16: head_tiles = 0, head_size = 0 (causes memory calculation errors!)
+
+Expected: head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH
+
+This test demonstrates the bug with head_dim=16 and verifies the fix for the decode variant.
+"""
+
+import pytest
+from loguru import logger
+import torch
+import ttnn
+from models.common.utility_functions import tt2torch_tensor, comp_pcc
+
+
+def run_nlp_create_qkv_heads_decode_small_head_dim_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    dtype,
+    device,
+):
+    """
+    Test nlp_create_qkv_heads_decode with head_dim < 32 (TILE_WIDTH)
+
+    This reproduces a bug where integer division causes incorrect tile calculations
+    in the decode operation (used for inference with batch_size=1, seq_len=1).
+    """
+    torch.manual_seed(1234)
+
+    # Decode operation: batch=1, seq_len=1 (single token generation)
+    # Input shape: [batch, 1, 1, (num_q_heads + 2*num_kv_heads) * head_dim]
+    qkv_width = (num_q_heads + 2 * num_kv_heads) * head_dim
+
+    logger.info(f"Testing decode variant with head_dim={head_dim} < TILE_WIDTH(32)")
+    logger.info(
+        f"batch={batch}, seq_len={seq_len}, num_q_heads={num_q_heads}, num_kv_heads={num_kv_heads}, head_dim={head_dim}"
+    )
+
+    # Create fused QKV tensor for decode: [batch, 1, seq_len, qkv_width]
+    # For decode, seq_len is typically 1 (single token)
+    in0_shape = [batch, 1, seq_len, qkv_width]
+    A = torch.randn(in0_shape)
+
+    # Create sharded input tensor (decode typically uses sharding)
+    # For decode, we need to create output tensors with proper sharding
+    q_shape = ttnn.Shape([batch, num_q_heads, seq_len, head_dim])
+    kv_shape = ttnn.Shape([batch, num_kv_heads, seq_len, head_dim])
+
+    # Create shard specs for decode operation
+    # Use simple height sharding for batch dimension
+    compute_grid_size = device.compute_with_storage_grid_size()
+    num_cores = min(batch, compute_grid_size.x * compute_grid_size.y)
+
+    shard_shape = [batch // num_cores, num_q_heads * seq_len * head_dim]
+    q_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+
+    kv_shard_shape = [batch // num_cores, num_kv_heads * seq_len * head_dim]
+    kv_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))}),
+        kv_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+
+    q_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, q_shard_spec
+    )
+    kv_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, kv_shard_spec
+    )
+
+    # Create output tensors
+    q_output = ttnn.allocate_tensor_on_device(q_shape, dtype, ttnn.TILE_LAYOUT, device, q_mem_config)
+    k_output = ttnn.allocate_tensor_on_device(kv_shape, dtype, ttnn.TILE_LAYOUT, device, kv_mem_config)
+    v_output = ttnn.allocate_tensor_on_device(kv_shape, dtype, ttnn.TILE_LAYOUT, device, kv_mem_config)
+
+    # Create input tensor (interleaved for this test)
+    in0_t = ttnn.Tensor(A, dtype).to(ttnn.TILE_LAYOUT).to(device, ttnn.DRAM_MEMORY_CONFIG)
+
+    # Call nlp_create_qkv_heads_decode - this triggers the bug when head_dim < 32
+    # Use interleaved input variant for simplicity in testing
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+        in0_t,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        output_tensors=[q_output, k_output, v_output],
+    )
+
+    # CRITICAL: Check output shapes - this is where the bug manifests
+    expected_q_shape = [batch, num_q_heads, seq_len, head_dim]
+    expected_kv_shape = [batch, num_kv_heads, seq_len, head_dim]
+
+    logger.info(f"Expected Q shape: {expected_q_shape}")
+    logger.info(f"Q output shape: {list(q.padded_shape)}")
+    logger.info(f"Expected K shape: {expected_kv_shape}")
+    logger.info(f"K output shape: {list(k.padded_shape)}")
+    logger.info(f"Expected V shape: {expected_kv_shape}")
+    logger.info(f"V output shape: {list(v.padded_shape)}")
+
+    # Verify shapes are correct
+    assert list(q.padded_shape) == expected_q_shape, f"Q shape mismatch! Expected {expected_q_shape}, got {list(q.padded_shape)}"
+    assert list(k.padded_shape) == expected_kv_shape, f"K shape mismatch! Expected {expected_kv_shape}, got {list(k.padded_shape)}"
+    assert list(v.padded_shape) == expected_kv_shape, f"V shape mismatch! Expected {expected_kv_shape}, got {list(v.padded_shape)}"
+
+    # Verify numerical correctness
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    # Split reference QKV
+    # For decode: Q has num_q_heads * head_dim, K and V each have num_kv_heads * head_dim
+    q_width = num_q_heads * head_dim
+    kv_width = num_kv_heads * head_dim
+    (ref_q, ref_k, ref_v) = torch.split(A, [q_width, kv_width, kv_width], dim=-1)
+
+    # Reshape to match expected output: [batch, num_heads, seq_len, head_dim]
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc = 0.99
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
+    logger.info(f"Q PCC: {output_pcc_q} (passing={passing_pcc_q})")
+    assert passing_pcc_q, f"Q tensor PCC check failed: {output_pcc_q}"
+
+    passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
+    logger.info(f"K PCC: {output_pcc_k} (passing={passing_pcc_k})")
+    assert passing_pcc_k, f"K tensor PCC check failed: {output_pcc_k}"
+
+    passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
+    logger.info(f"V PCC: {output_pcc_v} (passing={passing_pcc_v})")
+    assert passing_pcc_v, f"V tensor PCC check failed: {output_pcc_v}"
+
+    logger.info("Decode test passed - bug is fixed")
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16, ttnn.bfloat8_b),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize(
+    "batch, seq_len, head_dim, num_q_heads, num_kv_heads",
+    (
+        # Critical test cases: head_dim < 32 (TILE_WIDTH)
+        # Decode typically uses batch=32 (parallel decode), seq_len=1
+        (32, 1, 16, 8, 1),  # head_dim=16: Triggers bug, GQA (8:1 ratio)
+        (32, 1, 16, 4, 4),  # head_dim=16: Triggers bug, MHA
+        (32, 1, 8, 8, 2),  # head_dim=8: Even smaller, GQA
+        (32, 1, 8, 8, 8),  # head_dim=8: Even smaller, MHA
+        # Edge case: head_dim=32 (boundary - should work regardless)
+        (32, 1, 32, 8, 1),  # head_dim=32: Control case, GQA
+        (32, 1, 32, 4, 4),  # head_dim=32: Control case, MHA
+    ),
+    ids=[
+        "batch32_seq1_head16_q8_kv1_gqa",
+        "batch32_seq1_head16_q4_kv4_mha",
+        "batch32_seq1_head8_q8_kv2_gqa",
+        "batch32_seq1_head8_q8_kv8_mha",
+        "batch32_seq1_head32_q8_kv1_gqa_control",
+        "batch32_seq1_head32_q4_kv4_mha_control",
+    ],
+)
+def test_nlp_create_qkv_heads_decode_small_head_dim(
+    batch,
+    seq_len,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    dtype,
+    device,
+):
+    """
+    Test nlp_create_qkv_heads_decode with head_dim < TILE_WIDTH (32)
+
+    This test specifically targets the bug where integer division
+    head_tiles = head_dim / TILE_WIDTH returns 0 when head_dim < 32,
+    causing head_size = 0 and incorrect memory calculations.
+    """
+    run_nlp_create_qkv_heads_decode_small_head_dim_test(
+        batch,
+        seq_len,
+        head_dim,
+        num_q_heads,
+        num_kv_heads,
+        dtype,
+        device,
+    )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for nlp_create_qkv_heads bug when head_dim < TILE_WIDTH (32)
+
+BUG: Integer division bug in nlp_create_qkv_heads_program_factory.cpp causes
+incorrect output shapes when head_dim < 32.
+
+Root cause: q_num_tiles = num_heads * (head_dim / TILE_WIDTH)
+When head_dim=16: q_num_tiles = num_heads * 0 = 0 (reads zero tiles!)
+
+Expected: q_num_tiles = (num_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH
+
+This test demonstrates the bug with head_dim=16 and verifies the fix.
+"""
+
+import pytest
+from loguru import logger
+import torch
+import ttnn
+from models.common.utility_functions import tt2torch_tensor, comp_pcc
+
+
+def run_nlp_create_qkv_heads_small_head_dim_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_heads,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Test nlp_create_qkv_heads with head_dim < 32 (TILE_WIDTH)
+
+    This reproduces a bug where integer division causes incorrect tile calculations.
+    """
+    torch.manual_seed(1234)
+
+    embedding_dim = num_heads * head_dim
+    qkv_width = embedding_dim * 3  # Q + K + V concatenated
+
+    logger.info(f"Testing head_dim={head_dim} < TILE_WIDTH(32) bug fix")
+    logger.info(f"batch={batch}, seq_len={seq_len}, num_heads={num_heads}, embedding_dim={embedding_dim}")
+
+    # Create fused QKV tensor: [batch, 1, seq_len, embedding_dim * 3]
+    in0_shape = [batch, 1, seq_len, qkv_width]
+    A = torch.randn(in0_shape)
+    in0_t = ttnn.Tensor(A, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
+
+    # Call nlp_create_qkv_heads - this triggers the bug when head_dim < 32
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+        in0_t,
+        None,  # No separate KV tensor
+        num_heads=num_heads,
+        num_kv_heads=num_heads,
+        transpose_k_heads=False,
+        memory_config=out_mem_config,
+    )
+
+    # Check memory configurations
+    assert in0_t.memory_config().buffer_type == in_mem_config.buffer_type
+    assert q.memory_config().buffer_type == out_mem_config.buffer_type
+    assert k.memory_config().buffer_type == out_mem_config.buffer_type
+    assert v.memory_config().buffer_type == out_mem_config.buffer_type
+
+    # CRITICAL: Check output shapes - this is where the bug manifests
+    # Expected: [batch, num_heads, seq_len, head_dim]
+    expected_shape = [batch, num_heads, seq_len, head_dim]
+
+    logger.info(f"Expected shape: {expected_shape}")
+    logger.info(f"Q output shape: {list(q.padded_shape)}")
+    logger.info(f"K output shape: {list(k.padded_shape)}")
+    logger.info(f"V output shape: {list(v.padded_shape)}")
+
+    # Verify shapes are correct
+    assert list(q.padded_shape) == expected_shape, \
+        f"Q shape mismatch! Expected {expected_shape}, got {list(q.padded_shape)}"
+    assert list(k.padded_shape) == expected_shape, \
+        f"K shape mismatch! Expected {expected_shape}, got {list(k.padded_shape)}"
+    assert list(v.padded_shape) == expected_shape, \
+        f"V shape mismatch! Expected {expected_shape}, got {list(v.padded_shape)}"
+
+    # Verify numerical correctness
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    # Split reference QKV
+    (ref_q, ref_k, ref_v) = torch.split(
+        A, [embedding_dim, embedding_dim, embedding_dim], dim=-1
+    )
+
+    # Reshape to match expected output: [batch, num_heads, seq_len, head_dim]
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc = 0.99
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
+    logger.info(f"Q PCC: {output_pcc_q} (passing={passing_pcc_q})")
+    assert passing_pcc_q, f"Q tensor PCC check failed: {output_pcc_q}"
+
+    passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
+    logger.info(f"K PCC: {output_pcc_k} (passing={passing_pcc_k})")
+    assert passing_pcc_k, f"K tensor PCC check failed: {output_pcc_k}"
+
+    passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
+    logger.info(f"V PCC: {output_pcc_v} (passing={passing_pcc_v})")
+    assert passing_pcc_v, f"V tensor PCC check failed: {output_pcc_v}"
+
+    logger.info("Test passed - bug is fixed")
+
+
+def run_nlp_create_qkv_heads_with_sdpa_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_heads,
+    device,
+):
+    """
+    Integration test: nlp_create_qkv_heads → SDPA (Scaled Dot-Product Attention)
+
+    This verifies that outputs from nlp_create_qkv_heads with head_dim < 32
+    work correctly with downstream operations like SDPA. Tests for potential
+    memory layout or tiling issues that could cause crashes.
+    """
+    torch.manual_seed(1234)
+
+    embedding_dim = num_heads * head_dim
+    qkv_width = embedding_dim * 3  # Q + K + V concatenated
+
+    logger.info(f"Integration test: head_dim={head_dim} with SDPA")
+    logger.info(f"batch={batch}, seq_len={seq_len}, num_heads={num_heads}")
+
+    # Create fused QKV tensor: [batch, 1, seq_len, embedding_dim * 3]
+    in0_shape = [batch, 1, seq_len, qkv_width]
+    A = torch.randn(in0_shape)
+    in0_t = ttnn.Tensor(A, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device, ttnn.DRAM_MEMORY_CONFIG)
+
+    # Call nlp_create_qkv_heads
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+        in0_t,
+        None,
+        num_heads=num_heads,
+        num_kv_heads=num_heads,
+        transpose_k_heads=False,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # CRITICAL: Run SDPA on the outputs
+    # This will crash if memory layout/tiling is incorrect
+    scale = 1.0 / (head_dim ** 0.5)
+
+    try:
+        attn_output = ttnn.transformer.scaled_dot_product_attention(
+            q, k, v,
+            is_causal=True,
+            scale=scale,
+        )
+    except Exception as e:
+        logger.error(f"SDPA failed with head_dim={head_dim}: {e}")
+        raise AssertionError(f"SDPA operation failed - likely memory layout issue: {e}")
+
+    # Verify output shape
+    # Expected: [batch, num_heads, seq_len, head_dim]
+    expected_shape = [batch, num_heads, seq_len, head_dim]
+    assert list(attn_output.padded_shape) == expected_shape, \
+        f"SDPA output shape mismatch! Expected {expected_shape}, got {list(attn_output.padded_shape)}"
+
+    # Verify numerical correctness against PyTorch reference
+    attn_output_torch = tt2torch_tensor(attn_output)
+
+    # Compute reference using PyTorch
+    (ref_q, ref_k, ref_v) = torch.split(
+        A, [embedding_dim, embedding_dim, embedding_dim], dim=-1
+    )
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_heads, head_dim]).transpose(-3, -2)
+
+    # PyTorch SDPA (use manual computation for compatibility)
+    attn_weights = torch.matmul(ref_q, ref_k.transpose(-2, -1)) * scale
+
+    # Apply causal mask
+    causal_mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
+    attn_weights = attn_weights.masked_fill(causal_mask, float('-inf'))
+
+    attn_weights = torch.softmax(attn_weights, dim=-1)
+    ref_attn_output = torch.matmul(attn_weights, ref_v)
+
+    # Compare with reference
+    passing_pcc, output_pcc = comp_pcc(attn_output_torch, ref_attn_output, 0.99)
+    logger.info(f"SDPA output PCC: {output_pcc} (passing={passing_pcc})")
+    assert passing_pcc, f"SDPA output PCC check failed: {output_pcc}"
+
+    logger.info("Integration test passed - nlp_create_qkv_heads outputs work with SDPA")
+
+
+@pytest.mark.parametrize(
+    "batch, seq_len, head_dim, num_heads",
+    (
+        (1, 32, 8, 8),     # head_dim=8: Smallest case
+        (1, 32, 16, 4),    # head_dim=16: Main bug case
+        (1, 32, 32, 4),    # head_dim=32: Boundary case
+    ),
+    ids=[
+        "sdpa_head8",
+        "sdpa_head16",
+        "sdpa_head32_boundary",
+    ],
+)
+def test_nlp_create_qkv_heads_with_sdpa_integration(
+    batch,
+    seq_len,
+    head_dim,
+    num_heads,
+    device,
+):
+    """
+    Integration test: Verify nlp_create_qkv_heads outputs work with SDPA
+
+    Tests that outputs from nlp_create_qkv_heads (especially with head_dim < 32)
+    can be consumed by downstream operations like scaled_dot_product_attention
+    without crashes or errors. This catches potential memory layout issues.
+    """
+    run_nlp_create_qkv_heads_with_sdpa_test(
+        batch,
+        seq_len,
+        head_dim,
+        num_heads,
+        device,
+    )
+
+
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
+    ),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16, ttnn.bfloat8_b),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize(
+    "batch, seq_len, head_dim, num_heads",
+    (
+        # Critical test cases: head_dim < 32 (TILE_WIDTH)
+        (1, 32, 16, 4),    # head_dim=16: Triggers bug
+        (1, 64, 16, 4),    # head_dim=16: Different seq_len
+        (1, 32, 8, 8),     # head_dim=8: Even smaller
+        (2, 32, 16, 2),    # head_dim=16: Different batch/heads
+        # Edge case: head_dim=32 (should work regardless)
+        (1, 32, 32, 4),    # head_dim=32: Control case
+    ),
+    ids=[
+        "batch1_seq32_head16_nheads4",
+        "batch1_seq64_head16_nheads4",
+        "batch1_seq32_head8_nheads8",
+        "batch2_seq32_head16_nheads2",
+        "batch1_seq32_head32_nheads4_control",
+    ],
+)
+def test_nlp_create_qkv_heads_small_head_dim(
+    batch,
+    seq_len,
+    head_dim,
+    num_heads,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Test nlp_create_qkv_heads with head_dim < TILE_WIDTH (32)
+
+    This test specifically targets the bug where integer division
+    q_num_tiles = num_heads * (head_dim / TILE_WIDTH) returns 0
+    when head_dim < 32.
+    """
+    run_nlp_create_qkv_heads_small_head_dim_test(
+        batch,
+        seq_len,
+        head_dim,
+        num_heads,
+        dtype,
+        in_mem_config,
+        out_mem_config,
+        device,
+    )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py
@@ -1,0 +1,468 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression tests for nlp_create_qkv_heads to ensure the bug fix doesn't break existing functionality.
+
+These tests explicitly cover combinations of features with existing "working" head_dim values
+(64, 96, 128) to ensure our ceiling division fix doesn't introduce regressions.
+
+TEST STRATEGY:
+- Run these tests BEFORE applying the bug fix (should PASS)
+- Run these tests AFTER applying the bug fix (should still PASS)
+- Any failures indicate a regression introduced by the fix
+"""
+
+import pytest
+from loguru import logger
+import torch
+import ttnn
+from models.common.utility_functions import tt2torch_tensor, comp_pcc, is_grayskull
+
+
+def run_nlp_create_qkv_heads_regression_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    transpose_k_heads,
+    read_from_input_tensor_kv,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Comprehensive regression test for nlp_create_qkv_heads.
+
+    Tests various feature combinations with "known good" head_dim values.
+    """
+    torch.manual_seed(1234)
+
+    logger.info(
+        f"Regression test: head_dim={head_dim}, transpose_k={transpose_k_heads}, "
+        f"separate_kv={read_from_input_tensor_kv}, {num_q_heads}Q:{num_kv_heads}KV"
+    )
+
+    if read_from_input_tensor_kv:
+        in0_shape = [batch, 1, seq_len, num_q_heads * head_dim]
+        in1_shape = [batch, 1, seq_len, 2 * num_kv_heads * head_dim]
+        A = torch.randn(in0_shape)
+        B = torch.randn(in1_shape)
+        in0_t = ttnn.Tensor(A, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
+        in1_t = ttnn.Tensor(B, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
+    else:
+        in0_shape = [batch, 1, seq_len, (num_q_heads + 2 * num_kv_heads) * head_dim]
+        A = torch.randn(in0_shape)
+        in0_t = ttnn.Tensor(A, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
+
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+        in0_t,
+        in1_t if read_from_input_tensor_kv else None,
+        num_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=transpose_k_heads,
+        memory_config=out_mem_config,
+    )
+
+    # Check shapes
+    expected_q_shape = [batch, num_q_heads, seq_len, head_dim]
+    if transpose_k_heads:
+        expected_k_shape = [batch, num_kv_heads, head_dim, seq_len]
+    else:
+        expected_k_shape = [batch, num_kv_heads, seq_len, head_dim]
+    expected_v_shape = [batch, num_kv_heads, seq_len, head_dim]
+
+    assert list(q.padded_shape) == expected_q_shape, \
+        f"Q shape mismatch! Expected {expected_q_shape}, got {list(q.padded_shape)}"
+    assert list(k.padded_shape) == expected_k_shape, \
+        f"K shape mismatch! Expected {expected_k_shape}, got {list(k.padded_shape)}"
+    assert list(v.padded_shape) == expected_v_shape, \
+        f"V shape mismatch! Expected {expected_v_shape}, got {list(v.padded_shape)}"
+
+    # Verify numerical correctness
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    if read_from_input_tensor_kv:
+        ref_q = A
+        (ref_k, ref_v) = torch.split(B, [num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1)
+    else:
+        (ref_q, ref_k, ref_v) = torch.split(
+            A, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+        )
+
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if transpose_k_heads:
+        ref_k = ref_k.transpose(-2, -1)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc = 0.99
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
+    passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
+    passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
+
+    assert passing_pcc_q, f"Q PCC check failed: {output_pcc_q}"
+    assert passing_pcc_k, f"K PCC check failed: {output_pcc_k}"
+    assert passing_pcc_v, f"V PCC check failed: {output_pcc_v}"
+
+    logger.info(f"  Q PCC: {output_pcc_q:.6f}, K PCC: {output_pcc_k:.6f}, V PCC: {output_pcc_v:.6f}")
+
+
+# ============================================================================
+# REGRESSION TEST 1: Transpose with all existing head_dims
+# ============================================================================
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16, ttnn.bfloat8_b),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize(
+    "head_dim, transpose_k",
+    (
+        (64, True),   # Most common - MUST NOT BREAK
+        (64, False),  # Control
+        (96, True),   # From existing tests - MUST NOT BREAK
+        (96, False),  # Control
+        (128, True),  # Llama - MUST NOT BREAK
+        (128, False), # Control
+    ),
+    ids=[
+        "head64_transpose",
+        "head64_no_transpose",
+        "head96_transpose",
+        "head96_no_transpose",
+        "head128_transpose",
+        "head128_no_transpose",
+    ],
+)
+def test_nlp_create_qkv_heads_regression_transpose(
+    head_dim,
+    transpose_k,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Regression test: Verify transpose works correctly with existing head_dims.
+
+    CRITICAL: These MUST pass both before and after the bug fix.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=1,
+        seq_len=128,
+        head_dim=head_dim,
+        num_q_heads=8,
+        num_kv_heads=8,
+        transpose_k_heads=transpose_k,
+        read_from_input_tensor_kv=False,
+        dtype=dtype,
+        in_mem_config=in_mem_config,
+        out_mem_config=out_mem_config,
+        device=device,
+    )
+
+
+# ============================================================================
+# REGRESSION TEST 2: Separate KV tensor with all existing head_dims
+# ============================================================================
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16, ttnn.bfloat8_b),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize(
+    "head_dim",
+    (64, 96, 128),
+    ids=["head64", "head96", "head128"],
+)
+def test_nlp_create_qkv_heads_regression_separate_kv(
+    head_dim,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Regression test: Verify separate KV tensor works with existing head_dims.
+
+    CRITICAL: These MUST pass both before and after the bug fix.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=1,
+        seq_len=128,
+        head_dim=head_dim,
+        num_q_heads=8,
+        num_kv_heads=8,
+        transpose_k_heads=False,
+        read_from_input_tensor_kv=True,
+        dtype=dtype,
+        in_mem_config=in_mem_config,
+        out_mem_config=out_mem_config,
+        device=device,
+    )
+
+
+# ============================================================================
+# REGRESSION TEST 3: GQA with all existing head_dims
+# ============================================================================
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG,),
+    ids=["out_DRAM"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG,),
+    ids=["in_DRAM"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=["BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "head_dim, num_q_heads, num_kv_heads",
+    (
+        (64, 16, 2),   # GQA 8:1 - common ratio
+        (64, 32, 4),   # GQA 8:1 - Llama style with head_dim=64
+        (96, 8, 2),    # GQA 4:1 - with head_dim=96
+        (128, 32, 4),  # GQA 8:1 - Llama 2/3 actual config
+        (128, 32, 8),  # GQA 4:1 - Llama variant
+    ),
+    ids=[
+        "head64_gqa_16q_2kv",
+        "head64_gqa_32q_4kv",
+        "head96_gqa_8q_2kv",
+        "head128_gqa_32q_4kv_llama",
+        "head128_gqa_32q_8kv",
+    ],
+)
+def test_nlp_create_qkv_heads_regression_gqa(
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Regression test: Verify GQA works correctly with existing head_dims.
+
+    CRITICAL: These MUST pass both before and after the bug fix.
+    Tests various Q:KV ratios with known good head_dims.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=1,
+        seq_len=128,
+        head_dim=head_dim,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=False,
+        read_from_input_tensor_kv=False,
+        dtype=dtype,
+        in_mem_config=in_mem_config,
+        out_mem_config=out_mem_config,
+        device=device,
+    )
+
+
+# ============================================================================
+# REGRESSION TEST 4: Feature combinations (stress test)
+# ============================================================================
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=["BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "head_dim, num_q_heads, num_kv_heads, transpose_k, separate_kv",
+    (
+        # head_dim=64 combinations
+        (64, 16, 2, True, False),   # GQA + transpose
+        (64, 16, 2, False, True),   # GQA + separate_kv
+        (64, 8, 8, True, True),     # transpose + separate_kv
+        (64, 16, 2, True, True),    # ALL features
+
+        # head_dim=96 combinations
+        (96, 8, 2, True, False),    # GQA + transpose
+        (96, 8, 2, False, True),    # GQA + separate_kv
+
+        # head_dim=128 combinations
+        (128, 32, 4, True, False),  # Llama GQA + transpose
+        (128, 32, 4, False, True),  # Llama GQA + separate_kv
+        (128, 16, 16, True, True),  # All features
+    ),
+    ids=[
+        "head64_gqa_transpose",
+        "head64_gqa_sepkv",
+        "head64_transpose_sepkv",
+        "head64_all_features",
+        "head96_gqa_transpose",
+        "head96_gqa_sepkv",
+        "head128_llama_gqa_transpose",
+        "head128_llama_gqa_sepkv",
+        "head128_all_features",
+    ],
+)
+def test_nlp_create_qkv_heads_regression_feature_combinations(
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    transpose_k,
+    separate_kv,
+    dtype,
+    device,
+):
+    """
+    Regression test: Verify feature combinations work correctly.
+
+    CRITICAL STRESS TEST: These test multiple features together.
+    MUST pass both before and after the bug fix.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=1,
+        seq_len=128,
+        head_dim=head_dim,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=transpose_k,
+        read_from_input_tensor_kv=separate_kv,
+        dtype=dtype,
+        in_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        out_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        device=device,
+    )
+
+
+# ============================================================================
+# REGRESSION TEST 5: Boundary case head_dim=32
+# ============================================================================
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16, ttnn.bfloat8_b),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize(
+    "transpose_k, separate_kv",
+    (
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
+    ),
+    ids=["basic", "transpose", "separate_kv", "all_features"],
+)
+def test_nlp_create_qkv_heads_regression_head_dim_32_boundary(
+    transpose_k,
+    separate_kv,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    """
+    Regression test: head_dim=32 (exactly TILE_WIDTH).
+
+    BOUNDARY CASE: head_dim = 32 should work BOTH before and after fix.
+    This is the boundary between buggy (<32) and working (>=32) regions.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=1,
+        seq_len=128,
+        head_dim=32,
+        num_q_heads=8,
+        num_kv_heads=8,
+        transpose_k_heads=transpose_k,
+        read_from_input_tensor_kv=separate_kv,
+        dtype=dtype,
+        in_mem_config=in_mem_config,
+        out_mem_config=out_mem_config,
+        device=device,
+    )
+
+
+# ============================================================================
+# REGRESSION TEST 6: Large dimensions (sanity check)
+# ============================================================================
+@pytest.mark.parametrize(
+    "dtype",
+    (ttnn.bfloat16,),
+    ids=["BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "batch, seq_len, head_dim",
+    (
+        (8, 256, 64),    # Larger batch
+        (1, 2048, 64),   # Long sequence
+        (1, 1024, 128),  # Llama-style long
+        (2, 512, 96),    # Mixed large
+    ),
+    ids=["large_batch", "long_seq_64", "long_seq_128", "mixed_large"],
+)
+def test_nlp_create_qkv_heads_regression_large_dimensions(
+    batch,
+    seq_len,
+    head_dim,
+    dtype,
+    device,
+):
+    """
+    Regression test: Large dimension combinations.
+
+    SANITY CHECK: Ensure fix doesn't break with larger tensors.
+    """
+    run_nlp_create_qkv_heads_regression_test(
+        batch=batch,
+        seq_len=seq_len,
+        head_dim=head_dim,
+        num_q_heads=16,
+        num_kv_heads=16,
+        transpose_k_heads=False,
+        read_from_input_tensor_kv=False,
+        dtype=dtype,
+        in_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        out_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        device=device,
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -61,12 +61,13 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     // NOTE: Output h and w dims are identical for Q, K, V, so any arg that is related to these dims for q_* can be
     // shared for K, V
     uint32_t q_out_h_tiles = input_shape[2] / TILE_HEIGHT;
-    uint32_t q_out_w_tiles = head_dim / TILE_WIDTH;  // tiles along head_dim
+    uint32_t q_out_w_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;  // FIX: ceiling division for head_dim < 32
     uint32_t q_out_HtWt = q_out_h_tiles * q_out_w_tiles;
     uint32_t q_out_CHtWt = num_q_heads * q_out_HtWt;
     uint32_t kv_out_CHtWt = num_kv_heads * q_out_HtWt;
-    uint32_t q_num_tiles = num_q_heads * q_out_w_tiles;
-    uint32_t kv_num_tiles = num_kv_heads * q_out_w_tiles;
+    // FIX: Use ceiling division to handle head_dim < TILE_WIDTH (32)
+    uint32_t q_num_tiles = (num_q_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
+    uint32_t kv_num_tiles = (num_kv_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
 
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     // Block is a unit of work; ie. num of in0_w_tiles per core
@@ -338,7 +339,7 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
 
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;  // FIX: ceiling division for head_dim < 32
     uint32_t head_size = head_tiles * single_tile_size;
 
     auto q_shard_spec = std::get<0>(output).shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -68,7 +68,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_de
 
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
     uint32_t head_size = head_tiles * single_tile_size;
 
     uint32_t element_size = input_tensor.element_size();
@@ -222,7 +222,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_de
 
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
     uint32_t head_size = head_tiles * single_tile_size;
 
     uint32_t element_size = input_tensor.element_size();
@@ -500,7 +500,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_de
 
     const uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    const uint32_t head_tiles = head_dim / TILE_WIDTH;
+    const uint32_t head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
     const uint32_t head_size = head_tiles * single_tile_size;
 
     const uint32_t element_size = input_tensor.element_size();


### PR DESCRIPTION
# WIP: Fix integer division bug in nlp_create_qkv_heads for head_dim < 32

Issue: https://github.com/tenstorrent/tt-metal/issues/30418

## Status: CRITICAL BUG IDENTIFIED IN FIX - DO NOT MERGE

### Summary
This PR attempts to fix a silent data corruption bug in `nlp_create_qkv_heads` and 
related operations where integer division causes tile count calculations to truncate 
to zero when `head_dim < TILE_WIDTH (32)`.

**Current Issue**: The fix itself contains a semantic error that makes the bug worse 
in certain code paths.

---

## Root Cause (Original Bug)
```cpp
// BUGGY:
uint32_t q_out_w_tiles = head_dim / TILE_WIDTH;        // 16/32 = 0
uint32_t q_num_tiles = num_q_heads * q_out_w_tiles;    // 4 * 0 = 0
```
When `head_dim=16, num_q_heads=4`: Kernel reads zero tiles, output shape becomes 
`[1, 4, 32, 32]` instead of `[1, 4, 32, 16]`.

---

## Problem with Current Fix
The fix in commit `e8b3193e1d` applies ceiling division but **incorrectly multiplies 
by head counts**:
```cpp
// CURRENT FIX (WRONG):
uint32_t q_num_tiles = (num_q_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
uint32_t kv_num_tiles = (num_kv_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
```

**Why this breaks**: The reader kernel treats `q_num_tiles` as **tiles per head per 
block**, not total tiles. The reader loop runs once per block and increments tile ID 
linearly. Multiplying by `num_q_heads` causes the reader to read 4x too much data 
per block iteration.

**Correct fix should be**:
```cpp
uint32_t q_num_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
uint32_t kv_num_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
```

---

## Affected Files (Partial Fixes Applied)
✓ FIXED (correctly):
- `nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp` (Sharded 
  variant `head_tiles` calculation) - line 337
- `nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp` 
  (3 instances of `head_tiles` calculation)

✗ BROKEN (wrong formula):
- `nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp` (Interleaved 
  variant lines 69-70: `q_num_tiles`, `kv_num_tiles`)
- `nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp` 
  (Interleaved variant lines 69-70: `q_num_tiles`, `kv_num_tiles`)

✗ NOT FIXED (same original bug):
- `create_qkv_heads/device/create_qkv_heads_program_factory.cpp` (3 instances)
- `create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.cpp`
- `nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp` (2 instances)
- `all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp`

---

## Next Steps
1. **URGENT**: Correct `q_num_tiles` and `kv_num_tiles` calculations in Interleaved 
   variants (remove `num_q_heads`/`num_kv_heads` multiplication)
2. Apply same ceiling-division fix to remaining 5 operations with identical bug pattern
3. Re-run test suite (270 test cases included) - currently tests will fail due to 
   semantic error in fix
4. Verify kernel semantics: confirm `q_num_tiles` represents tiles per head, not total

---

## Test Status
- 40 C++ test cases added (will fail with current fix)
- 230 Python test cases added (will fail with current fix)
- Tests correctly identify head_dim < 32 as buggy case before fix
- Tests will PASS once semantic error in fix is corrected





Commit comment:

…or head_dim < 32

BUG DESCRIPTION:
The nlp_create_qkv_heads operation and its decode variant produced incorrect output shapes when head_dim < TILE_WIDTH (32) due to integer division truncating to zero. This is a critical bug affecting any multi-head attention implementation where embedding_dim / num_heads < 32.

SYMPTOM - Concrete Example:
  Input:  [1, 1, 32, 192] where 192 = 64*3 (Q+K+V), 4 heads, head_dim=16
  Expected: Q, K, V each [1, 4, 32, 16] (4 heads, head_dim=16)
  Actual:   Q, K, V each [1, 4, 32, 32] WRONG!

This is silent data corruption - no error thrown, just wrong tensor shapes.

ROOT CAUSE:
In nlp_create_qkv_heads_program_factory.cpp (line 69) and the boltz variant (line 70), the calculation:
  uint32_t q_out_w_tiles = head_dim / TILE_WIDTH;  // Integer division!
  uint32_t q_num_tiles = num_q_heads * q_out_w_tiles;
  uint32_t kv_num_tiles = num_kv_heads * q_out_w_tiles;

In nlp_create_qkv_heads_decode_program_factory.cpp (lines 71, 225, 503):
  uint32_t head_tiles = head_dim / TILE_WIDTH;    // Integer division!
  uint32_t head_size = head_tiles * single_tile_size;  // Used for memory calculations

When head_dim=16 and TILE_WIDTH=32:
  q_out_w_tiles = 16 / 32 = 0  (integer division truncates)
  q_num_tiles = 4 * 0 = 0      (reads ZERO Q tiles!)
  head_tiles = 0, head_size = 0  (decode variant)
  Result: Kernel reads zero tiles, causing wrong memory offsets
          Output dimension becomes 32 instead of 16

FIX APPLIED:
Replaced integer division with ceiling division in both operations:

Main operation:
  uint32_t q_num_tiles = (num_q_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
  uint32_t kv_num_tiles = (num_kv_heads * head_dim + TILE_WIDTH - 1) / TILE_WIDTH;

Decode operation (3 instances):
  uint32_t head_tiles = (head_dim + TILE_WIDTH - 1) / TILE_WIDTH;
  uint32_t head_size = head_tiles * single_tile_size;

This correctly handles head_dim < 32 while remaining mathematically equivalent for head_dim >= 32 (no behavioral change for existing use cases).

Example with fix:
  q_num_tiles = (4 * 16 + 31) / 32 = 95 / 32 = 2 tiles (correct!)
  head_tiles = (16 + 31) / 32 = 47 / 32 = 1 tile (correct!)

MATHEMATICAL VERIFICATION:
For head_dim >= 32, both formulas produce identical results:
- head_dim=32:  num_heads * 1  (unchanged)
- head_dim=64:  num_heads * 2  (unchanged)
- head_dim=96:  num_heads * 3  (unchanged)
- head_dim=128: num_heads * 4  (unchanged)

For head_dim < 32, the fix now produces correct non-zero values:
- head_dim=8:  ceiling(num_heads * 8 / 32) = ceiling(num_heads * 0.25)
- head_dim=16: ceiling(num_heads * 16 / 32) = ceiling(num_heads * 0.5)

WORKAROUND (if fix not available):
Until ttnn is fixed, manually split heads using ttnn::slice + ttnn::reshape:
  auto q_flat = ttnn::slice(qkv, {0,0,0,0}, {B,1,S,E}, {1,1,1,1});
  auto q = ttnn::reshape(q_flat, {B, H, S, E/H});

FILES MODIFIED:
- ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
- ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
- ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp (3 instances)
- tests/tt_eager/CMakeLists.txt (added new C++ test)
- tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py (added integration tests)
- tt-train/tests/CMakeLists.txt (removed misplaced test)

FILES ADDED:
- tests/tt_eager/ops/test_nlp_create_qkv_heads.cpp (40 C++ test cases)
- tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py (43 Python test cases)
- tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py (175 Python test cases)
- tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py (12 Python test cases)

FILES DELETED:
- tt-train/tests/ttnn_fixed/nlp_create_qkv_heads_head_dim_bug_test.cpp (wrong location - TTNN tests belong in tests/tt_eager)

TEST COVERAGE ADDED (270 new test cases total):

1. Bug Reproduction Tests - Main Operation (53 cases):
   - test_nlp_create_qkv_heads_head_dim_bug.py: 43 Python test cases * 40 unit tests for shape and numerical correctness * 3 integration tests with SDPA (Scaled Dot-Product Attention)
   - test_nlp_create_qkv_heads.cpp: 10 C++ test cases
   - Focus: head_dim = 8, 16 (bug cases) + 32 (boundary)
   - These tests FAIL before the fix, PASS after the fix

2. Bug Reproduction Tests - Decode Operation (12 cases):
   - test_nlp_create_qkv_heads_decode_head_dim_bug.py: 12 Python test cases
   - Tests decode operation (batch=32, seq_len=1) with head_dim = 8, 16, 32
   - Tests both MHA (Multi-Head Attention) and GQA (Grouped Query Attention)
   - Focus: Inference use case with single token generation
   - These tests FAIL before the fix, PASS after the fix

3. Regression Protection Tests (190 cases):
   - test_nlp_create_qkv_heads_regression.py: 175 Python test cases
   - test_nlp_create_qkv_heads.cpp: 15 additional C++ test cases
   - Comprehensive testing of head_dim = 32, 64, 96, 128
   - Feature combinations: transpose_k, separate_kv, GQA, memory configs
   - These tests MUST PASS both before and after the fix

4. C++ Integration Tests (40 total C++ test cases):
   - test_nlp_create_qkv_heads.cpp: Complete operation test suite
   - 7 test categories: bug regression, transpose, GQA, separate KV, memory configs, large dimensions, edge cases

5. Python Integration Tests with SDPA (3 test cases):
   - test_nlp_create_qkv_heads_head_dim_bug.py: Integration with attention
   - Tests nlp_create_qkv_heads → scaled_dot_product_attention pipeline
   - Verifies outputs work with downstream operations (catches memory layout issues)
   - Tests head_dim = 8, 16, 32 with SDPA
   - Validates end-to-end attention computation against PyTorch reference

DECODE OPERATION BUG:
The decode variant (nlp_create_qkv_heads_decode) had the same bug in 3 functions:
- multi_core_nlp_create_qkv_heads_decode_interleaved_input (line 71)
- multi_core_nlp_create_qkv_heads_decode_sharded_input (line 225)
- multi_core_nlp_create_qkv_heads_decode_sharded_input_subcoregrid (line 503)

The decode operation is used for inference (autoregressive token generation) where batch typically represents parallel decode sequences and seq_len=1. The bug would cause incorrect head_size calculations, leading to memory corruption in kernels. This is critical for deployment scenarios with small models where head_dim < 32.

REGRESSION PROTECTION:
The extensive regression test suite ensures the fix does not break existing functionality. Tests cover:
- All "working" head_dim values (32, 64, 96, 128)
- transpose_k_heads: True/False
- separate KV tensors: True/False
- GQA (Grouped Query Attention) with various Q:KV ratios
- Memory configurations: DRAM, L1
- Data types: bfloat16, bfloat8_b, float32
- Boundary case: head_dim=32 (critical boundary)
- Large batch sizes and long sequences
- Decode operation: interleaved, sharded, and subcoregrid variants

INTEGRATION TEST RATIONALE:
The SDPA integration tests verify that nlp_create_qkv_heads outputs can be consumed by downstream operations without crashes or errors. This catches:
- Memory layout issues that could cause SDPA to fail
- Incorrect tensor tiling that produces wrong shapes in attention
- End-to-end numerical correctness of the full attention pipeline These tests provide confidence that the fix works in real-world usage patterns.

TEST DISCOVERY:
- Python tests use pytest auto-discovery (test_*.py pattern) - no explicit registration needed
- C++ tests are registered in tests/tt_eager/CMakeLists.txt

AFFECTED USE CASES:
  - Small BERT models (embedding_dim=64, num_heads=4) previously failed
  - Any config where embedding_dim/num_heads < 32 produced wrong results
  - Edge deployment scenarios with small models
  - Testing and development with minimal configurations
  - Inference (decode) with small head dimensions

HOW TO REPRODUCE THE BUG (before fix):
C++ test:
  cd /workspace/bert-model-for-ttml
  cmake --build build -- -j
  ./build/test/tt_eager/ops/test_nlp_create_qkv_heads --gtest_filter=*bug_regression*

Python test (main operation):
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py -v

Python test (decode operation):
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py -v

Expected without fix: Tests FAIL with shape assertion errors or memory issues
Expected with fix: All tests PASS

IMPACT:
- Fixes head_dim < 32 use cases (previously broken) for both training and inference
- Zero impact on existing head_dim >= 32 use cases (mathematically equivalent)
- Comprehensive test coverage ensures no regressions
- Critical for small model deployment scenarios

================================================================================ COMPREHENSIVE 3-STEP TESTING PLAN
================================================================================

STEP 1: BASELINE (No Changes)
------------------------------
Goal: Verify all existing tests pass before any changes.

1a. Existing C++ Tests:
  cd /workspace/bert-model-for-ttml
  cmake --build build -- -j
  ./build/test/tt_eager/integration_tests/test_bert

  Expected: All tests PASS

1b. Existing Python Tests:
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py -v

  Expected: All tests PASS

STEP 2: Apply Test Changes Only (Bug Should Be Visible) -------------------------------------------------------- Goal: Prove the bug exists. Tests with head_dim < 32 should FAIL.

Files to Apply (NO BUG FIX YET):
  - tests/tt_eager/CMakeLists.txt
  - tests/tt_eager/ops/test_nlp_create_qkv_heads.cpp (NEW)
  - tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py (NEW - includes integration tests)
  - tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py (NEW)
  - tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py (NEW)
  - tt-train/tests/CMakeLists.txt (remove line 22)
  - DELETE tt-train/tests/ttnn_fixed/nlp_create_qkv_heads_head_dim_bug_test.cpp

  DO NOT APPLY BUG FIX FILES YET!

2a. Rebuild:
  cmake --build build -- -j

2b. Run NEW C++ Tests (Should Show Bug):
  ./build/test/tt_eager/ops/test_nlp_create_qkv_heads

  Expected Results:
  - FAIL: bug_regression_head_dim_16 (shape mismatch)
  - FAIL: bug_regression_head_dim_8 (shape mismatch)
  - FAIL: All tests with head_dim < 32
  - PASS: regression_boundary_head32_* (boundary case)
  - PASS: All tests with head_dim >= 32
  - PASS: All regression tests

  Key Observation: Should see ~10-15 failures, all with head_dim < 32

2c. Run NEW Python Bug Tests (Should Show Bug):
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py -v
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py -v

  Expected Results:
  - FAIL: test_*_head16_* (assertion on shape)
  - FAIL: test_*_head8_* (assertion on shape)
  - FAIL: test_nlp_create_qkv_heads_with_sdpa_integration[sdpa_head8] (shape or SDPA crash)
  - FAIL: test_nlp_create_qkv_heads_with_sdpa_integration[sdpa_head16] (shape or SDPA crash)
  - FAIL: test_nlp_create_qkv_heads_decode_small_head_dim[*head16*] (shape or memory errors)
  - FAIL: test_nlp_create_qkv_heads_decode_small_head_dim[*head8*] (shape or memory errors)
  - PASS: test_*_head32_*_control (boundary case)
  - PASS: test_nlp_create_qkv_heads_with_sdpa_integration[sdpa_head32_boundary] (boundary case)

  Key Observation: Should see ~42 failures (32 main + 2 SDPA + 8 decode)

2d. Run NEW Python Regression Tests (Should ALL PASS):
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py -v

  Expected: ALL 175 tests PASS

  CRITICAL: If any regression test fails here, STOP! The test setup is wrong.

2e. Verify Existing Tests Still Pass:
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py -v
  ./build/test/tt_eager/integration_tests/test_bert

  Expected: All existing tests still PASS

STEP 3: Apply Bug Fix (Everything Should Pass)
-----------------------------------------------
Goal: Prove the fix works. All tests should now PASS.

Files to Apply:
  - ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
  - ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
  - ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp

3a. Rebuild:
  cmake --build build -- -j

3b. Run ALL C++ Tests:
  ./build/test/tt_eager/ops/test_nlp_create_qkv_heads

  Expected: ALL 40 tests PASS (including head_dim=8,16 that failed before)

3c. Run ALL New Python Tests:
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py -v
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py -v
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_regression.py -v

  Expected: ALL 230 tests PASS (43 bug tests + 12 decode tests + 175 regression tests)

  Key Observation: All integration tests with SDPA now pass, confirming outputs work correctly with downstream operations

3d. Final Verification - Existing Tests:
  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py -v
  ./build/test/tt_eager/integration_tests/test_bert

  Expected: All existing tests still PASS

QUICK TEST COMMANDS (After Step 3):
------------------------------------
# C++ tests
./build/test/tt_eager/ops/test_nlp_create_qkv_heads ./build/test/tt_eager/integration_tests/test_bert

# Python tests - all nlp_create_qkv_heads tests
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads*.py -v

# Run only integration tests with SDPA
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_head_dim_bug.py::test_nlp_create_qkv_heads_with_sdpa_integration -v

# Run only decode tests
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode_head_dim_bug.py -v

SUCCESS CRITERIA:
-----------------
Step 1: All existing tests pass - no failures in baseline Step 2: Bug tests FAIL for head_dim < 32 (proves bug exists in both operations)
        Regression tests ALL PASS (proves tests are correct)
        Existing tests still PASS (proves no test setup breakage)
        Integration tests FAIL (proves SDPA would receive broken inputs)
        Decode tests FAIL (proves decode variant has the same bug)
Step 3: ALL new tests PASS (proves fix works for both operations)
        ALL integration tests PASS (proves outputs work with SDPA)
        ALL decode tests PASS (proves decode variant is fixed)
        ALL existing tests still PASS (proves no regressions)

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes