### PR TITLE
Upgrade pytest to fix python3.12 deprecated calls.

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -39,11 +39,11 @@ transformers == 4.53.0
 huggingface-hub >= 0.30.0
 
 # testing
-pytest==7.2.2
-pytest-timeout==2.2.0
-pytest-split==0.8.2
-pytest-xdist==3.6.1
-pytest-benchmark==4.0.0
+pytest==8.4.2
+pytest-timeout==2.4.0
+pytest-split==0.10.0
+pytest-xdist==3.8.0
+pytest-benchmark==5.1.0
 jsbeautifier==1.14.7
 datasets==2.9.0
 pyarrow==20.0.0


### PR DESCRIPTION
### Ticket
N/A

### Problem description
" Warning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead" by the thousands. Source is an older pytest version. https://github.com/tenstorrent/tt-metal/actions/runs/18636584431/job/53129179066

### What's changed
pytest libraries updated to their latest versions. 

### Checklist
- [ ] APC Ubuntu 22.04, Python 3.10: https://github.com/tenstorrent/tt-metal/actions/runs/18639193576
- [ ] APC Ubuntu 24.04, Python 3.12: https://github.com/tenstorrent/tt-metal/actions/runs/18639169195
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18639694657)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18639710473)
- [ ] [Device performance regression][(https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml](https://github.com/tenstorrent/tt-metal/actions/runs/18639727016)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18639741827)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/18639753454)
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18639774464) 
- [x] New/Existing tests provide coverage for changes