### PR TITLE
readability-redundant-string-cstr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -173,7 +173,6 @@ Checks: >
   -readability-qualified-auto,
   -readability-redundant-casting,
   -readability-redundant-member-init,
-  -readability-redundant-string-cstr,
   -readability-redundant-string-init,
   -readability-reference-to-constructed-temporary,
   -readability-static-accessed-through-instance,

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -71,8 +71,8 @@ std::map<std::string, std::string> get_defines(BinaryOpType::Enum op_type) {
             break;
         default: TT_THROW("Undefined op type");
     }
-    defines["ELTWISE_OP"] = op_name.c_str();
-    defines["ELTWISE_OP_TYPE"] = op_binary_type.c_str();
+    defines["ELTWISE_OP"] = op_name;
+    defines["ELTWISE_OP_TYPE"] = op_binary_type;
     return defines;
 }
 

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -753,7 +753,7 @@ GlobalNodeId MeshGraphDescriptor::populate_graph_instance(
         // Check that the child instance created has the same type as rest of the graph descriptor
         if (child_instance.kind == NodeKind::Graph) {
             if (child_graph_type.empty()) {
-                child_graph_type = child_instance.type.c_str();
+                child_graph_type = child_instance.type;
             } else {
                 TT_FATAL(child_graph_type == child_instance.type, "Graph instance type {} does not match graph descriptor child type {}", std::string(child_graph_type), std::string(child_instance.type));
             }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
             }
         } else if ((s.rfind("-n=", 0) == 0) || (s.rfind("--num-hw-cqs==", 0) == 0)) {
             string value_str = s.substr(s.find("=") + 1);
-            num_hw_cqs = std::stoi(value_str.c_str());
+            num_hw_cqs = std::stoi(value_str);
         } else if (s == "-w" || s == "--dump-watcher") {
             dump_watcher = true;
         } else if (s == "-c" || s == "--dump-cqs") {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -161,8 +161,8 @@ std::map<std::string, std::string> get_defines(
         defines.insert({"SFPU_OP_TYPECAST_INCLUDE", "1"});
     }
 
-    defines["ELTWISE_OP"] = op_name.c_str();
-    defines["ELTWISE_OP_TYPE"] = op_binary_type.c_str();
+    defines["ELTWISE_OP"] = op_name;
+    defines["ELTWISE_OP_TYPE"] = op_binary_type;
     if (fused_activations.has_value()) {
         if (op_type == BinaryOpType::ADD and fused_activations->size() == 1 and
             fused_activations->at(0).type() == UnaryOpType::RELU and not input_tensor_a_activation.has_value()) {


### PR DESCRIPTION
### Ticket
#22758 
Closes #30811 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-string-cstr.html

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18624488317) CI passes
- [x] New/Existing tests provide coverage for changes