### PR TITLE
generalize more of core fabric impl away from hardcoded/implicit static channels

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_channel_traits.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_channel_traits.hpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace tt::tt_fabric {
+
+/**
+ * Channel traits system for extracting compile-time properties from channel types.
+ * This allows functions to query channel properties without requiring explicit
+ * template parameters for buffer counts.
+ */
+
+// Forward declarations for supported channel types
+template <uint8_t EDM_NUM_BUFFER_SLOTS>
+struct RouterStaticSizedChannelWriterAdapter;
+
+template <uint8_t SLOTS_PER_CHUNK, uint16_t CHUNK_SIZE_BYTES>
+struct RouterElasticChannelWriterAdapter;
+
+/**
+ * Primary template for channel traits.
+ * Specialized for each channel type to expose their properties.
+ */
+template <typename T, typename Enable = void>
+struct ChannelTraits;
+
+/**
+ * Specialization for RouterStaticSizedChannelWriterAdapter
+ */
+template <uint8_t NUM_BUFFERS>
+struct ChannelTraits<RouterStaticSizedChannelWriterAdapter<NUM_BUFFERS>> {
+    static constexpr uint8_t num_buffers = NUM_BUFFERS;
+    static constexpr bool is_elastic = false;
+    using channel_type = RouterStaticSizedChannelWriterAdapter<NUM_BUFFERS>;
+};
+
+/**
+ * Specialization for RouterElasticChannelWriterAdapter
+ */
+template <uint8_t SLOTS_PER_CHUNK, uint16_t CHUNK_SIZE_BYTES>
+struct ChannelTraits<RouterElasticChannelWriterAdapter<SLOTS_PER_CHUNK, CHUNK_SIZE_BYTES>> {
+    static constexpr uint8_t num_buffers = SLOTS_PER_CHUNK;
+    static constexpr bool is_elastic = true;
+    using channel_type = RouterElasticChannelWriterAdapter<SLOTS_PER_CHUNK, CHUNK_SIZE_BYTES>;
+};
+
+/**
+ * Helper to detect if a type has channel traits
+ */
+template <typename T, typename = void>
+struct has_channel_traits : std::false_type {};
+
+template <typename T>
+struct has_channel_traits<T, std::void_t<decltype(ChannelTraits<T>::num_buffers)>> : std::true_type {};
+
+/**
+ * Helper function to get num_buffers from a channel type at compile time
+ */
+template <typename ChannelT>
+constexpr uint8_t get_num_buffers() {
+    return ChannelTraits<ChannelT>::num_buffers;
+}
+
+/**
+ * Helper function to check if a channel type is elastic
+ */
+template <typename ChannelT>
+constexpr bool is_elastic_channel() {
+    return ChannelTraits<ChannelT>::is_elastic;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -165,6 +165,27 @@ public:
     }
 };
 
+// Elastic sender channel implementation (stub for now)
+// Issue #26311
+template <typename HEADER_TYPE>
+class ElasticSenderEthChannel : public SenderEthChannelInterface<HEADER_TYPE, 0, ElasticSenderEthChannel<HEADER_TYPE>> {
+public:
+    explicit ElasticSenderEthChannel() = default;
+
+    void init_impl(size_t channel_base_address, size_t max_eth_payload_size_in_bytes, size_t header_size_bytes) {
+        // TODO: Issue #26311
+    }
+
+    size_t get_cached_next_buffer_slot_addr_impl() const {
+        // TODO: Issue #26311
+        return 0;
+    }
+
+    void advance_to_next_cached_buffer_slot_addr_impl() {
+        // TODO: Issue #26311
+    }
+};
+
 // Elastic channel buffer implementation (stub for now)
 // Issue #26311
 template <typename HEADER_TYPE>

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -124,8 +124,8 @@ class EthChannelBufferInterface {
 public:
     explicit EthChannelBufferInterface() = default;
 
-    FORCE_INLINE void init(size_t channel_base_address, size_t buffer_size_bytes, size_t header_size_bytes) {
-        static_cast<DERIVED_T*>(this)->init_impl(channel_base_address, buffer_size_bytes, header_size_bytes);
+    FORCE_INLINE void init(size_t channel_base_address, size_t max_eth_payload_size_in_bytes, size_t header_size_bytes) {
+        static_cast<DERIVED_T*>(this)->init_impl(channel_base_address, max_eth_payload_size_in_bytes, header_size_bytes);
     }
 
     [[nodiscard]] FORCE_INLINE size_t get_buffer_address(const BufferIndex& buffer_index) const {


### PR DESCRIPTION
this change further removes relatively hardcoded codepaths in the fabric router that expect static channels. This abstraction and refactoring will enable the router to use either or both or static or elastic channels (or any future channel types as they are enabled).

The change is incremental to minimize conflicts and regression risk

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18607273057
  - https://github.com/tenstorrent/tt-metal/actions/runs/18636468938
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18608921175