### PR TITLE
Update fabric configuration for llama70b unit tests to Fabric 1D Ring

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_decoder_prefill.py
@@ -53,7 +53,7 @@ from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
     indirect=True,
 )
 def test_llama_decoder_inference(

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
@@ -35,7 +35,7 @@ from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}],
     indirect=True,
 )
 def test_llama_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensure_gc):


### PR DESCRIPTION
### Problem description
CI failure due to incorrect fabric configuration

### What's changed
- Update Fabric 1d to Fabric 1d Ring in test llama mlp prefill and test llama decoder prefill tests

### Checklist
- [ ] [Galaxy Unit Test](https://github.com/tenstorrent/tt-metal/actions/runs/18662877980) CI passes