### PR TITLE
Adding Hard approximation of GELU unary op 

### DIFF
--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -522,6 +522,22 @@ def eltwise_hardmish(
     return ttnn_tensor_to_torch(t1)
 
 
+def eltwise_hardgelu(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.hardgelu(t0, memory_config=output_mem_config)
+
+    return ttnn_tensor_to_torch(t1)
+
+
 def eltwise_multigammaln(
     x,
     *args,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -2041,3 +2041,90 @@ def test_unary_bitcast_ttnn(
                 ), f"Value {i}: Expected {expected}, got {actual}, diff: {abs(expected - actual)}"
             else:
                 assert expected == actual, f"Value {i}: Expected {expected}, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([100])),
+        (torch.Size([10, 10])),
+        (torch.Size([3, 128, 32])),
+        (torch.Size([1, 1, 102400, 32])),
+        (torch.Size([1, 1, 102400, 64])),
+        (torch.Size([1, 1, 400, 512])),
+    ),
+)
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_unary_hardgelu(input_shapes, torch_dtype, ttnn_dtype, device):
+    in_data1 = create_full_range_tensor(input_shapes, torch_dtype)
+
+    # limit the range to avoid overflow in hardgelu
+    in_data1 = in_data1[(in_data1 + 1.58).abs() < 3.3e38 / 3.16]
+
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.hardgelu(input_tensor1)
+    golden_function = ttnn.get_golden_function(ttnn.hardgelu)
+
+    golden_tensor = golden_function(in_data1, device=device)
+    tt_res = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(tt_res, golden_tensor, pcc=0.9999)
+
+
+def test_hardgelu_bfloat16_ulp(device):
+    # Generate all possible bit pattern for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    # Mask NaN, special values where hardgelu has ULP>1 (Covered in atol test below).
+    mask = (
+        torch.isnan(input_tensor)
+        | ((input_tensor >= -2.0847e-23) & (input_tensor <= 2.0939e-23))
+        | (input_tensor == -0.0)
+        | (input_tensor >= 6.8122e37)
+        | (input_tensor == -torch.inf)
+    )
+    input_tensor[mask] = 0.0
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    golden_function = ttnn.get_golden_function(ttnn.hardgelu)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.hardgelu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+def test_hardgelu_bfloat16_allclose(device):
+    # Generate all possible bit pattersn for bf16
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)
+    input_tensor = input_tensor.to(torch.float32)
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    golden_function = ttnn.get_golden_function(ttnn.hardgelu)
+    golden = golden_function(input_tensor, device=device)
+
+    tt_result = ttnn.hardgelu(tt_in)
+    result = ttnn.to_torch(tt_result)
+    assert_allclose(golden, result, rtol=1e-05, atol=1e-35)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardgelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardgelu.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void hardgelu() {
+    // hardgelu(x) = x * torch.clamp(x + 1.58, 0.0, 3.16) / 3.16
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[0] + 1.58f;
+
+        v_if(a < 0.0f) { a = 0.0f; }
+        v_endif;
+
+        v_if(a > 3.16f) { a = 3.16f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = sfpi::dst_reg[0] * a * 0.3164556962f;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardgelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardgelu.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_hardgelu.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_hardgelu_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardgelu, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardgelu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::hardgelu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -137,4 +137,5 @@ enum class SfpuType {
     reduce,
     add_top_row,
     rdiv,
+    hardgelu,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardgelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardgelu.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void hardgelu() {
+    // hardgelu(x) = x * torch.clamp(x + 1.58, 0.0, 3.16) / 3.16
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[0] + 1.58f;
+
+        v_if(a < 0.0f) { a = 0.0f; }
+        v_endif;
+
+        v_if(a > 3.16f) { a = 3.16f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = sfpi::dst_reg[0] * a * 0.3164556962f;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardgelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardgelu.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_hardgelu.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_hardgelu_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::hardgelu, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_hardgelu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::hardgelu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -137,4 +137,5 @@ enum class SfpuType {
     reduce,
     add_top_row,
     rdiv,
+    hardgelu,
 };

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/hardgelu.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/hardgelu.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_hardgelu.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs element-wise computation of hardgelu(x) = x * (x + 2.8).clamp(0.0, 5.0) / 5 on each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void hardgelu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_hardgelu<APPROX>(idst))); }
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void hardgelu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_hardgelu_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -176,6 +176,10 @@
 #include "compute_kernel_api/eltwise_unary/hardmish.h"
 #endif
 
+#if SFPU_OP_HARDGELU_INCLUDE
+#include "compute_kernel_api/eltwise_unary/hardgelu.h"
+#endif
+
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -121,6 +121,7 @@ enum class UnaryOpType {
     RPOW,
     CBRT,
     LOGSIGMOID,
+    HARDGELU,
 };
 
 enum class VecMode {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -94,6 +94,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::HARDTANH: return "SFPU_OP_HARDTANH_INCLUDE";
         case UnaryOpType::RPOW: return "SFPU_OP_RPOW_INCLUDE";
         case UnaryOpType::HARDMISH: return "SFPU_OP_HARDMISH_INCLUDE";
+        case UnaryOpType::HARDGELU: return "SFPU_OP_HARDGELU_INCLUDE";
         default: return "SFPU_OP_COMPUTE_KERNEL_API_INCLUDE";
     };
 }
@@ -586,6 +587,12 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 "sqrt_tile_init<false>();", fmt::format("sqrt_tile<false, {1}>({0});", idst, param0_raw)};
             break;
         }
