### PR TITLE
[skip ci] temp revert of scikit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.8.0",
-    "pybind11>=2.10.0",
-    "wheel",
+  "setuptools==70.1.0",
+  "setuptools-scm==8.1.0",
+  "wheel",
 ]
-build-backend = "scikit_build_core.build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "ttnn"
@@ -50,51 +50,6 @@ skip = ["__init__.py"]
 
 [tool.ruff]
 line-length = 120
-
-[tool.scikit-build]
-build-dir = "build"
-
-[tool.scikit-build.cmake]
-version = ">=3.24"
-build-type = {env="CIBW_BUILD_TYPE", default="Release"}
-
-[tool.scikit-build.cmake.define]
-ENABLE_TRACY = {env="CIBW_ENABLE_TRACY", default="OFF"}
-CMAKE_BUILD_TYPE = {env="CIBW_BUILD_TYPE", default="Release"}
-BUILD_SHARED_LIBS = "ON"
-TT_INSTALL = "ON"
-TT_UNITY_BUILDS = "ON"
-TT_ENABLE_LIGHT_METAL_TRACE = "ON"
-WITH_PYTHON_BINDINGS = "ON"
-TT_USE_SYSTEM_SFPI = "ON"
-ENABLE_CCACHE = "TRUE"
-CMAKE_INSTALL_LIBDIR = "ttnn"
-CMAKE_INSTALL_LIBEXECDIR = "ttnn"
-
-[tool.scikit-build.wheel]
-# Package discovery - include all packages that were found by setup.py find_packages
-packages = [
-    "ttnn/tracy",
-    "ttnn/tt_lib",
-    "ttnn/ttnn",
-    "tools/tracy",
-    "tools/triage",
-]
-# Exclude examples from wheel
-exclude = ["ttnn/examples", "ttnn/examples/**"]
-
-[tool.scikit-build.install]
-# Use CMake install components for packaging
-components = ["umd-runtime", "metalium-runtime", "ttnn-runtime", "tracy"]
-
-# Conditionally add tracy component when enabled
-[[tool.scikit-build.overrides]]
-if.env.CIBW_ENABLE_TRACY = "ON"
-install.components = ["umd-runtime", "metalium-runtime", "ttnn-runtime", "tracy"]
-
-# Handle version from git via setuptools-scm-like behavior
-[tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 # Supported tag formats:

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -412,4 +412,4 @@ from ttnn._ttnn.operations.data_movement import TileReshapeMapMode
 
 if "TT_METAL_HOME" not in os.environ:
     this_dir = os.path.dirname(__file__)
-    SetRootDir(os.path.join(os.path.abspath(this_dir), "tt-metalium"))
+    SetRootDir(os.path.abspath(this_dir))


### PR DESCRIPTION
### Ticket
NA

### Problem description
The transition to use scikit-build overlooked the impact on the existing editable install developer flow.
That flow relied on a two part build.
1. create_venv.sh -> creates a ttnn virtual environment without compiled C++ code
2. build_metal.sh -> compiles C++ code, and allows the editable install ttnn module to pick up compiled libraries

### What's changed
- Revert the changes to `pyproject.toml` and `setup.py`.
- Do not revert the enhancements made to ensure that missing files are in the debian package.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18655238019) CI passes
- [x] New/Existing tests provide coverage for changes