### PR TITLE
Fix falcon7b single card e2e perf target that was too tight

### DIFF
--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -153,7 +153,7 @@ class TestParametrized:
             ("prefill", 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.89),
             ("decode", 32, 32, 1, 128, "BFLOAT16-DRAM", 0.099),
             ("decode", 32, 32, 1, 128, "BFLOAT16-L1", 0.089),
-            ("decode", 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.055),
+            ("decode", 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.063),
             ("decode", 32, 32, 1, 1024, "BFLOAT16-DRAM", 0.38),
             ("decode", 32, 32, 1, 1024, "BFLOAT16-L1", 0.29),
             ("decode", 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.059),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7b single card model perf e2e target for decode-128-l1sharded was set too tight in https://github.com/tenstorrent/tt-metal/pull/29064. 

### What's changed
- Fixed perf target.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes

Single-card model e2e perf tests (Falcon7b only, passes) - https://github.com/tenstorrent/tt-metal/actions/runs/18658468656.