### PR TITLE
#15508: [skip ci] Shift right blackhole post commit tests that are in metal L2 / BH nightly

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -25,8 +25,8 @@ on:
         required: false
         type: boolean
         default: false
-      run_bh_multi_card_nightly_ttnn_stress_tests:
-        description: 'Run Blackhole multi card nightly ttnn stress tests'
+      run_bh_ttnn_stress_tests:
+        description: 'Run Blackhole nightly ttnn stress tests'
         required: false
         type: boolean
         default: false
@@ -114,8 +114,8 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  blackhole-multi-card-ttnn-stress-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_ttnn_stress_tests }}
+  blackhole-ttnn-stress-tests:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bh_ttnn_stress_tests }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
@@ -123,6 +123,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
+          - name: P150b ttnn stress tests
+            runner-label: P150b
           - name: LLMBox ttnn stress tests
             runner-label: BH-LLMBox
           - name: DeskBox ttnn stress tests

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -260,36 +260,6 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  # LLMBox-only demo tests
-  blackhole-llmbox-demo-tests:
-    needs: [build-artifact, generate-matrix]
-    if: ${{ inputs.enable-llmbox-tests }}
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      extra-tag: pipeline-perf
-      num_devices: 4
-
-  # LLMBox-only unit tests
-  blackhole-llmbox-unit-tests:
-    needs: [build-artifact-profiler, generate-matrix]
-    if: ${{ inputs.enable-llmbox-tests }}
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
-    with:
-      arch: blackhole
-      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-
   # TT-CNN Unit Tests
   tt-cnn-unit-tests:
     needs: [build-artifact, generate-matrix]

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -190,21 +190,6 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  fabric-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-
   ttnn-unit-tests:
     needs: [build-artifact, generate-matrix]
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runner-label:
-          description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only), ["BH-LLMBox"] (4xP150 only, needs boolean enable-llmbox-tests)'
+          description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
           required: false
           type: string
           default: '["P150"]'
@@ -12,14 +12,10 @@ on:
           description: 'Enable watcher in BH Post commit'
           default: false
           type: boolean
-      enable-llmbox-tests:
-          description: 'Run tests on LLMBox instead of single card (must set runner-label to BH-LLMBox)'
-          default: false
-          type: boolean
   workflow_dispatch:
     inputs:
       runner-label:
-        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only), ["BH-LLMBox"] (4xP150 only, needs boolean enable-llmbox-tests)'
+        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
         required: false
         type: string
         default: '["P150"]'
@@ -38,10 +34,6 @@ on:
         description: 'Enable watcher in BH Post commit'
         default: false
         type: boolean
-      enable-llmbox-tests:
-        description: 'Run tests on LLMBox instead of single card (must set runner-label to BH-LLMBox)'
-        default: false
-        type: boolean
   schedule:
     - cron: "0 */4 * * *"
     - cron: "0 7 * * *"  # Every day at 7:00 UTC
@@ -49,7 +41,7 @@ on:
   # push:
   #  branches: ["main"]
 
-run-name: ${{ inputs.enable-llmbox-tests == true && 'Blackhole LLMBox tests' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
+run-name: ${{ inputs.runner-label == '["P100"]' && 'Blackhole post-commit tests (P100)' || (inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled)') || ((github.event_name == 'schedule' && github.event.schedule == '0 7 * * *') && 'Blackhole post-commit tests (P100 nightly)') || 'Blackhole post-commit tests' }}
 
 permissions:
   actions: read
@@ -79,13 +71,6 @@ jobs:
             matrix='["P100"]'
             civ2_matrix='["P100a"]'
             civ2_viommu_matrix='["P100a-viommu"]'
-          elif [ "${{ inputs.enable-llmbox-tests }}" = "true" ]; then
-            if [[ "$runner_label" != *"BH-LLMBox"* ]]; then
-              echo "::warning::LLMBox tests are enabled but runner-label does not contain BH-LLMBox. Current value: $runner_label"
-            fi
-            matrix='["BH-LLMBox"]'
-            civ2_matrix='["BH-LLMBox"]'
-            civ2_viommu_matrix='["BH-LLMBox"]'
           else
             matrix="$runner_label"
             civ2_matrix="$runner_label"
@@ -160,36 +145,6 @@ jobs:
       runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  sd-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  fd-unit-tests:
-    needs: [build-artifact, generate-matrix]
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    with:
-      timeout: 40
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: [build-artifact, generate-matrix]
@@ -235,6 +190,21 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
+  fabric-unit-tests:
+    needs: [build-artifact, generate-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
   ttnn-unit-tests:
     needs: [build-artifact, generate-matrix]
     secrets: inherit
@@ -250,21 +220,6 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
-  ttnn-stress-tests:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      timeout: 45
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   metalium-smoke-tests:
     needs: [build-artifact, generate-matrix]
     strategy:
@@ -325,15 +280,15 @@ jobs:
 
   # LLMBox-only unit tests
   blackhole-llmbox-unit-tests:
-    needs: [build-artifact, generate-matrix]
+    needs: [build-artifact-profiler, generate-matrix]
     if: ${{ inputs.enable-llmbox-tests }}
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
     with:
       arch: blackhole
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
 
   # TT-CNN Unit Tests
   tt-cnn-unit-tests:
@@ -381,8 +336,3 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-
-  # We used to use this for post-commit, but we didn't have enough runners
-  # to support the number of developers running this workflow
-  # build-and-test-measure-perf:
-  # build-and-test-measure-perf-device:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -230,21 +230,6 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
-  test-ttnn-tutorials:
-    needs: [build-artifact, generate-matrix]
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-
   # TT-CNN Unit Tests
   tt-cnn-unit-tests:
     needs: [build-artifact, generate-matrix]

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -148,6 +148,8 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
+          { arch: blackhole, runner-label: P150 },  # Use P150 instead of P150b to stay on CIv1 for capacity reasons
+          { arch: blackhole, runner-label: P100 },
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     with:
@@ -167,6 +169,8 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
+          { arch: blackhole, runner-label: P150 },  # Use P150 instead of P150b to stay on CIv1 for capacity reasons
+          { arch: blackhole, runner-label: P100 },
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
@@ -185,6 +189,8 @@ jobs:
       matrix:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
+          { arch: blackhole, runner-label: P150b },
+          { arch: blackhole, runner-label: P100 },
         ]
     with:
       arch: ${{ matrix.test-group.arch }}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/15508

### Problem description
Tests shifted right in APC have not been shifted in BHPC.
Some tests that run in APC don't run in BHPC.

### What's changed
Moved from BHPC:
- p150 ttnn stress to BH nightly
- SD and FD unit tests to metal L2
- ttnn tutorials to metal L2

Removed:
- multi-card (LLMbox) tests from BHPC, these run in BH nightly.

### Checklist
- [x] BHPC https://github.com/tenstorrent/tt-metal/actions/runs/18723038002
- [x] BH Nightly https://github.com/tenstorrent/tt-metal/actions/runs/18722098552
- [x] Metal L2 https://github.com/tenstorrent/tt-metal/actions/runs/18722120724