### PR TITLE
Embedding Support Tiled Indices for Tiny Row Sizes, Update Embedding Output dtype Specifications

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -42,7 +42,6 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
         if (is_sharded(this->output_mem_config.memory_layout())) {
             TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Embedding only supports height sharded Row Major outputs");
         }
-        TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     if(a.layout() == Layout::ROW_MAJOR) {
         TT_FATAL(a.padded_shape()[1] == 1 && a.padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -62,7 +62,6 @@ std::vector<TensorSpec> Embeddings::compute_output_specs(const std::vector<Tenso
 
     ttnn::Shape output_shape({batch_num, 1, num_output_embeddings, num_embedding_dims});
     auto output_layout = (tilized && input_tensors.at(0).layout() != Layout::TILE)? Layout::TILE : Layout::ROW_MAJOR;
-    // return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(output_layout), output_mem_config))};
     return {TensorSpec(output_shape, TensorLayout(weight_tensor.dtype(), PageConfig(output_layout), output_mem_config))};
 }
 

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -63,7 +63,8 @@ std::vector<TensorSpec> Embeddings::compute_output_specs(const std::vector<Tenso
 
     ttnn::Shape output_shape({batch_num, 1, num_output_embeddings, num_embedding_dims});
     auto output_layout = (tilized && input_tensors.at(0).layout() != Layout::TILE)? Layout::TILE : Layout::ROW_MAJOR;
-    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(output_layout), output_mem_config))};
+    // return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(output_layout), output_mem_config))};
+    return {TensorSpec(output_shape, TensorLayout(weight_tensor.dtype(), PageConfig(output_layout), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks Embeddings::create_program(

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
@@ -19,7 +19,6 @@ struct Embeddings {
     const bool tilized;
     const EmbeddingsType embeddings_type;
     const std::optional<uint32_t> pad_token;
-    const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -637,6 +637,7 @@ inline tt::tt_metal::operation::ProgramWithCallbacks embeddings_tilized_indices(
     uint32_t batch_size = a.logical_shape()[0];  // num rows
     uint32_t num_cols = a.logical_shape()[-1];
     uint32_t volume = num_cols * batch_size;
+    auto alignment = a.buffer()->alignment();
 
     // setup problem and grid size
 
@@ -663,7 +664,7 @@ inline tt::tt_metal::operation::ProgramWithCallbacks embeddings_tilized_indices(
     tt::DataFormat weights_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(weights.dtype());
 
     constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t rounded_weight_page_size = round_up_to_mul32(weight_page_size);
+    uint32_t rounded_weight_page_size = tt::align(weight_page_size, alignment);
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(2 * rounded_weight_page_size, {{src0_cb_index, weights_cb_data_format}})
             .set_page_size(src0_cb_index, rounded_weight_page_size);
@@ -717,6 +718,9 @@ inline tt::tt_metal::operation::ProgramWithCallbacks embeddings_tilized_indices(
         {enchantum::to_string(embeddings_type).data(), "1"},
         {enchantum::to_string(embeddings_index_type).data(), "1"}};
 
+    if (a.logical_shape()[-1] <= FACE_HEIGHT) {
+        embedding_defines["ONLY_ONE_FACE_COLUMN"] = "1";
+    }
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp",

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/embedding/device/embedding_device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
+#include <ttnn/operations/copy/typecast/typecast.hpp>
 
 namespace ttnn::operations::embedding {
 
@@ -70,6 +71,9 @@ ttnn::Tensor EmbeddingOperation::invoke(
         embeddings = ttnn::reshape(embeddings, Shape({batch_size, sentence_size, hidden_embedding_dim}));
     }
     embeddings = ttnn::to_layout(embeddings, layout.value_or(weight_arg.layout()));
+    if (embeddings.layout() == ttnn::TILE_LAYOUT) {
+        embeddings = ttnn::typecast(embeddings, dtype.value_or(weight.dtype()));
+    }
     return embeddings;
 }
 

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -52,6 +52,8 @@ ttnn::Tensor EmbeddingOperation::invoke(
             }
         } else if (weight_arg.layout() == ttnn::TILE_LAYOUT) {
             fused_tilized = true;
+        } else {
+            TT_FATAL(!dtype.has_value(), "Can only typecast output embeddings when producing TILE_LAYOUT output");
         }
     }
 
@@ -61,7 +63,7 @@ ttnn::Tensor EmbeddingOperation::invoke(
                               .tilized = fused_tilized,
                               .embeddings_type = embeddings_type,
                               .pad_token = pad_token,
-                              .output_dtype = dtype.value_or(weight.dtype())},
+                          },
                           {input_tensor, weight})
                           .at(0);
     // Don't include batch_size if there was none


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28011?reload=1)

### Problem description
Accuracy errors for when:
 - tiled indices embedding where indices rows are very small
 - embedding error when output dtype is specified

### What's changed
If the tiled indices rows are less than 16 (one face) elements, then we need to skip past faces 1 and 3.
Previously, we were just creating an output tensor with layout of element size of the specified output dtype without actually handling typecasting, it was a strict reinterpret cast. So I removed that and simply added a typecast as if all is needed is a reinterpret cast, it's a meta data change, and this allows for actually typecasting bf16 to fp32 as mentioned in the original issue.

I also found 2 other bugs, one for BH alignment and another where the face skip calculation was incorrect.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18665797311) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18665799097) CI with demo tests passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18665800748) CI passes.