### PR TITLE
#30233 - Improve `test_tutorials.py` exception handling in module setup.

### DIFF
--- a/tests/ttnn/notebook_tests/test_tutorials.py
+++ b/tests/ttnn/notebook_tests/test_tutorials.py
@@ -5,6 +5,7 @@
 import os
 import subprocess
 from pathlib import Path
+from loguru import logger
 
 from models.common.utility_functions import skip_for_blackhole
 import nbformat
@@ -89,8 +90,8 @@ def setup_once(model_location_generator):
                 local_path_obj.unlink()  # Remove existing symlink/file
             local_path_obj.symlink_to(data_placement.parent)
         except Exception as e:
-            print(
-                f"Warning: Could not set up data for tutorial {tutorial_id}. Error: {e}. Data will be downloaded at runtime from original source."
+            logger.warning(
+                f"Could not set up data for tutorial {tutorial_id}. Error: {e}. Data will be downloaded at runtime from original source."
             )
 
 


### PR DESCRIPTION
### Ticket
#30233

### Problem Description
Previously, two scripts responsible for training and saving weights for the tutorials were included in the full test suite, which unnecessarily increased the overall runtime. Additionally, there was no exception handling when downloading data from CIv2 LFC in the `setup_once` function.

### What’s Changed
- Added an excluded tutorials container to skip training scripts during tests.
- Introduced try-catch error handling for data downloads.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18685651101
- [ ] [L2 nightly C++ test](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?) CI with demo tests passes https://github.com/tenstorrent/tt-metal/actions/runs/18648824440/job/53162369965