### PR TITLE
#30571: fix paths that where missed when moving ops unit tests

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -177,7 +177,7 @@ test_suite_wh_6u_metal_qsfp_links_health_check_tests() {
 test_suite_wh_6u_model_unit_tests() {
     echo "[upstream-tests] running WH 6U upstream model unit tests"
     pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
-    pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+    pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
     pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py::test_matmul_1d_ring_llama_perf
     pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
     # pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py hang???

--- a/models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
+++ b/models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
@@ -8,7 +8,7 @@ import ttnn
 
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
-from tests.ttnn.unit_tests.operations.test_prefetcher_TG import (
+from tests.ttnn.unit_tests.operations.transformers.test_prefetcher_TG import (
     LLAMA_INPUT_SHAPES,
     LLAMA_INPUT_DTYPES,
 )
@@ -41,7 +41,9 @@ def test_dram_prefetcher_perf(
     step_name = f"dram_prefetcher"
 
     subdir = "llama_tg_perf"
-    command = f"pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py::test_run_prefetcher_llama_perf"
+    command = (
+        f"pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py::test_run_prefetcher_llama_perf"
+    )
     cols = ["DEVICE NCRISC KERNEL"]
     op_name = "DramPrefetcher"
 

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
@@ -8,7 +8,7 @@ from models.common.utility_functions import comp_pcc
 
 from models.common.utility_functions import skip_for_blackhole
 from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import FF1_CRS_RS_OUT
-from tests.ttnn.unit_tests.operations.test_distributed_layernorm_sharded import (
+from tests.ttnn.unit_tests.operations.fused.test_distributed_layernorm_sharded import (
     create_input_and_weight_tensors,
     create_tt_tensors,
     create_output_memory_config,
@@ -23,7 +23,9 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_create_qkv_hea
     run_test_create_min_width_shard,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_concat_heads_decode import run_test_concat_head
-from tests.ttnn.unit_tests.operations.test_paged_fused_update_cache import run_test_paged_fused_update_cache_decode
+from tests.ttnn.unit_tests.operations.fused.test_paged_fused_update_cache import (
+    run_test_paged_fused_update_cache_decode,
+)
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_rotary_embedding_llama import (
     run_test_rotary_embedding_llama,
     run_test_row_major_rotary_embedding_llama,

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
@@ -23,7 +23,7 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_create_qkv_hea
     run_test_create_min_width_shard,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_concat_heads_decode import run_test_concat_head
-from tests.ttnn.unit_tests.operations.fused.test_paged_fused_update_cache import (
+from tests.ttnn.unit_tests.operations.transformers.test_paged_fused_update_cache import (
     run_test_paged_fused_update_cache_decode,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_rotary_embedding_llama import (

--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -267,7 +267,7 @@ The distributed implementation is designed for cases where activations are **sha
 - Non-Distributed Norm Op Code [[1]](https://github.com/tenstorrent/tt-metal/tree/main/ttnn/cpp/ttnn/operations/normalization/layernorm) [[2]](https://github.com/tenstorrent/tt-metal/tree/main/ttnn/cpp/ttnn/operations/normalization/rmsnorm)
 - Distributed Norm Op Code [[3]](https://github.com/tenstorrent/tt-metal/tree/main/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed) [[4]](https://github.com/tenstorrent/tt-metal/tree/main/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed)
 - Non-Distributed Norms Unit Tests [[5]](https://github.com/tenstorrent/tt-metal/blob/main/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py) [[6]](https://github.com/tenstorrent/tt-metal/blob/main/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py)
-- Distributed Norms Unit Tests [[7]](https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py) [[8]](https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py)
+- Distributed Norms Unit Tests [[7]](https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py) [[8]](https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py)
 - Distributed Norm in TT-Transformers [[9]](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/distributed_norm.py)
 
 ### 2.4 Attention

--- a/tests/README.md
+++ b/tests/README.md
@@ -130,10 +130,10 @@ export POSTGRES_USER="your-username"
 export POSTGRES_PASSWORD="your-password"
 
 # Run a single test file
-python tests/ttnn/unit_test_runner.py tests/ttnn/unit_tests/operations/test_concat.py
+python tests/ttnn/unit_test_runner.py tests/ttnn/unit_tests/operations/data_movement/test_concat.py
 
 # Run multiple test files
-python tests/ttnn/unit_test_runner.py "tests/ttnn/unit_tests/operations/test_concat.py,tests/ttnn/unit_tests/operations/test_add.py"
+python tests/ttnn/unit_test_runner.py "tests/ttnn/unit_tests/operations/data_movement/test_concat.py,tests/ttnn/unit_tests/operations/eltwise/test_add.py"
 
 # Run all tests in a directory
 python tests/ttnn/unit_test_runner.py tests/ttnn/unit_tests/operations/

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -295,7 +295,7 @@ run_t3000_tteager_tests() {
   pytest -n auto tests/ttnn/unit_tests/operations/debug/test_apply_device_delay_t3000.py ; fail+=$?
 
   # distributed layernorm
-  pytest tests/ttnn/unit_tests/operations/test_distributed_layernorm.py ; fail+=$?
+  pytest tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -311,7 +311,7 @@ run_t3000_trace_stress_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_trace_stress_tests"
-  NUM_TRACE_LOOPS=15 pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
+  NUM_TRACE_LOOPS=15 pytest -n auto tests/ttnn/unit_tests/base_functionality/test_multi_device_trace.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -103,11 +103,11 @@ run_t3000_ttnn_tests() {
   ./build/test/ttnn/unit_tests_ttnn_ccl_ops
   ./build/test/ttnn/unit_tests_ttnn_accessor
   ./build/test/ttnn/test_ccl_multi_cq_multi_device
-  pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
-  pytest tests/ttnn/unit_tests/test_multi_device_events.py ; fail+=$?
-  pytest tests/ttnn/unit_tests/operations/test_prefetcher.py::test_run_prefetcher_post_commit_multi_device ; fail+=$?
-  pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?
-  pytest -n auto tests/ttnn/unit_tests/test_multi_device_async.py ; fail+=$?
+  pytest tests/ttnn/unit_tests/base_functionality/test_multi_device_trace.py ; fail+=$?
+  pytest tests/ttnn/unit_tests/base_functionality/test_multi_device_events.py ; fail+=$?
+  pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher.py::test_run_prefetcher_post_commit_multi_device ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/base_functionality/test_multi_device.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/base_functionality/test_multi_device_async.py ; fail+=$?
   pytest tests/ttnn/distributed/test_tensor_parallel_example_T3000.py ; fail+=$?
   pytest tests/ttnn/distributed/test_data_parallel_example.py ; fail+=$?
   pytest tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py ; fail+=$?

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -44,7 +44,7 @@ run_tg_tests() {
     ## The jit build also has different behaviour for IRAM enabled/disabled so we enable it globally.
     TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/distributed/test_data_parallel_example_TG.py --timeout=900 ; fail+=$?
     TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/distributed/test_multidevice_TG.py --timeout=900 ; fail+=$?
-    TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
+    TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/unit_tests/base_functionality/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
     TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py --timeout=300 ; fail+=$?
     #TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py --timeout=500 ; fail+=$? #See issue #30017
     #TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto tests/ttnn/unit_tests/operations/ccl/test_all_to_all_combine_6U.py --timeout=500 ; fail+=$? #See issue #30017

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -73,7 +73,7 @@ run_tg_prefetcher_tests() {
 
   echo "LOG_METAL: Running run_tg_prefetcher_tests"
 
-  pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py --timeout 600; fail+=$?
+  pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py --timeout 600; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/ttnn/cpp/ttnn/operations/generic/generic_op_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op_pybind.cpp
@@ -26,7 +26,7 @@ void bind_generic_operation(py::module& module) {
             ttnn.Tensor: Handle to the output tensor.
 
         Example:
-            Refer to tests/ttnn/unit_tests/operations/test_generic_op.py for usage examples
+            Refer to tests/ttnn/unit_tests/operations/debug/test_generic_op.py for usage examples
         )doc";
 
     bind_registered_operation(


### PR DESCRIPTION
### Ticket
Link to Github Issue #30571

### Problem description
When moving ops unit tests, some paths were missed that used those tests.

### What's changed
Fix the missing paths.

Used grep 
```
grep 'unit_tests.operations\/[^/]*\.py' -r * > a.txt
grep 'unit_tests.operations.test_[^u]' -r * > b.txt
grep 'ttnn.unit_tests.test_[^u]' -r * > c.txt 
grep 'ttnn.unit_tests.test_u' -r * > d.txt
```
to identify missing paths.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18655765137 all green although still waiting for galaxy-apc-fast-tests which should not be affected by this PR
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes