### PR TITLE
Use ttnn.avg_pool2d instead of ttnn.global_avg_pool2d

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10003.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13500.0],
+        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10415.0],
+        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14730.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10415.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14730.0],
+        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10601.0],
+        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14779.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [MOBILENETV2_BATCH_SIZE, 3601],
+        [MOBILENETV2_BATCH_SIZE, 3677],
     ],
 )
 def test_perf_device_mobilenetv2(batch_size, expected_perf):

--- a/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [MOBILENETV2_BATCH_SIZE, 3595],
+        [MOBILENETV2_BATCH_SIZE, 3601],
     ],
 )
 def test_perf_device_mobilenetv2(batch_size, expected_perf):

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -870,6 +870,9 @@ class resnet50:
             padding=[0, 0, 0, 0],
             output_layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat8_b,
+            compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                self.device.arch(), math_fidelity=ttnn.MathFidelity.LoFi
+            ),
         )
 
         grid_size = (8, 4)

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -8,76 +8,35 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import _nearest_y, is_blackhole, is_wormhole_b0
+from models.common.utility_functions import _nearest_y, is_blackhole, is_wormhole_b0, nearest_32
 from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_model_utils import (
     get_conv_input_memory_config,
     is_blackhole_p100,
 )
 
-hardcoded_matmul_config_linear = {
-    8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(8, 4),
-        in0_block_w=2,
-        out_subblock_h=1,
-        out_subblock_w=1,
-        per_core_M=1,
-        per_core_N=1,
-        fuse_batch=True,
-        fused_activation=None,
-        mcast_in0=True,
-    ),
-    16: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(8, 4),
-        in0_block_w=2,
-        out_subblock_h=1,
-        out_subblock_w=1,
-        per_core_M=1,
-        per_core_N=1,
-        fuse_batch=True,
-        fused_activation=None,
-        mcast_in0=True,
-    ),
-    20: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(8, 8),
-        in0_block_w=1,
-        out_subblock_h=1,
-        out_subblock_w=1,
-        per_core_M=1,
-        per_core_N=1,
-        fuse_batch=True,
-        fused_activation=None,
-        mcast_in0=True,
-    ),
-    32: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(8, 8),
-        in0_block_w=1,
-        out_subblock_h=1,
-        out_subblock_w=1,
-        per_core_M=1,
-        per_core_N=1,
-        fuse_batch=True,
-        fused_activation=None,
-        mcast_in0=True,
-    ),
-}
-
 
 def ResnetLinear(
-    in_features: int,
-    out_features: int,
     weight: ttnn.Tensor,
     bias: ttnn.Tensor,
     output_mem_config,
     model_config,
-    device,
-    batch_size,
     compute_kernel_config,
 ):
     """
     Returns a function for linear operation in resnet with bias.
     """
 
-    matmul_config = hardcoded_matmul_config_linear[batch_size]
+    matmul_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=2,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
     weight = weight.reshape(weight.shape.to_rank(4))
     bias = bias.reshape(bias.shape.to_rank(4))
 
@@ -94,13 +53,6 @@ def ResnetLinear(
         return output
 
     return linear_
-
-
-import math
-
-
-def _nearest_32(x):
-    return math.ceil(x / 32) * 32
 
 
 class resnet50Bottleneck:
@@ -148,7 +100,6 @@ class resnet50Bottleneck:
         reshard_if_not_optimal=False,
         height_sharding=None,
         packer_l1_accum_enabled=True,
-        enable_act_double_buffer=False,
     ):
         if self.downsample:
             logger.debug(f"Running downsample")
@@ -172,13 +123,12 @@ class resnet50Bottleneck:
                         else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                     ),
                     deallocate_activation=True,
-                    reallocate_halo_output=True,
+                    reallocate_halo_output=False,
                     reshard_if_not_optimal=reshard_if_not_optimal,
-                    enable_act_double_buffer=(
-                        enable_act_double_buffer if height_sharding else True if input_width < 56 else False
-                    ),
+                    enable_act_double_buffer=True,
                     enable_weights_double_buffer=True if input_width < 56 else False,
                     full_inner_dim=True,
+                    enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
                 ),
             }
 
