### PR TITLE
#30740 Enable local sfpi builds

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -33,23 +33,32 @@ set(IRAM_OPTIONS
 )
 
 # determine sfpi version information
-set(SFPI_ROOT "${PROJECT_SOURCE_DIR}/runtime/sfpi")
-file(MAKE_DIRECTORY ${SFPI_ROOT})
-# sfpi-version.sh generates a cmake script, which we include just below.
+set(SFPI_BASE "${PROJECT_SOURCE_DIR}/runtime")
+file(MAKE_DIRECTORY ${SFPI_BASE})
+
+# sfpi-info.sh generates a cmake script, which we include just below.
 execute_process(
     COMMAND
         ${CMAKE_CURRENT_SOURCE_DIR}/../sfpi-info.sh CMAKE txz
-    OUTPUT_FILE ${SFPI_ROOT}/sfpi-version.cmake
+    OUTPUT_FILE ${SFPI_BASE}/sfpi-version.cmake
     COMMAND_ERROR_IS_FATAL ANY
 )
+# sfpi-info.sh sources sfpi-version, if either changes we should reconfigure
+set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY
+        CMAKE_CONFIGURE_DEPENDS
+            "../sfpi-info.sh;../sfpi-version"
+)
 # this script sets a bunch of variables of the form SFPI_snake_case_name
-include(${SFPI_ROOT}/sfpi-version.cmake)
+include(${SFPI_BASE}/sfpi-version.cmake)
 
 if(TT_USE_SYSTEM_SFPI)
     # we'll use the system's version
-    set(SFPI_ROOT "/opt/tenstorrent/sfpi")
+    set(SFPI_BASE "/opt/tenstorrent")
 elseif(NOT "${SFPI_md5}" STREQUAL "")
-    # download a toolchain as directed by sfpi_info's output
+    # download a toolchain
     include(FetchContent)
     FetchContent_Declare(
         sfpi
@@ -57,28 +66,41 @@ elseif(NOT "${SFPI_md5}" STREQUAL "")
             "${SFPI_url}/${SFPI_filename}"
         URL_HASH "MD5=${SFPI_md5}"
         SOURCE_DIR
-        "${SFPI_ROOT}"
+        "${SFPI_BASE}/sfpi"
     )
     FetchContent_MakeAvailable(sfpi)
 else()
