### PR TITLE
Add p300_mesh_graph_descriptor.yaml to CMakeLists

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -175,6 +175,7 @@ target_sources(
             fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml


### PR DESCRIPTION
### Ticket
None

### Problem description
BH post commit and nightly failing on p300 due to missing mesh graph descriptor
https://github.com/tenstorrent/tt-metal/actions/runs/18582053010/job/53018679661#step:6:419

```
E       Mesh graph descriptor file not found: /opt/venv/lib/python3.10/site-packages/ttnn/tt-metalium/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.yaml
```

### What's changed
Add the missing yaml to CMakeLists

### Checklist
- [x] BH nightly p300 demos: https://github.com/tenstorrent/tt-metal/actions/runs/18595784227/job/53022264278
- [x] BH post commit (p300 ccl test): https://github.com/tenstorrent/tt-metal/actions/runs/18596280484/job/53023905505