@@ -196,8 +146,6 @@ class resnet50Bottleneck:
                 return_weights_and_bias=True,
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
             )
-            ttnn.deallocate(x)
-            ds_out = ttnn.reallocate(ds_out)
         else:
             ds_out = x
         return ds_out
@@ -212,7 +160,6 @@ class resnet50Bottleneck:
         reshard_if_not_optimal=False,
         height_sharding=None,
         packer_l1_acc=True,
-        enable_act_double_buffer=False,
         layer_module=None,
     ):
         logger.debug(
@@ -224,8 +171,6 @@ class resnet50Bottleneck:
 
         # conv1 is 1x1 conv
         logger.debug(f"Running conv1")
-        module_input_height = input_height
-        module_input_width = input_width
         conv_kwargs_1 = {
             "in_channels": self.conv1_input_channels,
             "out_channels": self.conv1_output_channels,
@@ -284,24 +229,29 @@ class resnet50Bottleneck:
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
                 deallocate_activation=True,
-                reallocate_halo_output=not is_wormhole_b0(),
+                reallocate_halo_output=False,
                 act_block_h_override=act_block_h_override,
                 shard_layout=(
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 reshard_if_not_optimal=reshard_if_not_optimal,
-                enable_act_double_buffer=enable_act_double_buffer,
+                enable_act_double_buffer=True,
                 enable_weights_double_buffer=True,
                 full_inner_dim=True,
+                enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
             ),
         }
 
         if is_blackhole():
-            if layer_module == "layer1_module2":
+            if layer_module == "layer1_module3":
                 conv_kwargs_2["conv_config"].act_block_h_override = 16 * 32
             if batch_size == 32 and is_blackhole_p100(device):
                 if layer_module == "layer1_module3" or layer_module == "layer2_module1":
                     conv_kwargs_2["conv_config"].act_block_h_override = 32
+
+        if is_wormhole_b0():
+            if layer_module == "layer1_module2" or layer_module == "layer1_module3":
+                conv_kwargs_2["conv_config"].act_block_h_override = 14 * 32
 
         out, [input_height, input_width], [self.conv2_weight_tensor, self.conv2_bias_tensor] = ttnn.conv2d(
             input_tensor=out,
@@ -338,6 +288,7 @@ class resnet50Bottleneck:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 reshard_if_not_optimal=reshard_if_not_optimal,
+                deallocate_activation=True,
             ),
         }
 
@@ -365,7 +316,6 @@ class resnet50Bottleneck:
             reshard_if_not_optimal,
             height_sharding,
             packer_l1_accum_enabled=packer_l1_acc,
-            enable_act_double_buffer=enable_act_double_buffer,
         )
 
         if ds_out.memory_config() != out.memory_config():
@@ -467,16 +417,11 @@ class resnet50:
         self.layer4_module2 = self.layer4[1]
         self.layer4_module3 = self.layer4[2]
 
-        self.avgpool = ttnn.global_avg_pool2d
         self.fc = ResnetLinear(
-            in_features=512 * resnet50Bottleneck.expansion,
-            out_features=1024,
             weight=ttnn.to_device(parameters.fc.weight, device),
             bias=ttnn.to_device(parameters.fc.bias, device),
             output_mem_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
             model_config=model_config,
-            device=self.device,
-            batch_size=batch_size,
             compute_kernel_config=compute_kernel_config,
         )  # num_classes = 1000
 
@@ -672,10 +617,6 @@ class resnet50:
             dtype=self.model_config["ACTIVATIONS_DTYPE"],
         )
 
