### PR TITLE
CCL Sweep test improvements

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -591,7 +591,7 @@ on:
     - cron: "0 5 * * 6" # This cron schedule runs the workflow at 5:00 AM UTC on Saturdays (comprehensive run)
 
 concurrency:
-  group: ttnn-sweeps-${{ github.ref }}
+  group: ttnn-sweeps-${{ github.ref }}-${{ github.event.inputs.arch }}-${{ github.event.inputs.runner-label }}
   cancel-in-progress: true
 
 jobs:
@@ -604,7 +604,7 @@ jobs:
       build-wheel: true
       version: "22.04"
   ttnn-generate-sweeps:
-    name: Generate sweeps vectors
+    name: Generate Sweep Vectors ${{ inputs.arch }} ${{ inputs.runner-label }}
     needs: build-artifact
     strategy:
       matrix:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -751,7 +751,10 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >-
+        --device /dev/tenstorrent
+        --device /dev/ipmi0
+        --privileged
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -563,6 +563,28 @@ on:
         description: "Upload sweep results to Superset?"
         type: boolean
         default: true
+      arch:
+        required: true
+        type: choice
+        options:
+          - wormhole_b0
+          - blackhole
+        default: "wormhole_b0"
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - N150
+          - N300
+          - P100
+          - P150
+          - config-t3000
+          - topology-6u
+          - BH-LLMBox
+          - BH-DeskBox
+          - BH-LoudBox
+        default: "N150"
+
   schedule:
     - cron: "0 4 * * 1,2,4,5" # This cron schedule runs the workflow at 4:00 AM UTC on Mon, Tue, Thu, Fri (nightly runs)
     - cron: "0 4 * * 3" # This cron schedule runs the workflow at 4:00 AM UTC on Wednesdays (comprehensive run)
@@ -587,7 +609,7 @@ jobs:
     strategy:
       matrix:
         arch:
