### PR TITLE
[Fabric] Fix pkt header

### DIFF
--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -106,7 +106,7 @@ struct NocUnicastAtomicIncCommandHeader {
 
     uint64_t noc_address;
     uint16_t wrap;
-    uint8_t val;
+    uint16_t val;
     bool flush;
 };
 struct NocUnicastAtomicIncFusedCommandHeader {
@@ -117,7 +117,7 @@ struct NocUnicastAtomicIncFusedCommandHeader {
     uint64_t noc_address;
     uint64_t semaphore_noc_address;
     uint16_t wrap;
-    uint8_t val;
+    uint16_t val;
     bool flush;
 };
 struct NocMulticastCommandHeader {
@@ -138,11 +138,13 @@ struct NocMulticastAtomicIncCommandHeader {
 };
 static_assert(sizeof(NocUnicastCommandHeader) == 8, "NocUnicastCommandHeader size is not 8 bytes");
 static_assert(sizeof(NocMulticastCommandHeader) == 8, "NocMulticastCommandHeader size is not 8 bytes");
-static_assert(sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocMulticastCommandHeader size is not 16 bytes");
-static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastCommandHeader size is not 16 bytes");
+static_assert(
+    sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocUnicastInlineWriteCommandHeader size is not 16 bytes");
+static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastAtomicIncCommandHeader size is not 16 bytes");
 static_assert(
     sizeof(NocUnicastAtomicIncFusedCommandHeader) == 24, "NocUnicastAtomicIncFusedCommandHeader size is not 24 bytes");
-static_assert(sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocAtomicIncCommandHeader size is not 12 bytes");
+static_assert(
+    sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocMulticastAtomicIncCommandHeader size is not 12 bytes");
 union NocCommandFields {
     NocUnicastCommandHeader unicast_write;
     NocUnicastInlineWriteCommandHeader unicast_inline_write;


### PR DESCRIPTION
### Ticket
None

### Problem description
For atomic incs we were taking 16 bit input but storing only 8 bits

### What's changed
Update the storage to be 16 bits as well

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18599756877)
- [x] New/Existing tests provide coverage for changes