### PR TITLE
[skip ci] adding gist bash script support to bisect and skipping skip ci commits

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -209,6 +209,67 @@ jobs:
           chmod +x /work/bisect_gist_script.sh
           echo "Gist script downloaded and made executable"
 
+      - name: Validate Inputs
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Parse commit range from combined input
+          COMMIT_RANGE='${{ inputs.commit-range }}'
+          IFS=',' read -r GOOD_COMMIT BAD_COMMIT <<< "$COMMIT_RANGE"
+
+          # Validate parsed values
+          if [ -z "$GOOD_COMMIT" ] || [ -z "$BAD_COMMIT" ]; then
+            echo "ERROR: Invalid commit-range format. Expected 'good,bad' (e.g., 'abc1234,def5678')"
+            exit 1
+          fi
+
+          echo "✓ Parsed good commit: $GOOD_COMMIT"
+          echo "✓ Parsed bad commit: $BAD_COMMIT"
+
+          # Parse timeout and retries from combined input
+          TIMEOUT_RETRIES='${{ inputs.timeout-retries }}'
+          IFS=',' read -r TIMEOUT RETRIES <<< "$TIMEOUT_RETRIES"
+
+          # Validate parsed values
+          if [ -z "$TIMEOUT" ] || [ -z "$RETRIES" ]; then
+            echo "ERROR: Invalid timeout-retries format. Expected 'timeout,retries' (e.g., '30m,3')"
+            exit 1
+          fi
+
+          echo "✓ Parsed timeout: $TIMEOUT"
+          echo "✓ Parsed retries: $RETRIES"
+
+          # Validate command/gist-url exclusivity
+          GIST_URL='${{ inputs.gist-url }}'
+          COMMAND='${{ inputs.command }}'
+
+          if [ -z "$GIST_URL" ] && [ -z "$COMMAND" ]; then
+            echo "ERROR: Either gist-url or command must be provided"
+            exit 1
+          fi
+
+          if [ -n "$GIST_URL" ] && [ -n "$COMMAND" ]; then
+            echo "ERROR: Cannot specify both gist-url and command"
+            exit 1
+          fi
+
+          if [ -n "$GIST_URL" ]; then
+            echo "✓ Using gist URL: $GIST_URL"
+          else
+            echo "✓ Using inline command"
+          fi
+
+          echo ""
+          echo "All inputs validated successfully"
+
+          # Export parsed values as outputs for next step
+          echo "good-commit=$GOOD_COMMIT" >> $GITHUB_OUTPUT
+          echo "bad-commit=$BAD_COMMIT" >> $GITHUB_OUTPUT
+          echo "timeout=$TIMEOUT" >> $GITHUB_OUTPUT
+          echo "retries=$RETRIES" >> $GITHUB_OUTPUT
+
       - name: Run Git Bisect
         shell: bash
         env:
@@ -224,46 +285,16 @@ jobs:
           chmod +x ./build_bisect/tt_bisect.sh
           chmod +x ./build_bisect/download_artifacts.sh
 
-          # Parse commit range from combined input
-          COMMIT_RANGE='${{ inputs.commit-range }}'
-          IFS=',' read -r GOOD_COMMIT BAD_COMMIT <<< "$COMMIT_RANGE"
-
-          # Validate parsed values
-          if [ -z "$GOOD_COMMIT" ] || [ -z "$BAD_COMMIT" ]; then
-            echo "ERROR: Invalid commit-range format. Expected 'good,bad' (e.g., 'abc1234,def5678')"
-            exit 1
-          fi
-
-          echo "Parsed good commit: $GOOD_COMMIT, bad commit: $BAD_COMMIT"
-
-          # Parse timeout and retries from combined input
-          TIMEOUT_RETRIES='${{ inputs.timeout-retries }}'
-          IFS=',' read -r TIMEOUT RETRIES <<< "$TIMEOUT_RETRIES"
-
-          # Validate parsed values
-          if [ -z "$TIMEOUT" ] || [ -z "$RETRIES" ]; then
-            echo "ERROR: Invalid timeout-retries format. Expected 'timeout,retries' (e.g., '30m,3')"
-            exit 1
-          fi
-
-          echo "Parsed timeout: $TIMEOUT, retries: $RETRIES"
+          # Use parsed values from validation step
+          GOOD_COMMIT='${{ steps.validate.outputs.good-commit }}'
+          BAD_COMMIT='${{ steps.validate.outputs.bad-commit }}'
+          TIMEOUT='${{ steps.validate.outputs.timeout }}'
+          RETRIES='${{ steps.validate.outputs.retries }}'
 
           # Determine which script to run
           SCRIPT_PATH=""
-
-          # Check gist-url first
           GIST_URL='${{ inputs.gist-url }}'
-          COMMAND='${{ inputs.command }}'
 
-          if [ -z "$GIST_URL" ] && [ -z "$COMMAND" ]; then
-            echo "ERROR: Either gist-url or command must be provided"
-            exit 1
-          fi
-
-          if [ -n "$GIST_URL" ] && [ -n "$COMMAND" ]; then
-            echo "ERROR: Cannot specify both gist-url and command"
-            exit 1
-          fi
           if [ -n "$GIST_URL" ]; then
             SCRIPT_PATH="/work/bisect_gist_script.sh"
           else

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -56,11 +56,6 @@ on:
         default: ""
         description: "Optional GitHub gist URL for a .sh script to run instead of command"
 
