### PR TITLE
Fix test_layer_norm_sharded.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -332,6 +332,7 @@ class CMakeBuild(build_ext):
             "ttnn/operations/data_movement/**/*",
             "ttnn/operations/moreh/**/*",
             "ttnn/kernel/*",
+            "ttnn/operations/normalization/kernel_util/compute/*",
         ]
         tt_metal_patterns = [
             "api/tt-metalium/buffer_constants.hpp",


### PR DESCRIPTION
### Ticket
NA

### Problem description
Failure on main right now, caused by packaging issue.
https://github.com/tenstorrent/tt-metal/actions/runs/18659917749/attempts/1
Developer correctly specified files for inclusion in CMake, however, CMake install rules are not respected by ttnn python package.

### What's changed
- Duplicate kernel source requirement for python package.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18663974822) CI passes
- [x] New/Existing tests provide coverage for changes