### PR TITLE
Move `data_format.hpp` out of API directory

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -42,7 +42,6 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/constants.hpp
     api/tt-metalium/control_plane.hpp
     api/tt-metalium/core_coord.hpp
-    api/tt-metalium/data_format.hpp
     api/tt-metalium/data_types.hpp
     api/tt-metalium/device.hpp
     api/tt-metalium/device_pool.hpp

--- a/tt_metal/api/tt-metalium/data_format.hpp
+++ b/tt_metal/api/tt-metalium/data_format.hpp
@@ -18,10 +18,8 @@ enum class ExpPrecision : std::uint8_t {
     B = 1,
 };
 
-bool is_valid_conversion(DataFormat input_format, DataFormat output_format);
 bool is_exp_b_format(DataFormat data_format);
 ExpPrecision get_exp_precision(DataFormat data_format);
-void dump_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
 
 /*
  * Checks operand data formats for same exponent width format
@@ -29,20 +27,11 @@ void dump_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
  */
 DataFormat check_consistent_format_across_buffers(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
 
-/*
- * Checks operand data formats for same data format
- * Returns the last valid data-format in operand buffers.
- */
-DataFormat check_same_format_across_buffers(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
-
 DataFormat check_valid_formats_in_out_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
 ExpPrecision get_data_exp_precision(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]);
 
 // Checks if all formats in format array are fp32/tf32/invalid, then data can be unpacked as tf32 for fp32 accumulation
 bool is_all_fp32_formats(const DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
-
-const DataFormat get_single_pack_src_format(
-    DataFormat input_format, DataFormat unpack_conditional_dst_format, bool fp32_dest_acc_en, tt::ARCH arch);
 
 std::vector<DataFormat> get_unpack_src_formats(DataFormat buf_formats[NUM_CIRCULAR_BUFFERS]);
 std::vector<DataFormat> get_unpack_dst_formats(

--- a/tt_metal/api/tt-metalium/data_format.hpp
+++ b/tt_metal/api/tt-metalium/data_format.hpp
@@ -18,15 +18,6 @@ enum class ExpPrecision : std::uint8_t {
     B = 1,
 };
 
-bool is_exp_b_format(DataFormat data_format);
-ExpPrecision get_exp_precision(DataFormat data_format);
-
-/*
- * Checks operand data formats for same exponent width format
- * Returns the last valid data-format between operand buffers.
- */
-DataFormat check_consistent_format_across_buffers(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
-
 DataFormat check_valid_formats_in_out_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
 ExpPrecision get_data_exp_precision(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]);
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -51,12 +51,6 @@ ExpPrecision get_exp_precision(DataFormat data_format) {
     return (is_exp_b_format(data_format) ? ExpPrecision::B : ExpPrecision::A);
 }
 
-void dump_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        std::cout << "Operand idx " << i << ": " << data_format[i] << "," << std::endl;
-    }
-}
-
 DataFormat check_consistent_format_across_buffers(DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
     DataFormat last_valid_format = DataFormat::Invalid;
     for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -5,8 +5,8 @@
 #pragma once
 #include <cstdint>
 #include <vector>
-#include <tt-metalium/tt_backend_api_types.hpp>  // for DataFormat
-#include <umd/device/types/arch.hpp>             // for ARCH
+#include <tt-metalium/tt_backend_api_types.hpp>     // for DataFormat
+#include <umd/device/types/arch.hpp>                // for ARCH
 #include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
 
 enum class UnpackToDestMode : std::uint8_t;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -5,7 +5,7 @@
 #include "jit_build/genfiles.hpp"
 
 #include <circular_buffer_constants.h>
-#include <data_format.hpp>
+#include "data_format.hpp"
 #include <stdint.h>
 #include <tt_backend_api_types.hpp>
 #include <cstddef>


### PR DESCRIPTION
### Ticket
Close #30809

### Problem description
Metal Runtime is reducing their API exposure. Concepts within `data_format.hpp` is not used outside of runtime.

### What's changed
Move `data_format.hpp` into jit build directory where the only use case is found.

### Checklist
- [ ] Compilation should indicate soundness.