### PR TITLE
Cluster updates for P300_X2

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -175,6 +175,7 @@ target_sources(
             fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.yaml
             fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.yaml
@@ -191,6 +192,7 @@ target_sources(
             fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto
+            fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.textproto

--- a/tt_metal/api/tt-metalium/cluster.hpp
+++ b/tt_metal/api/tt-metalium/cluster.hpp
@@ -42,6 +42,7 @@ enum class ClusterType : std::uint8_t {
     P300 = 14,                   // Production P300
     SIMULATOR_QUASAR = 15,       // Simulator Quasar
     BLACKHOLE_GALAXY = 16,       // Blackhole Galaxy, all chips with mmio
+    P300_X2 = 17,                // 2 P300 cards
 };
 
 /**

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -70,6 +70,7 @@ const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std:
                 {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.yaml"},
                 {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.yaml"},
+                {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.yaml"},
             });
 
 const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std::string_view>>&
@@ -92,6 +93,7 @@ const tt::stl::Indestructible<std::unordered_map<tt::tt_metal::ClusterType, std:
                 {tt::tt_metal::ClusterType::N300_2x2, "n300_2x2_mesh_graph_descriptor.textproto"},
                 {tt::tt_metal::ClusterType::P300, "p300_mesh_graph_descriptor.textproto"},
                 {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_mesh_graph_descriptor.textproto"},
+                {tt::tt_metal::ClusterType::P300_X2, "p300_x2_mesh_graph_descriptor.textproto"},
             });
 
 bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }

--- a/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto
@@ -1,0 +1,12 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 2, 2 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.yaml
@@ -1,0 +1,27 @@
+ChipSpec: {
+  arch: blackhole,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+Board: [
+  { name: P300,
+    type: Mesh,
+    topology: [2, 2]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: P300,
+  device_topology: [2, 2],
+  host_topology: [1, 1],
+}
+]
+
+Graph: [
+]

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -179,8 +179,14 @@ tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
                 TT_THROW("Unknown cluster type for P150 board with {} chips", num_chips);
             }
         } else if (board_type == BoardType::P300) {
-            TT_FATAL(num_chips == 2, "Unknown cluster type for P300 board with {}", num_chips);
-            cluster_type = tt::tt_metal::ClusterType::P300;
+            // PCIe is enabled to both chips on the P300 board
+            if (num_chips == 2) {
+                cluster_type = tt::tt_metal::ClusterType::P300;
+            } else if (num_chips == 4) {
+                cluster_type = tt::tt_metal::ClusterType::P300_X2;
+            } else {
+                TT_THROW("Unknown cluster type for P300 board with {} chips", num_chips);
+            }
         } else if (board_type == BoardType::UBB) {
             cluster_type = tt::tt_metal::ClusterType::GALAXY;
         } else if (board_type == BoardType::UBB_BLACKHOLE) {

--- a/ttnn/cpp/ttnn-pybind/cluster.cpp
+++ b/ttnn/cpp/ttnn-pybind/cluster.cpp
@@ -74,7 +74,8 @@ void py_cluster_module_types(py::module& module) {
         .value("N300_2x2", tt::tt_metal::ClusterType::N300_2x2, "2 N300 cards, ethernet connected to form 2x2")
         .value("P300", tt::tt_metal::ClusterType::P300, "Production P300")
         .value(
-            "BLACKHOLE_GALAXY", tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "Blackhole Galaxy, all chips with mmio");
+            "BLACKHOLE_GALAXY", tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "Blackhole Galaxy, all chips with mmio")
+        .value("P300_X2", tt::tt_metal::ClusterType::P300_X2, "2 P300 cards");
 }
 
 void py_cluster_module(py::module& module) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30885

### Problem description
- Missing tt Cluster support for 2 P300

### What's changed
- Added Cluster changes to support 2 P300 as a 2x2 topology
- Updated PyBinding enum for `P300_X2`

### Checklist
Blackhole
https://github.com/tenstorrent/tt-metal/actions/runs/18667004315
Blackhole Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/18667006684
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18667005488
Build Test Upstream Tests
https://github.com/tenstorrent/tt-metal/actions/runs/18667931665