### PR TITLE
Remove dead include in kernel source again

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
-#include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"


### PR DESCRIPTION
### Ticket
NA

### Problem description
This is a TTNN kernel that is including a kernel header file from the
tests directory.
This source file <-> test file interaction is problematic to begin with.
Furthermore, nothing in the tests/ directory is packaged, so this should
never work in a clean packaged environment.
Lastly, this header file provides nothing to this translation unit. It
is a dead include.

### What's changed
- rm -rf

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes