### PR TITLE
Extend Llama long context demo tests by 15min

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         test-group: [
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "Galaxy Llama3 long context demo tests", arch: wormhole_b0, model: llama3_long_context, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "Galaxy Llama3 long context demo tests", arch: wormhole_b0, model: llama3_long_context, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "Galaxy Llama3 evals tests", arch: wormhole_b0, model: llama3_evals, timeout: 45, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
           { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic


### PR DESCRIPTION
### Problem description
CI failure in long context tests on llama 70b because of a recent PR that compiles all the prefill traces in the beginning of the run to avoid output mismatch issues. Hence each test now takes slightly longer time.

### What's changed
- Extending the timeout of long context tests by 15min

### Checklist
- [ ] [Galaxy Demo CI](https://github.com/tenstorrent/tt-metal/actions/runs/18662872743)