### PR TITLE
Fix support for Qwen2.5-VL-7B

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -221,7 +221,7 @@ jobs:
             -e ARCH_NAME=${{ inputs.arch }}
             ${{ matrix.test-group.civ2-compatible && '-e TT_GH_CI_INFRA=1' || '' }}
             ${{ !matrix.test-group.civ2-compatible && '-e HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub' || '' }}
-            -v /mnt/MLPerf:/mnt/MLPerf:ro
+            -v /mnt/MLPerf:/mnt/MLPerf
             --cap-add=ALL
             --security-opt seccomp=unconfined
             --ulimit nproc=65536:65536

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -221,7 +221,7 @@ jobs:
             -e ARCH_NAME=${{ inputs.arch }}
             ${{ matrix.test-group.civ2-compatible && '-e TT_GH_CI_INFRA=1' || '' }}
             ${{ !matrix.test-group.civ2-compatible && '-e HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub' || '' }}
-            -v /mnt/MLPerf:/mnt/MLPerf
+            -v /mnt/MLPerf:/mnt/MLPerf:ro
             --cap-add=ALL
             --security-opt seccomp=unconfined
             --ulimit nproc=65536:65536

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -110,7 +110,7 @@ jobs:
             { name: "yolov5x", runner-label: "N300", performance: false, cmd: "pytest models/demos/yolov5x/demo/demo.py", owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
   #          # Moved to t3k tests until OOM on single card runners resolved
             # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
-            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_func, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_perfunc, owner_id: U07RY6B5FLJ},  #Gongyu Wang
             { name: "ds_r1_qwen", runner-label: "N300", performance: false, cmd: run_ds_r1_qwen_func, owner_id: U07RY6B5FLJ, civ2-compatible: true},  #Gongyu Wang
             # { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews TODO: Gemma3 N150 tests pulled due to OOM; will be addressed in future PR
             { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # {
-          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
+          {
+            name: "[WH-T3K] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -50,81 +50,81 @@ jobs:
             additional-args: "--max_model_len 2048",
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          # {
-          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: BH-DeskBox,
-          #   mesh-device: P150x2,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 2}",
-          #   multimodal: false,
-          #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # },
-          # {
-          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 5,
-          #   benchmark-timeout: 5,
-          #   runner-label: bh-LLMBox,
-          #   mesh-device: P150x4,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 4}",
-          #   multimodal: false,
-          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[BH-LB] Llama-3.1-8B-Instruct",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: bh-rackbox,
-          #   mesh-device: P150x8,
-          #   tt-llama-text-ver: tt_transformers,
-          #   override-tt-config: "{\"data_parallel\": 8}",
-          #   multimodal: false,
-          #   owner_id: U08GELBB1AP, # Ambrose Ling
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
-          #   model: "meta-llama/Llama-3.3-70B-Instruct",
-          #   server-timeout: 35,
-          #   benchmark-timeout: 10,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   tt-llama-text-ver: llama3_70b_galaxy,
-          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          # },
-          # {
-          #   name: "[WH-GLX] Llama-8B DP=16",
-          #   model: "meta-llama/Llama-3.1-8B-Instruct",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: topology-6u,
-          #   mesh-device: TG,
-          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false,
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
-          # {
-          #   name: "[WH-T3K] Gemma3-27B",
-          #   model: "google/gemma-3-27b-it",
-          #   server-timeout: 10,
-          #   benchmark-timeout: 5,
-          #   runner-label: config-t3000,
-          #   mesh-device: T3K,
-          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-          #   tt-llama-text-ver: tt_transformers,
-          #   multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
-          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          # },
+          {
+            name: "[BH-DB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: BH-DeskBox,
+            mesh-device: P150x2,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 2}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[BH-QB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 5,
+            benchmark-timeout: 5,
+            runner-label: bh-LLMBox,
+            mesh-device: P150x4,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 4}",
+            multimodal: false,
+            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[BH-LB] Llama-3.1-8B-Instruct",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-rackbox,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 8}",
+            multimodal: false,
+            owner_id: U08GELBB1AP, # Ambrose Ling
+          },
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          },
+          {
+            name: "[WH-GLX] Llama-8B DP=16",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: topology-6u,
+            mesh-device: TG,
+            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false,
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
+          {
+            name: "[WH-T3K] Gemma3-27B",
+            model: "google/gemma-3-27b-it",
+            server-timeout: 10,
+            benchmark-timeout: 5,
+            runner-label: config-t3000,
+            mesh-device: T3K,
+            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+            tt-llama-text-ver: tt_transformers,
+            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
+            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -24,19 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "[WH-T3K] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
+          # {
+          #   name: "[WH-T3K] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
           {
             name: "[WH-T3K] Qwen2.5-VL-72B-Instruct",
             model: "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -50,81 +50,81 @@ jobs:
             additional-args: "--max_model_len 2048",
             co-owner-1-id: U07RY6B5FLJ, # Gongyu Wang
           },
-          {
-            name: "[BH-DB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: BH-DeskBox,
-            mesh-device: P150x2,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 2}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[BH-QB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 5,
-            benchmark-timeout: 5,
-            runner-label: bh-LLMBox,
-            mesh-device: P150x4,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 4}",
-            multimodal: false,
-            owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[BH-LB] Llama-3.1-8B-Instruct",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: bh-rackbox,
-            mesh-device: P150x8,
-            tt-llama-text-ver: tt_transformers,
-            override-tt-config: "{\"data_parallel\": 8}",
-            multimodal: false,
-            owner_id: U08GELBB1AP, # Ambrose Ling
-          },
-          {
-            name: "[WH-GLX] Llama-3.3-70B-Instruct",
-            model: "meta-llama/Llama-3.3-70B-Instruct",
-            server-timeout: 35,
-            benchmark-timeout: 10,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            tt-llama-text-ver: llama3_70b_galaxy,
-            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
-          },
-          {
-            name: "[WH-GLX] Llama-8B DP=16",
-            model: "meta-llama/Llama-3.1-8B-Instruct",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: topology-6u,
-            mesh-device: TG,
-            override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false,
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
-          {
-            name: "[WH-T3K] Gemma3-27B",
-            model: "google/gemma-3-27b-it",
-            server-timeout: 10,
-            benchmark-timeout: 5,
-            runner-label: config-t3000,
-            mesh-device: T3K,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
-            tt-llama-text-ver: tt_transformers,
-            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
-            co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
-            co-owner-2-id: U08BH66EXAL, # Radoica Draskic
-          },
+          # {
+          #   name: "[BH-DB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: BH-DeskBox,
+          #   mesh-device: P150x2,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 2}",
+          #   multimodal: false,
+          #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # },
+          # {
+          #   name: "[BH-QB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 5,
+          #   benchmark-timeout: 5,
+          #   runner-label: bh-LLMBox,
+          #   mesh-device: P150x4,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 4}",
+          #   multimodal: false,
+          #   owner_id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[BH-LB] Llama-3.1-8B-Instruct",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: bh-rackbox,
+          #   mesh-device: P150x8,
+          #   tt-llama-text-ver: tt_transformers,
+          #   override-tt-config: "{\"data_parallel\": 8}",
+          #   multimodal: false,
+          #   owner_id: U08GELBB1AP, # Ambrose Ling
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-3.3-70B-Instruct",
+          #   model: "meta-llama/Llama-3.3-70B-Instruct",
+          #   server-timeout: 35,
+          #   benchmark-timeout: 10,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   tt-llama-text-ver: llama3_70b_galaxy,
+          #   override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08CEGF78ET, # Salar Hosseini Khorasgani
+          # },
+          # {
+          #   name: "[WH-GLX] Llama-8B DP=16",
+          #   model: "meta-llama/Llama-3.1-8B-Instruct",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: topology-6u,
+          #   mesh-device: TG,
+          #   override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false,
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
+          # {
+          #   name: "[WH-T3K] Gemma3-27B",
+          #   model: "google/gemma-3-27b-it",
+          #   server-timeout: 10,
+          #   benchmark-timeout: 5,
+          #   runner-label: config-t3000,
+          #   mesh-device: T3K,
+          #   override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+          #   tt-llama-text-ver: tt_transformers,
+          #   multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
+          #   co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
+          #   co-owner-2-id: U08BH66EXAL, # Radoica Draskic
+          # },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -375,6 +375,7 @@ def test_demo(
             mesh_device,
             max_batch_size=batch_size,
             max_seq_len=max_seq_len,
+            optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
         visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args, debug=False)  # show PCC

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -622,8 +622,13 @@ def test_demo(
     # Finish profiling at the end of inference for all repeated batches
     profiler.end("run")
 
-    if is_ci_env and "bert-score" in test_id and "Qwen2.5-VL-3B" not in model_args.base_model_name:
-        # todo)) fix this issue before enabling BERTScore check for 3B model:
+    if (
+        is_ci_env
+        and "bert-score" in test_id
+        and "Qwen2.5-VL-3B" not in model_args.base_model_name
+        and "Qwen2.5-VL-7B" not in model_args.base_model_name
+    ):
+        # todo)) fix this issue before enabling BERTScore check for 3B and 7B models:
         #        https://github.com/tenstorrent/tt-metal/issues/28442
         assert mesh_device.get_num_devices() > 2, "BERTScore is only supported for T3K for now"
         expected_output = load_expected_text(model_args.base_model_name)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -138,7 +138,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             mesh_device,
             max_batch_size=model_args.max_batch_size,
             max_seq_len=model_args.max_seq_len,
-            optimizations=optimizations,
+            optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
         visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -138,7 +138,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             mesh_device,
             max_batch_size=model_args.max_batch_size,
             max_seq_len=model_args.max_seq_len,
-            optimizations=DecodersPrecision.accuracy(config.vision_config.depth, ref_model_name),
+            optimizations=DecodersPrecision.performance(config.vision_config.depth, ref_model_name),
         )
         vision_model_args.hf_config.vision_config.depth = config.vision_config.depth
         visual_model = DropInVisionTransformer(reference_model.visual, vision_model_args)

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -37,7 +37,7 @@ run_qwen25_vl_perfunc() {
   # Qwen2.5-VL-3B-Instruct
   qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
   # Qwen2.5-VL-7B-Instruct
-  qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct/
+  qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct
 
   # simple generation-accuracy tests for qwen25_vl_3b
   MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -46,7 +46,7 @@ run_qwen25_vl_perfunc() {
   # complete demo tests
   for qwen_model in "$qwen25_vl_3b" "$qwen25_vl_7b"; do
     cache_path=$TT_CACHE_HOME/$qwen_model
-    MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
+    MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 3600 || fail=1
     echo "LOG_METAL: Tests for $qwen_model on N300 completed"
   done
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -46,7 +46,7 @@ run_qwen25_vl_perfunc() {
   # complete demo tests
   for qwen_model in "$qwen25_vl_7b"; do
     cache_path=$TT_CACHE_HOME/$qwen_model
-    MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 3600 || fail=1
+    MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
     echo "LOG_METAL: Tests for $qwen_model on N300 completed"
   done
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -25,7 +25,7 @@ run_qwen7b_func() {
 
 }
 
-run_qwen25_vl_func() {
+run_qwen25_vl_perfunc() {
   fail=0
 
   # install qwen25_vl requirements
@@ -34,18 +34,19 @@ run_qwen25_vl_func() {
   # export PYTEST_ADDOPTS for concise pytest output
   export PYTEST_ADDOPTS="--tb=short"
 
-  # Qwen2.5-VL-3B
-  qwen25_vl_3b=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2.5-VL-3B-Instruct/
-  # todo)) Qwen2.5-VL-7B-Instruct
+  # Qwen2.5-VL-3B-Instruct
+  qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
+  # Qwen2.5-VL-7B-Instruct
+  qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct/
 
   # simple generation-accuracy tests for qwen25_vl_3b
   MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
   echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests
-  for qwen_dir in "$qwen25_vl_3b"; do
-    MESH_DEVICE=N300 HF_MODEL=$qwen_dir pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 600 || fail=1
-    echo "LOG_METAL: Tests for $qwen_dir on N300 completed"
+  for qwen_model in "$qwen25_vl_3b" "$qwen25_vl_7b"; do
+    MESH_DEVICE=N300 HF_MODEL=$qwen_model pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
+    echo "LOG_METAL: Tests for $qwen_model on N300 completed"
   done
 
   if [[ $fail -ne 0 ]]; then

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -35,16 +35,16 @@ run_qwen25_vl_perfunc() {
   export PYTEST_ADDOPTS="--tb=short"
 
   # Qwen2.5-VL-3B-Instruct
-  qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
+  # qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
   # Qwen2.5-VL-7B-Instruct
   qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct
 
   # simple generation-accuracy tests for qwen25_vl_3b
-  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
-  echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
+  # MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
+  # echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests
-  for qwen_model in "$qwen25_vl_3b" "$qwen25_vl_7b"; do
+  for qwen_model in "$qwen25_vl_7b"; do
     cache_path=$TT_CACHE_HOME/$qwen_model
     MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 3600 || fail=1
     echo "LOG_METAL: Tests for $qwen_model on N300 completed"

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -40,12 +40,13 @@ run_qwen25_vl_perfunc() {
   qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct/
 
   # simple generation-accuracy tests for qwen25_vl_3b
-  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
+  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
   echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests
   for qwen_model in "$qwen25_vl_3b" "$qwen25_vl_7b"; do
-    MESH_DEVICE=N300 HF_MODEL=$qwen_model pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
+    cache_path=$TT_CACHE_HOME/$qwen_model
+    MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
     echo "LOG_METAL: Tests for $qwen_model on N300 completed"
   done
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -35,16 +35,16 @@ run_qwen25_vl_perfunc() {
   export PYTEST_ADDOPTS="--tb=short"
 
   # Qwen2.5-VL-3B-Instruct
-  # qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
+  qwen25_vl_3b=Qwen/Qwen2.5-VL-3B-Instruct
   # Qwen2.5-VL-7B-Instruct
   qwen25_vl_7b=Qwen/Qwen2.5-VL-7B-Instruct
 
   # simple generation-accuracy tests for qwen25_vl_3b
-  # MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
-  # echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
+  MESH_DEVICE=N300 HF_MODEL=$qwen25_vl_3b TT_CACHE_PATH=$TT_CACHE_HOME/$qwen25_vl_3b pytest -n auto models/demos/qwen25_vl/demo/combined.py -k tt_vision --timeout 1200 || fail=1
+  echo "LOG_METAL: demo/combined.py tests for $qwen25_vl_3b on N300 completed"
 
   # complete demo tests
-  for qwen_model in "$qwen25_vl_7b"; do
+  for qwen_model in "$qwen25_vl_3b" "$qwen25_vl_7b"; do
     cache_path=$TT_CACHE_HOME/$qwen_model
     MESH_DEVICE=N300 HF_MODEL=$qwen_model TT_CACHE_PATH=$cache_path pytest -n auto models/demos/qwen25_vl/demo/demo.py --timeout 900 || fail=1
     echo "LOG_METAL: Tests for $qwen_model on N300 completed"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There is a config error that we have been put off in favor of higher-priority model variants. Now we are ready to tackle 7B variant. After investigation, it is due to a unique config of 7B -- it has more fewer decoder layers in the text part of the model than the vision part of the model (28 versus 32). In our code, we have been using text model's `n_layers` to construction optimization strategies for each decoder layer in both vision and text parts of the model. This bug is triggered by 7B because `n_layers` of text model is smaller than vision model's. 

### What's changed
This PR adds code that explicitly construct the optimization strategy for the vision model using the vision model's `n_layers`. This solves the bug.

### Checklist
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/18660962912
- [x] revert [359be85](https://github.com/tenstorrent/tt-metal/pull/30786/commits/359be8553df9c04785f6f45f027f2a0a52e8608d) 
  - through [9777b81](https://github.com/tenstorrent/tt-metal/pull/30786/commits/9777b81d509d426975b8add124fd379f02884a49)
- [x] revert [36ee689](https://github.com/tenstorrent/tt-metal/pull/30786/commits/36ee6899041da6a4de33a24c135daad7a878323e)
  - through 0a18e7bc57aa55ee65722190aca51054d1133755 
- [x] vLLM nightly
  - https://github.com/tenstorrent/tt-metal/actions/runs/18687081948
- [x] revert 2ce924a557ec53ec53d96cbc195a3c8edf5c89dc
  - through [010cadb](https://github.com/tenstorrent/tt-metal/pull/30786/commits/010cadb60f6971459e92333cbef29d62c5f3c427) 