-        # Relu is fused with conv1
-        if self.batch_size == 20:
-            x = ttnn.reallocate(x)
-
         x = ttnn.max_pool2d(
             input_tensor=x,
             batch_size=self.batch_size,
@@ -690,12 +631,11 @@ class resnet50:
 
         x_height = 56
         x_width = 56
-        x = ttnn.reshape(x, (1, 1, x_height * x_width * self.batch_size, 64))
 
         if is_wormhole_b0():
             core_range_set = ttnn.CoreGrid(x=8, y=7)
             mem_config = ttnn.create_sharded_memory_config_(
-                ttnn.Shape([self.batch_size * x_height * x_width, 64]),
+                x.shape,
                 core_range_set,
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                 ttnn.ShardOrientation.ROW_MAJOR,
@@ -705,7 +645,6 @@ class resnet50:
             x = ttnn.to_layout(x, ttnn.TILE_LAYOUT, dtype=self.model_config["ACTIVATIONS_DTYPE"])
 
         logger.debug(f"==== Running layer 1 module 1")
-        layer1_module1_input_shape = ttnn.Shape(x.padded_shape)
 
         reshard = is_blackhole()
         height_shard = True
@@ -718,7 +657,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            enable_act_double_buffer=True,
             layer_module="layer1_module1",
         )
 
@@ -729,7 +667,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=False,
             layer_module="layer1_module2",
         )
 
@@ -740,11 +677,10 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=False,
             layer_module="layer1_module3",
         )
 
-        reshard = is_blackhole()
+        reshard = False
         height_shard = True
 
         logger.debug(f"==== Running layer 2 module 1")
@@ -756,7 +692,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            enable_act_double_buffer=True,
             layer_module="layer2_module1",
         )
 
@@ -767,7 +702,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer2_module2",
         )
 
@@ -778,7 +712,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer2_module3",
         )
 
@@ -789,12 +722,15 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer2_module4",
         )
 
-        reshard = True
+        reshard = is_blackhole()
         height_shard = is_blackhole()
+        if is_wormhole_b0():
+            x = ttnn.to_memory_config(
+                x, ttnn.create_sharded_memory_config(x.shape, ttnn.CoreGrid(x=8, y=8), ttnn.ShardStrategy.BLOCK)
+            )
 
         logger.debug(f"==== Running layer 3 module 1")
         x, x_height, x_width = self.layer3_module1(
@@ -805,7 +741,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            enable_act_double_buffer=True,
             layer_module="layer3_module1",
         )
 
@@ -816,7 +751,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer3_module2",
         )
 
@@ -827,7 +761,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer3_module3",
         )
 
@@ -838,7 +771,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer3_module4",
         )
 
@@ -849,7 +781,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer3_module5",
         )
 
@@ -860,12 +791,30 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer3_module6",
         )
 
-        reshard = is_blackhole()
+        reshard = False
         height_shard = False
+
+        if is_wormhole_b0():
+            block_mem_config = ttnn.create_sharded_memory_config(
+                x.shape,
+                ttnn.CoreGrid(x=8, y=7),
+                ttnn.ShardStrategy.BLOCK,
+            )
+            x = ttnn.to_memory_config(x, block_mem_config)
+        if is_blackhole():
+            grid_size = (8, 10)
+            block_mem_config = ttnn.create_sharded_memory_config_(
+                [nearest_32(x.shape[2] // grid_size[1]), x.shape[3] // grid_size[0]],
+                ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
+                tile_layout=True,
+                use_height_and_width_as_shard_shape=True,
+            )
+            x = ttnn.to_memory_config(x, block_mem_config)
 
         logger.debug(f"==== Running layer 4 module 1")
         x, x_height, x_width = self.layer4_module1(
@@ -876,7 +825,6 @@ class resnet50:
             x_width,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            enable_act_double_buffer=True,
             layer_module="layer4_module1",
         )
 
@@ -887,7 +835,6 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer4_module2",
         )
 
@@ -898,105 +845,43 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
-            enable_act_double_buffer=True,
             layer_module="layer4_module3",
         )
 
+        grid_size = (8, 8)
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
+        )
+        x = ttnn.to_memory_config(x, width_mem_config)
+
+        x = ttnn.avg_pool2d(
+            input_tensor=x,
+            batch_size=self.batch_size,
+            input_h=x_height,
+            input_w=x_width,
+            channels=x.shape[3],
+            kernel_size=[x_height, x_width],
+            stride=[1, 1],
+            padding=[0, 0, 0, 0],
+            output_layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
+        )
+
         grid_size = (8, 4)
-        if self.batch_size > 16:
-            grid_size = (8, 8)
-        shard_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
-                )
-            }
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
         )
-        shard_shape = [
-            x.volume() // x.padded_shape[-1],
-            x.padded_shape[-1] // (grid_size[0] * grid_size[1]),
-        ]
-        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        width_sharded_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
-        )
-        x = ttnn.to_memory_config(x, width_sharded_mem_config)
-
-        unpadded_shape = x.shape
-        x = ttnn.untilize_with_unpadding(
-            x,
-            output_tensor_end=(
-                unpadded_shape[0] - 1,
-                unpadded_shape[1] - 1,
-                unpadded_shape[2] - 1,
-                unpadded_shape[3] - 1,
-            ),
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-        )
-
-        x = ttnn.reshape(
-            x,
-            (
-                self.batch_size,
-                x.shape[1],
-                x.shape[2] // self.batch_size,
-                x.shape[3],
-            ),
-        )
-
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
-
-        x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
-
-        unpadded_shape_end = [
-            x.padded_shape[0] - 1,
-            x.padded_shape[1] - 1,
-            1 - 1,
-            x.padded_shape[3] - 1,
-        ]
-        x = ttnn.untilize_with_unpadding(
-            x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
-        )
-
-        x = ttnn.reshape(
-            x,
-            (
-                1,
-                x.padded_shape[1],
-                self.batch_size * x.padded_shape[2],
-                x.padded_shape[3],
-            ),
-        )
-
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
+        x = ttnn.to_memory_config(x, width_mem_config)
 
         x = self.fc(x)
         desired_shape = list(x.shape)

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large.py
@@ -8,7 +8,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_wormhole_b0
+from models.common.utility_functions import is_wormhole_b0, nearest_32
 
 hardcoded_matmul_config_linear = {
     1: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -1028,100 +1028,40 @@ class resnet50:
         x, x_height, x_width = self.layer4_module2(x, device, batch_size, x_height, x_width)
         x, x_height, x_width = self.layer4_module3(x, device, batch_size, x_height, x_width)
 
-        unpadded_shape = x.shape
-        x = ttnn.untilize_with_unpadding(
-            x,
-            output_tensor_end=(
-                unpadded_shape[0] - 1,
-                unpadded_shape[1] - 1,
-                unpadded_shape[2] - 1,
-                unpadded_shape[3] - 1,
-            ),
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+        grid_size = (8, 8)
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
         )
+        x = ttnn.to_memory_config(x, width_mem_config)
 
-        x = ttnn.reshape(
-            x,
-            (
-                self.batch_size,
-                x.shape[1],
-                x.shape[2] // self.batch_size,
-                x.shape[3],
-            ),
+        x = ttnn.avg_pool2d(
+            input_tensor=x,
+            batch_size=self.batch_size,
+            input_h=x_height,
+            input_w=x_width,
+            channels=x.shape[3],
+            kernel_size=[x_height, x_width],
+            stride=[1, 1],
+            padding=[0, 0, 0, 0],
+            output_layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
-                )
-            }
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
         )
-        shard_shape = [
-            x.volume() // x.padded_shape[-1],
-            x.padded_shape[-1] // (grid_size[0] * grid_size[1]),
-        ]
-        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        width_sharded_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
-        )
-        x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
-
-        x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
-
-        unpadded_shape_end = [
-            x.padded_shape[0] - 1,
-            x.padded_shape[1] - 1,
-            1 - 1,
-            x.padded_shape[3] - 1,
-        ]
-        x = ttnn.untilize_with_unpadding(
-            x,
-            output_tensor_end=unpadded_shape_end,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-        )
-
-        x = ttnn.reshape(
-            x,
-            (
-                1,
-                x.padded_shape[1],
-                self.batch_size * x.padded_shape[2],
-                x.padded_shape[3],
-            ),
-        )
-
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
+        x = ttnn.to_memory_config(x, width_mem_config)
 
         x = self.fc(x)
         desired_shape = list(x.shape)

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5943.0],
+        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 6090.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):


### PR DESCRIPTION
Replace global_avg_pool2d with avg_pool2d in MobileNetv2 and ResNet50 models for improved efficiency. AvgPool2d now supports tiled outputs, eliminating the need for reshape, tilize, and untilize operations.

Additionally optimize ResNet50 model for WH and BH architectures.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18761276539)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18761283155)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18594797573) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/18869808093) 