### PR TITLE
Delete disabled dispatch on Fabric fixtures

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -224,35 +224,4 @@ class UnitMeshCQMultiDeviceProgramFixture : public UnitMeshCQMultiDeviceFixture 
 
 class UnitMeshCQMultiDeviceBufferFixture : public UnitMeshCQMultiDeviceFixture {};
 
-class DISABLED_CQMultiDeviceOnFabricFixture
-    : public UnitMeshCQMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
-private:
-    inline static ARCH arch_ = tt::ARCH::Invalid;
-    inline static bool is_galaxy_ = false;
-
-protected:
-    // Multiple fabric configs so need to reset the devices for each test
-    static void SetUpTestSuite() {
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        is_galaxy_ = tt::tt_metal::IsGalaxyCluster();
-    }
-
-    static void TearDownTestSuite() {}
-
-    void SetUp() override {
-        // This will force dispatch init to inherit the FabricConfig param
-        tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-        UnitMeshCQMultiDeviceFixture::SetUp();
-    }
-
-    void TearDown() override {
-        if (::testing::Test::IsSkipped()) {
-            return;
-        }
-        UnitMeshCQMultiDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
-    }
-};
-
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1463,31 +1463,6 @@ TEST_F(UnitMeshCQFixture, TensixTestRuntimeArgsCorrectlySentSingleCore) {
     }
 }
 
-auto CQFabricConfigsToTest = ::testing::Values(
-    tt::tt_fabric::FabricConfig::FABRIC_1D,
-    tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
-    tt::tt_fabric::FabricConfig::FABRIC_2D,
-    tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
-
-INSTANTIATE_TEST_SUITE_P(CommandQueueMultiDevice, DISABLED_CQMultiDeviceOnFabricFixture, CQFabricConfigsToTest);
-
-INSTANTIATE_TEST_SUITE_P(
-    MultiCommandQueueMultiDevice, DISABLED_UnitMeshMultiCQMultiDeviceOnFabricFixture, CQFabricConfigsToTest);
-
-TEST_P(DISABLED_CQMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
-    for (const auto& device : devices_) {
-        local_test_functions::test_basic_dispatch_functions(device, 0);
-    }
-}
-
-TEST_P(DISABLED_UnitMeshMultiCQMultiDeviceOnFabricFixture, TensixTestBasicDispatchFunctions) {
-    for (const auto& device : devices_) {
-        for (uint32_t cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
-            local_test_functions::test_basic_dispatch_functions(device, cq_id);
-        }
-    }
-}
-
 }  // end namespace single_core_tests
 
 namespace multicore_tests {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -165,31 +165,4 @@ class UnitMeshMultiCQMultiDeviceBufferFixture : public UnitMeshMultiCQMultiDevic
 
 class UnitMeshMultiCQMultiDeviceEventFixture : public UnitMeshMultiCQMultiDeviceFixture {};
 
-class DISABLED_UnitMeshMultiCQMultiDeviceOnFabricFixture
-    : public UnitMeshMultiCQMultiDeviceFixture,
-      public ::testing::WithParamInterface<tt::tt_fabric::FabricConfig> {
-private:
-    // Save the result to reduce UMD calls
-    inline static bool should_skip_ = false;
-
-protected:
-    void SetUp() override {
-        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
-            GTEST_SKIP() << "Dispatch on Fabric tests only applicable on Wormhole B0";
-        }
-        // Skip for TG as it's still being implemented
-        if (tt::tt_metal::IsGalaxyCluster()) {
-            GTEST_SKIP();
-        }
-        // This will force dispatch init to inherit the FabricConfig param
-        tt::tt_fabric::SetFabricConfig(GetParam(), tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
-        UnitMeshMultiCQMultiDeviceFixture::SetUp();
-    }
-
-    void TearDown() override {
-        UnitMeshMultiCQMultiDeviceFixture::TearDown();
-        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
-    }
-};
-
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This fixtures were created to run CI for Dispatch on Fabric before the feature was fully enabled. Since it's been enabled by default, the fixtures have been disabled, and now it's stable now for a few months we can delete these temporary fixtures.

### What's changed
Delete disabled code

### Checklist
No changes to existing tests. PR & Merge Gate will be able to catch any build errors.