### PR TITLE
Change build directory for scikit-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ skip = ["__init__.py"]
 line-length = 120
 
 [tool.scikit-build]
-build-dir = "build/{wheel_tag}"
+build-dir = "build"
 
 [tool.scikit-build.cmake]
 version = ">=3.24"


### PR DESCRIPTION
### Ticket
NA

### Problem description
There is a hardcoded dependency between tracy python code and the location of files in the build tree.
https://github.com/tenstorrent/tt-metal/blob/2496be4518bca0a7a5b497a4cda3cfe7e2f59756/tools/tracy/common.py#L25

### What's changed
Remove level of hierarchy in build tree generated by scikit-build. To get things to line up.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18602830006) CI passes
- [x] New/Existing tests provide coverage for changes