### PR TITLE
ND reduce_scatter

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -317,10 +317,9 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "ones_tensor",
     [
-        True,
         False,
     ],
-    ids=["ones", "random"],
+    ids=["random"],
 )
 @pytest.mark.parametrize(
     "use_barrier, use_persistent_buffers",
@@ -435,10 +434,9 @@ def test_reduce_scatter_async(
 @pytest.mark.parametrize(
     "ones_tensor",
     [
-        True,
         False,
     ],
-    ids=["ones", "random"],
+    ids=["random"],
 )
 @pytest.mark.parametrize(
     "device_params, rs_topology",
@@ -1076,8 +1074,6 @@ def _get_tensors(
 
     torch_reference = torch.concat(torch_reference_slices, dim=0)
 
-    print(f"{torch_reference.shape=}")
-
     tt_input = ttnn.from_torch(
         torch_input,
         layout=layout,
@@ -1091,7 +1087,9 @@ def _get_tensors(
 
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
-@pytest.mark.parametrize("input_shape", [[8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]])
+@pytest.mark.parametrize(
+    "input_shape", [[128, 128], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
+)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])
@@ -1130,8 +1128,5 @@ def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, t
         )
 
         tt_output_tensor = torch.cat([ttnn.to_torch(t) for t in ttnn.get_device_tensors(tt_out_tensor)])
-        print(f"{tt_output_tensor.shape=}")
-        print(f"{torch_reference.shape=}")
-
         eq, mess = comp_pcc(torch_reference, tt_output_tensor)
         assert eq, mess

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -317,9 +317,10 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "ones_tensor",
     [
+        True,
         False,
     ],
-    ids=["random"],
+    ids=["ones", "random"],
 )
 @pytest.mark.parametrize(
     "use_barrier, use_persistent_buffers",
@@ -434,9 +435,10 @@ def test_reduce_scatter_async(
 @pytest.mark.parametrize(
     "ones_tensor",
     [
+        True,
         False,
     ],
-    ids=["random"],
+    ids=["ones", "random"],
 )
 @pytest.mark.parametrize(
     "device_params, rs_topology",
@@ -1089,10 +1091,10 @@ def _get_tensors(
 
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
-@pytest.mark.parametrize("input_shape", [[8, 8, 32, 32], [8, 8, 32], [8, 8, 8, 32, 32], [8, 8, 8, 8, 32, 32]])
+@pytest.mark.parametrize("input_shape", [[8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
-@pytest.mark.parametrize("dim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("cluster_axis", [0])
 @pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
 def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, topology):
@@ -1115,6 +1117,8 @@ def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, t
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
     )
     semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(3)]
+
+    print(f"{tt_input.shape=}")
 
     for i in range(NUM_ITERS):
         tt_out_tensor = ttnn.experimental.reduce_scatter_minimal_async(

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1030,7 +1030,7 @@ def test_reduce_scatter_minimal_async_linear_sharded(
 MESH_SHAPE = (2, 4)
 LAYOUT = ttnn.TILE_LAYOUT
 
-NUM_ITERS = 2
+NUM_ITERS = 1
 
 
 def _valid_cluster_div(input_shape, dim, cluster_axis, mesh_shape, **kwargs):
@@ -1094,7 +1094,7 @@ def _get_tensors(
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("cluster_axis", [0])
-@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear, ttnn.Topology.Ring])
 def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, topology):
     if dim >= len(input_shape):
         pytest.skip("Invalid gather dim")

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1025,3 +1025,109 @@ def test_reduce_scatter_minimal_async_linear_sharded(
         num_buffers_per_channel=None,
         verify_output=True,
     )
+
+
+MESH_SHAPE = (2, 4)
+LAYOUT = ttnn.TILE_LAYOUT
+
+NUM_ITERS = 2
+
+
+def _valid_cluster_div(input_shape, dim, cluster_axis, mesh_shape, **kwargs):
+    return input_shape[dim] % (prod(mesh_shape) if cluster_axis is None else mesh_shape[cluster_axis]) == 0
+
+
+def _get_tensors(
+    input_shape,
+    mesh_shape,
+    dim,
+    cluster_axis,
+    dtype,
+    memory_config,
+    layout,
+    device,
+    math_op=ttnn.ReduceType.Sum,
+):
+    assert _valid_cluster_div(input_shape, dim, cluster_axis, mesh_shape)
+
+    num_devices = math.prod(mesh_shape)
+
+    elems = math.prod(input_shape)
+
+    torch_inputs = [
+        torch.linspace(i * elems, (i + 1) * elems, elems).reshape(input_shape).bfloat16() for i in range(num_devices)
+    ]
+    torch_input = torch.concat(torch_inputs, dim=0)
+
+    torch_reference = torch.reshape(torch_input, tuple(list(mesh_shape) + input_shape))
+    torch_reference = torch.sum(torch_reference, dim=cluster_axis)
+
+    dim_per_device = input_shape[dim] // mesh_shape[cluster_axis]
+
+    torch_reference_slices = []
+    for x in range(mesh_shape[0]):
+        for y in range(mesh_shape[1]):
+            i, j = (x, y) if cluster_axis == 1 else (y, x)
+
+            torch_reference_slice = torch_reference[i].split(dim_per_device, dim=dim)[j]
+            torch_reference_slices.append(torch_reference_slice)
+
+    torch_reference = torch.concat(torch_reference_slices, dim=0)
+
+    print(f"{torch_reference.shape=}")
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=layout,
+        memory_config=memory_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(device, dim=0),
+        device=device,
+    )
+
+    return tt_input, torch_reference
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
+@pytest.mark.parametrize("input_shape", [[8, 8, 32, 32], [8, 8, 32], [8, 8, 8, 32, 32], [8, 8, 8, 8, 32, 32]])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("dim", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, topology):
+    if dim >= len(input_shape):
+        pytest.skip("Invalid gather dim")
+
+    tt_input, torch_reference = _get_tensors(
+        input_shape,
+        tuple(mesh_device.shape),
+        dim,
+        cluster_axis,
+        dtype,
+        memory_config,
+        ttnn.TILE_LAYOUT,
+        mesh_device,
+    )
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(3)]
+
+    for i in range(NUM_ITERS):
+        tt_out_tensor = ttnn.experimental.reduce_scatter_minimal_async(
+            tt_input,
+            dim=dim,
+            multi_device_global_semaphore=semaphores,
+            cluster_axis=cluster_axis,
+            topology=topology,
+        )
+
+        tt_output_tensor = torch.cat([ttnn.to_torch(t) for t in ttnn.get_device_tensors(tt_out_tensor)])
+        print(f"{tt_output_tensor.shape=}")
+        print(f"{torch_reference.shape=}")
+
+        eq, mess = comp_pcc(torch_reference, tt_output_tensor)
+        assert eq, mess

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/hal.hpp>
 #include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 #include "ttnn/operations/experimental/ccl/llama_common.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -18,7 +18,13 @@ bool is_fabric_2d() {
 
 // Map a dimension of an ND tensor to 4D. If dim > than rank difference, subtract rank difference.
 std::tuple<uint32_t, int32_t> normalize_dim_4d(const uint32_t dim, const uint32_t rank) {
-    constexpr int32_t RANK_4D = 4;
+    constexpr int32_t RANK_4D = 4, RANK_2D = 2;
+
+    // special case for rank 2
+    if (rank == RANK_2D) {
+        return std::make_tuple(RANK_2D + dim, RANK_2D);
+    }
+
     const auto rank_diff = static_cast<int32_t>(rank) - RANK_4D;
     const auto normalized_dim = (dim < std::abs(rank_diff)) ? dim : dim - rank_diff;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -15,16 +15,11 @@ bool is_fabric_2d() {
     return (
         fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D ||
         fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC);
+}
 
 // Map a dimension of an ND tensor to 4D. If dim > than rank difference, subtract rank difference.
 std::tuple<uint32_t, int32_t> normalize_dim_4d(const uint32_t dim, const uint32_t rank) {
-    constexpr int32_t RANK_4D = 4, RANK_2D = 2;
-
-    // special case for rank 2
-    if (rank == RANK_2D) {
-        return std::make_tuple(RANK_2D + dim, RANK_2D);
-    }
-
+    constexpr int32_t RANK_4D = 4;
     const auto rank_diff = static_cast<int32_t>(rank) - RANK_4D;
     const auto normalized_dim = (dim < std::abs(rank_diff)) ? dim : dim - rank_diff;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -19,7 +19,13 @@ bool is_fabric_2d() {
 
 // Map a dimension of an ND tensor to 4D. If dim > than rank difference, subtract rank difference.
 std::tuple<uint32_t, int32_t> normalize_dim_4d(const uint32_t dim, const uint32_t rank) {
-    constexpr int32_t RANK_4D = 4;
+    constexpr int32_t RANK_4D = 4, RANK_2D = 2;
+
+    // special case for rank 2
+    if (rank == RANK_2D) {
+        return std::make_tuple(RANK_2D + dim, RANK_2D);
+    }
+
     const auto rank_diff = static_cast<int32_t>(rank) - RANK_4D;
     const auto normalized_dim = (dim < std::abs(rank_diff)) ? dim : dim - rank_diff;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -24,6 +24,8 @@
 
 namespace composite_common {
 
+std::tuple<uint32_t, int32_t> normalize_dim_4d(uint32_t dim, uint32_t rank);
+
 bool use_composite_reduce_scatter(const ttnn::Tensor& input_tensor, int32_t dim, std::optional<uint32_t> cluster_axis);
 bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const ttnn::MemoryConfig& output_mem_config);
 bool use_composite_all_gather(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -27,8 +27,7 @@ void reduce_scatter_common_validates(
         page_size % input_tensor.buffer()->alignment() == 0,
         "reduce_scatter_minimal_async currently requires aligned pages");
 
-    TT_FATAL(
-        dim == 1 || dim == 2 || dim == 3, "reduce_scatter_minimal_async only supports scattering on dim 1, 2, or 3");
+    TT_FATAL(dim != 0, "reduce_scatter_minimal_async does not support scattering on 0th dimension, got: {}", dim);
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_scatter_minimal_async_op.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/global_semaphore.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.cpp
@@ -27,8 +27,6 @@ void reduce_scatter_common_validates(
         page_size % input_tensor.buffer()->alignment() == 0,
         "reduce_scatter_minimal_async currently requires aligned pages");
 
-    TT_FATAL(dim != 0, "reduce_scatter_minimal_async does not support scattering on 0th dimension, got: {}", dim);
-
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(
         input_tensor.buffer() != nullptr,
@@ -38,9 +36,22 @@ void reduce_scatter_common_validates(
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "input_tensor must be on device");
     TT_FATAL(input_tensor.buffer() != nullptr, "input_tensor must have a buffer");
 
-    if (dim == 2 || dim == 3) {
+    const auto& rank = input_tensor.logical_shape().rank();
+
+    TT_FATAL(rank > 1, "reduce_scatter currently supports rank 2 tensors at minimum");
+    TT_FATAL(dim < rank, "Invalid scatter dim {} for rank {} tensor", dim, rank);
+
+    if (rank > 2) {
+        TT_FATAL(
+            dim != 0,
+            "reduce_scatter_minimal_async does not support scattering on 0th dimension (unless rank 2), got: {}",
+            dim);
+    }
+
+    const uint32_t normalized_dim = std::get<0>(composite_common::normalize_dim_4d(dim, rank));
+    if (normalized_dim == 2 || normalized_dim == 3) {
         const auto& input_shape = input_tensor.padded_shape();
-        uint32_t tile_size = dim == 2 ? tt::constants::TILE_HEIGHT : tt::constants::TILE_WIDTH;
+        uint32_t tile_size = normalized_dim == 2 ? tt::constants::TILE_HEIGHT : tt::constants::TILE_WIDTH;
         TT_FATAL(
             (input_shape[dim] / tile_size) % ring_size == 0,
             "Error, The number of tiles at input tensor dimension {} should be divisible by ring_size but the number "

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1103,15 +1103,17 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
     };
 
-    const auto [normalized_dim, input_tensor_C, input_tensor_B] = map_nd_to_4d();
+    auto map_2d_to_4d = [&]() {
+        const uint32_t normalized_dim = std::get<0>(composite_common::normalize_dim_4d(dim, input_tensor_shape.rank()));
+        const uint32_t input_tensor_C = 1, input_tensor_B = 1;
 
-    // const uint32_t input_tensor_B = input_tensor_shape[0];
-    //  const uint32_t input_tensor_C = input_tensor_shape[-3];
+        return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
+    };
+
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2) ? map_2d_to_4d() : map_nd_to_4d();
     const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
     const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
-
-    std::cout << "Norm dim: " << normalized_dim << " C: " << input_tensor_C << " B: " << input_tensor_B
-              << " H: " << input_tensor_Ht << " W: " << input_tensor_Wt << std::endl;
 
     uint32_t slice_C = input_tensor_C;
     uint32_t slice_Ht = input_tensor_Ht;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/fabric.hpp>
 #include <tt-metalium/hal.hpp>
 #include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1066,14 +1066,14 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     // Tensor Info
     const auto& input_tensor_shape = input_tensor.padded_shape();
     TT_FATAL(
-        !(input_tensor_shape[2] % tt::constants::TILE_HEIGHT),
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
         "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[2],
+        input_tensor_shape[-2],
         tt::constants::TILE_HEIGHT);
     TT_FATAL(
-        !(input_tensor_shape[3] % tt::constants::TILE_WIDTH),
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
         "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[3],
+        input_tensor_shape[-1],
         tt::constants::TILE_WIDTH);
 
     const uint32_t input_tensor_B = input_tensor_shape[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -129,6 +129,43 @@ uint32_t default_chunks_per_sync(
     uint32_t total_chunks = std::max((tiles_to_read - tiles_read) / tile_granularity / 2, (uint32_t)1);
     return std::min(default_value, total_chunks);
 }
+
+auto map_nd_to_4d(const ttnn::Shape& shape, const uint32_t dim) {
+    // Here we do a couple of tricks so that the kernels can handle ND tensors
+    // implicitly reshape lower dims so it is treated as 4D
+
+    TT_FATAL(shape.rank() > 2, "Expected rank 3 or greater");
+
+    uint32_t input_tensor_B = std::accumulate(shape.cbegin(), shape.cend() - 3, 1, std::multiplies<uint32_t>());
+
+    auto [normalized_dim, rank_diff] = composite_common::normalize_dim_4d(dim, shape.rank());
+
+    uint32_t c_includes_dim;
+    if (rank_diff >= 1 && dim <= rank_diff) {
+        // gather dim to rank-3 accumulated into C
+        c_includes_dim = dim;
+        normalized_dim = 1;
+    } else {
+        // C will be 4D normalized dim 1
+        c_includes_dim = 1 + rank_diff;
+    }
+
+    uint32_t input_tensor_C = std::accumulate(
+        shape.view().rbegin() + 2, shape.view().rend() - c_includes_dim, 1, std::multiplies<uint32_t>());
+
+    return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
+};
+
+auto map_2d_to_4d(const uint32_t dim) {
+    constexpr auto RANK_2D = 2;
+    TT_FATAL(dim == 0 || dim == 1, "Expected dim 0 or 1");
+
+    const uint32_t normalized_dim = std::get<0>(composite_common::normalize_dim_4d(dim, RANK_2D));
+    const uint32_t input_tensor_C = 1, input_tensor_B = 1;
+
+    return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
+};
+
 }  // namespace operations::experimental::ccl::detail
 
 using namespace ccl;
@@ -391,29 +428,30 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     // Tensor Info
     const auto& input_tensor_shape = input_tensor.padded_shape();
     TT_FATAL(
-        !(input_tensor_shape[2] % tt::constants::TILE_HEIGHT),
+        !(input_tensor_shape[-2] % tt::constants::TILE_HEIGHT),
         "Input tensor height ({}) must be divisible by tile height ({}).",
-        input_tensor_shape[2],
+        input_tensor_shape[-2],
         tt::constants::TILE_HEIGHT);
     TT_FATAL(
-        !(input_tensor_shape[3] % tt::constants::TILE_WIDTH),
+        !(input_tensor_shape[-1] % tt::constants::TILE_WIDTH),
         "Input tensor width ({}) must be divisible by tile width ({}).",
-        input_tensor_shape[3],
+        input_tensor_shape[-1],
         tt::constants::TILE_WIDTH);
 
-    const uint32_t input_tensor_B = input_tensor_shape[0];
-    const uint32_t input_tensor_C = input_tensor_shape[1];
-    const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
-    const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
+    const auto [normalized_dim, input_tensor_C, input_tensor_B] =
+        (input_tensor_shape.rank() == 2) ? operations::experimental::ccl::detail::map_2d_to_4d(dim)
+                                         : operations::experimental::ccl::detail::map_nd_to_4d(input_tensor_shape, dim);
+    const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
+    const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
 
     uint32_t slice_C = input_tensor_C;
     uint32_t slice_Ht = input_tensor_Ht;
     uint32_t slice_Wt = input_tensor_Wt;
-    if (dim == 1) {
+    if (normalized_dim == 1) {
         slice_C /= ring_size;
-    } else if (dim == 2) {
+    } else if (normalized_dim == 2) {
         slice_Ht /= ring_size;
-    } else if (dim == 3) {
+    } else if (normalized_dim == 3) {
         slice_Wt /= ring_size;
     } else {
         TT_FATAL(false, "reduce_scatter_minimal_async ring implementation only supports scattering on dim 1, 2, or 3");
@@ -576,7 +614,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                     fuse_op,                  // fused op
                     dir,                      // direction
                     chunks_per_sync_val,      // chunks_per_sync
-                    dim,                      // dim
+                    normalized_dim,           // dim normalized to 4D
                     start_pages_read_in_row,  // start_pages_read_in_row
                     start_row_offset,         // start_row_offset
                     start_tiles_read,         // start_tiles_read
@@ -641,7 +679,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                     slice_Wt,                       // slice_Wt
                     dir,                            // direction
                     chunks_per_sync_val,            // chunks_per_sync
-                    dim,                            // dim
+                    normalized_dim,                 // dim normalized to 4D
                     start_pages_read_in_row,        // start_pages_read_in_row
                     start_row_offset,               // start_row_offset
                     start_tiles_read,               // start_tiles_read
@@ -1076,42 +1114,9 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         input_tensor_shape[-1],
         tt::constants::TILE_WIDTH);
 
-    auto map_nd_to_4d = [&]() {
-        // Here we do a couple of tricks so that the kernels can handle ND tensors
-        // implicitly reshape lower dims so it is treated as 4D
-        uint32_t input_tensor_B =
-            std::accumulate(input_tensor_shape.cbegin(), input_tensor_shape.cend() - 3, 1, std::multiplies<uint32_t>());
-
-        auto [normalized_dim, rank_diff] = composite_common::normalize_dim_4d(dim, input_tensor_shape.rank());
-
-        uint32_t c_includes_dim;
-        if (rank_diff >= 1 && dim <= rank_diff) {
-            // gather dim to rank-3 accumulated into C
-            c_includes_dim = dim;
-            normalized_dim = 1;
-        } else {
-            // C will be 4D normalized dim 1
-            c_includes_dim = 1 + rank_diff;
-        }
-
-        uint32_t input_tensor_C = std::accumulate(
-            input_tensor_shape.view().rbegin() + 2,
-            input_tensor_shape.view().rend() - c_includes_dim,
-            1,
-            std::multiplies<uint32_t>());
-
-        return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
-    };
-
-    auto map_2d_to_4d = [&]() {
-        const uint32_t normalized_dim = std::get<0>(composite_common::normalize_dim_4d(dim, input_tensor_shape.rank()));
-        const uint32_t input_tensor_C = 1, input_tensor_B = 1;
-
-        return std::make_tuple(normalized_dim, input_tensor_C, input_tensor_B);
-    };
-
     const auto [normalized_dim, input_tensor_C, input_tensor_B] =
-        (input_tensor_shape.rank() == 2) ? map_2d_to_4d() : map_nd_to_4d();
+        (input_tensor_shape.rank() == 2) ? operations::experimental::ccl::detail::map_2d_to_4d(dim)
+                                         : operations::experimental::ccl::detail::map_nd_to_4d(input_tensor_shape, dim);
     const uint32_t input_tensor_Ht = input_tensor_shape[-2] / tt::constants::TILE_HEIGHT;
     const uint32_t input_tensor_Wt = input_tensor_shape[-1] / tt::constants::TILE_WIDTH;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -32,11 +32,14 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> num_buffers_per_channel) {
     log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
     if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
+        std::cout << "COMPOSITE REDUCE SCATTER" << std::endl;
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
             input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
         log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
+        std::cout << "MINIMAL REDUCE SCATTER" << std::endl;
+
         return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
             input_tensor,
             persistent_output_buffers,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -32,14 +32,11 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     std::optional<uint32_t> num_buffers_per_channel) {
     log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
     if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
-        std::cout << "COMPOSITE REDUCE SCATTER" << std::endl;
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
             input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
         log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
-        std::cout << "MINIMAL REDUCE SCATTER" << std::endl;
-
         return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
             input_tensor,
             persistent_output_buffers,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26574
https://github.com/tenstorrent/tt-metal/issues/15010
https://github.com/tenstorrent/tt-metal/issues/26572

### Problem description
Reduce scatter only supported 4D tensors.

### What's changed
- Add support for ND tensors to reduce scatter through implicit remapping.
- 2D and greater supported, reduce on any dim.
- Fall back to composite where appropriate: non-aligned and dim 0 reductions. 
- Composite and minimal cases tested

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18693752256
- [x] Blackhole Multi-Card demo https://github.com/tenstorrent/tt-metal/actions/runs/18693773661
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/18693790029
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/18727048144
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/18727052947
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/18760153754 (timing out but so is main. Runs ok locally)
- [x] New/Existing tests provide coverage for changes