### PR TITLE
#28246: revert llama pcc

### DIFF
--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -136,8 +136,7 @@ def test_model_inference(
 
         # Define tight final PCC thresholds for quick mode
         final_model_pcc = {
-            # TODO: Investigate why math reconfig fix lowers llama32_1b PCC from 0.9864 to 0.9863 (Issue #28246)
-            "llama32_1b": 0.9991 if mode_accuracy else 0.9863,
+            "llama32_1b": 0.9991 if mode_accuracy else 0.9864,
             "llama32_3b": 0.9989 if mode_accuracy else 0.9837,
             "llama31_8b": 0.9987 if mode_accuracy else 0.9850,
             "llama32_11b": 0.9987 if mode_accuracy else 0.9850,


### PR DESCRIPTION
### Ticket
Link to Github Issue #28246

### Problem description
An LLK fix degraded PCC. The LLK fix has ben re-merged into tt-metal and since then other fixes resulted in the PCC no longer degrading.

### What's changed
- revert the PCC reduction
LLama 3.2 1B passes now https://github.com/tenstorrent/tt-metal/actions/runs/18598416695/job/53031460517

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes