### PR TITLE
Modify vLLM Generators to separate tensor caches for K/V to fix cache race exposed by V1 DP

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -23,7 +23,7 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransform
         for _ in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})"):
             kv_tt_i = [
                 ttnn.as_tensor(
-                    lp,
+                    cache_kv,
                     device=submesh,
                     # TODO: this could be ShardTensorToMesh, removing the need for vLLM to know about TP for num_kv_heads.
                     # Could affect other calculations which use TTCacheEngine.num_kv_heads, though.
@@ -31,9 +31,10 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransform
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     dtype=ttnn.bfloat8_b,
-                    cache_file_name=tt_cache_path / f"empty_cache_paged_attention{kv_cache_shape}",
+                    # Separate cache files for K and V to avoid collision.
+                    cache_file_name=tt_cache_path / f"empty_{kv}cache_paged_attention{kv_cache_shape}",
                 )
-                for lp in (cache_kv, cache_kv)
+                for kv in ["k", "v"]
             ]
 
             kv_tt.append(kv_tt_i)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -42,7 +42,7 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
         for _ in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer (submesh {mesh_idx+1})"):
             kv_tt_i = [
                 ttnn.as_tensor(
-                    lp,
+                    cache_kv,
                     device=submesh,
                     # TODO: this could be ShardTensorToMesh, removing the need for vLLM to know about TP for num_kv_heads.
                     # Could affect other calculations which use TTCacheEngine.num_kv_heads, though.
@@ -50,9 +50,10 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Tra
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     dtype=ttnn.bfloat8_b,
-                    cache_file_name=tt_cache_path / f"empty_cache_paged_attention{kv_cache_shape}",
+                    # Separate cache files for K and V to avoid collision.
+                    cache_file_name=tt_cache_path / f"empty_{kv}cache_paged_attention{kv_cache_shape}",
                 )
-                for lp in (cache_kv, cache_kv)
+                for kv in ["k", "v"]
             ]
 
             kv_tt.append(kv_tt_i)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Testing with vLLM V1 DP exposed a possible race within `allocate_kv_cache` at `ttnn.as_tensor` where the cache files for K/V could collide and result in a segfault since the cache files correspond to the same tensors and file names.

### What's changed
- Separated K/V cache files in vLLM Generators.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/18659130526 (unrelated Gemma failure)