-      download-artifacts:
-        required: false
-        type: boolean
-        default: true
-        description: "Download artifacts from GitHub for each commit (requires gh cli to be authenticated)"
 
 permissions:
   actions: write

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -69,7 +69,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         ARCH_NAME: ${{ (inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150' || inputs.runner-label == 'config-t3000' || contains(inputs.runner-label, 'wormhole_b0')) && 'wormhole_b0' || 'blackhole' }}
         LOGURU_LEVEL: DEBUG
-        PYTHONPATH: /work:/work/ttnn
+        PYTHONPATH: /work:/work/ttnn:/work/tools
         LD_LIBRARY_PATH: /work/build/lib
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TT_METAL_HOME: /work

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -29,7 +29,6 @@ on:
           - config-t3000
           - config-tg
           - topology-6u
-          - config-t3000
         description: "Runner Type Label"
       commit-range:
         required: true
@@ -285,10 +284,6 @@ jobs:
           bisect_args+=(-b "$BAD_COMMIT")
           bisect_args+=(-g "$GOOD_COMMIT")
           bisect_args+=(-r "$RETRIES")
-
-          if [[ "${{ inputs.download-artifacts }}" == 'true' ]]; then
-            bisect_args+=(-a)
-          fi
 
           if [[ "${{ inputs.tracy }}" == 'true' ]]; then
             bisect_args+=(-p)

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -31,24 +31,31 @@ on:
           - topology-6u
           - config-t3000
         description: "Runner Type Label"
-      good-commit:
+      commit-range:
         required: true
         type: string
-      bad-commit:
-        required: true
-        type: string
+        description: "Good and bad commits (format: good,bad, e.g., abc1234,def5678)"
       command:
-        required: true
-        type: string
-      timeout:
-        required: true
-        type: string
-        description: "Timeout for one iteration (eg: 5m, 1h)"
-      retries:
         required: false
         type: string
-        default: "3"
-        description: "Number of retries (default 3)"
+        default: ""
+        description: "Test command to run (not needed if gist-url is provided)"
+      timeout-retries:
+        required: true
+        type: string
+        default: "30m,3"
+        description: "Timeout and retries (format: timeout,retries, e.g., 30m,3 or 1h,5)"
+      download-artifacts:
+        required: false
+        type: boolean
+        default: true
+        description: "Download artifacts from GitHub for each commit (requires gh cli to be authenticated)"
+      gist-url:
+        required: false
+        type: string
+        default: ""
+        description: "Optional GitHub gist URL for a .sh script to run instead of command"
+
       download-artifacts:
         required: false
         type: boolean
@@ -161,6 +168,52 @@ jobs:
           echo "Testing gh CLI with current repository:"
           echo "Repository: $(gh repo view --repo tenstorrent/tt-metal --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo 'Failed to get repo info')"
         shell: bash
+      - name: Download Gist Script
+        if: ${{ inputs.gist-url != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Downloading gist from ${{ inputs.gist-url }}"
+          GIST_URL="${{ inputs.gist-url }}"
+
+          # Extract gist ID and filename from various URL formats
+          if [[ "$GIST_URL" =~ gist\.github\.com/([^/]+)/([a-f0-9]+) ]]; then
+            # Regular gist URL: https://gist.github.com/username/gist_id
+            GIST_USER="${BASH_REMATCH[1]}"
+            GIST_ID="${BASH_REMATCH[2]}"
+            # Get the filename from the end of URL if present, otherwise use default
+            if [[ "$GIST_URL" =~ /([^/]+\.sh)$ ]]; then
+              FILENAME="${BASH_REMATCH[1]}"
+            else
+              FILENAME=""
+            fi
+          elif [[ "$GIST_URL" =~ gist\.githubusercontent\.com/([^/]+)/([a-f0-9]+)/raw/[^/]+/(.+\.sh)$ ]]; then
+            # Raw gist URL with revision: https://gist.githubusercontent.com/username/gist_id/raw/revision/filename.sh
+            GIST_USER="${BASH_REMATCH[1]}"
+            GIST_ID="${BASH_REMATCH[2]}"
+            FILENAME="${BASH_REMATCH[3]}"
+          elif [[ "$GIST_URL" =~ gist\.githubusercontent\.com/([^/]+)/([a-f0-9]+)/raw/(.+\.sh)$ ]]; then
+            # Raw gist URL without revision: https://gist.githubusercontent.com/username/gist_id/raw/filename.sh
+            GIST_USER="${BASH_REMATCH[1]}"
+            GIST_ID="${BASH_REMATCH[2]}"
+            FILENAME="${BASH_REMATCH[3]}"
+          else
+            echo "ERROR: Could not parse gist URL format"
+            exit 1
+          fi
+
+          # Construct the raw URL without revision hash to always get latest
+          if [ -n "$FILENAME" ]; then
+            RAW_URL="https://gist.githubusercontent.com/${GIST_USER}/${GIST_ID}/raw/${FILENAME}"
+          else
+            # If no filename, try to get the first .sh file
+            RAW_URL="https://gist.githubusercontent.com/${GIST_USER}/${GIST_ID}/raw"
+          fi
+
+          echo "Fetching from: $RAW_URL"
+          curl -fsSL "$RAW_URL" -o /work/bisect_gist_script.sh
+          chmod +x /work/bisect_gist_script.sh
+          echo "Gist script downloaded and made executable"
 
       - name: Run Git Bisect
         shell: bash
@@ -176,7 +229,101 @@ jobs:
           cp ./tests/scripts/download_artifacts.sh ./build_bisect/
           chmod +x ./build_bisect/tt_bisect.sh
           chmod +x ./build_bisect/download_artifacts.sh
-          ./build_bisect/tt_bisect.sh -t ${{ inputs.timeout }} -f '${{ inputs.command }}' -b ${{ inputs.bad-commit }} -g ${{ inputs.good-commit }} ${{ inputs.tracy == true && '-p' || '' }} -r ${{ inputs.retries }} ${{ inputs.nd-mode == true && '-n' || '' }} ${{ inputs.download-artifacts == true && '-a' || '' }}
+
+          # Parse commit range from combined input
+          COMMIT_RANGE='${{ inputs.commit-range }}'
+          IFS=',' read -r GOOD_COMMIT BAD_COMMIT <<< "$COMMIT_RANGE"
+
+          # Validate parsed values
+          if [ -z "$GOOD_COMMIT" ] || [ -z "$BAD_COMMIT" ]; then
+            echo "ERROR: Invalid commit-range format. Expected 'good,bad' (e.g., 'abc1234,def5678')"
+            exit 1
+          fi
+
+          echo "Parsed good commit: $GOOD_COMMIT, bad commit: $BAD_COMMIT"
+
+          # Parse timeout and retries from combined input
+          TIMEOUT_RETRIES='${{ inputs.timeout-retries }}'
+          IFS=',' read -r TIMEOUT RETRIES <<< "$TIMEOUT_RETRIES"
+
+          # Validate parsed values
+          if [ -z "$TIMEOUT" ] || [ -z "$RETRIES" ]; then
+            echo "ERROR: Invalid timeout-retries format. Expected 'timeout,retries' (e.g., '30m,3')"
+            exit 1
+          fi
+
+          echo "Parsed timeout: $TIMEOUT, retries: $RETRIES"
+
+          # Determine which script to run
+          SCRIPT_PATH=""
+
+          # Check gist-url first
+          GIST_URL='${{ inputs.gist-url }}'
+          COMMAND='${{ inputs.command }}'
+
+          if [ -z "$GIST_URL" ] && [ -z "$COMMAND" ]; then
+            echo "ERROR: Either gist-url or command must be provided"
+            exit 1
+          fi
+
+          if [ -n "$GIST_URL" ] && [ -n "$COMMAND" ]; then
+            echo "ERROR: Cannot specify both gist-url and command"
+            exit 1
+          fi
+          if [ -n "$GIST_URL" ]; then
+            SCRIPT_PATH="/work/bisect_gist_script.sh"
+          else
+            # Write command to a temporary script to avoid quoting issues
+            # Note: using heredoc with 'EOF' prevents variable expansion
+            cat > /work/bisect_command_script.sh << 'EOF'
+          #!/bin/bash
+          set -eo pipefail
+          ${{ inputs.command }}
+          EOF
+            chmod +x /work/bisect_command_script.sh
+            SCRIPT_PATH="/work/bisect_command_script.sh"
+          fi
+
+          # Build arguments in an array to avoid empty string issues
+          declare -a bisect_args
+          bisect_args+=(-t "$TIMEOUT")
+          bisect_args+=(-b "$BAD_COMMIT")
+          bisect_args+=(-g "$GOOD_COMMIT")
+          bisect_args+=(-r "$RETRIES")
+
+          if [[ "${{ inputs.download-artifacts }}" == 'true' ]]; then
+            bisect_args+=(-a)
+          fi
+
+          if [[ "${{ inputs.tracy }}" == 'true' ]]; then
+            bisect_args+=(-p)
+          fi
+          if [[ "${{ inputs.nd-mode }}" == 'true' ]]; then
+            bisect_args+=(-n)
+          fi
+          if [[ "${{ inputs.download-artifacts }}" == 'true' ]]; then
+            bisect_args+=(-a)
+          fi
+
+          bisect_args+=(-s "$SCRIPT_PATH")
+
+          # Run bisect with clean, properly quoted arguments
+          set +e
+          ./build_bisect/tt_bisect.sh "${bisect_args[@]}"
+          BISECT_EXIT_CODE=$?
+          set -e
+
+          # Handle exit codes
+          if [ $BISECT_EXIT_CODE -eq 2 ]; then
+            echo "════════════════════════════════════════════════════════════════"
+            echo "Bisect completed with exit code 2"
+            echo "Likely outcome: No problematic commit found, only skipped commits remain"
+            echo "════════════════════════════════════════════════════════════════"
+            exit 0
+          elif [ $BISECT_EXIT_CODE -ne 0 ]; then
+            echo "Bisect failed with exit code $BISECT_EXIT_CODE"
+            exit $BISECT_EXIT_CODE
+          fi
 
       - name: Upload ND results CSV
         if: ${{ hashFiles('docker-job/bisect_nd_results.csv') != '' }}

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -3,12 +3,6 @@ name: "Git bisect dispatch"
 on:
   workflow_dispatch:
     inputs:
-      arch:
-        required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
       tracy:
         required: true
         type: boolean
@@ -27,33 +21,33 @@ on:
           - N300
           - P150
           - config-t3000
-          - config-tg
-          - topology-6u
+          - config-BH-LoudBox
+          - topology-6u-wormhole_b0
+          - topology-6u-blackhole
         description: "Runner Type Label"
       commit-range:
         required: true
         type: string
         description: "Good and bad commits (format: good,bad, e.g., abc1234,def5678)"
-      command:
-        required: false
-        type: string
-        default: ""
-        description: "Test command to run (not needed if gist-url is provided)"
-      timeout-retries:
+      test-script:
         required: true
         type: string
-        default: "30m,3"
-        description: "Timeout and retries (format: timeout,retries, e.g., 30m,3 or 1h,5)"
+        description: "GitHub gist URL (e.g., https://gist.github.com/user/id) or inline command to run"
+      timeout:
+        required: true
+        type: string
+        default: "30"
+        description: "Timeout for each test run in minutes (positive integer only)"
+      attempts:
+        required: true
+        type: string
+        default: "3"
+        description: "Number of retry attempts for each test run"
       download-artifacts:
         required: false
         type: boolean
         default: true
         description: "Download artifacts from GitHub for each commit (requires gh cli to be authenticated)"
-      gist-url:
-        required: false
-        type: string
-        default: ""
-        description: "Optional GitHub gist URL for a .sh script to run instead of command"
 
 
 permissions:
@@ -73,7 +67,7 @@ jobs:
       image: ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
       env:
         GH_TOKEN: ${{ github.token }}
-        ARCH_NAME: ${{ inputs.arch }}
+        ARCH_NAME: ${{ (inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150' || inputs.runner-label == 'config-t3000' || contains(inputs.runner-label, 'wormhole_b0')) && 'wormhole_b0' || 'blackhole' }}
         LOGURU_LEVEL: DEBUG
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
@@ -163,12 +157,12 @@ jobs:
           echo "Repository: $(gh repo view --repo tenstorrent/tt-metal --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo 'Failed to get repo info')"
         shell: bash
       - name: Download Gist Script
-        if: ${{ inputs.gist-url != '' }}
+        if: ${{ contains(inputs.test-script, 'gist.github.com') || contains(inputs.test-script, 'gist.githubusercontent.com') }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "Downloading gist from ${{ inputs.gist-url }}"
-          GIST_URL="${{ inputs.gist-url }}"
+          echo "Downloading gist from ${{ inputs.test-script }}"
+          GIST_URL="${{ inputs.test-script }}"
 
           # Extract gist ID and filename from various URL formats
           if [[ "$GIST_URL" =~ gist\.github\.com/([^/]+)/([a-f0-9]+) ]]; then
@@ -228,35 +222,78 @@ jobs:
           echo "✓ Parsed good commit: $GOOD_COMMIT"
           echo "✓ Parsed bad commit: $BAD_COMMIT"
 
-          # Parse timeout and retries from combined input
-          TIMEOUT_RETRIES='${{ inputs.timeout-retries }}'
-          IFS=',' read -r TIMEOUT RETRIES <<< "$TIMEOUT_RETRIES"
-
-          # Validate parsed values
-          if [ -z "$TIMEOUT" ] || [ -z "$RETRIES" ]; then
-            echo "ERROR: Invalid timeout-retries format. Expected 'timeout,retries' (e.g., '30m,3')"
+          # Validate that commits exist
+          if ! git cat-file -e "$GOOD_COMMIT^{commit}" 2>/dev/null; then
+            echo "ERROR: Good commit does not exist: $GOOD_COMMIT"
             exit 1
           fi
 
-          echo "✓ Parsed timeout: $TIMEOUT"
-          echo "✓ Parsed retries: $RETRIES"
-
-          # Validate command/gist-url exclusivity
-          GIST_URL='${{ inputs.gist-url }}'
-          COMMAND='${{ inputs.command }}'
-
-          if [ -z "$GIST_URL" ] && [ -z "$COMMAND" ]; then
-            echo "ERROR: Either gist-url or command must be provided"
+          if ! git cat-file -e "$BAD_COMMIT^{commit}" 2>/dev/null; then
+            echo "ERROR: Bad commit does not exist: $BAD_COMMIT"
             exit 1
           fi
 
-          if [ -n "$GIST_URL" ] && [ -n "$COMMAND" ]; then
-            echo "ERROR: Cannot specify both gist-url and command"
+          echo "✓ Both commits exist in repository"
+
+          # Validate that good commit is an ancestor of bad commit
+          if ! git merge-base --is-ancestor "$GOOD_COMMIT" "$BAD_COMMIT" 2>/dev/null; then
+            echo "ERROR: Good commit ($GOOD_COMMIT) is not an ancestor of bad commit ($BAD_COMMIT)"
+            echo "This means the good commit does not come before the bad commit in git history."
+            echo "Please verify your commit range."
             exit 1
           fi
 
-          if [ -n "$GIST_URL" ]; then
-            echo "✓ Using gist URL: $GIST_URL"
+          echo "✓ Good commit is an ancestor of bad commit"
+
+          # Validate timeout and attempts
+          TIMEOUT='${{ inputs.timeout }}'
+          ATTEMPTS='${{ inputs.attempts }}'
+
+          if [ -z "$TIMEOUT" ]; then
+            echo "ERROR: Timeout must be provided"
+            exit 1
+          fi
+
+          # Validate timeout is a positive integer
+          if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Timeout must be a positive integer (got: '$TIMEOUT')"
+            exit 1
+          fi
+
+          if [ "$TIMEOUT" -le 0 ]; then
+            echo "ERROR: Timeout must be greater than 0 (got: $TIMEOUT)"
+            exit 1
+          fi
+
+          if [ -z "$ATTEMPTS" ]; then
+            echo "ERROR: Attempts must be provided"
+            exit 1
+          fi
+
+          # Validate attempts is a positive integer
+          if ! [[ "$ATTEMPTS" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Attempts must be a positive integer (got: '$ATTEMPTS')"
+            exit 1
+          fi
+
+          if [ "$ATTEMPTS" -le 0 ]; then
+            echo "ERROR: Attempts must be greater than 0 (got: $ATTEMPTS)"
+            exit 1
+          fi
+
+          echo "✓ Timeout: $TIMEOUT minutes"
+          echo "✓ Attempts: $ATTEMPTS"
+
+          # Validate test-script is provided
+          TEST_SCRIPT='${{ inputs.test-script }}'
+          if [ -z "$TEST_SCRIPT" ]; then
+            echo "ERROR: test-script must be provided"
+            exit 1
+          fi
+
+          # Determine if it's a gist or inline command
+          if [[ "$TEST_SCRIPT" == *"gist.github.com"* ]] || [[ "$TEST_SCRIPT" == *"gist.githubusercontent.com"* ]]; then
+            echo "✓ Detected gist URL: $TEST_SCRIPT"
           else
             echo "✓ Using inline command"
           fi
@@ -267,8 +304,6 @@ jobs:
           # Export parsed values as outputs for next step
           echo "good-commit=$GOOD_COMMIT" >> $GITHUB_OUTPUT
           echo "bad-commit=$BAD_COMMIT" >> $GITHUB_OUTPUT
-          echo "timeout=$TIMEOUT" >> $GITHUB_OUTPUT
-          echo "retries=$RETRIES" >> $GITHUB_OUTPUT
 
       - name: Run Git Bisect
         shell: bash
@@ -288,22 +323,23 @@ jobs:
           # Use parsed values from validation step
           GOOD_COMMIT='${{ steps.validate.outputs.good-commit }}'
           BAD_COMMIT='${{ steps.validate.outputs.bad-commit }}'
-          TIMEOUT='${{ steps.validate.outputs.timeout }}'
-          RETRIES='${{ steps.validate.outputs.retries }}'
+          TIMEOUT='${{ inputs.timeout }}'
+          ATTEMPTS='${{ inputs.attempts }}'
 
-          # Determine which script to run
+          # Determine which script to run based on test-script input
           SCRIPT_PATH=""
-          GIST_URL='${{ inputs.gist-url }}'
+          TEST_SCRIPT='${{ inputs.test-script }}'
 
-          if [ -n "$GIST_URL" ]; then
+          if [[ "$TEST_SCRIPT" == *"gist.github.com"* ]] || [[ "$TEST_SCRIPT" == *"gist.githubusercontent.com"* ]]; then
+            # It's a gist URL, use the downloaded gist script
             SCRIPT_PATH="/work/bisect_gist_script.sh"
           else
-            # Write command to a temporary script to avoid quoting issues
+            # It's an inline command, write it to a temporary script to avoid quoting issues
             # Note: using heredoc with 'EOF' prevents variable expansion
             cat > /work/bisect_command_script.sh << 'EOF'
           #!/bin/bash
           set -eo pipefail
-          ${{ inputs.command }}
+          ${{ inputs.test-script }}
           EOF
             chmod +x /work/bisect_command_script.sh
             SCRIPT_PATH="/work/bisect_command_script.sh"
@@ -314,7 +350,7 @@ jobs:
           bisect_args+=(-t "$TIMEOUT")
           bisect_args+=(-b "$BAD_COMMIT")
           bisect_args+=(-g "$GOOD_COMMIT")
-          bisect_args+=(-r "$RETRIES")
+          bisect_args+=(-r "$ATTEMPTS")
 
           if [[ "${{ inputs.tracy }}" == 'true' ]]; then
             bisect_args+=(-p)

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -69,7 +69,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         ARCH_NAME: ${{ (inputs.runner-label == 'N150' || inputs.runner-label == 'N300' || inputs.runner-label == 'P150' || inputs.runner-label == 'config-t3000' || contains(inputs.runner-label, 'wormhole_b0')) && 'wormhole_b0' || 'blackhole' }}
         LOGURU_LEVEL: DEBUG
-        PYTHONPATH: /work
+        PYTHONPATH: /work:/work/ttnn
         LD_LIBRARY_PATH: /work/build/lib
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         TT_METAL_HOME: /work

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -114,7 +114,7 @@ verify_import_path() {
   if [ -x "./python_env/bin/python" ]; then
     PY_BIN="./python_env/bin/python"
   fi
-  
+
   echo "DEBUG: Checking ttnn installation..."
   echo "DEBUG: PYTHONPATH=$PYTHONPATH"
   echo "DEBUG: Looking for ttnn at /work/ttnn/ttnn/__init__.py"
@@ -123,7 +123,7 @@ verify_import_path() {
   find /work/ttnn/ttnn -name "_ttnn*.so" -ls || echo "WARNING: _ttnn.so not found!"
   echo "DEBUG: Looking for built libraries in build_Release"
   ls -la /work/build_Release/lib/_ttnn*.so || ls -la /work/build/lib/_ttnn*.so || echo "WARNING: _ttnn.so not in build libs!"
-  
+
   "$PY_BIN" - <<'PY'
 import sys
 print("DEBUG: Python sys.path:", sys.path)
@@ -162,7 +162,7 @@ try_download_artifacts() {
     "$download_script" "$commit_sha"
   fi
 }
-
+# START GIT BISECT
 echo "Starting git bisect…"
 git bisect start "$bad_commit" "$good_commit"
 

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -9,7 +9,7 @@ Usage:
   -s SCRIPT      : path to script to run instead of test command (optional)
   -g GOOD_SHA    : known good commit
   -b BAD_SHA     : known bad commit
-  -t TIMEOUT     : per-iteration timeout (default 30m)
+  -t TIMEOUT     : per-iteration timeout in minutes (default 30)
   -p             : enable Tracy profiling
   -r RETRIES     : number of retries (default 3)
   -n             : enable non-deterministic detection mode (ND mode)
@@ -17,7 +17,7 @@ Usage:
 Note: Either -f or -s must be specified, but not both.
 END
 
-timeout_duration_iteration="30m"
+timeout_duration_iteration="30"
 test=""
 script_path=""
 good_commit=""
@@ -259,7 +259,7 @@ while [[ "$found" == "false" ]]; do
         run_cmd="$test"
       fi
 
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
+      if timeout -k 10s "${timeout_duration_iteration}m" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
         if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
           echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
           skip_count=$((skip_count+1))
@@ -347,7 +347,7 @@ while [[ "$found" == "false" ]]; do
         run_cmd="$test"
       fi
 
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
+      if timeout -k 10s "${timeout_duration_iteration}m" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
         timeout_rc=0
         echo "--- Logs (attempt $run_idx) ---"
         sed -n '1,200p' "$output_file" || true

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -196,37 +196,6 @@ while [[ "$found" == "false" ]]; do
         --build-all \
         --enable-ccache || build_rc=$?
     fi
-
-  # Try to download artifacts first if artifact mode is enabled
-  if [ "$artifact_mode" = true ]; then
-    if try_download_artifacts "$full_sha"; then
-      echo "Using downloaded artifacts for $rev"
-      build_rc=0
-    else
-      echo "WARNING: Artifact download failed, falling back to local build"
-      if [ "$tracy_enabled" -eq 1 ]; then
-        ./build_metal.sh \
-          --build-all \
-          --enable-ccache \
-          --enable-profiler || build_rc=$?
-      else
-        ./build_metal.sh \
-          --build-all \
-          --enable-ccache || build_rc=$?
-      fi
-    fi
-  else
-    # Standard local build
-    if [ "$tracy_enabled" -eq 1 ]; then
-      ./build_metal.sh \
-        --build-all \
-        --enable-ccache \
-        --enable-profiler || build_rc=$?
-    else
-      ./build_metal.sh \
-        --build-all \
-        --enable-ccache || build_rc=$?
-    fi
   fi
 
   echo "::endgroup::"

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -45,6 +45,9 @@ while getopts ":f:s:g:b:t:pr:na" opt; do
   esac
 done
 
+export CXX=clang++-17
+export CC=clang-17
+
 # Either test or script_path must be specified, but not both
 if [ -n "$script_path" ] && [ -n "$test" ]; then
   die "Cannot specify both -f TEST and -s SCRIPT. Use one or the other."
@@ -75,7 +78,7 @@ fi
 # Set up environment (skip if already in CI container with pre-configured venv)
 if [ ! -d "$PYTHON_ENV_DIR" ]; then
   echo "Creating virtual environment and installing dependencies..."
-  CXX=clang++-17 CC=clang-17 ./create_venv.sh
+  ./create_venv.sh
   pip install -r models/tt_transformers/requirements.txt
 else
   echo "Using existing virtual environment: $PYTHON_ENV_DIR"

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -114,10 +114,34 @@ verify_import_path() {
   if [ -x "./python_env/bin/python" ]; then
     PY_BIN="./python_env/bin/python"
   fi
+  
+  echo "DEBUG: Checking ttnn installation..."
+  echo "DEBUG: PYTHONPATH=$PYTHONPATH"
+  echo "DEBUG: Looking for ttnn at /work/ttnn/ttnn/__init__.py"
+  ls -la /work/ttnn/ttnn/__init__.py || echo "WARNING: ttnn __init__.py not found!"
+  echo "DEBUG: Looking for _ttnn.so"
+  find /work/ttnn/ttnn -name "_ttnn*.so" -ls || echo "WARNING: _ttnn.so not found!"
+  echo "DEBUG: Looking for built libraries in build_Release"
+  ls -la /work/build_Release/lib/_ttnn*.so || ls -la /work/build/lib/_ttnn*.so || echo "WARNING: _ttnn.so not in build libs!"
+  
   "$PY_BIN" - <<'PY'
-import ttnn, sys
-print(ttnn.get_arch_name())
-print("ttnn imported from:", ttnn.__file__)
+import sys
+print("DEBUG: Python sys.path:", sys.path)
+try:
+    import ttnn
+    print("✓ ttnn imported from:", ttnn.__file__)
+    print("DEBUG: ttnn module attributes:", dir(ttnn))
+    if hasattr(ttnn, 'get_arch_name'):
+        print("✓ Arch:", ttnn.get_arch_name())
+    else:
+        print("ERROR: get_arch_name not found in ttnn")
+        print("DEBUG: Available functions starting with 'get':", [x for x in dir(ttnn) if x.startswith('get')])
+        sys.exit(1)
+except Exception as e:
+    print(f"ERROR during ttnn import/test: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)
 PY
 }
 

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -75,17 +75,11 @@ if [ "$artifact_mode" = true ]; then
   echo "Artifact download optimization enabled."
 fi
 
-# Set up environment (skip if already in CI container with pre-configured venv)
-if [ ! -d "$PYTHON_ENV_DIR" ]; then
-  echo "Creating virtual environment and installing dependencies..."
-  ./create_venv.sh
-  pip install -r models/tt_transformers/requirements.txt
-else
-  echo "Using existing virtual environment: $PYTHON_ENV_DIR"
-  source $PYTHON_ENV_DIR/bin/activate
-  pip install -r models/tt_transformers/requirements.txt
-  pip install -r $(pwd)/tt_metal/python_env/requirements-dev.txt
-fi
+
+echo "Creating virtual environment and installing dependencies..."
+./create_venv.sh
+pip install -r models/tt_transformers/requirements.txt
+
 
 git cat-file -e "$good_commit^{commit}" 2>/dev/null || die "Invalid good commit: $good_commit"
 git cat-file -e "$bad_commit^{commit}" 2>/dev/null  || die "Invalid bad commit: $bad_commit"

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -6,6 +6,7 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 : << 'END'
 Usage:
   -f TEST        : test command to run (quote if it has spaces)
+  -s SCRIPT      : path to script to run instead of test command (optional)
   -g GOOD_SHA    : known good commit
   -b BAD_SHA     : known bad commit
   -t TIMEOUT     : per-iteration timeout (default 30m)
@@ -13,10 +14,12 @@ Usage:
   -r RETRIES     : number of retries (default 3)
   -n             : enable non-deterministic detection mode (ND mode)
   -a             : enable artifact download optimization (requires gh CLI)
+Note: Either -f or -s must be specified, but not both.
 END
 
 timeout_duration_iteration="30m"
 test=""
+script_path=""
 good_commit=""
 bad_commit=""
 tracy_enabled=0
@@ -26,9 +29,10 @@ artifact_mode=false
 run_idx=0
 timeout_rc=1
 
-while getopts ":f:g:b:t:pr:na" opt; do
+while getopts ":f:s:g:b:t:pr:na" opt; do
   case "$opt" in
     f) test="$OPTARG" ;;
+    s) script_path="$OPTARG" ;;
     g) good_commit="$OPTARG" ;;
     b) bad_commit="$OPTARG" ;;
     t) timeout_duration_iteration="$OPTARG" ;;
@@ -41,9 +45,20 @@ while getopts ":f:g:b:t:pr:na" opt; do
   esac
 done
 
-[ -n "$test" ] || die "Please specify -f TEST."
+# Either test or script_path must be specified, but not both
+if [ -n "$script_path" ] && [ -n "$test" ]; then
+  die "Cannot specify both -f TEST and -s SCRIPT. Use one or the other."
+elif [ -z "$script_path" ] && [ -z "$test" ]; then
+  die "Please specify either -f TEST or -s SCRIPT."
+fi
+
 [ -n "$good_commit" ] || die "Please specify -g GOOD_SHA."
 [ -n "$bad_commit" ] || die "Please specify -b BAD_SHA."
+
+# Validate script exists if specified
+if [ -n "$script_path" ] && [ ! -f "$script_path" ]; then
+  die "Script not found: $script_path"
+fi
 
 echo "TT_METAL_HOME: $TT_METAL_HOME"
 echo "PYTHONPATH: $PYTHONPATH"
@@ -94,7 +109,12 @@ fresh_clean() {
 
 # After building, verify we import from the workspace
 verify_import_path() {
-  python - <<'PY'
+  # Prefer the venv python if it exists so imports reflect the built workspace
+  PY_BIN="python"
+  if [ -x "./python_env/bin/python" ]; then
+    PY_BIN="./python_env/bin/python"
+  fi
+  "$PY_BIN" - <<'PY'
 import ttnn, sys
 print(ttnn.get_arch_name())
 print("ttnn imported from:", ttnn.__file__)
@@ -126,11 +146,56 @@ found=false
 while [[ "$found" == "false" ]]; do
   rev="$(git rev-parse --short=12 HEAD)"
   full_sha="$(git rev-parse HEAD)"
+
+  commit_msg="$(git log -1 --pretty=%s HEAD)"
+
+  echo "Commit message: $commit_msg"
+
+  # Check if commit message contains [skip-ci] or [skip ci] (case-insensitive) and skip if so
+  case "$commit_msg" in
+    *"[skip ci]"* | *"[skip CI]"* | *"[skip-ci]"* | *"[skip-CI]"* )
+      echo "Commit $rev contains [skip ci] or [skip-ci], skipping: $commit_msg"
+      git bisect skip
+      continue
+      ;;
+  esac
+
   echo "::group::Building $rev"
 
   fresh_clean
 
   build_rc=0
+
+  # Try to download artifacts first if artifact mode is enabled
+  if [ "$artifact_mode" = true ]; then
+    if try_download_artifacts "$full_sha"; then
+      echo "Using downloaded artifacts for $rev"
+      build_rc=0
+    else
+      echo "WARNING: Artifact download failed, falling back to local build"
+      if [ "$tracy_enabled" -eq 1 ]; then
+        ./build_metal.sh \
+          --build-all \
+          --enable-ccache \
+          --enable-profiler || build_rc=$?
+      else
+        ./build_metal.sh \
+          --build-all \
+          --enable-ccache || build_rc=$?
+      fi
+    fi
+  else
+    # Standard local build
+    if [ "$tracy_enabled" -eq 1 ]; then
+      ./build_metal.sh \
+        --build-all \
+        --enable-ccache \
+        --enable-profiler || build_rc=$?
+    else
+      ./build_metal.sh \
+        --build-all \
+        --enable-ccache || build_rc=$?
+    fi
 
   # Try to download artifacts first if artifact mode is enabled
   if [ "$artifact_mode" = true ]; then
@@ -173,7 +238,7 @@ while [[ "$found" == "false" ]]; do
   fi
 
   echo "::group::Import sanity ($rev)"
-  if ! verify_import_path; then
+  if ! verify_import_path 2>&1; then
     echo "Import path check failed; skipping this commit"
     git bisect skip
     echo "::endgroup::"
@@ -217,8 +282,15 @@ while [[ "$found" == "false" ]]; do
         tt-smi -r >/dev/null 2>&1 || true  # use regular reset mode
       fi
 
-      echo "Run: $test"
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+      if [ -n "$script_path" ]; then
+        echo "Run: $script_path"
+        run_cmd="$script_path"
+      else
+        echo "Run: $test"
+        run_cmd="$test"
+      fi
+
+      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
         if grep -qiE "(^|[^a-zA-Z])(SKIP|SKIPPED)([^a-zA-Z]|$)" "$output_file"; then
           echo "Attempt $run_idx: detected skip (exit 0 with 'SKIP' in output)"
           skip_count=$((skip_count+1))
@@ -294,8 +366,19 @@ while [[ "$found" == "false" ]]; do
     timeout_rc=1
     while [ $run_idx -le $retries ]; do
       echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
-      echo "Run: $test"
-      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then
+      echo "Resetting devices..."
+      tt-smi -r >/dev/null 2>&1 || true
+      echo "Devices reset"
+
+      if [ -n "$script_path" ]; then
+        echo "Run: $script_path"
+        run_cmd="$script_path"
+      else
+        echo "Run: $test"
+        run_cmd="$test"
+      fi
+
+      if timeout -k 10s "$timeout_duration_iteration" bash -lc "$run_cmd" 2>&1 | tee "$output_file"; then
         timeout_rc=0
         echo "--- Logs (attempt $run_idx) ---"
         sed -n '1,200p' "$output_file" || true


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30621

### Problem description
Currently the only way to run tests with the bisect tool is to run the test with a single bash command. This PR offers the capacity to use a gist bash script to run the test instead, as well as to input a bash script path to the tt_bisect shell script to run more complex tests locally.

Also, commits that are marked as [skip ci] don't need to be tested with the bisect tool, especially since they necessarily require that metal be rebuilt as they don't have a past CI run to get a build artifact from.

### What's changed
Gist support has been added, and the inputs to the workflow have changed. Now there's a check to see if the title of a commit has [skip ci] and git bisect skip is run if that's the case. 

<img width="320" height="699" alt="image" src="https://github.com/user-attachments/assets/da9ed3cc-f353-42dd-b218-9807389d1881" />


### Checklist
- [ ] [Bisect with command passes](https://github.com/tenstorrent/tt-metal/actions/workflows/bisect-dispatch.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18720293240
- [ ] [Bisect with gist passes](https://github.com/tenstorrent/tt-metal/actions/workflows/bisect-dispatch.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18720310320