-          - wormhole_b0
+          - input.arch
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
@@ -608,7 +630,11 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     timeout-minutes: 30
-    runs-on: tt-ubuntu-2204-n150-stable
+    runs-on: >-
+      ${{
+        (inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+        || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
+      }}
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
@@ -700,20 +726,14 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          [
-            {
-              name: "wormhole-n150-sweeps",
-              arch: wormhole_b0,
-              runs-on: tt-ubuntu-2204-n150-stable,
-              tt-smi-cmd: "tt-smi -r"
-            },
-            # {
-            #   name: "Wormhole N300 Sweeps",
-            #   arch: wormhole_b0,
-            #   runs-on: tt-ubuntu-2204-n300-stable,
-            #   tt-smi-cmd: "tt-smi-metal -r 0"
-            # }
-          ]
+          - name: ttnn sweep tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+            arch: ${{ inputs.arch }}
+            tt-smi-cmd: ${{ (inputs.runner-label == 'topology-6u' ) && 'tt-smi -glx_reset_auto' || 'tt-smi -r'}}
+            runs-on: >-
+              ${{
+                (inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+                || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
+              }}
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -571,14 +571,15 @@ on:
           - blackhole
         default: "wormhole_b0"
       runner-label:
+        description: "Single sweep only"
         required: true
         type: choice
         options:
           - N150
           - N300
-          - P100
-          - P150
-          - config-t3000
+          - P100a
+          - P150b
+          - n300-llmbox
           - topology-6u
           - BH-LLMBox
           - BH-DeskBox
@@ -632,7 +633,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{
-        (inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+        (inputs.runner-label == 'topology-6u' || inputs.runner-label == 'BH-LLMBox' || inputs.runner-label == 'BH-DeskBox' || inputs.runner-label== 'BH-LoudBox' ) && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
         || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
       }}
     steps:
@@ -731,7 +732,7 @@ jobs:
             tt-smi-cmd: ${{ (inputs.runner-label == 'topology-6u' ) && 'tt-smi -glx_reset_auto' || 'tt-smi -r'}}
             runs-on: >-
               ${{
-                (inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+                (inputs.runner-label == 'topology-6u' || inputs.runner-label == 'BH-LLMBox' || inputs.runner-label == 'BH-DeskBox' || inputs.runner-label == 'BH-LoudBox' ) && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
                 || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
               }}
     container:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -609,7 +609,7 @@ jobs:
     strategy:
       matrix:
         arch:
-          - input.arch
+          - ${{ inputs.arch }}
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:

--- a/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
@@ -81,10 +81,15 @@ parameters = {
         "num_links": [1],
         "input_shape": [
             [1, 1, 32, 1440],  # GPT-OSS 20B. Dim: 3, cluster_axis 1
-            [1, 1, 32, 32],  # Qwen3 dim:3 cluster_axis: 1
-            [1, 8, 8, 128],  # Qwen3 dim:3 cluster_axis: 1
+            [1, 1, 32, 32],  # Qwen3, Llama on Glx, DeepSeek dim:3 cluster_axis: 1
+            [1, 8, 8, 128],  # Qwen3, Llama on Glx dim:3 cluster_axis: 1
             [3, 1, 4096, 192],  # Gemma3 Dim: 3
             [3, 1, 4096, 144],  # Gemma3 Dim: 3
+            [1, 1, 32, 896],  # DeepSeek dim:3 cluster_axis 1
+            [1, 1, 32, 192],  # DeepSeek dim:3 cluster_axis 1
+            [1, 1, 32, 576],  # DeepSeek dim: 1 cluster_axis 1
+            [1, 1, 32, 224],  # DeepSeek dim:3 cluster_axis 0
+            [1, 4, 128, 512],  # DeepSeek dim: 1 cluster_axis 1
         ],
         "dim": [1, 3],
         "cluster_axis": [0, 1],

--- a/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
@@ -108,19 +108,23 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["shard_specs"] is not None and test_vector["buffer_type"] == ttnn.BufferType.DRAM:
         return True, "L1 Sharding only"
 
+    cluster_axis = test_vector["cluster_axis"]
+    mesh_shape = test_vector["mesh_shape"]
     input_shape = test_vector["input_shape"]
-    if not validate_serializable_shard_spec(input_shape, test_vector["shard_specs"]):
+    dim = test_vector["dim"]
+    cluster_size = mesh_shape[cluster_axis] if cluster_axis is not None else prod(mesh_shape)
+
+    if not validate_serializable_shard_spec(input_shape, test_vector["shard_specs"], dim, cluster_size, "gather"):
         return True, "Invalid shard spec"
 
     # hardcode for 6U
-    if test_vector["mesh_shape"] in [(16, 2), (2, 16)]:
+    if mesh_shape in [(16, 2), (2, 16)]:
         return True, "Invalid mesh shape for 6U"
 
-    cluster_axis = test_vector["cluster_axis"]
     if cluster_axis is not None and test_vector["mesh_shape"][cluster_axis] == 1:
         return True, "Only one device along axis"
 
-    if test_vector["dim"] >= len(input_shape):
+    if dim >= len(input_shape):
         return True, "Dim greater than rank"
     if (
         test_vector["topology"] == ttnn.Topology.Ring
@@ -142,7 +146,7 @@ def _get_tensors(input_shape, mesh_shape, dim, cluster_axis, dtype, buffer_type,
     replicate_dim = mesh_shape[cluster_axis] if cluster_axis is not None else prod(mesh_shape)
     torch_reference = torch_input.repeat(tuple((1 if i != dim else replicate_dim) for i in range(len(input_shape))))
 
-    input_memory_config, output_memory_config = get_mem_configs(buffer_type, shard_specs, torch_reference.shape)
+    input_memory_config, output_memory_config = get_mem_configs(buffer_type, shard_specs, layout, torch_reference.shape)
 
     assert input_memory_config.memory_layout == output_memory_config.memory_layout
 

--- a/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
@@ -67,6 +67,24 @@ def _model_shape_iterator(model_shapes, batch_params):
 
 LEAD_MODEL_SHARD_SPECS = [
     get_serializable_shard_specs(
+        input_shape=(32, 128),
+        input_cores=(4, 4),
+        input_strategy="w",
+        output_shape=None,
+        output_cores=(4, 4),
+        output_strategy="w",
+        valid_tensor_shapes=[[1, 1, 32, 4096]],
+    ),
+    get_serializable_shard_specs(
+        input_shape=(32, 256),
+        input_cores=(4, 4),
+        input_strategy="w",
+        output_shape=None,
+        output_cores=(4, 4),
+        output_strategy="w",
+        valid_tensor_shapes=[[1, 1, 32, 2048]],
+    ),
+    get_serializable_shard_specs(
         input_shape=(32, 64),
         input_cores=(4, 6),
         input_strategy="w",
@@ -124,6 +142,8 @@ parameters = {
         "fabric_config": FABRIC_CONFIGS,
         "num_links": [1],
         "input_shape": [
+            [1, 1, 32, 2048],  # Llama Galaxy. cluster_axis: 0
+            [1, 1, 32, 4096],  # Llama 8x2. cluster_axis: 0
             [1, 1, 32, 1280],  # Qwen3 Galaxy. cluster_axis: 0
             [1, 1, 32, 2560],  # Qwen3 2x8. Cluster axis 0
         ],

--- a/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
@@ -89,7 +89,7 @@ LEAD_MODEL_SHARD_SPECS = [
         input_cores=(4, 6),
         input_strategy="w",
         output_shape=None,
-        output_cores=(1, 10),
+        output_cores=(2, 5),
         output_strategy="w",
         valid_tensor_shapes=[[1, 1, 32, 1280]],
     ),
@@ -98,7 +98,7 @@ LEAD_MODEL_SHARD_SPECS = [
         input_cores=(4, 6),
         input_strategy="w",
         output_shape=None,
-        output_cores=(1, 10),
+        output_cores=(2, 5),
         output_strategy="w",
         valid_tensor_shapes=[[1, 1, 32, 2560]],
     ),
@@ -171,10 +171,12 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["shard_specs"] is not None and test_vector["buffer_type"] == ttnn.BufferType.DRAM:
         return True, "L1 Sharding only"
 
-    if not validate_serializable_shard_spec(test_vector["input_shape"], test_vector["shard_specs"]):
+    mesh_shape, cluster_axis = test_vector["mesh_shape"], test_vector["cluster_axis"]
+    cluster_size = mesh_shape[cluster_axis] if cluster_axis is not None else prod(mesh_shape)
+
+    if not validate_serializable_shard_spec(test_vector["input_shape"], test_vector["shard_specs"], None, cluster_size):
         return True, "Invalid shard spec"
 
-    mesh_shape, cluster_axis = test_vector["mesh_shape"], test_vector["cluster_axis"]
     if cluster_axis and mesh_shape[cluster_axis] == 1:
         return True, "Unit cluster axis"
 
@@ -219,7 +221,7 @@ def _get_tensors(input_shape, cluster_axis, mesh_shape, math_op, dtype, layout, 
     # The final result is then replicated back to all devices.
     torch_reference = _reference_map_op(math_op)(torch.stack([torch_input] * num_devices_in_cluster), dim=0)
 
-    input_memory_config, output_memory_config = get_mem_configs(buffer_type, shard_specs, torch_reference.shape)
+    input_memory_config, output_memory_config = get_mem_configs(buffer_type, shard_specs, layout, torch_reference.shape)
 
     tt_input = ttnn.from_torch(
         torch_input,

--- a/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
@@ -67,7 +67,7 @@ def _model_shape_iterator(model_shapes, batch_params):
 
 LEAD_MODEL_SHARD_SPECS = [
     get_serializable_shard_specs(
-        input_shape=(32, 128),
+        input_shape=(32, 256),
         input_cores=(4, 4),
         input_strategy="w",
         output_shape=None,
@@ -76,7 +76,7 @@ LEAD_MODEL_SHARD_SPECS = [
         valid_tensor_shapes=[[1, 1, 32, 4096]],
     ),
     get_serializable_shard_specs(
-        input_shape=(32, 256),
+        input_shape=(32, 128),
         input_cores=(4, 4),
         input_strategy="w",
         output_shape=None,

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all_combine.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all_combine.py
@@ -51,6 +51,23 @@ parameters = {
         "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
         "num_iters": [1],
     },
+    "lead_model_suite": {
+        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
+        "fabric_config": FABRIC_CONFIGS,
+        "input_shape": [[_pd(1), 1, 2, 2880], [_pd(1), 128, 1, 7168]],  # GPT-OSS  # deepseek cluster_axis=0
+        "experts": [_pd(i) for i in [2, 4, 8]],
+        "select_experts_k": [2, 4, 8],
+        "local_reduce": [False, True],
+        "cluster_axis": [0, 1],
+        "num_links": [1],
+        "input_dtype": [ttnn.bfloat16],
+        "mem_config": [
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+        ],
+        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+        "num_iters": [1],
+    },
 }
 
 

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all_dispatch.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all_dispatch.py
@@ -50,6 +50,22 @@ parameters = {
         "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
         "num_iters": [1],
     },
+    "lead_model_suite": {
+        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
+        "fabric_config": FABRIC_CONFIGS,
+        "input_shape": [[_pd(1), 1, 32, 2880], [_pd(4), 1, 1, 7168]],  # GPT-OSS  # deepseek cluster_axis=0
+        "experts": [_pd(i) for i in [2, 4, 8]],
+        "select_experts_k": [2, 4, 8],
+        "cluster_axis": [0, 1],
+        "num_links": [1],
+        "input_dtype": [ttnn.bfloat16],
+        "mem_config": [
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+        ],
+        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+        "num_iters": [1],
+    },
 }
 
 

--- a/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
@@ -34,6 +34,24 @@ FABRIC_CONFIGS = [
 
 LEAD_MODEL_SHARD_SPECS = [
     get_serializable_shard_specs(
+        input_shape=(32, 128),
+        input_cores=(2, 5),
+        input_strategy="w",
+        output_shape=None,
+        output_cores=(2, 5),
+        output_strategy="w",
+        valid_tensor_shapes=[[1, 1, 32, 1280]],
+    ),
+    get_serializable_shard_specs(
+        input_shape=(32, 160),
+        input_cores=(4, 6),
+        input_strategy="w",
+        output_shape=None,
+        output_cores=(5, 6),
+        output_strategy="w",
+        valid_tensor_shapes=[[1, 1, 32, 3584]],
+    ),
+    get_serializable_shard_specs(
         input_shape=(32, 64),
         input_cores=(4, 6),
         input_strategy="w",
@@ -51,6 +69,15 @@ LEAD_MODEL_SHARD_SPECS = [
         output_strategy="w",
         valid_tensor_shapes=[[1, 1, 32, 3200]],
     ),
+    get_serializable_shard_specs(
+        input_shape=(32, 128),
+        input_cores=(7, 8),
+        input_strategy="w",
+        output_shape=None,
+        output_cores=(4, 4),
+        output_strategy="w",
+        valid_tensor_shapes=[[1, 1, 32, 7168]],
+    ),
 ]
 
 parameters = {
@@ -64,7 +91,6 @@ parameters = {
             [1, 1, 1, 32, 256],
             [2, 32, 256],
             [1, 1, 32, 16384],
-            [1, 1, 32, 2880],  # GPT-OSS 20B
         ],
         "dim": [0, 1, 2, 3, 4],
         "cluster_axis": [0, 1, None],
@@ -81,10 +107,14 @@ parameters = {
         "num_links": [1],
         "input_shape": [
             [1, 1, 32, 2880],  # GPT-OSS 20B. Dim: 3, cluster_axis 1
-            [1, 1, 32, 1280],  # Qwen3 dim: 1 cluster_axis: 1
+            [1, 1, 32, 1280],  # Qwen3 dim: 1 cluster_axis: 1; Llama glx dim: 2 cluster_axis 1
             [1, 1, 32, 3200],  # Qwen3 dim: 3 cluster_axis: 1
+            [1, 1, 32, 3584],  # Llama Glx. dim:3 cluster_axis:1
+            [1, 1, 32, 7168],  # DeepSeek dim:3 cluster_axis 1
+            [1, 1, 32, 1536],  # DeepSeek dim:3 cluster_axis 1
+            [1, 32, 128, 576],  # DeepSeek dim: 1 cluster_axis 1
         ],
-        "dim": [2, 3],
+        "dim": [1, 2, 3],
         "cluster_axis": [0, 1],
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
         "input_dtype": [ttnn.bfloat16],

--- a/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
@@ -107,7 +107,7 @@ parameters = {
         "num_links": [1],
         "input_shape": [
             [1, 1, 32, 2880],  # GPT-OSS 20B. Dim: 3, cluster_axis 1
-            [1, 1, 32, 1280],  # Qwen3 dim: 1 cluster_axis: 1; Llama glx dim: 2 cluster_axis 1
+            [1, 1, 32, 1280],  # Qwen3 dim: 2 cluster_axis: 1; Llama glx dim: 2 cluster_axis 1
             [1, 1, 32, 3200],  # Qwen3 dim: 3 cluster_axis: 1
             [1, 1, 32, 3584],  # Llama Glx. dim:3 cluster_axis:1
             [1, 1, 32, 7168],  # DeepSeek dim:3 cluster_axis 1
@@ -201,7 +201,9 @@ def _get_tensors(
     torch_reference = torch_input.unsqueeze(0).repeat([replicate_dim] + [1] * len(input_shape))
     torch_references = _reference_map_op(math_op)(torch_reference, dim=0).split(per_device_dim, dim=dim)
 
-    input_memory_config, output_memory_config = get_mem_configs(buffer_type, shard_specs, layout, torch_references[0].shape)
+    input_memory_config, output_memory_config = get_mem_configs(
+        buffer_type, shard_specs, layout, torch_references[0].shape
+    )
 
     tt_input = ttnn.from_torch(
         torch_input,


### PR DESCRIPTION
### Ticket
NA

### Problem description
- CCL sweep test updates for lead model shapes were required

### What's changed
- Add some lead model shapes to CCL sweep tests
- Fix logic for sharding in CCL sweeps
- Try to get rudimentary support for multi-device runners in CI CCL sweeps

### Checklist
- [x] N150 Sweep Run https://github.com/tenstorrent/tt-metal/actions/runs/18604022927
- [x] T3K sweep run https://github.com/tenstorrent/tt-metal/actions/runs/18655667130/job/53189084512
- [ ] Galaxy sweep run https://github.com/tenstorrent/tt-metal/actions/runs/18658981721
- [x] BH LLM-Box sweep run https://github.com/tenstorrent/tt-metal/actions/runs/18658992892