-    # FIXME:This is where we'd clone sfpi and build it locally
-    # something like (untested meta-code)
-    # git clone -b ${SFPI_version} -depth 1 ${SFPI_repo} ${LOCAL_PATH}
-    # cd ${LOCAL_PATH}
-    # scripts/build.sh --test-tt
-    # tar -C build cf - sfpi | tar -C ${SFPI_ROOT} xf -
-    # add some caching so we don't do this every time!
-    # you'll have to install a bunch of packages for this to work
-    # Perhaps, sfpi-version.sh should be augmented to do all that,
-    # seems like the right place.
-    # if NOT EXISTS $LOCATION/sfpi.tgz
-    # sfpi-version.sh BUILD $LOCATION > sfpi-build.log
-    # endif
-    # tar xzf $LOCATION/sfpi.tgz -c ${SFPI_ROOT}/..
-    message(FATAL_ERROR "SFPI tarball for ${SFPI_arch} ${SFPI_dist} is not available")
+    message(STATUS "No downloadable SFPI tarball for ${SFPI_arch} ${SFPI_dist}")
+    if(IS_READABLE "${SFPI_BASE}/${SFPI_filename}")
+        message(STATUS "Locally-built ${SFPI_filename} present")
+    else()
+        file(REMOVE_RECURSE "${SFPI_BASE}/sfpi")
+        message(
+            STATUS
+            "Building SFPI, this could take some time (~10 CPU-hours)\n"
+            "Logging to ${SFPI_BASE}/sfpi-build.log ..."
+        )
+        execute_process(
+            COMMAND
+                ${CMAKE_CURRENT_SOURCE_DIR}/../sfpi-info.sh BUILD ${SFPI_BASE}/sfpi-src
+            OUTPUT_FILE ${SFPI_BASE}/sfpi-build.log
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+    endif()
+    if(EXISTS "${SFPI_BASE}/sfpi")
+        message(STATUS "Locally-built toolchain present")
+    else()
+        message(STATUS "Unpacking locally-built ${SFPI_filename}")
+        execute_process(
+            COMMAND
+                tar xJf ${SFPI_BASE}/${SFPI_filename}
+            WORKING_DIRECTORY ${SFPI_BASE}
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+    endif()
 endif()
 
-set(GPP_CMD "${SFPI_ROOT}/compiler/bin/riscv-tt-elf-g++")
+set(GPP_CMD "${SFPI_BASE}/sfpi/compiler/bin/riscv-tt-elf-g++")
 if(NOT EXISTS "${GPP_CMD}")
     message(FATAL_ERROR "GPP_CMD path '${GPP_CMD}' does not exist. Please check your configuration.")
 endif()
@@ -95,7 +117,14 @@ message(STATUS "Using SFPI compiler: ${GPP_CMD} ${GPP_VERSION}")
 # check this is the version we want (the system version might be wrong)
 string(REGEX REPLACE "^\\([^:]*:([^)]*)\\) .*$" "\\1" GPP_VERSION ${GPP_VERSION})
 if(NOT ${GPP_VERSION} STREQUAL ${SFPI_version})
-    message(FATAL_ERROR "SFPI compiler version ${GPP_VERSION} does not match required SFPI version ${SFPI_version}")
+    if(TT_USE_SYSTEM_SFPI)
+        message(
+            FATAL_ERROR
+            "Installed SFPI version ${GPP_VERSION} does not match required version ${SFPI_version}\nYou need to run `${PROJECT_SOURCE_DIR}/install_dependencies.sh --sfpi`."
+        )
+    else()
+        message(FATAL_ERROR "SFPI packaging malfunction, ${SFPI_version} delivers ${GPP_VERSION}")
+    endif()
 endif()
 
 if(NOT TT_USE_SYSTEM_SFPI)
@@ -104,8 +133,8 @@ if(NOT TT_USE_SYSTEM_SFPI)
     # undefined symbol: blob\t(./a.out)
     file(
         GLOB SFPI_BINARIES
-        "${SFPI_ROOT}/compiler/bin/*"
-        "${SFPI_ROOT}/compiler/libexec/gcc/*"
+        "${SFPI_BASE}/sfpi/compiler/bin/*"
+        "${SFPI_BASE}/sfpi/compiler/libexec/gcc/riscv-tt-elf/*/*"
     )
     execute_process(
         COMMAND

--- a/tt_metal/sfpi-info.sh
+++ b/tt_metal/sfpi-info.sh
@@ -157,13 +157,13 @@ echo "Fetching the repository ..." >&1 >&2
 if ! [[ -d .git ]]; then
     (set -x; \
      git clone -b $sfpi_version --depth 1 $sfpi_repo .; \
-     git submodules update --depth 1 --init --recursive; \
+     git submodule update --depth 1 --init --recursive; \
      )
 else
     (set -x; \
      git fetch --depth 1 $sfpi_repo $sfpi_version; \
      git checkout $sfpi_version; \
-     git submodules update --depth 1 --init --recursive; \
+     git submodule update --depth 1 --init --recursive; \
      )
 fi
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30740

### Problem description
Users on non-debian-like, non-fedora-like systems or non-x86_64, non-aarch64 systems need to build their own sfpi, and integrate that into tt_metal.  That is not trivial.

### What's changed
* Add smarts to sfpi-info.sh to clone, build & package sfpi.
* Add smarts to CMakeLists.txt to invoke that flow when there is no available tarball.

While there we also noticed an versioning issue (https://tenstorrent.slack.com/archives/C06JU0GUNGY/p1760995856623709 )
1) the cmake file didn't mark sfpi-info.sh nor sfpi-version as cmake dependencies, so there wouldn't be a reconfigure on their update
2) the error message from a mismatch could be clearer about what the remedial action is

Manually tested by disabling download of tarball.  The build output looks like:
```
-- No downloadable SFPI tarball for x86_64 linux
-- Building SFPI, this could take some time (~10 CPU-hours)
Logging to /home/nathan/tt-metal/build-30740/runtime/sfpi-build.log ...
Building SFPI 7.5.0
Working Directory: /home/nathan/tt-metal/build-30740/runtime/sfpi-src

Install (or otherwise provide) the following components:
Common names: autoconf automake bison expect flex gawk patchutils python3 texinfo
Debian names: gcc g++ libgmp-dev libmpc-dev libmpfr-dev
Fedora names: gcc gcc-c++ gmp-devel libmpc-devel mpfr-devel

This script cannot install them as it knows neither your system's
packaging system, nor how it might have named them. You will have to
research that from the above clues. If required components are missing
the build will fail, sometimes with a clueful message. Please report
any additional packages you discover are necessary.

Fetching the repository ...
+ git clone -b 7.5.0 --depth 1 https://github.com/tenstorrent/sfpi .
Cloning into '.'...
Note: switching to '36823de85ccc1314f17f587c06e0a6508e766fb9'.
---8< snip 8< sno[ 8< snip
Building ...
+ rm -rf build
+ scripts/build.sh --test-tt
+ scripts/release.sh --txz-only
INFO: Version: 7.5.0
INFO: Tarball: build/release/sfpi_7.5.0_x86_64_linux.txz
INFO: MD5: build/release/sfpi_7.5.0_x86_64_linux.md5
SFPI build completed
-- Unpacking locally-built sfpi_7.5.0_x86_64_linux.txz
-- Using SFPI compiler: /home/nathan/tt-metal/build-30740/runtime/sfpi/compiler/bin/riscv-tt-elf-g++ (tenstorrent/sfpi:7.5.0) 15.1.0
```

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes