### PR TITLE
Gemma3 uses vLLM v1

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -159,7 +159,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -300,8 +300,10 @@ jobs:
                       "text": "Describe this image in 50 words."
                     },
                     {
-                      "type": "image",
-                      "image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                      "type": "image_url",
+                      "image_url": {
+                        "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                      }
                     }
                   ]
                 }

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -285,30 +285,41 @@ jobs:
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
-          echo "Using: $(pip list | grep datasets)"
-          unset HF_HUB_OFFLINE # Disable offline mode to allow downloading the dataset
-
-          python3 vllm/benchmarks/benchmark_serving.py \
-            --backend openai-chat \
-            --endpoint /v1/chat/completions \
-            --model ${{ matrix.test-group.model }} \
-            --dataset-name hf \
-            --dataset-path lmarena-ai/vision-arena-bench-v0.1 \
-            --no-stream \
-            --num-prompts 32 \
-            --random-input-len 100 \
-            --random-output-len 100 \
-            --ignore-eos \
-            --percentile-metrics ttft,tpot,itl,e2el \
-            --save-result \
-            --result-filename output/vllm_result.json \
-            2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
+          curl http://localhost:8000/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -H "X-User-ID: vllm_test" \
+            -d '{
+              "model": ${{ matrix.test-group.model }},
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "Describe this image in 50 words."
+                    },
+                    {
+                      "type": "image",
+                      "image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                    }
+                  ]
+                }
+              ],
+              "max_tokens": 512,
+              "temperature": 0.0,
+              "top_p": 0.9,
+              "top_k": 10,
+              "repetition_penalty": 1.0,
+              "stream": false,
+              "ignore_eos": false
+          }' \
+          2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
 
           # If the backend fails, the benchmark will still complete successfully but with all-zero results.
           # It will contain a warning message, though
-          warning_message="All requests failed"
-          if grep -q "$warning_message" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
-            echo "❌ All requests failed"
+          expected_word="cat"
+          if grep -q -i "$expected_word" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
+            echo "❌ Expected word \"$expected_word\" not found in the response"
             echo "Check out the server log in a step below."
             exit 1
           fi

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -262,10 +262,9 @@ jobs:
           vllm bench serve \
             --backend vllm \
             --model ${{ matrix.test-group.model }} \
-            --dataset-name sonnet \
-            --sonnet-input-len 300 \
-            --sonnet-output-len 100 \
-            --dataset-path $vllm_dir/benchmarks/sonnet.txt \
+            --dataset-name random \
+            --random-input-len 100 \
+            --random-output-len 100 \
             --num-prompts 32 \
             --ignore-eos \
             --percentile-metrics ttft,tpot,itl,e2el \
@@ -319,9 +318,9 @@ jobs:
           2>&1 | tee ${FILE_MULTIMODAL_TEST_LOG}
 
           # If the test fails, the response will not contain the expected word
-          status_ok="\"code\":200"
-          if ! grep -q -i "$status_ok" "${FILE_MULTIMODAL_TEST_LOG}"; then
-            echo "❌ Status OK ($status_ok) not found in the response"
+          keyword="cat"
+          if ! grep -q -i "$keyword" "${FILE_MULTIMODAL_TEST_LOG}"; then
+            echo "❌ The keyword \"$keyword\" not found in the response"
             echo "Check out the server log in a step below."
             exit 1
           fi

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -129,7 +129,8 @@ jobs:
             mesh-device: T3K,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
             tt-llama-text-ver: tt_transformers,
-            multimodal: false, # Disabled until the error seen in https://github.com/tenstorrent/tt-metal/actions/runs/18021096729/job/51279632451 is fixed
+            multimodal: true,
+            use-vllm-v1: true,
             co-owner-1-id: U08E1JCDVNX, # Pavle Petrovic
             co-owner-2-id: U08BH66EXAL, # Radoica Draskic
           },
@@ -198,9 +199,9 @@ jobs:
         timeout-minutes: 1
         run: |
           if [ -n "${{ matrix.test-group.override-tt-config }}" ]; then
-            export OVERRIDE_TT_CONFIG=(--override-tt-config "$(printf "%s" '${{ matrix.test-group.override-tt-config }}')")
+            OVERRIDE_TT_CONFIG=(--override-tt-config "$(printf "%s" '${{ matrix.test-group.override-tt-config }}')")
           else
-            export OVERRIDE_TT_CONFIG=()
+            OVERRIDE_TT_CONFIG=()
           fi
 
           echo "Override config: ${OVERRIDE_TT_CONFIG[@]}"
@@ -215,12 +216,21 @@ jobs:
 
           # vLLM environment variables
           export VLLM_RPC_TIMEOUT=300000
+          USE_V1="${{ matrix.test-group.use-vllm-v1 }}"
+          if [[ "${USE_V1}" == "true" ]]; then
+            export VLLM_USE_V1=1
+          fi
 
-          python3 vllm/examples/server_example_tt.py \
-            --model ${{ matrix.test-group.model }} \
-            ${{ matrix.test-group.additional-args }} \
-            "${OVERRIDE_TT_CONFIG[@]}" \
-            > "${FILE_SERVER_LOG}" 2>&1 &
+          # Build the VLLM server arguments array
+          declare -a VLLM_SERVER_ARGS
+          VLLM_SERVER_ARGS+=(--model "$HF_MODEL")
+          VLLM_SERVER_ARGS+=("${{ matrix.test-group.additional-args }}")
+          VLLM_SERVER_ARGS+=("${OVERRIDE_TT_CONFIG[@]}")
+          if [[ "${USE_V1}" == "true" ]]; then
+            VLLM_SERVER_ARGS+=("--num_scheduler_steps" "1")
+          fi
+
+          python3 vllm/examples/server_example_tt.py "${VLLM_SERVER_ARGS[@]}" > "${FILE_SERVER_LOG}" 2>&1 &
 
           # Store server's pid for cleanup
           echo $! > ${FILE_SERVER_PID}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -159,7 +159,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -155,7 +155,7 @@ jobs:
         FILE_SERVER_PID: "./server.pid"
         FILE_SERVER_LOG: "./output/vllm_server.log"
         FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
-        FILE_MULTIMODAL_BENCHMARK_LOG: "./output/vllm_multimodal_benchmark.log"
+        FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -281,7 +281,7 @@ jobs:
             exit 1
           fi
 
-      - name: 🖼️ Run multimodal benchmark
+      - name: 🖼️ Run multimodal test
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
@@ -289,7 +289,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "X-User-ID: vllm_test" \
             -d '{
-              "model": ${{ matrix.test-group.model }},
+              "model": "${{ matrix.test-group.model }}",
               "messages": [
                 {
                   "role": "user",
@@ -313,13 +313,12 @@ jobs:
               "stream": false,
               "ignore_eos": false
           }' \
-          2>&1 | tee ${FILE_MULTIMODAL_BENCHMARK_LOG}
+          2>&1 | tee ${FILE_MULTIMODAL_TEST_LOG}
 
-          # If the backend fails, the benchmark will still complete successfully but with all-zero results.
-          # It will contain a warning message, though
-          expected_word="cat"
-          if grep -q -i "$expected_word" "${FILE_MULTIMODAL_BENCHMARK_LOG}"; then
-            echo "❌ Expected word \"$expected_word\" not found in the response"
+          # If the test fails, the response will not contain the expected word
+          status_ok="\"code\":200"
+          if ! grep -q -i "$status_ok" "${FILE_MULTIMODAL_TEST_LOG}"; then
+            echo "❌ Status OK ($status_ok) not found in the response"
             echo "Check out the server log in a step below."
             exit 1
           fi

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -259,13 +259,14 @@ jobs:
       - name: 📐 Run benchmark
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         run: |
-          python3 vllm/benchmarks/benchmark_serving.py \
+          vllm bench serve \
             --backend vllm \
             --model ${{ matrix.test-group.model }} \
-            --dataset-name random \
+            --dataset-name sonnet \
+            --sonnet-input-len 300 \
+            --sonnet-output-len 100 \
+            --dataset-path $vllm_dir/benchmarks/sonnet.txt \
             --num-prompts 32 \
-            --random-input-len 100 \
-            --random-output-len 100 \
             --ignore-eos \
             --percentile-metrics ttft,tpot,itl,e2el \
             --save-result \

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -204,7 +204,11 @@ jobs:
             OVERRIDE_TT_CONFIG=()
           fi
 
-          echo "Override config: ${OVERRIDE_TT_CONFIG[@]}"
+          if [ -n "${{ matrix.test-group.additional-args }}" ]; then
+            ADDITIONAL_ARGS=(${{ matrix.test-group.additional-args }})
+          else
+            ADDITIONAL_ARGS=()
+          fi
 
           export MESH_DEVICE=${{ matrix.test-group.mesh-device }}
           export TT_LLAMA_TEXT_VER=${{ matrix.test-group.tt-llama-text-ver }}
@@ -224,11 +228,13 @@ jobs:
           # Build the VLLM server arguments array
           declare -a VLLM_SERVER_ARGS
           VLLM_SERVER_ARGS+=(--model "$HF_MODEL")
-          VLLM_SERVER_ARGS+=("${{ matrix.test-group.additional-args }}")
+          VLLM_SERVER_ARGS+=("${ADDITIONAL_ARGS[@]}")
           VLLM_SERVER_ARGS+=("${OVERRIDE_TT_CONFIG[@]}")
           if [[ "${USE_V1}" == "true" ]]; then
             VLLM_SERVER_ARGS+=("--num_scheduler_steps" "1")
           fi
+
+          echo "vLLM server args: ${VLLM_SERVER_ARGS[@]}"
 
           python3 vllm/examples/server_example_tt.py "${VLLM_SERVER_ARGS[@]}" > "${FILE_SERVER_LOG}" 2>&1 &
 
@@ -344,7 +350,7 @@ jobs:
           fi
 
       - name: Show server log
-        if: ${{ failure() }}
+        if: always()
         continue-on-error: true
         run: |
           cat "${FILE_SERVER_LOG}"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -127,7 +127,7 @@ jobs:
             runner-label: config-t3000,
             arch: arch-wormhole_b0,
             mesh-device: T3K,
-            override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
+            override-tt-config: "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"worker_l1_size\": 1344544, \"trace_region_size\": 21448704, \"l1_small_size\": 24576}",
             tt-llama-text-ver: tt_transformers,
             multimodal: true,
             use-vllm-v1: true,
@@ -159,7 +159,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -6,12 +6,17 @@ import os
 from typing import List, Mapping, Optional, Sequence, Union
 
 import torch
+import vllm.envs as envs
 from llama_models.llama3.api.chat_format import create_vision_mask
 from loguru import logger
 from PIL.Image import Image
 from tqdm import tqdm
 from transformers import BatchFeature
-from vllm.model_executor.models.gemma3_mm import Gemma3ProcessingInfo
+from vllm.model_executor.models.gemma3_mm import (
+    Gemma3DummyInputsBuilder,
+    Gemma3MultiModalProcessor,
+    Gemma3ProcessingInfo,
+)
 from vllm.model_executor.models.interfaces import SupportsMultiModal, SupportsV0Only
 from vllm.model_executor.models.mllama import MllamaProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -508,9 +513,7 @@ class MultiModalProcessor(BaseMultiModalProcessor):
         tokenization_kwargs: Optional[Mapping[str, object]] = None,
         return_mm_hashes: bool = False,
     ) -> MultiModalInputs:
-        # Getting mm kwargs from model config since hf_processor_mm_kwargs is empty (TODO: resolve this)
-        mm_processor_kwargs = getattr(self.info.ctx.model_config, "mm_processor_kwargs", None) or {}
-        input_processor = self.info.get_hf_processor(**mm_processor_kwargs)
+        input_processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
 
         # WORKAROUND
         # When using /v1/chat/completions endpoint prompt is already tokenized
@@ -546,8 +549,11 @@ class MultiModalProcessor(BaseMultiModalProcessor):
         return mm_inputs
 
 
-# TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.gemma3_mm::Gemma3MultiModalProcessor
-@MULTIMODAL_REGISTRY.register_processor(MultiModalProcessor, info=Gemma3ProcessingInfo, dummy_inputs=DummyInputsBuilder)
+@MULTIMODAL_REGISTRY.register_processor(
+    Gemma3MultiModalProcessor if envs.VLLM_USE_V1 else MultiModalProcessor,
+    info=Gemma3ProcessingInfo,
+    dummy_inputs=Gemma3DummyInputsBuilder,
+)
 class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -590,13 +596,13 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, **kwargs):
-        data = kwargs.get("images", None)
-        pixel_values = [im.pixel_values if hasattr(im, "pixel_values") else None for im in data] if data else None
+        if not envs.VLLM_USE_V1:
+            data = kwargs.get("images", None)
+            kwargs["pixel_values"] = (
+                [im.pixel_values if hasattr(im, "pixel_values") else None for im in data] if data else None
+            )
 
-        return super().prefill_forward_text(
-            pixel_values=pixel_values,
-            **kwargs,
-        )
+        return super().prefill_forward_text(**kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30843

### What's changed
- Gemma3 uses vLLM's Gemma3MultiModalProcessor.
- Use vLLM v1.
- Update vLLM Nightly to use v1:
  - Change dataset from `random` to `sonnet` as v1 can't detokenize random output
  - Image test is now a simple curl to avoid dataset download in CI

### Note about prompts
Every prompt should define the multimodal processor kwargs.
For Gemma3: `"mm_processor_kwargs": {"use_fast": true, "do_convert_rgb": true, "do_pan_and_scan": true}`

### Checklist
[All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/18870839160) ✅
[(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18783587477) ✅ Only Gemma3
[vLLM Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/18868650361/) ✅ (Llama70B Galaxy fails as on main)