### PR TITLE
#28221: revert yolov7 pcc lowering

### DIFF
--- a/models/demos/yolov7/tests/pcc/test_ttnn_yolov7.py
+++ b/models/demos/yolov7/tests/pcc/test_ttnn_yolov7.py
@@ -38,5 +38,4 @@ def test_yolov7(device, reset_seeds, model_location_generator):
 
     output = ttnn.to_torch(output)
 
-    # TODO: PCC was lowered from 0.999 to 0.998 to enable math reconfig LLK fix (Issue #28221)
-    assert_with_pcc(torch_output_tensor[0], output, pcc=0.998)
+    assert_with_pcc(torch_output_tensor[0], output, pcc=0.999)


### PR DESCRIPTION
### Ticket
Link to Github Issue #28221

### Problem description
PCC was lowered for yolov7 to have it pass on pipelines after a reconfig fix (which for some reason lowered the pcc, probably due to exposing some other bug)

### What's changed
Whatever was going wrong has been fixed since the last time the reconfig change was attempted. Therefore revert the PCC change.

(Single-card) Frequent model and ttnn tests passes including yolov7 https://github.com/tenstorrent/tt-metal/actions/runs/18631798321

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes