### PR TITLE
📈 Add Exponential Moving Average (EMA) Op

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -33,7 +33,7 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     )
 
     alpha = 0.25
-    num_itr = 1  # second iteration to help catch potential runtime args issue.
+    num_itr = 2  # second iteration to help catch potential runtime args issue.
     for _ in range(num_itr):
         tt_output_tensor = ttnn.ema(ttnn_input_tensor, alpha=alpha, core_grid=grid_size)
         ttnn.synchronize_device(device)
@@ -46,10 +46,10 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     # Calculate golden EMA output
     golden_output_tensor = torch.empty_like(torch_input_tensor)
 
-    # Compare with golden output
     prev_value = 0 * torch_input_tensor[0, :, :, 0]
     for t in range(T):
-        golden_output_tensor[0, :, :, t] = prev_value * alpha + (1 - alpha) * torch_input_tensor[0, :, :, t]
+        golden_output_tensor[0, :, :, t] = (prev_value * alpha) + ((1 - alpha) * torch_input_tensor[0, :, :, t])
         prev_value = golden_output_tensor[0, :, :, t]
 
+    # Compare with golden output
     assert torch.allclose(golden_output_tensor, torch_output_tensor, atol=1e-3)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -24,12 +24,12 @@ def test_ema(device, T, B, C, cores_y, cores_x):
 
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
     # torch input tensor
-    torch_input_tensor = torch.rand(T * B * C, dtype=torch.bfloat16).reshape(B, C, T // 1024, 1024)
+    torch_input_tensor = torch.rand(T * B * C, dtype=torch.bfloat16).reshape(1, B, C, T)
     # input tensor
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
@@ -37,7 +37,7 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     ttnn_output_tensor = ttnn.from_torch(
         torch_input_tensor * 0,
         dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -7,7 +7,6 @@ import torch
 from loguru import logger
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize(
@@ -19,7 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 def test_ema(device, T, B, C, cores_y, cores_x):
     torch.manual_seed(0)
 
-    grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
+    grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x) if cores_y > 0 and cores_x > 0 else None
 
     # torch input tensor
     torch_input_tensor = torch.ones(T * B * C, dtype=torch.bfloat16).reshape(1, B, C, T)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -13,8 +13,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "T, B, C, cores_y, cores_x",
     [
-        (32, 1, 32, 1, 1),  # simple case
-        # (16384, 4, 8192, 8, 8),  # base case
+        (16384, 4, 8192, 8, 8),  # base case
     ],
 )
 def test_ema(device, T, B, C, cores_y, cores_x):
@@ -54,5 +53,4 @@ def test_ema(device, T, B, C, cores_y, cores_x):
         golden_output_tensor[0, :, :, t] = prev_value * alpha + (1 - alpha) * torch_input_tensor[0, :, :, t]
         prev_value = golden_output_tensor[0, :, :, t]
 
-    breakpoint()
     assert torch.allclose(golden_output_tensor, torch_output_tensor, atol=1e-3)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -13,7 +13,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "T, B, C, cores_y, cores_x",
     [
-        (16384, 4, 8192, 8, 8),  # base case
+        (16384, 4, 8192, 0, 0),  # base case
     ],
 )
 def test_ema(device, T, B, C, cores_y, cores_x):

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -44,7 +44,7 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     logger.info("Finished OP, comparing outputs")
 
     # Calculate golden EMA output
-    golden_output_tensor = torch.zeros_like(torch_input_tensor)
+    golden_output_tensor = torch.empty_like(torch_input_tensor)
 
     # Compare with golden output
     prev_value = 0 * torch_input_tensor[0, :, :, 0]

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+from loguru import logger
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "T, B, C, cores_y, cores_x",
+    [
+        (16384, 4, 8192, 8, 8),  # base case
+    ],
+)
+def test_ema(device, T, B, C, cores_y, cores_x):
+    torch.manual_seed(0)
+
+    grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
+    # torch input tensor
+    torch_input_tensor = torch.rand(T * B * C, dtype=torch.bfloat16).reshape(B, C, T // 1024, 1024)
+    # input tensor
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_output_tensor = ttnn.from_torch(
+        torch_input_tensor * 0,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    num_itr = 1  # second iteration to help catch potential runtime args issue.
+    for _ in range(num_itr):
+        tt_output_tensor = ttnn.ema(ttnn_input_tensor, alpha=1e-2, core_grid=grid_size, out=ttnn_output_tensor)
+        ttnn.synchronize_device(device)
+    dev_output_tensor = ttnn.from_device(tt_output_tensor)
+    torch_output_tensor = ttnn.to_torch(dev_output_tensor)
+    assert torch.allclose(2 * torch_input_tensor, torch_output_tensor, atol=1e-3)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -13,7 +13,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "T, B, C, cores_y, cores_x",
     [
-        (16384, 4, 8192, 8, 8),  # base case
+        (32, 1, 32, 1, 1),  # simple case
+        # (16384, 4, 8192, 8, 8),  # base case
     ],
 )
 def test_ema(device, T, B, C, cores_y, cores_x):
@@ -22,7 +23,7 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
 
     # torch input tensor
-    torch_input_tensor = torch.rand(T * B * C, dtype=torch.bfloat16).reshape(1, B, C, T)
+    torch_input_tensor = torch.ones(T * B * C, dtype=torch.bfloat16).reshape(1, B, C, T)
 
     # move to the device
     ttnn_input_tensor = ttnn.from_torch(
@@ -48,10 +49,10 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     golden_output_tensor = torch.zeros_like(torch_input_tensor)
 
     # Compare with golden output
-    torch_input_tensor = 2 * torch_input_tensor
     prev_value = 0 * torch_input_tensor[0, :, :, 0]
     for t in range(T):
         golden_output_tensor[0, :, :, t] = prev_value * alpha + (1 - alpha) * torch_input_tensor[0, :, :, t]
         prev_value = golden_output_tensor[0, :, :, t]
 
+    breakpoint()
     assert torch.allclose(golden_output_tensor, torch_output_tensor, atol=1e-3)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -3,13 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 import torch
-
 from loguru import logger
 
 import ttnn
-
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -23,9 +20,11 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     torch.manual_seed(0)
 
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
+
     # torch input tensor
     torch_input_tensor = torch.rand(T * B * C, dtype=torch.bfloat16).reshape(1, B, C, T)
-    # input tensor
+
+    # move to the device
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=ttnn.DataType.BFLOAT16,
@@ -34,18 +33,13 @@ def test_ema(device, T, B, C, cores_y, cores_x):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    ttnn_output_tensor = ttnn.from_torch(
-        torch_input_tensor * 0,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
     alpha = 0.25
     num_itr = 1  # second iteration to help catch potential runtime args issue.
     for _ in range(num_itr):
-        tt_output_tensor = ttnn.ema(ttnn_input_tensor, alpha=alpha, core_grid=grid_size, out=ttnn_output_tensor)
+        tt_output_tensor = ttnn.ema(ttnn_input_tensor, alpha=alpha, core_grid=grid_size)
         ttnn.synchronize_device(device)
+
+    # move to the host
     dev_output_tensor = ttnn.from_device(tt_output_tensor)
     torch_output_tensor = ttnn.to_torch(dev_output_tensor)
     logger.info("Finished OP, comparing outputs")
@@ -53,6 +47,7 @@ def test_ema(device, T, B, C, cores_y, cores_x):
     # Calculate golden EMA output
     golden_output_tensor = torch.zeros_like(torch_input_tensor)
 
+    # Compare with golden output
     torch_input_tensor = 2 * torch_input_tensor
     prev_value = 0 * torch_input_tensor[0, :, :, 0]
     for t in range(T):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -12,7 +12,7 @@ inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<Sfpu
 
 inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
 
-inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_prev_output_(); }
+inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_previous_output_(); }
 
 inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -12,7 +12,7 @@ inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<Sfpu
 
 inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
 
-inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_previous_output_(); }
+inline void llk_math_ema_sfpu_clear_previous_output() { sfpu::_clear_previous_output_(); }
 
 inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -10,10 +10,13 @@ namespace ckernel {
 
 inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>(); }
 
-template <uint32_t input_dst_index>
-inline void llk_math_ema_sfpu(bool first_sample) {
+inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
+
+inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_prev_output_(); }
+
+inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);
-    ckernel::sfpu::_calculate_ema_online_(first_sample);
+    sfpu::_calculate_ema_tile_();
     _llk_math_eltwise_ternary_sfpu_done_();
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_ternary_sfpu.h"
+
+namespace ckernel {
+
+inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>(); }
+
+template <uint32_t input_dst_index>
+inline void llk_math_ema_sfpu(bool first_sample) {
+    _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);
+    ckernel::sfpu::_calculate_ema_online_(first_sample);
+    _llk_math_eltwise_ternary_sfpu_done_();
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_sfpu_types.h"
+#include "llk_math_ema_sfpu.h"
+#include "llk_math_eltwise_ternary_sfpu.h"
+
+namespace ckernel {
+
+inline void llk_math_ema_sfpu_init() { _llk_math_ema_sfpu_init_(); }
+
+template <uint32_t input_dst_index>
+inline void llk_math_ema_sfpu(bool first_sample) {
+    _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);
+    ckernel::sfpu::_calculate_ema_online_(first_sample);
+    _llk_math_eltwise_ternary_sfpu_done_();  // Finalize
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -12,7 +12,7 @@ inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<Sfpu
 
 inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
 
-inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_previous_output_(); }
+inline void llk_math_ema_sfpu_clear_previous_output() { sfpu::_clear_previous_output_(); }
 
 inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -10,10 +10,13 @@ namespace ckernel {
 
 inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>(); }
 
-template <uint32_t input_dst_index>
-inline void llk_math_ema_sfpu(bool first_sample) {
+inline void llk_math_ema_sfpu_load_alpha_beta(uint32_t alpha, uint32_t beta) { sfpu::_load_alpha_beta_(alpha, beta); }
+
+inline void llk_math_ema_sfpu_clear_prev_output() { sfpu::_clear_previous_output_(); }
+
+inline void llk_math_ema_sfpu_tile(uint32_t input_dst_index) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);
-    ckernel::sfpu::_calculate_ema_online_(first_sample);
+    sfpu::_calculate_ema_tile_();
     _llk_math_eltwise_ternary_sfpu_done_();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_ema_sfpu_entry.h
@@ -4,19 +4,17 @@
 
 #pragma once
 
-#include "llk_sfpu_types.h"
-#include "llk_math_ema_sfpu.h"
 #include "llk_math_eltwise_ternary_sfpu.h"
 
 namespace ckernel {
 
-inline void llk_math_ema_sfpu_init() { _llk_math_ema_sfpu_init_(); }
+inline void llk_math_ema_sfpu_init() { _llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>(); }
 
 template <uint32_t input_dst_index>
 inline void llk_math_ema_sfpu(bool first_sample) {
     _llk_math_eltwise_ternary_sfpu_start_<DST_SYNC_MODE>(input_dst_index);
     ckernel::sfpu::_calculate_ema_online_(first_sample);
-    _llk_math_eltwise_ternary_sfpu_done_();  // Finalize
+    _llk_math_eltwise_ternary_sfpu_done_();
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/ema.h
+++ b/tt_metal/include/compute_kernel_api/ema.h
@@ -12,9 +12,10 @@
 namespace ckernel {
 ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
 
-template <uint32_t input_dst_index>
-ALWI void ema_tile(bool first_sample) {
-    MATH((llk_math_ema_sfpu<input_dst_index>(first_sample)));
-}
+ALWI void ema_load_alpha_beta(uint32_t alpha, uint32_t beta) { MATH((llk_math_ema_sfpu_load_alpha_beta(alpha, beta))); }
+
+ALWI void ema_clear_prev_output() { MATH((llk_math_ema_sfpu_clear_prev_output())); }
+
+ALWI void ema_tile(uint32_t input_dst_index) { MATH((llk_math_ema_sfpu_tile(input_dst_index))); }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/ema.h
+++ b/tt_metal/include/compute_kernel_api/ema.h
@@ -10,9 +10,10 @@
 #endif
 
 namespace ckernel {
-ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
-
-ALWI void ema_load_alpha_beta(uint32_t alpha, uint32_t beta) { MATH((llk_math_ema_sfpu_load_alpha_beta(alpha, beta))); }
+ALWI void ema_init(uint32_t alpha, uint32_t beta) {
+    MATH((llk_math_ema_sfpu_init()));
+    MATH((llk_math_ema_sfpu_load_alpha_beta(alpha, beta)));
+}
 
 ALWI void ema_clear_previous_output() { MATH((llk_math_ema_sfpu_clear_previous_output())); }
 

--- a/tt_metal/include/compute_kernel_api/ema.h
+++ b/tt_metal/include/compute_kernel_api/ema.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_ema_sfpu_entry.h"
+#endif
+
+namespace ckernel {
+/**
+ * @brief Performs a ema's online algorithm update for mean and m2 on a tile in the DST register.
+ *
+ * This operation computes the running mean and m2 for a stream of data, enabling numerically stable
+ * calculation of statistics in a single pass. The DST register buffer must be in acquired state via @ref
+ * tile_regs_acquire call. This call is blocking and is only available on the compute engine.
+ *
+ * @tparam input_dst_index   The index of the tile in DST register buffer containing the new input.
+ *                           Must be less than the size of the DST register.
+ * @param first_sample       Whether this is the first sample in the stream.
+ * @note All TILE_WIDTH (32) columns of the input tile are processed by this function.
+ *
+ * @return None. Mean and m2 tiles are updated in place.
+ */
+
+template <uint32_t input_dst_index>
+ALWI void ema_tile(bool first_sample) {
+    MATH((llk_math_ema_sfpu<input_dst_index>(first_sample)));
+}
+
+/**
+ * Uses a copy of the ternery_sfpu_init
+ * Programs the replay for fast LLK. Needed otherwise LLK wont work
+ */
+ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/ema.h
+++ b/tt_metal/include/compute_kernel_api/ema.h
@@ -14,7 +14,7 @@ ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
 
 ALWI void ema_load_alpha_beta(uint32_t alpha, uint32_t beta) { MATH((llk_math_ema_sfpu_load_alpha_beta(alpha, beta))); }
 
-ALWI void ema_clear_prev_output() { MATH((llk_math_ema_sfpu_clear_prev_output())); }
+ALWI void ema_clear_previous_output() { MATH((llk_math_ema_sfpu_clear_previous_output())); }
 
 ALWI void ema_tile(uint32_t input_dst_index) { MATH((llk_math_ema_sfpu_tile(input_dst_index))); }
 

--- a/tt_metal/include/compute_kernel_api/ema.h
+++ b/tt_metal/include/compute_kernel_api/ema.h
@@ -4,38 +4,17 @@
 
 #pragma once
 
-#include <optional>
-
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
 #include "llk_math_ema_sfpu_entry.h"
 #endif
 
 namespace ckernel {
-/**
- * @brief Performs a ema's online algorithm update for mean and m2 on a tile in the DST register.
- *
- * This operation computes the running mean and m2 for a stream of data, enabling numerically stable
- * calculation of statistics in a single pass. The DST register buffer must be in acquired state via @ref
- * tile_regs_acquire call. This call is blocking and is only available on the compute engine.
- *
- * @tparam input_dst_index   The index of the tile in DST register buffer containing the new input.
- *                           Must be less than the size of the DST register.
- * @param first_sample       Whether this is the first sample in the stream.
- * @note All TILE_WIDTH (32) columns of the input tile are processed by this function.
- *
- * @return None. Mean and m2 tiles are updated in place.
- */
+ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
 
 template <uint32_t input_dst_index>
 ALWI void ema_tile(bool first_sample) {
     MATH((llk_math_ema_sfpu<input_dst_index>(first_sample)));
 }
-
-/**
- * Uses a copy of the ternery_sfpu_init
- * Programs the replay for fast LLK. Needed otherwise LLK wont work
- */
-ALWI void ema_init() { MATH((llk_math_ema_sfpu_init())); }
 
 }  // namespace ckernel

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -305,6 +305,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/argmax_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/accumulation/ema/ema_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/moe/moe_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/sampling/sampling_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -39,6 +39,9 @@ target_sources(
         accumulation/accumulation_common.cpp
         accumulation/cumprod/cumprod.cpp
         accumulation/cumsum/cumsum.cpp
+        accumulation/ema/ema.cpp
+        accumulation/ema/ema_op.cpp
+        accumulation/ema/ema_multicore.cpp
         accumulation/device/accumulation_device_operation.cpp
         accumulation/device/accumulation_program_factory.cpp
         sampling/device/sampling_op.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <utility>
+
+#include "ema.hpp"
+#include "ema_op.hpp"
+
+namespace ttnn::operations::reduction::accumulation {
+
+Tensor EmaOperation::invoke(
+    const Tensor& input_tensor,
+    const float& alpha,
+    std::optional<Tensor> optional_out,
+    std::optional<CoreGrid> core_grid,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    return tt::tt_metal::operation::run(
+               Ema{
+                   .alpha = alpha,
+                   .grid_size = core_grid.value_or(CoreGrid(0, 0)).to_CoreCoord(),
+                   .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+                   .compute_kernel_config =
+                       init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config),
+               },
+               {input_tensor},
+               {},
+               {std::move(optional_out)})
+        .at(0);
+}
+
+}  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
@@ -21,8 +21,12 @@ Tensor EmaOperation::invoke(
                    .alpha = alpha,
                    .grid_size = core_grid.value_or(CoreGrid(0, 0)).to_CoreCoord(),
                    .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
-                   .compute_kernel_config =
-                       init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config),
+                   .compute_kernel_config = init_device_compute_kernel_config(
+                       input_tensor.device()->arch(),
+                       compute_kernel_config,
+                       /*math_fidelity=*/MathFidelity::HiFi4,
+                       /*default_approx_mode=*/false,
+                       /*fp32_acc=*/true),
                },
                {input_tensor},
                {},

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <utility>
-
 #include "ema.hpp"
 #include "ema_op.hpp"
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.cpp
@@ -22,9 +22,9 @@ Tensor EmaOperation::invoke(
                    .compute_kernel_config = init_device_compute_kernel_config(
                        input_tensor.device()->arch(),
                        compute_kernel_config,
-                       /*math_fidelity=*/MathFidelity::HiFi4,
+                       /*default_fidelity=*/MathFidelity::HiFi4,
                        /*default_approx_mode=*/false,
-                       /*fp32_acc=*/true),
+                       /*default_fp32_acc=*/true),
                },
                {input_tensor},
                {},

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn {
+namespace operations::reduction::accumulation {
+
+struct EmaOperation {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const float& alpha,
+        std::optional<Tensor> optional_out,
+        std::optional<CoreGrid> core_grid = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+};
+
+}  // namespace operations::reduction::accumulation
+
+constexpr auto ema = ttnn::register_operation<"ttnn::ema", ttnn::operations::reduction::accumulation::EmaOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
@@ -50,6 +50,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     // ----------------------
     auto src_cb_index = tt::CBIndex::c_0;
     auto dst_cb_index = tt::CBIndex::c_1;
+    auto prev_cb_index = tt::CBIndex::c_2;
 
     auto src_data_format = datatype_to_dataformat_converter(a.dtype());
     auto dst_data_format = datatype_to_dataformat_converter(output.dtype());
@@ -59,6 +60,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
 
     auto src_cb_size = src_tile_size * ema_buffer_depth;
     auto dst_cb_size = dst_tile_size * ema_buffer_depth;
+    auto prev_cb_size = src_tile_size;
 
     auto src_cb_cfg = tt::tt_metal::CircularBufferConfig(src_cb_size, {{src_cb_index, src_data_format}})
                           .set_page_size(src_cb_index, src_tile_size);
@@ -67,6 +69,10 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     auto dst_cb_cfg = tt::tt_metal::CircularBufferConfig(dst_cb_size, {{dst_cb_index, dst_data_format}})
                           .set_page_size(dst_cb_index, dst_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_grid, dst_cb_cfg);
+
+    auto prev_cb_cfg = tt::tt_metal::CircularBufferConfig(prev_cb_size, {{prev_cb_index, src_data_format}})
+                           .set_page_size(prev_cb_index, src_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, core_grid, prev_cb_cfg);
 
     // Compile time args for the kernels
     // ---------------------------------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
@@ -28,12 +28,9 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     if ((grid_size.x == 0) && (grid_size.y == 0)) {
         grid_size = a.device()->compute_with_storage_grid_size();
     }
-    auto num_cores = grid_size.x * grid_size.y;
-    auto core_grid = CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1));
-    auto all_cores = grid_to_cores(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1), false);
+    auto num_cores_available = grid_size.x * grid_size.y;
 
-    // Tensor sizing
-    // -------------
+    // Compute total_tiles to determine core split
     auto a_shape = a.padded_shape();
     auto num_batches = a_shape[1];
     auto num_channels = a_shape[2];
@@ -42,8 +39,26 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     auto tiles_per_channel = a_shape[3] / a.tensor_spec().tile().get_width();
 
     auto total_tiles = num_batches * num_channel_tiles * tiles_per_channel;
+
+    // We pick the maximum number of cores (from the available) that divides total_tiles equally
+    uint32_t num_cores = num_cores_available;
+    while ((num_cores > 1) && (total_tiles % num_cores != 0)) {
+        --num_cores;
+    }
+
+    // We now have the number of cores to use, compute per core parameters
+    auto all_cores = CoreRangeSet(grid_to_cores(num_cores, grid_size.x, grid_size.y, false));
+    log_warning(tt::LogOp, "Using {} cores out of {} available", num_cores, num_cores_available);
+    log_warning(tt::LogOp, "Provided grid size: {}x{}", grid_size.x, grid_size.y);
+
     auto total_tiles_per_core = total_tiles / num_cores;
     auto total_batches_per_core = total_tiles_per_core / tiles_per_channel;
+
+    // Premcompute the alpha and beta bits
+    // Used by the EMA SFPU instructions
+    // ----------------------------------
+    auto alpha_bits = std::bit_cast<uint32_t>(alpha);
+    auto beta_bits = std::bit_cast<uint32_t>(1.0f - alpha);
 
     // Create program
     // --------------
@@ -67,33 +82,37 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
 
     auto src_cb_cfg = tt::tt_metal::CircularBufferConfig(src_cb_size, {{src_cb_index, src_data_format}})
                           .set_page_size(src_cb_index, src_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_grid, src_cb_cfg);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, src_cb_cfg);
 
     auto dst_cb_cfg = tt::tt_metal::CircularBufferConfig(dst_cb_size, {{dst_cb_index, dst_data_format}})
                           .set_page_size(dst_cb_index, dst_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_grid, dst_cb_cfg);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, dst_cb_cfg);
 
     auto prev_cb_cfg = tt::tt_metal::CircularBufferConfig(prev_cb_size, {{prev_cb_index, src_data_format}})
                            .set_page_size(prev_cb_index, src_tile_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_grid, prev_cb_cfg);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, prev_cb_cfg);
 
     // Compile time args for the kernels
     // ---------------------------------
     std::vector<uint32_t> reader_compile_args = {total_tiles_per_core, src_tile_size};
     tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_compile_args);
 
-    std::vector<uint32_t> writer_compile_args = {
-        total_tiles_per_core,
-        dst_tile_size,
-    };
+    std::vector<uint32_t> writer_compile_args = {total_tiles_per_core, dst_tile_size};
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_args);
+
+    std::vector<uint32_t> compute_compile_args = {
+        total_batches_per_core,
+        tiles_per_channel,
+        alpha_bits,
+        beta_bits,
+    };
 
     // Create kernels
     // --------------
     auto reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp",
-        core_grid,
+        all_cores,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
@@ -102,7 +121,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     auto writer_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp",
-        core_grid,
+        all_cores,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::RISCV_0_default,
@@ -113,13 +132,13 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
     CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp",
-        core_grid,
+        all_cores,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = dst_full_sync_en,
             .math_approx_mode = math_approx_mode,
-            .compile_args = {total_batches_per_core, tiles_per_channel}});
+            .compile_args = compute_compile_args});
 
     // Set runtime args
     // ---------------
@@ -134,14 +153,16 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
 
     uint32_t src_start_tile = 0;
     uint32_t dst_start_tile = 0;
-    for (const auto& core : all_cores) {
-        reader_runtime_args[1] = src_start_tile;
-        writer_runtime_args[1] = dst_start_tile;
-        src_start_tile += total_tiles_per_core;
-        dst_start_tile += total_tiles_per_core;
+    for (const auto& range : all_cores.ranges()) {
+        for (const auto& core : range) {
+            reader_runtime_args[1] = src_start_tile;
+            writer_runtime_args[1] = dst_start_tile;
+            src_start_tile += total_tiles_per_core;
+            dst_start_tile += total_tiles_per_core;
 
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        }
     }
 
     // runtime_args_callback: If only the tensor changes, invoke this callback and skip the rest
@@ -156,11 +177,13 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
         auto dst_buffer = output_tensors.at(0).buffer()->address();
 
         // Update buffer addresses for all cores
-        for (const auto& core : all_cores) {
-            auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            reader_runtime_args[0] = src_buffer;
-            auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            writer_runtime_args[0] = dst_buffer;
+        for (const auto& range : all_cores.ranges()) {
+            for (const auto& core : range) {
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                reader_runtime_args[0] = src_buffer;
+                auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                writer_runtime_args[0] = dst_buffer;
+            }
         }
     };
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
@@ -48,8 +48,8 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
 
     // We now have the number of cores to use, compute per core parameters
     auto all_cores = CoreRangeSet(grid_to_cores(num_cores, grid_size.x, grid_size.y, false));
-    log_warning(tt::LogOp, "Using {} cores out of {} available", num_cores, num_cores_available);
-    log_warning(tt::LogOp, "Provided grid size: {}x{}", grid_size.x, grid_size.y);
+    log_debug(tt::LogOp, "Provided grid size: y={}, x={}", grid_size.y, grid_size.x);
+    log_debug(tt::LogOp, "Using {} cores out of {} available", num_cores, num_cores_available);
 
     auto total_tiles_per_core = total_tiles / num_cores;
     auto total_batches_per_core = total_tiles_per_core / tiles_per_channel;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
@@ -52,7 +52,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
 
     auto total_batches_per_core = total_tiles_per_core / tiles_per_channel;
 
-    // Premcompute the alpha and beta bits
+    // Precompute the alpha and beta bits
     // Used by the EMA SFPU instructions
     // ----------------------------------
     auto alpha_bits = std::bit_cast<uint32_t>(alpha);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_multicore.cpp
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+
+#include <tt-metalium/circular_buffer_config.hpp>
+#include "ema_op.hpp"
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/math.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::reduction::accumulation {
+
+constexpr auto ema_buffer_depth = 2;
+
+tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
+    const Tensor& a,
+    Tensor& output,
+    float alpha,
+    CoreCoord grid_size,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
+    // Args to size the grid
+    // If empty grid size, use all cores
+    if ((grid_size.x == 0) && (grid_size.y == 0)) {
+        grid_size = a.device()->compute_with_storage_grid_size();
+    }
+    auto num_cores = grid_size.x * grid_size.y;
+    auto core_grid = CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1));
+
+    // Args based on the tensor shape
+    auto a_shape = a.padded_shape();
+    auto batch = a_shape[0];
+    auto channel = a_shape[1];
+    auto pages = a_shape[2];
+
+    auto total_pages = batch * channel * pages;
+    auto pages_per_core = total_pages / num_cores;
+
+    auto batches_per_core = batch * channel / num_cores;
+
+    auto program = Program();
+
+    // Circular buffer config
+    // ----------------------
+    auto src_cb_index = tt::CBIndex::c_0;
+    auto dst_cb_index = tt::CBIndex::c_1;
+
+    auto a_data_format = datatype_to_dataformat_converter(a.dtype());
+    auto dst_data_format = datatype_to_dataformat_converter(output.dtype());
+
+    auto src_cb_size = a.buffer()->aligned_page_size() * ema_buffer_depth;
+    auto dst_cb_size = output.buffer()->aligned_page_size() * ema_buffer_depth;
+
+    auto src_cb_cfg = tt::tt_metal::CircularBufferConfig(src_cb_size, {{src_cb_index, a_data_format}})
+                          .set_page_size(src_cb_index, a.buffer()->aligned_page_size());
+    tt::tt_metal::CreateCircularBuffer(program, core_grid, src_cb_cfg);
+
+    auto dst_cb_cfg = tt::tt_metal::CircularBufferConfig(dst_cb_size, {{dst_cb_index, dst_data_format}})
+                          .set_page_size(dst_cb_index, output.buffer()->aligned_page_size());
+    tt::tt_metal::CreateCircularBuffer(program, core_grid, dst_cb_cfg);
+
+    // Compile time args for the kernels
+    // ---------------------------------
+    std::vector<uint32_t> reader_compile_args = {pages_per_core, a.buffer()->aligned_page_size()};
+    tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_compile_args);
+
+    std::vector<uint32_t> writer_compile_args = {
+        pages_per_core,
+        output.buffer()->aligned_page_size(),
+    };
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_args);
+
+    // Create kernels
+    // --------------
+    auto reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp",
+        core_grid,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .compile_args = reader_compile_args});
+
+    auto writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp",
+        core_grid,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .compile_args = writer_compile_args});
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+    CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp",
+        core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = {batches_per_core, pages}});
+
+    auto all_cores = grid_to_cores(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1), false);
+    // Runtime args
+    std::vector<uint32_t> reader_runtime_args = {
+        a.buffer()->address(),
+        0,  // Placeholder for src_start_page
+    };
+    std::vector<uint32_t> writer_runtime_args = {
+        output.buffer()->address(),
+        0,  // Placeholder for dst_start_page
+    };
+
+    uint32_t src_start_page = 0;
+    uint32_t dst_start_page = 0;
+    for (const auto& core : all_cores) {
+        reader_runtime_args[1] = src_start_page;
+        writer_runtime_args[1] = dst_start_page;
+        src_start_page += pages_per_core;
+        dst_start_page += pages_per_core;
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, all_cores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto src_buffer = input_tensors.at(0).buffer()->address();
+        auto dst_buffer = output_tensors.at(0).buffer()->address();
+
+        for (const auto& core : all_cores) {
+            auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            reader_runtime_args[0] = src_buffer;
+            auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            writer_runtime_args[0] = dst_buffer;
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+}  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
@@ -6,13 +6,60 @@
 
 #include <optional>
 
+#include <tt_stl/assert.hpp>
 #include "ttnn/operations/math.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::reduction::accumulation {
 
-void Ema::validate(const std::vector<Tensor>& input_tensors) const {}
+void Ema::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) const {
+    TT_FATAL(input_tensors.size() == 1, "Must have exactly 1 input tensor, got {} tensors", input_tensors.size());
+
+    const auto& input_tensor = input_tensors.at(0);
+
+    // Dtype, Device and layout checks
+    TT_FATAL(
+        input_tensor.dtype() == DataType::BFLOAT16, "Input tensor must be BFLOAT16, got: {}", input_tensor.dtype());
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "Input tensor must be on device, got: {}",
+        input_tensor.storage_type());
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in a device buffer");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor must have TILE layout, got: {}", input_tensor.layout());
+
+    // Shape constraints: [1, B, C, T]
+    const auto& input_shape = input_tensor.logical_shape();
+    TT_FATAL(input_shape.rank() == 4, "EMA input must be 4D [1, B, C, T], got rank {}", input_shape.rank());
+    TT_FATAL(input_shape[0] == 1, "EMA expects leading dimension to be 1, got {}", input_shape[0]);
+
+    // This OP produces as many elements in output as there are in input
+    // Thus, the volume must be the same to avoid writing outside the output buffer
+    if ((!optional_output_tensors.empty()) && (optional_output_tensors.at(0).has_value())) {
+        const auto& output_tensor = optional_output_tensors.at(0).value();
+        TT_FATAL(
+            output_tensor.dtype() == DataType::BFLOAT16,
+            "Output tensor must be BFLOAT16, got: {}",
+            output_tensor.dtype());
+        TT_FATAL(
+            output_tensor.storage_type() == StorageType::DEVICE,
+            "Output tensor must be on device, got: {}",
+            output_tensor.storage_type());
+        TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor must be allocated in a device buffer");
+        TT_FATAL(
+            output_tensor.layout() == Layout::TILE,
+            "Output tensor must have TILE layout, got: {}",
+            output_tensor.layout());
+        TT_FATAL(
+            input_tensor.padded_shape().volume() == output_tensor.padded_shape().volume(),
+            "Input and output must have the same volume");
+    }
+
+    // Alpha validation
+    TT_FATAL(!std::isnan(this->alpha), "EMA alpha must be a valid number, got {}", this->alpha);
+}
 
 std::vector<TensorSpec> Ema::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
@@ -16,7 +16,7 @@ void Ema::validate(const std::vector<Tensor>& input_tensors) const {}
 
 std::vector<TensorSpec> Ema::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.tensor_spec()};
+    return {input_tensor.tensor_spec().with_memory_config(this->output_mem_config)};
 }
 
 std::vector<Tensor> Ema::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ema_op.hpp"
+
+#include <optional>
+
+#include "ttnn/operations/math.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::reduction::accumulation {
+
+void Ema::validate(const std::vector<Tensor>& input_tensors) const {}
+
+std::vector<TensorSpec> Ema::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    return {input_tensor.tensor_spec()};
+}
+
+std::vector<Tensor> Ema::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) const {
+    return operation::default_create_output_tensors(*this, input_tensors, optional_output_tensors);
+}
+
+operation::ProgramWithCallbacks Ema::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& a = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+
+    return ema_multi_core(a, output_tensor, this->alpha, this->grid_size, this->compute_kernel_config);
+}
+
+}  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn::operations::reduction::accumulation {
+
+tt::tt_metal::operation::ProgramWithCallbacks ema_multi_core(
+    const Tensor& a,
+    Tensor& output,
+    float alpha,
+    CoreCoord grid_size,
+    const DeviceComputeKernelConfig& compute_kernel_config);
+
+struct Ema {
+    float alpha;
+    CoreCoord grid_size;
+    MemoryConfig output_mem_config;
+    const DeviceComputeKernelConfig compute_kernel_config;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<Tensor>>& optional_output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_op.hpp
@@ -26,7 +26,9 @@ struct Ema {
     MemoryConfig output_mem_config;
     const DeviceComputeKernelConfig compute_kernel_config;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<Tensor>>& optional_output_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -53,7 +53,7 @@ void bind_reduction_ema_operation(py::module& module) {
                  - Layouts
                  - Ranks
                * - BFLOAT16, FLOAT32
-                 - ROW MAJOR
+                 - TILE
                  - 4
 
         Memory Support:

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -22,10 +22,10 @@ void bind_reduction_ema_operation(py::module& module) {
 
         Returns the exponential moving average of `input` along the last dimension.
 
-        For a given `input` of size N along the last dimension, the `output` will also contain N elements and be such that:
+        For a given `input` of size T along the last dimension, the `output` will also contain T elements and be such that:
 
         .. math::
-            \mathrm{{output}}_i = \alpha \times \mathrm{{input}}_i + (1 - \alpha) \times \mathrm{{output}}_{i-1}
+            \mathrm{{output}}_t = \alpha \times \mathrm{{input}}_t + (1 - \alpha) \times \mathrm{{output}}_{t-1}
 
         with \mathrm{{output}}_0 = \mathrm{{input}}_0
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -25,7 +25,7 @@ void bind_reduction_ema_operation(py::module& module) {
         For a given `input` of size T along the last dimension, the `output` will also contain T elements and be such that:
 
         .. math::
-            \mathrm{{output}}_t = \alpha \times \mathrm{{input}}_t + (1 - \alpha) \times \mathrm{{output}}_{t-1}
+            \mathrm{{output}}_t = \alpha \times \mathrm{{output}}_{t-1} + (1 - \alpha) \times \mathrm{{input}}_t
 
         with \mathrm{{output}}_0 = \mathrm{{input}}_0
 
@@ -35,8 +35,8 @@ void bind_reduction_ema_operation(py::module& module) {
 
         Keyword Args:
             out (ttnn.Tensor, optional): preallocated output. If specified, `out` must have same shape as `input`, and must be on the same device.
-            core_grid (ttnn.CoreGrid, optional): core grid for the operation. If not provided, an optimal core grid will be selected.
-            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): core grid for the operation. If not provided, an optimal core grid will be selected based on the input tensor shape.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to input tensor memory config.
             compute_kernel_config (ttnn.ComputeKernelConfig, optional): compute kernel configuration for the operation. Defaults to `None`.
 
         Returns:
@@ -52,7 +52,7 @@ void bind_reduction_ema_operation(py::module& module) {
                * - Dtypes
                  - Layouts
                  - Ranks
-               * - BFLOAT16, FLOAT32
+               * - BFLOAT16
                  - TILE
                  - 4
 
@@ -66,13 +66,13 @@ void bind_reduction_ema_operation(py::module& module) {
             .. code-block:: python
 
                 # Create tensor
-                tensor_input = ttnn.rand((1, 2, 3, 4), device=device)
+                tensor_input = ttnn.rand((1, 2, 64, 128), device=device, layout=ttnn.TILE_LAYOUT)
 
                 # Apply ttnn.ema() with alpha=0.99
                 tensor_output = ttnn.ema(tensor_input, 0.99)
 
                 # With preallocated output
-                preallocated_output = ttnn.rand([1, 2, 3, 4], dtype=ttnn.bfloat16, device=device)
+                preallocated_output = ttnn.rand([1, 2, 64, 128], dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
 
                 tensor_output = ttnn.ema(tensor_input, 0.99, out=preallocated_output)
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -30,7 +30,7 @@ void bind_reduction_ema_operation(py::module& module) {
         with \mathrm{{output}}_0 = \mathrm{{input}}_0
 
         Args:
-            input (ttnn.Tensor): input tensor. Must be on the device.
+            input (ttnn.Tensor): input tensor of shape [1, B, C, T]. Must be on the device.
             alpha (float): the smoothing factor, typically between 0 and 1.
 
         Keyword Args:
@@ -66,13 +66,13 @@ void bind_reduction_ema_operation(py::module& module) {
             .. code-block:: python
 
                 # Create tensor
-                tensor_input = ttnn.rand((2,3,4), device=device)
+                tensor_input = ttnn.rand((1, 2, 3, 4), device=device)
 
                 # Apply ttnn.ema() with alpha=0.99
                 tensor_output = ttnn.ema(tensor_input, 0.99)
 
                 # With preallocated output
-                preallocated_output = ttnn.rand([2, 3, 4], dtype=ttnn.bfloat16, device=device)
+                preallocated_output = ttnn.rand([1, 2, 3, 4], dtype=ttnn.bfloat16, device=device)
 
                 tensor_output = ttnn.ema(tensor_input, 0.99, out=preallocated_output)
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ema_pybind.hpp"
+
+#include <cstdint>
+#include <optional>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn-pybind/decorators.hpp"
+#include "ttnn/operations/reduction/accumulation/ema/ema.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::reduction::accumulation::detail {
+void bind_reduction_ema_operation(py::module& module) {
+    auto docstring =
+        R"doc(
+        ``ttnn.ema(input: ttnn.Tensor, alpha: float, out: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor``
+
+        Returns the exponential moving average of `input` along the last dimension.
+
+        For a given `input` of size N along the last dimension, the `output` will also contain N elements and be such that:
+
+        .. math::
+            \mathrm{{output}}_i = \alpha \times \mathrm{{input}}_i + (1 - \alpha) \times \mathrm{{output}}_{i-1}
+
+        with \mathrm{{output}}_0 = \mathrm{{input}}_0
+
+        Args:
+            input (ttnn.Tensor): input tensor. Must be on the device.
+            alpha (float): the smoothing factor, typically between 0 and 1.
+
+        Keyword Args:
+            out (ttnn.Tensor, optional): preallocated output. If specified, `out` must have same shape as `input`, and must be on the same device.
+            core_grid (ttnn.CoreGrid, optional): core grid for the operation. If not provided, an optimal core grid will be selected.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            compute_kernel_config (ttnn.ComputeKernelConfig, optional): compute kernel configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+
+            Supported dtypes, layouts, ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - BFLOAT16, FLOAT32
+                 - ROW MAJOR
+                 - 4
+
+        Memory Support:
+            - Interleaved: DRAM and L1
+
+        Limitations:
+            - Preallocated output must have the same shape as the input
+
+        Example:
+            .. code-block:: python
+
+                # Create tensor
+                tensor_input = ttnn.rand((2,3,4), device=device)
+
+                # Apply ttnn.ema() with alpha=0.99
+                tensor_output = ttnn.ema(tensor_input, 0.99)
+
+                # With preallocated output
+                preallocated_output = ttnn.rand([2, 3, 4], dtype=ttnn.bfloat16, device=device)
+
+                tensor_output = ttnn.ema(tensor_input, 0.99, out=preallocated_output)
+
+        )doc";
+
+    using OperationType = decltype(ttnn::ema);
+    bind_registered_operation(
+        module,
+        ttnn::ema,
+        docstring,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const float& alpha,
+               std::optional<Tensor> optional_out,
+               const std::optional<CoreGrid>& core_grid,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) -> Tensor {
+                return self(input_tensor, alpha, optional_out, core_grid, memory_config, compute_kernel_config);
+            },
+            py::arg("input_tensor").noconvert(),
+            py::arg("alpha"),
+            py::kw_only(),
+            py::arg("out") = std::nullopt,
+            py::arg("core_grid") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+
+}  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::reduction::accumulation::detail {
+namespace py = pybind11;
+void bind_reduction_ema_operation(py::module& module);
+
+}  // namespace ttnn::operations::reduction::accumulation::detail

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -6,6 +6,63 @@
 #include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/ema.h"
 
+/*
+ * -------------------------------------------------------------------------------------------------
+ * The following snippet implements EMA using SFPI. This snippet assumes the following:
+ * 1. Each tile has 1 sample (t dimension) each of 1024 elements (32x32) in the input
+ * 2. Each tile has 4 faces
+ * 3. The dst regs at prev_dst_index hold the previous output for each sample in the tile.
+ *
+ * With this, it does the following:
+ * 1. Compute EMA for each sample in the tile
+ * 2. Write the output to the output buffer
+ * 3. Store the output in the previous dst regs for the next tile
+ *
+ * @note: To use this SFPI based implementation, the input tensor shape and reader/writer
+ *        kernels should be configured such that consecutive samples for a channel are in
+ *        consecutive tiles. Thus, the input is of shape [1, T, B, C].
+ *
+ *        Since this is 25% slower than the SFPU based implementation for similar shapes,
+ *        we retain this snippet for reference, but do not use it below.
+ */
+
+/*
+#ifdef TRISC_MATH
+inline void ema_sfpi_tile(
+    uint32_t inp_dst_index,
+    uint32_t prv_dst_index,
+    uint32_t out_dst_index) {
+    constexpr uint32_t n_vector_in_tile = 32;
+
+    const uint32_t inp_base_idx = inp_dst_index * n_vector_in_tile;
+    const uint32_t prv_base_idx = prv_dst_index * n_vector_in_tile;
+    const uint32_t out_base_idx = out_dst_index * n_vector_in_tile;
+
+    constexpr size_t vectors_per_face = 8;
+    for (size_t i = 0; i < vectors_per_face; i++) {
+        vFloat inp = dst_reg[inp_base_idx + i];
+        vFloat prv = dst_reg[prv_base_idx + i];
+        vFloat result = first_sample ? inp * beta : inp * beta + prv * alpha;
+        dst_reg[out_base_idx + i] = result;
+        dst_reg[prv_base_idx + i] = result;
+    }
+}
+#endif
+
+inline void ema_sfpi_tile(
+    uint32_t inp_dst_index,
+    uint32_t prv_dst_index,
+    uint32_t out_dst_index,
+    float alpha,
+    float beta,
+    bool first_sample) {
+    MATH(_llk_math_eltwise_binary_sfpu_params_<false>(
+        ema_sfpi_face, inp_dst_index, prv_dst_index, out_dst_index,
+        VectorMode::RC, alpha, beta, first_sample));
+}
+// ------------------------------------------------------------------------------------------------
+*/
+
 namespace NAMESPACE {
 void MAIN {
     // Compile time args
@@ -34,7 +91,7 @@ void MAIN {
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
         // For each batch, clear the previous output
-        ema_clear_prev_output();
+        ema_clear_previous_output();
         for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
             // Read input, transpose and compute ema
             cb_wait_front(src_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -4,7 +4,9 @@
 
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/transpose_wh_dest.h"
+#include "compute_kernel_api/ema.h"
 #include "debug/dprint_pages.h"
 #include "debug/dprint_tensix.h"
 
@@ -13,34 +15,47 @@ void MAIN {
     //-------------------------------------------------------------------------
     // Compile time args
     // -----------------
-    constexpr auto batches_per_core = get_compile_time_arg_val(0);
-    constexpr auto pages_per_batch = get_compile_time_arg_val(1);
+    constexpr auto total_batches_per_core = get_compile_time_arg_val(0);
+    constexpr auto tiles_per_channel = get_compile_time_arg_val(1);
 
     //-------------------------------------------------------------------------
     // CB indices
     // -----------------
     constexpr auto src_cb = tt::CBIndex::c_0;
     constexpr auto dst_cb = tt::CBIndex::c_1;
+    constexpr auto prev_cb = tt::CBIndex::c_2;
+
+    constexpr auto input_dst_index = 0;
+    constexpr auto prev_dst_index = input_dst_index + 1;
 
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
     binary_op_init_common(src_cb, src_cb, dst_cb);
     add_tiles_init(src_cb, src_cb);
+    ema_init();
+    // transpose_wh_init(src_cb, dst_cb);
     // copy_tile_init(src_cb);
-    for (uint32_t batch_id = 0; batch_id < batches_per_core; ++batch_id) {
-        for (uint32_t page_id = 0; page_id < pages_per_batch; ++page_id) {
+
+    for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
+        for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
             cb_wait_front(src_cb, 1);
             tile_regs_acquire();
+            // transpose_wh_init_short(src_cb);
+            // transpose_wh_tile(src_cb, 0, 0);
+            // transpose_wh_dest_init_short();
+            // transpose_wh_dest(0);
             // copy_tile(src_cb, 0, 0);
             // tt::compute::common::print_tile_rows(src_cb, 32, 0);
-            add_tiles(src_cb, src_cb, 0, 0, 0);
+            add_tiles(src_cb, src_cb, 0, 0, input_dst_index);
+            ema_tile<input_dst_index>((tile_id == 0));
             // dprint_tensix_dest_reg(0);
             tile_regs_commit();
             cb_pop_front(src_cb, 1);
 
             cb_reserve_back(dst_cb, 1);
             tile_regs_wait();
-            pack_tile(0, dst_cb);
+            pack_tile(input_dst_index, dst_cb);
+            // pack_tile(prev_dst_index, prev_cb);
             tile_regs_release();
             cb_push_back(dst_cb, 1);
         }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -29,15 +29,18 @@ void MAIN {
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
     ema_init();
+    ema_load_alpha_beta(alpha_bits, beta_bits);
     transpose_wh_init(src_cb, dst_cb);
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
+        // For each batch, clear the previous output
+        ema_clear_prev_output();
         for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
             // Read input, transpose and compute ema
             cb_wait_front(src_cb, 1);
             tile_regs_acquire();
             transpose_wh_tile(src_cb, 0, inp_dst_index);
-            ema_tile<inp_dst_index>((tile_id == 0));
+            ema_tile(inp_dst_index);
             tile_regs_commit();
             cb_pop_front(src_cb, 1);
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -85,8 +85,7 @@ void MAIN {
 
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
-    ema_init();
-    ema_load_alpha_beta(alpha_bits, beta_bits);
+    ema_init(alpha_bits, beta_bits);
     transpose_wh_init(src_cb, dst_cb);
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -14,6 +14,8 @@ void MAIN {
     // -----------------
     constexpr auto total_batches_per_core = get_compile_time_arg_val(0);
     constexpr auto tiles_per_channel = get_compile_time_arg_val(1);
+    constexpr auto alpha_bits = get_compile_time_arg_val(2);
+    constexpr auto beta_bits = get_compile_time_arg_val(3);
 
     // CB indices
     // ----------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/ema.h"
-#include "debug/dprint_pages.h"
-#include "debug/dprint_tensix.h"
 
 namespace NAMESPACE {
 void MAIN {
@@ -40,8 +38,6 @@ void MAIN {
             tile_regs_acquire();
             transpose_wh_tile(src_cb, 0, inp_dst_index);
             ema_tile<inp_dst_index>((tile_id == 0));
-            dprint_tensix_dest_reg(inp_dst_index);
-            dprint_tensix_dest_reg(output_dst_index);
             tile_regs_commit();
             cb_pop_front(src_cb, 1);
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/transpose_wh.h"
-#include "compute_kernel_api/transpose_wh_dest.h"
 #include "compute_kernel_api/ema.h"
 #include "debug/dprint_pages.h"
 #include "debug/dprint_tensix.h"
@@ -31,8 +29,6 @@ void MAIN {
 
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
-    binary_op_init_common(src_cb, src_cb, dst_cb);
-    add_tiles_init(src_cb, src_cb);
     ema_init();
     transpose_wh_init(src_cb, dst_cb);
 
@@ -40,7 +36,7 @@ void MAIN {
         // For the first tile (we don't need to load the previous data from CB)
         cb_wait_front(src_cb, 1);
         tile_regs_acquire();
-        transpose_wh_init_short(src_cb);
+        // transpose_wh_init_short(src_cb);
         transpose_wh_tile(src_cb, 0, input_dst_index);
         // tt::compute::common::print_tile_rows(src_cb, 32, 0);
         ema_tile<input_dst_index>(/*first_sample=*/true);
@@ -64,7 +60,7 @@ void MAIN {
             cb_wait_front(src_cb, 1);
             cb_wait_front(prev_cb, 1);
             tile_regs_acquire();
-            transpose_wh_init_short(src_cb);
+            // transpose_wh_init_short(src_cb);
             transpose_wh_tile(src_cb, 0, input_dst_index);
             // tt::compute::common::print_tile_rows(src_cb, 32, 0);
             ema_tile<input_dst_index>(/*first_sample=*/false);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint_tensix.h"
+
+namespace NAMESPACE {
+void MAIN {
+    //-------------------------------------------------------------------------
+    // Compile time args
+    // -----------------
+    constexpr auto batches_per_core = get_compile_time_arg_val(0);
+    constexpr auto pages_per_batch = get_compile_time_arg_val(1);
+
+    //-------------------------------------------------------------------------
+    // CB indices
+    // -----------------
+    constexpr auto src_cb = tt::CBIndex::c_0;
+    constexpr auto dst_cb = tt::CBIndex::c_1;
+
+    //-------------------------------------------------------------------------
+    // Main loop - compute ema for each batch
+    binary_op_init_common(src_cb, src_cb, dst_cb);
+    add_tiles_init(src_cb, src_cb);
+    // copy_tile_init(src_cb);
+    for (uint32_t batch_id = 0; batch_id < batches_per_core; ++batch_id) {
+        for (uint32_t page_id = 0; page_id < pages_per_batch; ++page_id) {
+            cb_wait_front(src_cb, 1);
+            tile_regs_acquire();
+            // copy_tile(src_cb, 0, 0);
+            // tt::compute::common::print_tile_rows(src_cb, 32, 0);
+            add_tiles(src_cb, src_cb, 0, 0, 0);
+            // dprint_tensix_dest_reg(0);
+            tile_regs_commit();
+            cb_pop_front(src_cb, 1);
+
+            cb_reserve_back(dst_cb, 1);
+            tile_regs_wait();
+            pack_tile(0, dst_cb);
+            tile_regs_release();
+            cb_push_back(dst_cb, 1);
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -12,19 +12,19 @@
 
 namespace NAMESPACE {
 void MAIN {
-    //-------------------------------------------------------------------------
     // Compile time args
     // -----------------
     constexpr auto total_batches_per_core = get_compile_time_arg_val(0);
     constexpr auto tiles_per_channel = get_compile_time_arg_val(1);
 
-    //-------------------------------------------------------------------------
     // CB indices
-    // -----------------
+    // ----------
     constexpr auto src_cb = tt::CBIndex::c_0;
     constexpr auto dst_cb = tt::CBIndex::c_1;
     constexpr auto prev_cb = tt::CBIndex::c_2;
 
+    // DST indices
+    // -----------
     constexpr auto input_dst_index = 0;
     constexpr auto prev_dst_index = input_dst_index + 1;
     constexpr auto output_dst_index = prev_dst_index + 1;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -27,6 +27,7 @@ void MAIN {
 
     constexpr auto input_dst_index = 0;
     constexpr auto prev_dst_index = input_dst_index + 1;
+    constexpr auto output_dst_index = prev_dst_index + 1;
 
     //-------------------------------------------------------------------------
     // Main loop - compute ema for each batch
@@ -37,8 +38,34 @@ void MAIN {
     // copy_tile_init(src_cb);
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
-        for (uint32_t tile_id = 0; tile_id < tiles_per_channel; ++tile_id) {
+        // For the first tile (we don't need to load the previous data from CB)
+        cb_wait_front(src_cb, 1);
+        tile_regs_acquire();
+        // transpose_wh_init_short(src_cb);
+        // transpose_wh_tile(src_cb, 0, 0);
+        // transpose_wh_dest_init_short();
+        // transpose_wh_dest(0);
+        // copy_tile(src_cb, 0, 0);
+        // tt::compute::common::print_tile_rows(src_cb, 32, 0);
+        add_tiles(src_cb, src_cb, 0, 0, input_dst_index);
+        ema_tile<input_dst_index>(/*first_sample=*/true);
+        // dprint_tensix_dest_reg(0);
+        tile_regs_commit();
+        cb_pop_front(src_cb, 1);
+
+        cb_reserve_back(dst_cb, 1);
+        cb_reserve_back(prev_cb, 1);
+        tile_regs_wait();
+        pack_tile(prev_dst_index, prev_cb);
+        pack_tile(output_dst_index, dst_cb);
+        tile_regs_release();
+        cb_push_back(dst_cb, 1);
+        cb_push_back(prev_cb, 1);
+
+        // For all tiles except the first one
+        for (uint32_t tile_id = 1; tile_id < tiles_per_channel; ++tile_id) {
             cb_wait_front(src_cb, 1);
+            cb_wait_front(prev_cb, 1);
             tile_regs_acquire();
             // transpose_wh_init_short(src_cb);
             // transpose_wh_tile(src_cb, 0, 0);
@@ -47,18 +74,25 @@ void MAIN {
             // copy_tile(src_cb, 0, 0);
             // tt::compute::common::print_tile_rows(src_cb, 32, 0);
             add_tiles(src_cb, src_cb, 0, 0, input_dst_index);
-            ema_tile<input_dst_index>((tile_id == 0));
+            ema_tile<input_dst_index>(/*first_sample=*/false);
             // dprint_tensix_dest_reg(0);
             tile_regs_commit();
             cb_pop_front(src_cb, 1);
+            cb_pop_front(prev_cb, 1);
 
             cb_reserve_back(dst_cb, 1);
+            cb_reserve_back(prev_cb, 1);
             tile_regs_wait();
-            pack_tile(input_dst_index, dst_cb);
-            // pack_tile(prev_dst_index, prev_cb);
+            pack_tile(prev_dst_index, prev_cb);
+            pack_tile(output_dst_index, dst_cb);
             tile_regs_release();
             cb_push_back(dst_cb, 1);
+            cb_push_back(prev_cb, 1);
         }
+
+        // We don't need the previous data anymore, so we can pop it from the CB
+        cb_wait_front(prev_cb, 1);
+        cb_pop_front(prev_cb, 1);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/compute/ema_compute.cpp
@@ -34,29 +34,26 @@ void MAIN {
     binary_op_init_common(src_cb, src_cb, dst_cb);
     add_tiles_init(src_cb, src_cb);
     ema_init();
-    // transpose_wh_init(src_cb, dst_cb);
-    // copy_tile_init(src_cb);
+    transpose_wh_init(src_cb, dst_cb);
 
     for (uint32_t batch_id = 0; batch_id < total_batches_per_core; ++batch_id) {
         // For the first tile (we don't need to load the previous data from CB)
         cb_wait_front(src_cb, 1);
         tile_regs_acquire();
-        // transpose_wh_init_short(src_cb);
-        // transpose_wh_tile(src_cb, 0, 0);
-        // transpose_wh_dest_init_short();
-        // transpose_wh_dest(0);
-        // copy_tile(src_cb, 0, 0);
+        transpose_wh_init_short(src_cb);
+        transpose_wh_tile(src_cb, 0, input_dst_index);
         // tt::compute::common::print_tile_rows(src_cb, 32, 0);
-        add_tiles(src_cb, src_cb, 0, 0, input_dst_index);
         ema_tile<input_dst_index>(/*first_sample=*/true);
-        // dprint_tensix_dest_reg(0);
+        dprint_tensix_dest_reg(input_dst_index);
+        dprint_tensix_dest_reg(prev_dst_index);
+        dprint_tensix_dest_reg(output_dst_index);
         tile_regs_commit();
         cb_pop_front(src_cb, 1);
 
         cb_reserve_back(dst_cb, 1);
         cb_reserve_back(prev_cb, 1);
         tile_regs_wait();
-        pack_tile(prev_dst_index, prev_cb);
+        // pack_tile(prev_dst_index, prev_cb);
         pack_tile(output_dst_index, dst_cb);
         tile_regs_release();
         cb_push_back(dst_cb, 1);
@@ -67,15 +64,13 @@ void MAIN {
             cb_wait_front(src_cb, 1);
             cb_wait_front(prev_cb, 1);
             tile_regs_acquire();
-            // transpose_wh_init_short(src_cb);
-            // transpose_wh_tile(src_cb, 0, 0);
-            // transpose_wh_dest_init_short();
-            // transpose_wh_dest(0);
-            // copy_tile(src_cb, 0, 0);
+            transpose_wh_init_short(src_cb);
+            transpose_wh_tile(src_cb, 0, input_dst_index);
             // tt::compute::common::print_tile_rows(src_cb, 32, 0);
-            add_tiles(src_cb, src_cb, 0, 0, input_dst_index);
             ema_tile<input_dst_index>(/*first_sample=*/false);
-            // dprint_tensix_dest_reg(0);
+            dprint_tensix_dest_reg(input_dst_index);
+            dprint_tensix_dest_reg(prev_dst_index);
+            dprint_tensix_dest_reg(output_dst_index);
             tile_regs_commit();
             cb_pop_front(src_cb, 1);
             cb_pop_front(prev_cb, 1);
@@ -83,7 +78,7 @@ void MAIN {
             cb_reserve_back(dst_cb, 1);
             cb_reserve_back(prev_cb, 1);
             tile_regs_wait();
-            pack_tile(prev_dst_index, prev_cb);
+            // pack_tile(prev_dst_index, prev_cb);
             pack_tile(output_dst_index, dst_cb);
             tile_regs_release();
             cb_push_back(dst_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -21,9 +21,11 @@ void kernel_main() {
     const uint32_t src_start_tile = get_arg_val<uint32_t>(1);
 
     // Tensor accessor
+    // ---------------
     const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_tile_size);
 
     // CB indices
+    // ----------
     constexpr auto src_cb = tt::CBIndex::c_0;
 
     //-------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -12,16 +12,16 @@ void kernel_main() {
     // Runtime args
     // ------------
     const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t src_start_page = get_arg_val<uint32_t>(1);
+    const uint32_t src_start_tile = get_arg_val<uint32_t>(1);
 
     // Compile time args
     // -----------------
-    constexpr uint32_t pages_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t src_page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t src_tile_size = get_compile_time_arg_val(1);
     constexpr auto s_src_args = TensorAccessorArgs<2>();
 
     //-------------------------------------------------------------------------
-    const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_page_size);
+    const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_tile_size);
 
     //-------------------------------------------------------------------------
     // CB indices
@@ -30,11 +30,11 @@ void kernel_main() {
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from src and push to src_cb
-    for (uint32_t page_id = src_start_page; page_id < (src_start_page + pages_per_core); ++page_id) {
+    for (uint32_t tile_id = src_start_tile; tile_id < (src_start_tile + total_tiles_per_core); ++tile_id) {
         cb_reserve_back(src_cb, 1);
         const uint32_t l1_write_addr = get_write_ptr(src_cb);
-        const uint64_t src_noc_addr = get_noc_addr(page_id, src_accessor);
-        noc_async_read(src_noc_addr, l1_write_addr, src_page_size);
+        const uint64_t src_noc_addr = get_noc_addr(tile_id, src_accessor);
+        noc_async_read(src_noc_addr, l1_write_addr, src_tile_size);
         noc_async_read_barrier();
         // tt::data_movement::common::print_bf16_pages(l1_write_addr, 32, 32);
         cb_push_back(src_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "dataflow_api.h"
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
     for (uint32_t tile_id = src_start_tile; tile_id < (src_start_tile + total_tiles_per_core); ++tile_id) {
         cb_reserve_back(src_cb, 1);
         const uint32_t l1_write_addr = get_write_ptr(src_cb);
-        const uint64_t src_noc_addr = get_noc_addr(tile_id, src_accessor);
+        const uint64_t src_noc_addr = src_accessor.get_noc_addr(tile_id);
         noc_async_read(src_noc_addr, l1_write_addr, src_tile_size);
         noc_async_read_barrier();
         cb_push_back(src_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Runtime args
+    // ------------
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src_start_page = get_arg_val<uint32_t>(1);
+
+    // Compile time args
+    // -----------------
+    constexpr uint32_t pages_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(1);
+    constexpr auto s_src_args = TensorAccessorArgs<2>();
+
+    //-------------------------------------------------------------------------
+    const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_page_size);
+
+    //-------------------------------------------------------------------------
+    // CB indices
+    // -----------------
+    constexpr auto src_cb = tt::CBIndex::c_0;
+
+    //-------------------------------------------------------------------------
+    // Main loop - pull pages from src and push to src_cb
+    for (uint32_t page_id = src_start_page; page_id < (src_start_page + pages_per_core); ++page_id) {
+        cb_reserve_back(src_cb, 1);
+        const uint32_t l1_write_addr = get_write_ptr(src_cb);
+        const uint64_t src_noc_addr = get_noc_addr(page_id, src_accessor);
+        noc_async_read(src_noc_addr, l1_write_addr, src_page_size);
+        noc_async_read_barrier();
+        // tt::data_movement::common::print_bf16_pages(l1_write_addr, 32, 32);
+        cb_push_back(src_cb, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -9,23 +9,21 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
-    // Runtime args
-    // ------------
-    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t src_start_tile = get_arg_val<uint32_t>(1);
-
     // Compile time args
     // -----------------
     constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
     constexpr uint32_t src_tile_size = get_compile_time_arg_val(1);
     constexpr auto s_src_args = TensorAccessorArgs<2>();
 
-    //-------------------------------------------------------------------------
+    // Runtime args
+    // ------------
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src_start_tile = get_arg_val<uint32_t>(1);
+
+    // Tensor accessor
     const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_tile_size);
 
-    //-------------------------------------------------------------------------
     // CB indices
-    // -----------------
     constexpr auto src_cb = tt::CBIndex::c_0;
 
     //-------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -5,15 +5,13 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "debug/dprint_pages.h"
-#include "debug/dprint.h"
 
 void kernel_main() {
     // Compile time args
     // -----------------
     constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
     constexpr uint32_t src_tile_size = get_compile_time_arg_val(1);
-    constexpr auto s_src_args = TensorAccessorArgs<2>();
+    constexpr auto src_args = TensorAccessorArgs<2>();
 
     // Runtime args
     // ------------
@@ -22,7 +20,7 @@ void kernel_main() {
 
     // Tensor accessor
     // ---------------
-    const auto src_accessor = TensorAccessor(s_src_args, src_base_addr, src_tile_size);
+    const auto src_accessor = TensorAccessor(src_args, src_base_addr, src_tile_size);
 
     // CB indices
     // ----------
@@ -36,7 +34,6 @@ void kernel_main() {
         const uint64_t src_noc_addr = get_noc_addr(tile_id, src_accessor);
         noc_async_read(src_noc_addr, l1_write_addr, src_tile_size);
         noc_async_read_barrier();
-        // tt::data_movement::common::print_bf16_pages(l1_write_addr, 32, 32);
         cb_push_back(src_cb, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_reader.cpp
@@ -10,21 +10,24 @@ void kernel_main() {
     // Compile time args
     // -----------------
     constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t src_tile_size = get_compile_time_arg_val(1);
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto src_args = TensorAccessorArgs<1>();
 
     // Runtime args
     // ------------
     const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
     const uint32_t src_start_tile = get_arg_val<uint32_t>(1);
 
-    // Tensor accessor
-    // ---------------
-    const auto src_accessor = TensorAccessor(src_args, src_base_addr, src_tile_size);
-
     // CB indices
     // ----------
     constexpr auto src_cb = tt::CBIndex::c_0;
+
+    // Tile sizes
+    // ----------
+    constexpr uint32_t src_tile_size = get_tile_size(src_cb);
+
+    // Tensor accessor
+    // ---------------
+    const auto src_accessor = TensorAccessor(src_args, src_base_addr, src_tile_size);
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from src and push to src_cb

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "dataflow_api.h"
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -21,9 +21,11 @@ void kernel_main() {
     const uint32_t dst_start_tile = get_arg_val<uint32_t>(1);
 
     // Tensor accessor
+    // ---------------
     const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
 
     // CB indices
+    // ----------
     constexpr auto dst_cb = tt::CBIndex::c_1;
 
     //-------------------------------------------------------------------------

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -9,24 +9,22 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
-    // Runtime args
-    // ------------
-    const uint32_t dst_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t dst_start_tile = get_arg_val<uint32_t>(1);
-
     // Compile time args
     // -----------------
     constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
     constexpr uint32_t dst_tile_size = get_compile_time_arg_val(1);
     constexpr auto dst_args = TensorAccessorArgs<2>();
 
-    //-------------------------------------------------------------------------
-    // CB indices
-    // -----------------
-    constexpr auto dst_cb = tt::CBIndex::c_1;
+    // Runtime args
+    // ------------
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_start_tile = get_arg_val<uint32_t>(1);
 
-    //-------------------------------------------------------------------------
+    // Tensor accessor
     const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
+
+    // CB indices
+    constexpr auto dst_cb = tt::CBIndex::c_1;
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from dst_cb and push to dst

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Runtime args
+    // ------------
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_start_page = get_arg_val<uint32_t>(1);
+
+    // Compile time args
+    // -----------------
+    constexpr uint32_t pages_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    //-------------------------------------------------------------------------
+    // CB indices
+    // -----------------
+    constexpr auto dst_cb = tt::CBIndex::c_1;
+
+    //-------------------------------------------------------------------------
+    const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_page_size);
+
+    //-------------------------------------------------------------------------
+    // Main loop - pull pages from dst_cb and push to dst
+    for (uint32_t page_id = dst_start_page; page_id < (dst_start_page + pages_per_core); ++page_id) {
+        cb_wait_front(dst_cb, 1);
+        const uint32_t l1_read_addr = get_read_ptr(dst_cb);
+        const uint64_t dst_noc_addr = get_noc_addr(page_id, dst_accessor);
+        noc_async_write(l1_read_addr, dst_noc_addr, dst_page_size);
+        noc_async_write_barrier();
+        // tt::data_movement::common::print_bf16_pages(l1_read_addr, 32, 32);
+        cb_pop_front(dst_cb, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -5,8 +5,6 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "debug/dprint_pages.h"
-#include "debug/dprint.h"
 
 void kernel_main() {
     // Compile time args
@@ -36,7 +34,6 @@ void kernel_main() {
         const uint64_t dst_noc_addr = get_noc_addr(tile_id, dst_accessor);
         noc_async_write(l1_read_addr, dst_noc_addr, dst_tile_size);
         noc_async_write_barrier();
-        // tt::data_movement::common::print_bf16_pages(l1_read_addr, 32, 32);
         cb_pop_front(dst_cb, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -10,21 +10,24 @@ void kernel_main() {
     // Compile time args
     // -----------------
     constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_tile_size = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     // Runtime args
     // ------------
     const uint32_t dst_base_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_start_tile = get_arg_val<uint32_t>(1);
 
-    // Tensor accessor
-    // ---------------
-    const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
-
     // CB indices
     // ----------
     constexpr auto dst_cb = tt::CBIndex::c_1;
+
+    // Tile sizes
+    // ----------
+    constexpr uint32_t dst_tile_size = get_tile_size(dst_cb);
+
+    // Tensor accessor
+    // ---------------
+    const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from dst_cb and push to dst

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
     for (uint32_t tile_id = dst_start_tile; tile_id < (dst_start_tile + total_tiles_per_core); ++tile_id) {
         cb_wait_front(dst_cb, 1);
         const uint32_t l1_read_addr = get_read_ptr(dst_cb);
-        const uint64_t dst_noc_addr = get_noc_addr(tile_id, dst_accessor);
+        const uint64_t dst_noc_addr = dst_accessor.get_noc_addr(tile_id);
         noc_async_write(l1_read_addr, dst_noc_addr, dst_tile_size);
         noc_async_write_barrier();
         cb_pop_front(dst_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -12,12 +12,12 @@ void kernel_main() {
     // Runtime args
     // ------------
     const uint32_t dst_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t dst_start_page = get_arg_val<uint32_t>(1);
+    const uint32_t dst_start_tile = get_arg_val<uint32_t>(1);
 
     // Compile time args
     // -----------------
-    constexpr uint32_t pages_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t total_tiles_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_tile_size = get_compile_time_arg_val(1);
     constexpr auto dst_args = TensorAccessorArgs<2>();
 
     //-------------------------------------------------------------------------
@@ -26,15 +26,15 @@ void kernel_main() {
     constexpr auto dst_cb = tt::CBIndex::c_1;
 
     //-------------------------------------------------------------------------
-    const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_page_size);
+    const auto dst_accessor = TensorAccessor(dst_args, dst_base_addr, dst_tile_size);
 
     //-------------------------------------------------------------------------
     // Main loop - pull pages from dst_cb and push to dst
-    for (uint32_t page_id = dst_start_page; page_id < (dst_start_page + pages_per_core); ++page_id) {
+    for (uint32_t tile_id = dst_start_tile; tile_id < (dst_start_tile + total_tiles_per_core); ++tile_id) {
         cb_wait_front(dst_cb, 1);
         const uint32_t l1_read_addr = get_read_ptr(dst_cb);
-        const uint64_t dst_noc_addr = get_noc_addr(page_id, dst_accessor);
-        noc_async_write(l1_read_addr, dst_noc_addr, dst_page_size);
+        const uint64_t dst_noc_addr = get_noc_addr(tile_id, dst_accessor);
+        noc_async_write(l1_read_addr, dst_noc_addr, dst_tile_size);
         noc_async_write_barrier();
         // tt::data_movement::common::print_bf16_pages(l1_read_addr, 32, 32);
         cb_pop_front(dst_cb, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -6,6 +6,8 @@
 
 #include "dataflow_api.h"
 
+#include "argmax_common.hpp"
+
 void kernel_main() {
     // Runtime args
     // ------------

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -6,8 +6,6 @@
 
 #include "dataflow_api.h"
 
-#include "argmax_common.hpp"
-
 void kernel_main() {
     // Runtime args
     // ------------

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
@@ -14,6 +14,7 @@
 #include "ttnn/operations/reduction/argmax/argmax_pybind.hpp"
 #include "ttnn/operations/reduction/accumulation/cumprod/cumprod_pybind.hpp"
 #include "ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.hpp"
+#include "ttnn/operations/reduction/accumulation/ema/ema_pybind.hpp"
 #include "ttnn/operations/reduction/moe/moe_pybind.hpp"
 #include "ttnn/operations/reduction/prod/prod_pybind.hpp"
 #include "ttnn/operations/reduction/sampling/sampling_pybind.hpp"
@@ -36,6 +37,7 @@ void py_module(py::module& module) {
     detail::bind_reduction_argmax_operation(module);
     accumulation::detail::bind_reduction_cumsum_operation(module);
     accumulation::detail::bind_reduction_cumprod_operation(module);
+    accumulation::detail::bind_reduction_ema_operation(module);
     detail::bind_reduction_moe_operation(module);
     detail::bind_reduction_prod_operation(module, ttnn::prod);
     detail::bind_reduction_sampling_operation(module);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30850

## 📊 Problem Description

Exponential Moving Average (EMA) is a fundamental statistical operation widely used in time series analysis, signal processing, and machine learning applications. EMA provides a smoothed representation of data by giving more weight to recent observations while maintaining a memory of historical values. The mathematical formula for EMA is:

```
output_t = α × output_{t-1} + (1 - α) × input_t
```

where `α` (alpha) is the smoothing factor typically between 0 and 1, `input_t` is the current input value, and `output_{t-1}` is the previous output value.

## 🔧 What's Changed

This PR introduces a complete implementation of the EMA operation for TTNN, including:

### 🏗️ **Core Implementation**
- **Multi-core** (`ema_multicore.cpp`) with intelligent work distribution across available cores
- **Kernels** (`ema_compute.cpp`, `ema_reader.cpp` and `ema_writer.cpp`) implementing the EMA algorithm with proper tile-based processing
- **LLK (Low Level Kernel) integration** with SFPU (Scalar Floating Point Unit) operations

### 🎯 **Key Features**
- **Automatic core allocation**: Uses maximum available cores for optimal performance
- **Multi-architecture support**: Works on both Wormhole B0 and Blackhole hardware
- **Tile-based processing**: Efficiently processes data in 32x32 tile chunks

### 🔧 **API Design**
```python
ttnn.ema(
    input: ttnn.Tensor,           # Input tensor [1, B, C, T]
    alpha: float,                 # Smoothing factor (0-1)
    out: Optional[ttnn.Tensor] = None,
    core_grid: Optional[ttnn.CoreGrid] = None,
    memory_config: Optional[ttnn.MemoryConfig] = None,
    compute_kernel_config: Optional[ttnn.ComputeKernelConfig] = None
) -> ttnn.Tensor
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18962055098/job/54151696135 1 known timeout
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18962057479
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes