### PR TITLE
Configure routing tables predicated on FabricConfig, instead of MGD

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -502,7 +502,7 @@ TEST(MultiHost, TestBHQB4x4Fabric1DSanity) {
 
     // Intra-mesh adjacency count is determined by the MGD, independent of fabric config
     const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
-    EXPECT_EQ(intramesh_connections.size(), 128);
+    EXPECT_EQ(intramesh_connections.size(), 96);
 
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
         const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -31,6 +31,17 @@ enum class FabricTensixConfig : uint32_t {
     MUX = 1,       // using mux kernel as tensix extension
 };
 
+enum class FabricType {
+    MESH = 1 << 0,
+    TORUS_X = 1 << 1,  // Connections along mesh_coord[1]
+    TORUS_Y = 1 << 2,  // Connections along mesh_coord[0]
+    TORUS_XY = (TORUS_X | TORUS_Y),
+};
+
+FabricType operator|(FabricType lhs, FabricType rhs);
+FabricType operator&(FabricType lhs, FabricType rhs);
+bool has_flag(FabricType flags, FabricType test_flag);
+
 enum class FabricReliabilityMode : uint32_t {
 
     // When fabric is initialized, user expects live links/devices to exactly match the mesh graph descriptor.
@@ -46,7 +57,7 @@ enum class FabricReliabilityMode : uint32_t {
     DYNAMIC_RECONFIGURATION_SETUP_MODE = 2,
 };
 
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_fabric
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -40,17 +40,6 @@ struct ChipSpec {
     std::uint32_t num_z_ports;
 };
 
-enum class FabricType {
-    MESH = 1 << 0,
-    TORUS_X = 1 << 1,  // Connections along mesh_coord[1]
-    TORUS_Y = 1 << 2,  // Connections along mesh_coord[0]
-    TORUS_XY = (TORUS_X | TORUS_Y),
-};
-
-FabricType operator|(FabricType lhs, FabricType rhs);
-FabricType operator&(FabricType lhs, FabricType rhs);
-bool has_flag(FabricType flags, FabricType test_flag);
-
 enum class RoutingDirection {
     N = 0,
     E = 2,
@@ -110,7 +99,8 @@ using RequestedIntermeshPorts =
 
 class MeshGraph {
 public:
-    explicit MeshGraph(const std::string& mesh_graph_desc_file_path);
+    explicit MeshGraph(
+        const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config = std::nullopt);
     MeshGraph() = delete;
     ~MeshGraph() = default;
 
@@ -167,11 +157,9 @@ public:
 private:
     void validate_mesh_id(MeshId mesh_id) const;
     std::unordered_map<ChipId, RouterEdge> get_valid_connections(
-        const MeshCoordinate& src_mesh_coord,
-        const MeshCoordinateRange& mesh_coord_range,
-        FabricType fabric_type) const;
-    void initialize_from_yaml(const std::string& mesh_graph_desc_file_path);
-    void initialize_from_mgd(const MeshGraphDescriptor& mgd2);
+        const MeshCoordinate& src_mesh_coord, const MeshCoordinateRange& mesh_coord_range, FabricType fabric_type) const;
+    void initialize_from_yaml(const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config);
+    void initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config);
 
     void add_to_connectivity(
         MeshId src_mesh_id,

--- a/tt_metal/api/tt-metalium/mesh_graph_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph_descriptor.hpp
@@ -15,6 +15,7 @@
 #include <atomic>
 
 #include <tt_stl/assert.hpp>
+#include <tt-metalium/fabric_types.hpp>
 
 // Forward declaration
 namespace tt::tt_fabric {
@@ -148,6 +149,9 @@ public:
     // TODO: This will disappear after we move to Physical discovery
     proto::Architecture get_arch() const;
     uint32_t get_num_eth_ports_per_direction() const;
+
+    // Helper to infer FabricType from MGD dim_types
+    static FabricType infer_fabric_type_from_dim_types(const proto::MeshDescriptor* mesh_desc);
 
 private:
 

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -38,7 +38,8 @@ std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id);
 
 class RoutingTableGenerator {
 public:
-    explicit RoutingTableGenerator(const std::string& mesh_graph_desc_file);
+    explicit RoutingTableGenerator(
+        const std::string& mesh_graph_desc_file, std::optional<FabricConfig> fabric_config = std::nullopt);
     ~RoutingTableGenerator() = default;
 
     void dump_to_yaml();

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(
         fabric_context.cpp
         fabric_mux_config.cpp
         fabric_tensix_builder.cpp
+        fabric_types.cpp
         compressed_routing_table.cpp
         compressed_routing_path.cpp
         serialization/router_port_directions.cpp

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -444,7 +444,8 @@ void ControlPlane::init_control_plane(
     const auto& driver = cluster.get_driver();
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
+    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file, fabric_config);
     this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
         driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -30,7 +30,7 @@ bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
 
 FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config) {
     switch (fabric_config) {
-        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return FabricType::TORUS_XY;
+        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return FabricType::TORUS_X;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_X: return FabricType::TORUS_X;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_Y: return FabricType::TORUS_Y;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY: return FabricType::TORUS_XY;
@@ -39,6 +39,42 @@ FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config) {
         case tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_XY: return FabricType::TORUS_XY;
         default: return FabricType::MESH;
     }
+}
+
+bool requires_more_connectivity(FabricType requested_type, FabricType available_type, const MeshShape& mesh_shape) {
+    // Requesting MESH is always valid (can restrict any topology to MESH)
+    if (requested_type == FabricType::MESH) {
+        return false;
+    }
+
+    // Check if available topology can satisfy the requested topology
+    if (available_type == FabricType::MESH) {
+        // Special case: 2-element dimensions make torus wrap-around equivalent to mesh neighbor connections
+        // E.g., in a 2-row mesh, north/south wrap-around just connects to the adjacent row
+        bool has_two_rows = (mesh_shape[0] == 2);
+        bool has_two_cols = (mesh_shape[1] == 2);
+
+        if (has_flag(requested_type, FabricType::TORUS_Y) && !has_two_rows) {
+            return true;
+        }
+        if (has_flag(requested_type, FabricType::TORUS_X) && !has_two_cols) {
+            return true;
+        }
+        return false;
+    }
+
+    // For non-MESH available types, check if requested features are present
+    if (requested_type == FabricType::TORUS_XY) {
+        return available_type != FabricType::TORUS_XY;
+    }
+    if (requested_type == FabricType::TORUS_X) {
+        return !has_flag(available_type, FabricType::TORUS_X);
+    }
+    if (requested_type == FabricType::TORUS_Y) {
+        return !has_flag(available_type, FabricType::TORUS_Y);
+    }
+
+    return false;
 }
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -30,7 +30,7 @@ bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
 
 FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config) {
     switch (fabric_config) {
-        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return FabricType::TORUS_X;
+        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return FabricType::MESH;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_X: return FabricType::TORUS_X;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_Y: return FabricType::TORUS_Y;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY: return FabricType::TORUS_XY;

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -28,6 +28,11 @@ void set_routing_mode(Topology topology, tt::tt_fabric::FabricConfig fabric_conf
 
 FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config);
 
+// Helper to validate that requested FabricType doesn't require more connectivity than available FabricType provides
+// Returns true if requested_type requires more connections than available_type provides
+// mesh_shape: [rows, cols] - used to detect edge cases where 2-row/2-col torus is equivalent to mesh
+bool requires_more_connectivity(FabricType requested_type, FabricType available_type, const MeshShape& mesh_shape);
+
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);
 

--- a/tt_metal/fabric/fabric_types.cpp
+++ b/tt_metal/fabric/fabric_types.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/fabric_types.hpp>
+
+namespace tt::tt_fabric {
+
+FabricType operator|(FabricType lhs, FabricType rhs) {
+    return static_cast<FabricType>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+FabricType operator&(FabricType lhs, FabricType rhs) {
+    return static_cast<FabricType>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mesh_graph.hpp"
+#include "fabric_host_utils.hpp"
 
 #include <enchantum/enchantum.hpp>
 #include <yaml-cpp/yaml.h>
@@ -27,13 +28,6 @@ std::size_t std::hash<tt::tt_fabric::port_id_t>::operator()(const tt::tt_fabric:
 }
 
 namespace tt::tt_fabric {
-FabricType operator|(FabricType lhs, FabricType rhs) {
-    return static_cast<FabricType>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
-}
-
-FabricType operator&(FabricType lhs, FabricType rhs) {
-    return static_cast<FabricType>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
-}
 
 constexpr const char* MESH_GRAPH_DESCRIPTOR_DIR = "tt_metal/fabric/mesh_graph_descriptors";
 
@@ -123,15 +117,13 @@ const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mes
              {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.textproto"},
          }}});
 
-bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
-
-MeshGraph::MeshGraph(const std::string& mesh_graph_desc_file_path) {
+MeshGraph::MeshGraph(const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config) {
     if (mesh_graph_desc_file_path.ends_with(".textproto")) {
         auto filepath = std::filesystem::path(mesh_graph_desc_file_path);
         MeshGraphDescriptor mgd(filepath, true);
-        this->initialize_from_mgd(mgd);
+        this->initialize_from_mgd(mgd, fabric_config);
     } else if (mesh_graph_desc_file_path.ends_with(".yaml")) {
-        this->initialize_from_yaml(mesh_graph_desc_file_path);
+        this->initialize_from_yaml(mesh_graph_desc_file_path, fabric_config);
     } else {
         TT_THROW("Mesh graph descriptor file must end with .textproto or .yaml");
     }
@@ -231,7 +223,7 @@ std::unordered_map<ChipId, RouterEdge> MeshGraph::get_valid_connections(
     return valid_connections;
 }
 
-void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd) {
+void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config) {
     static const std::unordered_map<const proto::Architecture, tt::ARCH> proto_arch_to_arch = {
         {proto::Architecture::WORMHOLE_B0, tt::ARCH::WORMHOLE_B0},
         {proto::Architecture::BLACKHOLE, tt::ARCH::BLACKHOLE},
@@ -247,39 +239,8 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd) {
     };
 
     // Make intramesh connectivity
-    // NOTE: Not using MGD 2.0 Mesh graph because it currently does not support port direction
+    // NOTE: Building connectivity based on FabricConfig override (if provided) or MGD's fabric type
     this->intra_mesh_connectivity_.resize(mgd.all_meshes().size());
-
-    // This is to make sure emtpy elements are filled
-    for (const auto& mesh : mgd.all_meshes()) {
-        const auto& mesh_instance = mgd.get_instance(mesh);
-        this->intra_mesh_connectivity_[mesh_instance.local_id].resize(mesh_instance.sub_instances.size());
-    }
-
-    for (const auto& connection : mgd.connections_by_type("MESH")) {
-        const auto& connection_data = mgd.get_connection(connection);
-        const auto& src_instance = mgd.get_instance(connection_data.nodes[0]);
-        const auto& dst_instance = mgd.get_instance(connection_data.nodes[1]);
-
-        const auto& mesh_instance = mgd.get_instance(connection_data.parent_instance_id);
-
-        const MeshId src_mesh_id = MeshId(mesh_instance.local_id);
-
-        const ChipId src_chip_id = src_instance.local_id;
-        const ChipId dst_chip_id = dst_instance.local_id;  // ONly expect one single dest chip
-
-        RouterEdge router_edge{
-            .port_direction = routing_direction_to_port_direction(connection_data.routing_direction),
-            .connected_chip_ids = std::vector<ChipId>(chip_spec_.num_eth_ports_per_direction, dst_chip_id),
-            .weight = 0,
-        };
-
-        if (this->intra_mesh_connectivity_[*src_mesh_id].size() <= mesh_instance.sub_instances.size()) {
-            this->intra_mesh_connectivity_[*src_mesh_id].resize(mesh_instance.sub_instances.size());
-        }
-
-        this->intra_mesh_connectivity_[*src_mesh_id][src_chip_id].insert({dst_chip_id, router_edge});
-    }
 
     this->inter_mesh_connectivity_.resize(mgd.all_meshes().size());
 
@@ -341,6 +302,36 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd) {
 
         MeshId mesh_id(mesh_instance.local_id);
         MeshShape mesh_shape(mesh_desc->device_topology().dims().at(0), mesh_desc->device_topology().dims().at(1));
+
+        // Build intra-mesh connectivity based on FabricConfig override (if provided) or MGD's fabric type
+        FabricType mgd_fabric_type = MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc);
+        FabricType effective_fabric_type;
+
+        if (fabric_config.has_value()) {
+            FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+            // Validate that FabricConfig doesn't try to create connections that don't exist
+            if (requires_more_connectivity(requested_fabric_type, mgd_fabric_type, mesh_shape)) {
+                TT_THROW(
+                    "FabricConfig requests topology {} which requires more connectivity than MGD provides {}. "
+                    "FabricConfig can only restrict topology (e.g., torus→mesh), not create new connections.",
+                    enchantum::to_string(requested_fabric_type),
+                    enchantum::to_string(mgd_fabric_type));
+            }
+            effective_fabric_type = requested_fabric_type;
+        } else {
+            effective_fabric_type = mgd_fabric_type;
+        }
+
+        // Build connectivity using effective_fabric_type
+        MeshCoordinateRange mesh_coord_range(mesh_shape);
+        uint32_t mesh_size = mesh_shape[0] * mesh_shape[1];
+        this->intra_mesh_connectivity_[*mesh_id].resize(mesh_size);
+        for (const auto& src_mesh_coord : mesh_coord_range) {
+            ChipId src_chip_id = (src_mesh_coord[0] * mesh_shape[1]) + src_mesh_coord[1];
+            this->intra_mesh_connectivity_[*mesh_id][src_chip_id] =
+                this->get_valid_connections(src_mesh_coord, mesh_coord_range, effective_fabric_type);
+        }
+
         MeshShape host_shape(mesh_desc->host_topology().dims().at(0), mesh_desc->host_topology().dims().at(1));
 
         std::vector<MeshHostRankId> mesh_host_ranks_values;
@@ -436,7 +427,8 @@ const std::vector<std::unordered_map<port_id_t, ChipId, hash_pair>>& MeshGraph::
     return mesh_edge_ports_to_chip_id_;
 }
 
-void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_path) {
+void MeshGraph::initialize_from_yaml(
+    const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config) {
     std::ifstream fdesc(mesh_graph_desc_file_path);
     TT_FATAL(not fdesc.fail(), "Failed to open file: {}", mesh_graph_desc_file_path);
 
@@ -562,6 +554,25 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             MeshContainer<MeshHostRankId>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
 
         // Fill in connectivity for Mesh
+        // Determine FabricType: use FabricConfig if provided, otherwise use board's fabric type
+        FabricType board_fabric_type = board_name_to_fabric_type[mesh_board];
+        FabricType effective_fabric_type;
+
+        if (fabric_config.has_value()) {
+            FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+            // Validate that FabricConfig doesn't try to create connections that don't exist
+            if (requires_more_connectivity(requested_fabric_type, board_fabric_type, mesh_shape)) {
+                TT_THROW(
+                    "FabricConfig requests topology {} which requires more connectivity than board type provides {}. "
+                    "FabricConfig can only restrict topology (e.g., torus→mesh), not create new connections.",
+                    enchantum::to_string(requested_fabric_type),
+                    enchantum::to_string(board_fabric_type));
+            }
+            effective_fabric_type = requested_fabric_type;
+        } else {
+            effective_fabric_type = board_fabric_type;
+        }
+
         MeshCoordinateRange mesh_coord_range(mesh_shape);
         this->intra_mesh_connectivity_[*mesh_id].resize(mesh_size);
         for (const auto& src_mesh_coord : mesh_coord_range) {
@@ -569,7 +580,7 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             ChipId src_chip_id = (src_mesh_coord[0] * mesh_shape[1]) + src_mesh_coord[1];
             // Get the valid connections for the current chip
             this->intra_mesh_connectivity_[*mesh_id][src_chip_id] =
-                this->get_valid_connections(src_mesh_coord, mesh_coord_range, board_name_to_fabric_type[mesh_board]);
+                this->get_valid_connections(src_mesh_coord, mesh_coord_range, effective_fabric_type);
         }
 
         this->inter_mesh_connectivity_[*mesh_id].resize(this->intra_mesh_connectivity_[*mesh_id].size());

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -15,6 +15,7 @@
 #include "protobuf/mesh_graph_descriptor.pb.h"
 #include "tt-metalium/mesh_graph_descriptor.hpp"
 #include "tt-metalium/mesh_coord.hpp"
+#include "tt-metalium/fabric_types.hpp"
 #include <tt-logger/tt-logger.hpp>
 
 #include <google/protobuf/text_format.h>
@@ -156,6 +157,25 @@ proto::Architecture MeshGraphDescriptor::get_arch() const {
 
 uint32_t MeshGraphDescriptor::get_num_eth_ports_per_direction() const {
     return proto_->mesh_descriptors(0).channels().count();
+}
+
+FabricType MeshGraphDescriptor::infer_fabric_type_from_dim_types(const proto::MeshDescriptor* mesh_desc) {
+    const auto& dim_types = mesh_desc->device_topology().dim_types();
+    if (dim_types.size() < 2) {
+        return FabricType::MESH;
+    }
+
+    bool y_is_ring = (dim_types[0] == proto::TorusTopology::RING);
+    bool x_is_ring = (dim_types[1] == proto::TorusTopology::RING);
+
+    if (y_is_ring && x_is_ring) {
+        return FabricType::TORUS_XY;
+    } else if (y_is_ring) {
+        return FabricType::TORUS_Y;
+    } else if (x_is_ring) {
+        return FabricType::TORUS_X;
+    }
+    return FabricType::MESH;
 }
 
 void MeshGraphDescriptor::set_defaults(proto::MeshGraphDescriptor& proto) {

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -42,8 +42,9 @@ std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
     return os;
 }
 
-RoutingTableGenerator::RoutingTableGenerator(const std::string& mesh_graph_desc_file) {
-    this->mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_file);
+RoutingTableGenerator::RoutingTableGenerator(
+    const std::string& mesh_graph_desc_file, std::optional<FabricConfig> fabric_config) {
+    this->mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_file, fabric_config);
     // Use IntraMeshConnectivity to size all variables
     const auto& intra_mesh_connectivity = this->mesh_graph->get_intra_mesh_connectivity();
     const auto& inter_mesh_connectivity = this->mesh_graph->get_inter_mesh_connectivity();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When MGD specifies torus topology but `FabricConfig` specifies mesh, the router incorrectly configures deadlock avoidance for torus topology, leading to unsafe traffic on the torus links.

### What's changed
- Modified `MeshGraph` and `RoutingTableGenerator` to accept optional `FabricConfig` parameter, allowing routing table configuration based on `FabricConfig` instead of relying exclusively on MGD
- Router features like deadlock avoidance are now determined solely by `FabricConfig`, preventing topology mismatches
- Added validation to ensure `FabricConfig` doesn't request connections that don't exist in MGD (mesh→torus is invalid)
- Added unit tests: `TestFabricConfigOverrideTorusToMesh` validates safe restriction from torus to mesh, `TestFabricConfigInvalidMeshToTorus` validates exception on invalid mesh→torus request

### CI Runs
- [x] All post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19056011524
- [x] T3000 unit tests CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19053239318, https://github.com/tenstorrent/tt-metal/actions/runs/19061761338
- [ ] Galaxy fast tests: https://github.com/tenstorrent/tt-metal/actions/runs/19061741238 (pending)
- [x] New/Existing tests provide coverage for changes