+        case UnaryOpType::HARDGELU: {
+            op_init_and_name = {
+                fmt::format("hardgelu_tile_init<{}u>();", (uint32_t)param0),
+                fmt::format("hardgelu_tile<{1}u>({0});", idst, (uint32_t)param0)};
+            break;
+        }
         default: TT_THROW("unexpected parameterized op type {}", op_type);
     };
     return op_init_and_name;
@@ -841,6 +848,9 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
             op_init_and_name = {"hardmish_tile_init();", fmt::format("hardmish_tile({});", idst)};
             break;
         case UnaryOpType::LOGSIGMOID: op_init_and_name = {}; break;
+        case UnaryOpType::HARDGELU:
+            op_init_and_name = {"hardgelu_tile_init();", fmt::format("hardgelu_tile({});", idst)};
+            break;
         default: TT_THROW("Undefined non-parametrized op type {}", op_type);
     }
     return op_init_and_name;
@@ -929,6 +939,8 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::HARDMISH, static_cast<float>(true));
     } else if (name == "mish") {
         return UnaryWithParam(UnaryOpType::MISH);
+    } else if (name == "hardgelu") {
+        return UnaryWithParam(UnaryOpType::HARDGELU, static_cast<float>(true));
     }
     TT_THROW("Unknown unary op: {}", name);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -379,6 +379,15 @@ Tensor Hardmish::invoke(
     return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
+Tensor Hardgelu::invoke(
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::HARDGELU;
+
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+}
+
 Tensor Tanhshrink::invoke(
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -244,6 +244,13 @@ struct Hardmish {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Hardgelu {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Hardshrink {
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -474,6 +481,7 @@ constexpr auto abs = ttnn::register_operation<"ttnn::abs", ttnn::operations::una
 constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::unary::Eqz>();
 constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
 constexpr auto hardmish = ttnn::register_operation<"ttnn::hardmish", ttnn::operations::unary::Hardmish>();
+constexpr auto hardgelu = ttnn::register_operation<"ttnn::hardgelu", ttnn::operations::unary::Hardgelu>();
 constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
 constexpr auto elu = ttnn::register_operation<"ttnn::elu", ttnn::operations::unary::Elu>();
 constexpr auto hardtanh = ttnn::register_operation<"ttnn::hardtanh", ttnn::operations::unary::Hardtanh>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -1989,6 +1989,12 @@ void py_module(py::module& module) {
         R"doc(BFLOAT16, BFLOAT8_B)doc");
     bind_unary_operation(
         module,
+        ttnn::hardgelu,
+        R"doc(\mathrm{{output\_tensor}}_i = \verb|hardgelu|(\mathrm{{input\_tensor}}_i))doc",
+        "[Supported range -20 to inf]",
+        R"doc(BFLOAT16, BFLOAT8_B)doc");
+    bind_unary_operation(
+        module,
         ttnn::gez,
         R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ >= 0}}))doc",
         "",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29127
https://github.com/tenstorrent/tt-metal/issues/28395

### Problem description
GeLu comes from the same family of continuous/differentiable ReLUs such as Swish, Mish and SiLU, and is used in a variety of models such as SDXL, Segformer, ViT, GEMMA3, Bert,Swin, 

The exact formula for Gelu involves the standard Gaussian cumulative distribution function, since this can be computationally intensive, practical implementations often use an approximation involving the hyperbolic tangent function.

### What's changed

Since GeLu comes from the same family of continuous/differentiable ReLUs such as Swish and Mish (which can be approximated by **x.Relu6(x+3)/6** aka HardSwish), the intuition here was to find a similar way to approximate GeLu.

Grid search was done over the parameters p1, p2, p3 in x.Relu**p1**(x+**p2**)/**p3** and the function **x.Relu3.16(x+1.58)/3.16** was found to minimize the L1 Error.

A new SFPU kernel was added for this approximation called HardGeLU, which runs on average 39.2% faster on bfloat16, and 29.9% faster on float32 inputs:
`<google-sheets-html-origin style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">
Input_shape | dtype | HardGeLU - DEVICE KERNEL DURATION [ns] | GeLU - DEVICE KERNEL DURATION [ns] | Speedup
-- | -- | -- | -- | --
(torch.Size([100])), | bfloat16 | 2548 | 4080 | 37.55%
(torch.Size([10, 10])), | bfloat17 | 2526 | 4217 | 40.10%
(torch.Size([3, 128, 32])), | bfloat18 | 9184 | 14399 | 36.22%
(torch.Size([1, 1, 102400, 32])), | bfloat19 | 1508784 | 2537703 | 40.55%
(torch.Size([1, 1, 102400, 64])), | bfloat20 | 2972338 | 5088313 | 41.59%
(torch.Size([1, 1, 400, 512])), | bfloat21 | 98224 | 161548 | 39.20%
(torch.Size([100])), | float32 | 2969 | 4643 | 36.05%
(torch.Size([10, 10])), | float33 | 2942 | 4493 | 34.52%
(torch.Size([3, 128, 32])), | float34 | 20412 | 20101 | -1.55%
(torch.Size([1, 1, 102400, 32])), | float35 | 3434104 | 4469939 | 23.17%
(torch.Size([1, 1, 102400, 64])), | float36 | 6925459 | 8972433 | 22.81%
(torch.Size([1, 1, 400, 512])), | float37 | 223084 | 288285 | 22.62%

</google-sheets-html-origin>`

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/24267a5a-5ea3-498e-ad49-50355d4ee02b" />

<img width="2381" height="2568" alt="image" src="https://github.com/user-attachments/assets/ed0093e6-1ab5-4985-94e5-b0f9cb72e038" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18594291332) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18594364393) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes