### PR TITLE
[skip ci] Revert "SFPI 7.4.0 (#30519)"

### DIFF
--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -165,11 +165,7 @@ public:
     }
 
     std::string common_flags(const Params& params) const override {
-        std::string cflags = params.core_type == HalProgrammableCoreType::TENSIX &&
-                                     params.processor_class == HalProcessorClassType::COMPUTE
-                                 ? "-mcpu=tt-bh-tensix "
-                                 : "-mcpu=tt-bh ";
-        cflags += "-fno-rvtt-sfpu-replay ";
+        std::string cflags = "-mcpu=tt-bh -fno-rvtt-sfpu-replay ";
         if (!(params.core_type == HalProgrammableCoreType::TENSIX &&
               params.processor_class == HalProcessorClassType::COMPUTE)) {
             cflags += "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -153,10 +153,7 @@ public:
     }
 
     std::string common_flags(const Params& params) const override {
-        std::string cflags = params.core_type == HalProgrammableCoreType::TENSIX &&
-                                     params.processor_class == HalProcessorClassType::COMPUTE
-                                 ? "-mcpu=tt-wh-tensix "
-                                 : "-mcpu=tt-wh ";
+        std::string cflags = "-mcpu=tt-wh ";
         if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH) {
             cflags += "-fno-delete-null-pointer-checks ";
         } else if (

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -4,10 +4,10 @@ sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
 
 # convert md5 file into these variables
 # sed 's/^\([0-9a-f]*\) \*sfpi_\([-.0-9a-zA-Z]*\)_\([a-z0-9_A-Z]*\)\.\([a-z]*\)$/sfpi_version=\2'"\n"'sfpi_\3_\4_md5=\1/' *-build/sfpi_*.md5 | sort -u
-sfpi_aarch64_deb_md5=8b2cc93f495b2c44b1ef972dc8cb4c58
-sfpi_aarch64_rpm_md5=6ea19152598e34a447cb128c8ab2657c
-sfpi_aarch64_txz_md5=1abfa3f32200653b816e7e79d7ec84d7
-sfpi_version=7.4.0
-sfpi_x86_64_deb_md5=6609998049302ec4e28bf28972df5245
-sfpi_x86_64_rpm_md5=26c584b9e8ccdaacdaf560245a47d3f8
-sfpi_x86_64_txz_md5=15ed2781ad2cf46c78a8f0310de91f9f
+sfpi_aarch64_deb_md5=bbe267282dc8c36554bc91354e47fc7d
+sfpi_aarch64_rpm_md5=f146cc686ffd08f5d5bf55055f2010f2
+sfpi_aarch64_txz_md5=d03da69379ea08386ce88dfb2bcdb88c
+sfpi_version=7.3.0
+sfpi_x86_64_deb_md5=100e9834fe6877a186440b241f69da65
+sfpi_x86_64_rpm_md5=38def21cfa7cfebef8e9def61019f7cc
+sfpi_x86_64_txz_md5=17970c8034b039f269d9a9db8e841e45


### PR DESCRIPTION
This reverts commit bc1823c394cc248d1aa349df6453321926462e27.

### Problem description
https://github.com/tenstorrent/tt-metal/commit/bc1823c394cc248d1aa349df6453321926462e27 seems to has regressed the perf on SDXL. 

### What's changed
Revert "SFPI 7.4.0 (#30519)"

### Checklist
- [x] Device performance regression: https://github.com/tenstorrent/tt-metal/actions/runs/18597926907 CI passes
