### PR TITLE
#27100 expose model optimizations to vllm 

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -103,8 +103,16 @@ class LlamaForCausalLM(Generator):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len=131072, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len=131072,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations=None,
     ):
+        assert optimizations is None, "Custom optimizations are not supported for this model"
         # max_seq_len = 128
         # n_layers = 1
         tt_model, model_args = initialize_vllm_text_transformer(

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -111,7 +111,10 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1):
+    def initialize_vllm_model(
+        cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1, optimizations=None
+    ):
+        assert optimizations is None, "Custom optimizations are not supported for this model"
         optimizations, max_seq_len_native = get_platform_specific_optimizations(hf_config.name_or_path)
         if max_seq_len > max_seq_len_native:
             logger.warning(

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -403,8 +403,9 @@ class QwenForCausalLM(Generator):
         max_seq_len,
         n_layers=None,
         tt_data_parallel=1,
-        optimizations=DecodersPrecision.performance,
+        optimizations: str = "performance",
     ):
+        logger.info(f"DecodersPrecision: {optimizations}")
         tt_model, model_args = initialize_vllm_text_transformer(
             hf_config,
             tt_data_parallel,
@@ -444,7 +445,7 @@ class MistralForCausalLM(Generator):
         max_seq_len,
         n_layers=None,
         tt_data_parallel=1,
-        optimizations=DecodersPrecision.performance,
+        optimizations: str = "performance",
     ):
         tt_model, model_args = initialize_vllm_text_transformer(
             hf_config,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -623,6 +623,10 @@ class GptOssForCausalLM(Generator):
     ):
         from models.demos.gpt_oss.tt.common import create_tt_model
 
+        optimizations = (
+            DecodersPrecision.from_string(optimizations) if optimizations is not None else DecodersPrecision.performance
+        )
+
         submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
 
         model_args = []
@@ -635,9 +639,7 @@ class GptOssForCausalLM(Generator):
                 mesh_device=submesh,
                 instruct=True,
                 max_batch_size=max_batch_size // tt_data_parallel,
-                optimizations=lambda model_args: DecodersPrecision.from_string(optimizations)(
-                    model_args.n_layers, model_args.model_name
-                ),
+                optimizations=lambda model_args: optimizations(model_args.n_layers, model_args.model_name),
                 max_seq_len=max_seq_len,
                 paged_attention_config=None,
                 dtype=ttnn.bfloat8_b,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -264,6 +264,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal, SupportsV0On
     def initialize_vllm_model(
         cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1, optimizations: str = None
     ):
+        assert optimizations is None, "Custom optimizations are not supported for this model"
         from models.tt_transformers.demo.simple_vision_demo import create_multimodal_model
 
         submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
@@ -372,7 +373,9 @@ class LlamaForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
+            optimizations=DecodersPrecision.from_string(optimizations)
+            if optimizations is not None
+            else DecodersPrecision.performance,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -405,7 +408,6 @@ class QwenForCausalLM(Generator):
         tt_data_parallel=1,
         optimizations: str = "performance",
     ):
-        logger.info(f"DecodersPrecision: {optimizations}")
         tt_model, model_args = initialize_vllm_text_transformer(
             hf_config,
             tt_data_parallel,
@@ -414,7 +416,9 @@ class QwenForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
+            optimizations=DecodersPrecision.from_string(optimizations)
+            if optimizations is not None
+            else DecodersPrecision.performance,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -455,7 +459,9 @@ class MistralForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
+            optimizations=DecodersPrecision.from_string(optimizations)
+            if optimizations is not None
+            else DecodersPrecision.performance,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -554,8 +560,9 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         max_seq_len=131072,
         n_layers=None,
         tt_data_parallel=1,
-        optimizations=None,
+        optimizations: str = None,
     ):
+        assert optimizations is None, "Custom optimizations are not supported for this model"
         from models.demos.gemma3.demo.vision_demo import create_multimodal_model
 
         submesh_devices = create_submeshes(mesh_device, tt_data_parallel)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -261,7 +261,9 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal, SupportsV0On
         self.max_gen_len = self.model_args[0].max_seq_len - 1  # TODO: double check what this should be
 
     @classmethod
-    def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1):
+    def initialize_vllm_model(
+        cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1, optimizations: str = None
+    ):
         from models.tt_transformers.demo.simple_vision_demo import create_multimodal_model
 
         submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
@@ -340,7 +342,14 @@ class LlamaForCausalLM(Generator):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations: str = "performance",
     ):
         hf_model_name = hf_config._name_or_path
         if (
@@ -363,7 +372,7 @@ class LlamaForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.performance,
+            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -387,7 +396,14 @@ class QwenForCausalLM(Generator):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations=DecodersPrecision.performance,
     ):
         tt_model, model_args = initialize_vllm_text_transformer(
             hf_config,
@@ -397,7 +413,7 @@ class QwenForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.performance,
+            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -421,7 +437,14 @@ class MistralForCausalLM(Generator):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations=DecodersPrecision.performance,
     ):
         tt_model, model_args = initialize_vllm_text_transformer(
             hf_config,
@@ -431,7 +454,7 @@ class MistralForCausalLM(Generator):
             max_seq_len=max_seq_len,
             n_layers=n_layers,
             dtype=ttnn.bfloat8_b,
-            optimizations=DecodersPrecision.performance,
+            optimizations=DecodersPrecision.from_string(optimizations) if optimizations is not None else None,
         )
         return cls(tt_model, model_args, mesh_device)
 
@@ -523,7 +546,14 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len=131072, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len=131072,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations=None,
     ):
         from models.demos.gemma3.demo.vision_demo import create_multimodal_model
 
@@ -574,7 +604,14 @@ class GptOssForCausalLM(Generator):
 
     @classmethod
     def initialize_vllm_model(
-        cls, hf_config, mesh_device, max_batch_size, max_seq_len, n_layers=None, tt_data_parallel=1
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len,
+        n_layers=None,
+        tt_data_parallel=1,
+        optimizations: str = "performance",
     ):
         from models.demos.gpt_oss.tt.common import create_tt_model
 
@@ -590,7 +627,7 @@ class GptOssForCausalLM(Generator):
                 mesh_device=submesh,
                 instruct=True,
                 max_batch_size=max_batch_size // tt_data_parallel,
-                optimizations=lambda model_args: DecodersPrecision.performance(
+                optimizations=lambda model_args: DecodersPrecision.from_string(optimizations)(
                     model_args.n_layers, model_args.model_name
                 ),
                 max_seq_len=max_seq_len,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2924,7 +2924,9 @@ class DecodersPrecision:
         elif optimizations == "accuracy":
             return cls.accuracy
         else:
-            raise ValueError(f"Invalid optimizations: {optimizations}")
+            raise ValueError(
+                f"Invalid optimization configuration: {optimizations}. Allowed values are 'performance' or 'accuracy'"
+            )
 
     @classmethod
     def accuracy(cls, num_decoders, model_name):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2918,6 +2918,15 @@ class HfModelWrapper:
 
 class DecodersPrecision:
     @classmethod
+    def from_string(cls, optimizations: str):
+        if optimizations == "performance":
+            return cls.performance
+        elif optimizations == "accuracy":
+            return cls.accuracy
+        else:
+            raise ValueError(f"Invalid optimizations: {optimizations}")
+
+    @classmethod
     def accuracy(cls, num_decoders, model_name):
         inst = cls._precision_factory(num_decoders, model_name, ModelOptimizations.accuracy)
         inst.__name__ = "accuracy"


### PR DESCRIPTION
### Ticket
#27100

vLLM generator hardcodes the model optimizations to compile the model with. This change makes it configurable when calling `initialize_vllm_model` and is controlled via the `--override_tt_config` flag in vLLM server. Accepted values are `performance` and `accuracy` with fallback to `performance` as default in line with existing behaviour. 

### Checklist
APC: https://github.com/tenstorrent/tt-metal/actions/runs/18679418865
vLLM Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/18679434495