### PR TITLE
[Adaptive pool] Adaptive pool tests were missing random generator seed

### DIFF
--- a/tests/sweep_framework/sweep_utils/adaptive_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/adaptive_pool2d_common.py
@@ -42,6 +42,7 @@ def run_adaptive_pool2d(
     if dtype == ttnn.bfloat16 and in_n == 1 and in_c == 64 and in_h == 224 and in_w == 224:
         pytest.skip(f"Skipping memory-intensive case [1, 64, 224, 224] -> [{out_h}, {out_w}] with {dtype} due to OOM")
 
+    torch.manual_seed(1301)
     torch_input = randomize_tensor(tensor_map, input_shape)
 
     # Convert to TTNN format [1, 1, NHW, C]

--- a/tests/sweep_framework/sweep_utils/adaptive_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/adaptive_pool2d_common.py
@@ -42,7 +42,7 @@ def run_adaptive_pool2d(
     if dtype == ttnn.bfloat16 and in_n == 1 and in_c == 64 and in_h == 224 and in_w == 224:
         pytest.skip(f"Skipping memory-intensive case [1, 64, 224, 224] -> [{out_h}, {out_w}] with {dtype} due to OOM")
 
-    torch.manual_seed(1301)
+    torch.manual_seed(0)
     torch_input = randomize_tensor(tensor_map, input_shape)
 
     # Convert to TTNN format [1, 1, NHW, C]

--- a/tests/ttnn/unit_tests/operations/pool/test_adaptive_pool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_adaptive_pool2d.py
@@ -50,7 +50,7 @@ failing_parameters = [
     "pool_type",
     ["max", "avg"],
 )
-def test_adaptive_avg_pool2d(
+def test_adaptive_pool2d(
     device,
     tensor_map,
     input_shape,


### PR DESCRIPTION
### Problem description
Due to the fact that the input tensor random generator was missing a seed in the adaptive pool tests some of the APC runs were failing from time to time because pcc set were too strict for some seeds 

### What's changed
Random generator seed was added, and test function name was changed since it had specification of the pool type in the name whereas it tested both maxpool and avgpool.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18691247325)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18691258782)