### PR TITLE
#30782: In the bisect workflow script, use Galaxy reset for galaxies.

### DIFF
--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -134,7 +134,7 @@ while [[ "$found" == "false" ]]; do
       local smi_output=$(tt-smi -ls 2>/dev/null)
 
       if echo "$smi_output" | grep -q "Wormhole"; then
-          local device_count=$(echo "$smi_output" | grep -c "Device")
+          local device_count=$(echo "$smi_output" | grep -c "tt-galaxy-wh")
           if [[ "$device_count" -ge 32 ]]; then
               echo "topology-6u"
               return 0
@@ -164,7 +164,6 @@ while [[ "$found" == "false" ]]; do
       else
         tt-smi -r >/dev/null 2>&1 || true  # use regular reset mode
       fi
-      echo "Devices reset"
 
       echo "Run: $test"
       if timeout -k 10s "$timeout_duration_iteration" bash -lc "$test" 2>&1 | tee "$output_file"; then

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -129,6 +129,25 @@ while [[ "$found" == "false" ]]; do
   fi
   echo "::endgroup::"
 
+
+  detect_galaxy() {
+      local smi_output=$(tt-smi -ls 2>/dev/null)
+
+      if echo "$smi_output" | grep -q "Wormhole"; then
+          local device_count=$(echo "$smi_output" | grep -c "Device")
+          if [[ "$device_count" -ge 32 ]]; then
+              echo "topology-6u"
+              return 0
+          fi
+      fi
+
+      # Default for non-galaxy systems
+      echo ""
+  }
+
+  is_galaxy=$(detect_galaxy)
+  echo "Is Galaxy Detected: $is_galaxy"
+
   echo "::group::Testing $rev"
   output_file="bisect_test_output.log"
   if [ "$nd_mode" = true ]; then
@@ -139,7 +158,12 @@ while [[ "$found" == "false" ]]; do
     while [ $run_idx -le $retries ]; do
       echo "Attempt $run_idx/$retries on $(git rev-parse HEAD)"
       echo "Resetting devices..."
-      tt-smi -r >/dev/null 2>&1 || true
+      if [ "$is_galaxy" == "topology-6u" ]; then
+        echo "Using galaxy reset mode"
+        tt-smi -glx_reset_auto 2>&1 || true  # use galaxy reset mode
+      else
+        tt-smi -r >/dev/null 2>&1 || true  # use regular reset mode
+      fi
       echo "Devices reset"
 
       echo "Run: $test"


### PR DESCRIPTION
### Ticket
#30782 

### Problem description
Galaxy has a special reset that is separate from `tt-smi -r` reset. 
Use the galaxy reset `tt-smi -glx_reset_auto` when using Galaxy systems.

### What's changed

Using the output of `tt-smi -ls` identify the system and use the galaxy reset if this is a galaxy system.

### Checklist
- [x] Test using Bisect workflow 
------
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes