### PR TITLE
Revert "Make `TT_METAL_HOME` Optional (#30502)"

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -82,6 +82,7 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TT_METAL_HOME: /work
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -65,6 +65,7 @@ jobs:
         timeout-minutes: 2
         env:
           GTEST_COLOR: yes
+          TT_METAL_HOME: /usr/libexec/tt-metalium
           LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
           # TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
@@ -83,6 +84,7 @@ jobs:
         env:
           GTEST_COLOR: yes
           GTEST_OUTPUT: xml:/work/test-reports/
+          TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
           LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
           # TT_METAL_WATCHER: 5 TODO(#25305): Re-enable watcher after the race condition is fixed.
           TT_METAL_WATCHER_TEST_MODE: 1

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -51,7 +51,6 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
-        TT_METAL_RUNTIME_ROOT: /work
         LD_LIBRARY_PATH: /work/build/lib
         TEST_DATA_DIR: /work/data
         ENABLE_CI_ONLY_TT_TRAIN_TESTS: 1

--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -7,6 +7,11 @@ if [[ -z "$ARCH_NAME" ]]; then
   exit 1
 fi
 
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Must provide TT_METAL_HOME in environment" 1>&2
+    exit 1
+fi
+
 # Enable this on BH after #14613
 if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
     export TT_METAL_ENABLE_ERISC_IRAM=1

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Must provide TT_METAL_HOME in environment" 1>&2
+    exit 1
+fi
+
 if [ -z "${ARCH_NAME}" ]; then
   echo "Error: ARCH_NAME is not set. Exiting." >&2
   exit 1

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -68,6 +68,10 @@ private:
 
     bool are_env_vars_set() {
         bool are_set = true;
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().is_root_dir_specified()) {
+            log_info(tt::LogTest, "Skipping test: TT_METAL_HOME must be set");
+            are_set = false;
+        }
         if (!tt::tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
             log_info(tt::LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be set");
             are_set = false;

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -19,12 +19,11 @@
 
 #include <gtest/gtest.h>
 #include <tt-metalium/distributed.hpp>
-#include "impl/context/metal_context.hpp"
 
 namespace {
 
 // We recursively scan this directory for kernels named '*.cpp'.
-constexpr auto KernelDir = "tests/tt_metal/tt_metal/test_kernels/sfpi";
+constexpr std::string_view KernelDir = "tests/tt_metal/tt_metal/test_kernels/sfpi";
 
 using namespace tt::tt_metal;
 
@@ -120,8 +119,14 @@ bool runTests(
 }
 
 bool runTestsuite(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const tt::tt_metal::CoreCoord coord) {
-    std::string path = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir();
-    path += KernelDir;
+    std::string path;
+    if (auto* var = std::getenv("TT_METAL_HOME")) {
+        path.append(var);
+        if (!path.empty()) {
+            path.push_back('/');
+        }
+    }
+    path.append(KernelDir);
     return runTests(mesh_device, coord, path, path.find_last_of('/') + 1);
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -47,8 +47,8 @@ namespace {
 // If the path is not an absolute path, then it must be resolved relative to:
 // 1. CWD
 // 2. TT_METAL_KERNEL_PATH
-// 3. System Kernel Directory
-// 4. TT_METAL_HOME / SetRootDir (API)
+// 3. TT_METAL_HOME / SetRootDir (API)
+// 4. System Kernel Directory
 fs::path resolve_path(const fs::path& given_file_name) {
     // Priority 0: Absolute path
     if (given_file_name.is_absolute()) {
@@ -73,18 +73,18 @@ fs::path resolve_path(const fs::path& given_file_name) {
         }
     }
 
-    // Priority 3: System kernel directory
-    auto system_kernel_dir_search_path = fs::absolute(fs::path(rtoptions.get_system_kernel_dir()) / given_file_name);
-    if (fs::exists(system_kernel_dir_search_path)) {
-        return system_kernel_dir_search_path;
-    }
-
-    // Priority 4: Root directory
-    {
+    // Priority 3: Root directory
+    if (rtoptions.is_root_dir_specified()) {
         auto root_dir_search_path = fs::absolute(fs::path(rtoptions.get_root_dir()) / given_file_name);
         if (fs::exists(root_dir_search_path)) {
             return root_dir_search_path;
         }
+    }
+
+    // Priority 4: System kernel directory
+    auto system_kernel_dir_search_path = fs::absolute(fs::path(rtoptions.get_system_kernel_dir()) / given_file_name);
+    if (fs::exists(system_kernel_dir_search_path)) {
+        return system_kernel_dir_search_path;
     }
 
     // Not found

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -35,10 +35,3 @@ target_link_libraries(
 )
 target_include_directories(llrt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)
-
-include(GNUInstallDirs)
-
-set(TT_METAL_DEFAULT_INSTALL_ROOT "/usr/${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium")
-target_compile_definitions(llrt PRIVATE TT_METAL_INSTALL_ROOT="${TT_METAL_DEFAULT_INSTALL_ROOT}")
-
-message(STATUS "TT_METAL_INSTALL_ROOT == ${TT_METAL_DEFAULT_INSTALL_ROOT}")

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -95,6 +95,7 @@ struct InspectorSettings {
 };
 
 class RunTimeOptions {
+    bool is_root_dir_set = false;
     std::string root_dir;
 
     bool is_cache_dir_env_var_set = false;
@@ -226,6 +227,7 @@ public:
     RunTimeOptions(const RunTimeOptions&) = delete;
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 
+    bool is_root_dir_specified() const { return this->is_root_dir_set; }
     static void set_root_dir(const std::string& root_dir);
     const std::string& get_root_dir() const;
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -410,26 +410,6 @@ def get_arch_name():
 
 from ttnn._ttnn.operations.data_movement import TileReshapeMapMode
 
-import pathlib
-import importlib.util
-
-
-def _is_editable():
-    spec = importlib.util.find_spec(__package__)
-    if not spec or not spec.origin:
-        return False
-    path = pathlib.Path(spec.origin).resolve()
-    return "site-packages" not in str(path) and "dist-packages" not in str(path)
-
-
-if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-    this_dir = pathlib.Path(__file__).resolve().parent
-
-    if _is_editable():
-        # Go two levels up from the package's __init__.py location
-        root_dir = this_dir.parent.parent
-    else:
-        # For installed packages, reference bundled data directory
-        root_dir = this_dir / "tt-metalium"
-
-    SetRootDir(str(root_dir))
+if "TT_METAL_HOME" not in os.environ:
+    this_dir = os.path.dirname(__file__)
+    SetRootDir(os.path.join(os.path.abspath(this_dir), "tt-metalium"))


### PR DESCRIPTION
This reverts commit 1446f9ced50fac6d623885b82071cff6a1ea000e.

### Problem description
APC is red beacuse of this commit

### What's changed
Revert 1446f9ced50fac6d623885b82071cff6a1ea000e

### Checklist
- [x] [(Galaxy) APC fast tests](https://github.com/tenstorrent/tt-metal/actions/runs/18647514408) CI passes