### PR TITLE
Disable logs in query_op_constraints

### DIFF
--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -21,6 +21,22 @@
 namespace ttnn::graph {
 
 namespace detail {
+// Helper to temporarily change logger level
+class LogLevelGuard {
+public:
+    explicit LogLevelGuard(spdlog::level::level_enum new_level)
+        : saved_level_(tt::LoggerRegistry::instance().get(tt::LogOp)->level()) {
+        tt::LoggerRegistry::instance().set_level(new_level);
+    }
+    ~LogLevelGuard() {
+        tt::LoggerRegistry::instance().set_level(saved_level_);
+    }
+    LogLevelGuard(const LogLevelGuard&) = delete;
+    LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+
+private:
+    spdlog::level::level_enum saved_level_;
+};
 
 // These overloaded extract_output_tensor functions abstract the return type of an arbitrary op from the rest of the
 // constraints query function. An overload resolution failure means the return type for the op in that query is not yet
@@ -77,6 +93,7 @@ struct ConstraintQueryResponse {
  */
 template <typename Op, typename... Args>
 auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, Args&&... args) {
+    detail::LogLevelGuard log_guard(spdlog::level::level_enum::off);
     nlohmann::json op_trace;
     Tensor output;
     // outer graph capture is to avoid dispatching/allocating dummy input tensors


### PR DESCRIPTION
### Problem description

Apart from logs handled here https://github.com/tenstorrent/tt-metal/pull/30202, tt-forge CI is still overflowed with some critical logs coming from getOpConstraints calls in tt-mlir Optimizer, e.g.
```
2025-10-17T06:25:49.4544302Z [90m2025-10-17 06:25:49.451[0m | critical | [35m         Always[0m | [37mFor buffer index 1, number of CB pages 69029 is greater than 65535. Would cause wraparound in the CB calculations.[0m [90m(assert.hpp:103)[0m

2025-10-17T06:25:55.6438339Z [90m2025-10-17 06:25:55.643[0m | critical | [35m         Always[0m | [37m381 unique+common runtime args targeting kernel reshard_reader on (x=0,y=0) are too large. Max allowable is 341[0m [90m(assert.hpp:103)[0m

2025-10-17T05:32:28.6803141Z [90m2025-10-17 05:32:28.680[0m | critical | [35m         Always[0m | [37mTypecast operation requires Input and Output memory layout to match. Input layout: 0, Output layout: 4[0m [90m(assert.hpp:103)[0m

2025-10-17T05:32:39.8403544Z [90m2025-10-17 05:32:39.840[0m | critical | [35m         Always[0m | [37mInput and output tile size should be same[0m [90m(assert.hpp:103)[0m 
```

### What's changed

Temporarily disabled logs in `ttnn/api/ttnn/graph/graph_query_op_constraints.hpp` using `tt::LoggerRegistry`.