### PR TITLE
Prometheus Metrics Exporter

### DIFF
--- a/tt_telemetry/CMakeLists.txt
+++ b/tt_telemetry/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(
         telemetry/telemetry_collector.cpp
         telemetry/metric.cpp
         server/web_server.cpp
+        server/prom_writer.cpp
         server/collection_endpoint.cpp
         server/collection_clients.cpp
         topology/topology.cpp

--- a/tt_telemetry/include/server/prom_writer.hpp
+++ b/tt_telemetry/include/server/prom_writer.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <future>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <telemetry/telemetry_subscriber.hpp>
+
+/*
+ * server/prom_writer.hpp
+ *
+ * File writer of telemetry data in Prometheus (.prom) format.
+ */
+
+std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_prom_writer(std::string_view file_path);

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -243,3 +243,84 @@ static inline void from_json(const nlohmann::json &j, TelemetrySnapshot &t) {
     j.at("metric_unit_display_label_by_code").get_to(t.metric_unit_display_label_by_code);
     j.at("metric_unit_full_label_by_code").get_to(t.metric_unit_full_label_by_code);
 }
+
+static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snapshot) {
+    if (!snapshot) {
+        return;
+    }
+    
+    std::cout << "\n=== Telemetry Snapshot ===" << std::endl;
+    std::cout << "Timestamp: " << std::chrono::system_clock::now().time_since_epoch().count() << std::endl;
+    
+    // Print bool metrics
+    if (!snapshot->bool_metrics.empty()) {
+        std::cout << "\nBool metrics (" << snapshot->bool_metrics.size() << "):" << std::endl;
+        for (const auto& [path, value] : snapshot->bool_metrics) {
+            std::cout << "  " << path << ": " << (value ? "true" : "false");
+            
+            // Add timestamp if available
+            if (snapshot->bool_metric_timestamps.count(path)) {
+                std::cout << " (ts: " << snapshot->bool_metric_timestamps.at(path) << ")";
+            }
+            std::cout << std::endl;
+        }
+    }
+    
+    // Print uint metrics
+    if (!snapshot->uint_metrics.empty()) {
+        std::cout << "\nUint metrics (" << snapshot->uint_metrics.size() << "):" << std::endl;
+        for (const auto& [path, value] : snapshot->uint_metrics) {
+            std::cout << "  " << path << ": " << value;
+            
+            // Add unit if available
+            if (snapshot->uint_metric_units.count(path)) {
+                uint16_t unit_code = snapshot->uint_metric_units.at(path);
+                if (snapshot->metric_unit_display_label_by_code.count(unit_code)) {
+                    std::cout << " " << snapshot->metric_unit_display_label_by_code.at(unit_code);
+                }
+            }
+            
+            // Add timestamp if available
+            if (snapshot->uint_metric_timestamps.count(path)) {
+                std::cout << " (ts: " << snapshot->uint_metric_timestamps.at(path) << ")";
+            }
+            std::cout << std::endl;
+        }
+    }
+    
+    // Print double metrics
+    if (!snapshot->double_metrics.empty()) {
+        std::cout << "\nDouble metrics (" << snapshot->double_metrics.size() << "):" << std::endl;
+        for (const auto& [path, value] : snapshot->double_metrics) {
+            std::cout << "  " << path << ": " << std::fixed << std::setprecision(3) << value;
+            
+            // Add unit if available
+            if (snapshot->double_metric_units.count(path)) {
+                uint16_t unit_code = snapshot->double_metric_units.at(path);
+                if (snapshot->metric_unit_display_label_by_code.count(unit_code)) {
+                    std::cout << " " << snapshot->metric_unit_display_label_by_code.at(unit_code);
+                }
+            }
+            
+            // Add timestamp if available
+            if (snapshot->double_metric_timestamps.count(path)) {
+                std::cout << " (ts: " << snapshot->double_metric_timestamps.at(path) << ")";
+            }
+            std::cout << std::endl;
+        }
+    }
+    
+    // Print unit mappings if any new ones
+    if (!snapshot->metric_unit_display_label_by_code.empty()) {
+        std::cout << "\nUnit mappings:" << std::endl;
+        for (const auto& [code, label] : snapshot->metric_unit_display_label_by_code) {
+            std::cout << "  " << code << ": " << label;
+            if (snapshot->metric_unit_full_label_by_code.count(code)) {
+                std::cout << " (" << snapshot->metric_unit_full_label_by_code.at(code) << ")";
+            }
+            std::cout << std::endl;
+        }
+    }
+    
+    std::cout << "=========================" << std::endl;
+}

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <iomanip>
 
 #include <nlohmann/json.hpp>
 #include <telemetry/metric.hpp>
@@ -248,16 +249,16 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
     if (!snapshot) {
         return;
     }
-    
+
     std::cout << "\n=== Telemetry Snapshot ===" << std::endl;
     std::cout << "Timestamp: " << std::chrono::system_clock::now().time_since_epoch().count() << std::endl;
-    
+
     // Print bool metrics
     if (!snapshot->bool_metrics.empty()) {
         std::cout << "\nBool metrics (" << snapshot->bool_metrics.size() << "):" << std::endl;
         for (const auto& [path, value] : snapshot->bool_metrics) {
             std::cout << "  " << path << ": " << (value ? "true" : "false");
-            
+
             // Add timestamp if available
             if (snapshot->bool_metric_timestamps.count(path)) {
                 std::cout << " (ts: " << snapshot->bool_metric_timestamps.at(path) << ")";
@@ -265,13 +266,13 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
             std::cout << std::endl;
         }
     }
-    
+
     // Print uint metrics
     if (!snapshot->uint_metrics.empty()) {
         std::cout << "\nUint metrics (" << snapshot->uint_metrics.size() << "):" << std::endl;
         for (const auto& [path, value] : snapshot->uint_metrics) {
             std::cout << "  " << path << ": " << value;
-            
+
             // Add unit if available
             if (snapshot->uint_metric_units.count(path)) {
                 uint16_t unit_code = snapshot->uint_metric_units.at(path);
@@ -279,7 +280,7 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
                     std::cout << " " << snapshot->metric_unit_display_label_by_code.at(unit_code);
                 }
             }
-            
+
             // Add timestamp if available
             if (snapshot->uint_metric_timestamps.count(path)) {
                 std::cout << " (ts: " << snapshot->uint_metric_timestamps.at(path) << ")";
@@ -287,13 +288,13 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
             std::cout << std::endl;
         }
     }
-    
+
     // Print double metrics
     if (!snapshot->double_metrics.empty()) {
         std::cout << "\nDouble metrics (" << snapshot->double_metrics.size() << "):" << std::endl;
         for (const auto& [path, value] : snapshot->double_metrics) {
             std::cout << "  " << path << ": " << std::fixed << std::setprecision(3) << value;
-            
+
             // Add unit if available
             if (snapshot->double_metric_units.count(path)) {
                 uint16_t unit_code = snapshot->double_metric_units.at(path);
@@ -301,7 +302,7 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
                     std::cout << " " << snapshot->metric_unit_display_label_by_code.at(unit_code);
                 }
             }
-            
+
             // Add timestamp if available
             if (snapshot->double_metric_timestamps.count(path)) {
                 std::cout << " (ts: " << snapshot->double_metric_timestamps.at(path) << ")";
@@ -309,7 +310,7 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
             std::cout << std::endl;
         }
     }
-    
+
     // Print unit mappings if any new ones
     if (!snapshot->metric_unit_display_label_by_code.empty()) {
         std::cout << "\nUnit mappings:" << std::endl;
@@ -321,6 +322,6 @@ static inline void print_snapshot(const std::shared_ptr<TelemetrySnapshot>& snap
             std::cout << std::endl;
         }
     }
-    
+
     std::cout << "=========================" << std::endl;
 }

--- a/tt_telemetry/server/main.cpp
+++ b/tt_telemetry/server/main.cpp
@@ -198,15 +198,10 @@ int main(int argc, char* argv[]) {
     bool print_link_health = result["print-link-health"].as<bool>();
     int port = result["port"].as<int>();
     int collector_port = result["collector-port"].as<int>();
-<<<<<<< HEAD
-    std::string metal_src_dir = "";
-    if (result.contains("metal-src-dir")) {
-=======
 
     std::string metal_src_dir;
     // Check if metal-src-dir was provided; else fallback to environment var
     if (result.count("metal-src-dir")) {
->>>>>>> 7a54feed67 (Add initial PromWriter implementation)
         metal_src_dir = result["metal-src-dir"].as<std::string>();
     } else {
         const char* env_metal_home = std::getenv("TT_METAL_HOME");
@@ -283,8 +278,6 @@ int main(int argc, char* argv[]) {
         log_info(tt::LogAlways, "Starting Prometheus metrics writer");
         std::future<bool> prom_writer_future;
         std::shared_ptr<TelemetrySubscriber> prom_writer_subscriber;
-        // TODO(kkfernandez): figure out a nice location
-        // TODO(kkfernandez): portable path construction
         std::tie(prom_writer_future, prom_writer_subscriber) = run_prom_writer(prom_metrics_file);
         subscribers.push_back(prom_writer_subscriber);
     } else {

--- a/tt_telemetry/server/main.cpp
+++ b/tt_telemetry/server/main.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <optional>
 #include <sstream>
+#include <filesystem>
 
 #include <boost/functional/hash.hpp>
 #include <cxxopts.hpp>
@@ -157,6 +158,8 @@ int main(int argc, char* argv[]) {
     // Parse command line arguments
     cxxopts::Options options("tt_telemetry_server", "TT-Metal Telemetry Server");
 
+    std::filesystem::path relative_metrics_path = std::filesystem::path("tt_telemetry") / "output" / "metrics.prom";
+
     options.add_options()(
         "mock-telemetry",
         "Use mock telemetry data instead of real hardware",
@@ -177,7 +180,7 @@ int main(int argc, char* argv[]) {
         "Enable Prometheus metrics writer to periodically write metrics to a file",
         cxxopts::value<bool>()->default_value("false"))(
         "prom-metrics-file",
-        "Path to the Prometheus metrics file (default: <metal-src-dir>/tt_telemetry/telemetry/metrics.prom)",
+        "Path to the Prometheus metrics file (default: <metal-src-dir>/" + relative_metrics_path.string() + ")",
         cxxopts::value<std::string>())(
         "metal-src-dir",
         "Metal source directory (optional, defaults to TT_METAL_HOME env var)",
@@ -218,9 +221,9 @@ int main(int argc, char* argv[]) {
     if (result.count("prom-metrics-file")) {
         prom_metrics_file = result["prom-metrics-file"].as<std::string>();
     } else if (!metal_src_dir.empty()) {
-        prom_metrics_file = metal_src_dir + "/tt_telemetry/telemetry/metrics.prom"; // TODO(kkfernandez): portable paths
+        prom_metrics_file = (std::filesystem::path(metal_src_dir) / relative_metrics_path.string()).string();
     } else {
-        prom_metrics_file = "metrics.prom";
+        prom_metrics_file = relative_metrics_path.filename().string();
     }
 
     bool use_prom_writer = result["use-prom-writer"].as<bool>();

--- a/tt_telemetry/server/main.cpp
+++ b/tt_telemetry/server/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char* argv[]) {
     if (result.count("prom-metrics-file")) {
         prom_metrics_file = result["prom-metrics-file"].as<std::string>();
     } else if (!metal_src_dir.empty()) {
-        prom_metrics_file = (std::filesystem::path(metal_src_dir) / relative_metrics_path.string()).string();
+        prom_metrics_file = (std::filesystem::path(metal_src_dir) / relative_metrics_path).string();
     } else {
         prom_metrics_file = relative_metrics_path.filename().string();
     }

--- a/tt_telemetry/server/prom_writer.cpp
+++ b/tt_telemetry/server/prom_writer.cpp
@@ -13,6 +13,7 @@
 #include <condition_variable>
 #include <telemetry/telemetry_subscriber.hpp>
 #include <server/prom_writer.hpp>
+#include <unistd.h>
 
 class PromWriter : public TelemetrySubscriber {
 private:
@@ -23,7 +24,9 @@ private:
     std::queue<std::shared_ptr<TelemetrySnapshot>> pending_snapshots_;
     std::mutex snapshot_mutex_;
     std::condition_variable snapshot_cv_;
-    
+    std::string system_info_;
+    const std::string hostname_;
+
     // Current state of all metrics
     struct MetricState {
         struct MetricData {
@@ -36,116 +39,134 @@ private:
     };
     MetricState current_state_;
     std::mutex state_mutex_;
-    
+
     static constexpr std::chrono::milliseconds snapshot_check_timeout_{1000};
-    
+
+    static std::string get_hostname() {
+        char hostname[256];
+        if (gethostname(hostname, sizeof(hostname)) != 0) {
+            throw std::runtime_error("Failed to get hostname");
+        }
+        std::string hostname_str(hostname);
+        return hostname_str;
+    }
+
     std::string sanitize_metric_name(std::string_view path) {
-        // Prefix with a standard namespace
-        std::string sanitized_prefix = "tt_metal_";
-        
+        std::string path_str(path);
+
+        // Find and remove hostname from the path
+        size_t hostname_pos = path_str.find(hostname_);
+        if (hostname_pos == std::string::npos) {
+            throw std::runtime_error("Metric path does not contain hostname '" + hostname_ + "': " + path_str);
+        }
+
+        // Skip hostname and the expected slash after it
+        size_t after_hostname = hostname_pos + hostname_.length();
+        if (after_hostname >= path_str.length() || path_str[after_hostname] != '/') {
+            throw std::runtime_error("Expected slash after hostname in metric path: " + path_str);
+        }
+        after_hostname++;  // Skip the slash
+        path_str = path_str.substr(after_hostname);
+
         // Convert to valid Prometheus metric name
-        std::string sanitized_name;
-        
-        // Ensure first character is a letter or underscore
-        if (path.empty()) {
-            return sanitized_prefix + "unnamed_metric";
-        }
-        
-        // First character must be a letter or underscore
-        if (!std::isalpha(path[0]) && path[0] != '_') {
-            sanitized_name = '_';
-        }
-        
-        // Subsequent characters can be alphanumeric or underscore
-        for (char c : path) {
-            if (std::isalnum(c) || c == '_' || c == ':') {
-                sanitized_name += c;
+        std::string sanitized;  // TODO(kkfernandez): this could be prefixed with "tt_metal_"
+        for (char c : path_str) {
+            if (std::isalnum(c) || c == '_') {
+                sanitized += c;
             } else {
-                // Replace unsupported characters with underscore
-                sanitized_name += '_';
+                sanitized += '_';
             }
         }
-        
-        return sanitized_prefix + sanitized_name;
+
+        return sanitized;
     }
-    
+
     void update_state_from_snapshot(const TelemetrySnapshot& snapshot) {
         std::lock_guard<std::mutex> lock(state_mutex_);
-        
-        // Update bool metrics
-        for (const auto& [path, value] : snapshot.bool_metrics) {
-            MetricState::MetricData data;
-            data.value = std::to_string(value ? 1 : 0);
-            data.help_text = "Boolean metric from Tenstorrent Metal";
-            
-            auto ts_it = snapshot.bool_metric_timestamps.find(path);
-            data.timestamp = (ts_it != snapshot.bool_metric_timestamps.end()) ? ts_it->second : 0;
-            
-            current_state_.metrics[sanitize_metric_name(path)] = data;
-        }
-        
-        // Update uint metrics
-        for (const auto& [path, value] : snapshot.uint_metrics) {
-            MetricState::MetricData data;
-            data.value = std::to_string(value);
-            data.help_text = "Unsigned integer metric from Tenstorrent Metal";
-            
-            auto ts_it = snapshot.uint_metric_timestamps.find(path);
-            data.timestamp = (ts_it != snapshot.uint_metric_timestamps.end()) ? ts_it->second : 0;
-            
-            // Add unit label if available
-            auto unit_it = snapshot.uint_metric_units.find(path);
-            if (unit_it != snapshot.uint_metric_units.end()) {
-                auto label_it = snapshot.metric_unit_display_label_by_code.find(unit_it->second);
-                if (label_it != snapshot.metric_unit_display_label_by_code.end()) {
-                    data.unit_label = label_it->second;
+
+        // Helper lambda to process all metric types
+        auto process_metrics = [&](const auto& metrics,
+                                   const auto& timestamps,
+                                   const auto* units,  // nullable for bool metrics
+                                   const std::string& help_text,
+                                   auto value_converter) {
+            for (const auto& [path, value] : metrics) {
+                MetricState::MetricData data;
+                data.value = value_converter(value);
+                data.help_text = help_text;
+
+                // Get timestamp
+                auto ts_it = timestamps.find(path);
+                data.timestamp = (ts_it != timestamps.end()) ? ts_it->second : 0;
+
+                // Get unit label if units map is provided
+                if constexpr (!std::is_null_pointer_v<decltype(units)>) {
+                    if (units) {
+                        auto unit_it = units->find(path);
+                        if (unit_it != units->end()) {
+                            auto label_it = snapshot.metric_unit_display_label_by_code.find(unit_it->second);
+                            // Throw an error if no label is found
+                            if (label_it == snapshot.metric_unit_display_label_by_code.end()) {
+                                throw std::runtime_error(
+                                    "No display label found for unit code: " + std::to_string(unit_it->second) +
+                                    " for metric path: " + path);
+                            }
+                            data.unit_label = label_it->second;
+                        }
+                    }
                 }
+
+                current_state_.metrics[sanitize_metric_name(path)] = data;
             }
-            
-            current_state_.metrics[sanitize_metric_name(path)] = data;
-        }
-        
-        // Update double metrics
-        for (const auto& [path, value] : snapshot.double_metrics) {
-            MetricState::MetricData data;
-            data.value = std::to_string(value);
-            data.help_text = "Floating-point metric from Tenstorrent Metal";
-            
-            auto ts_it = snapshot.double_metric_timestamps.find(path);
-            data.timestamp = (ts_it != snapshot.double_metric_timestamps.end()) ? ts_it->second : 0;
-            
-            // Add unit label if available
-            auto unit_it = snapshot.double_metric_units.find(path);
-            if (unit_it != snapshot.double_metric_units.end()) {
-                auto label_it = snapshot.metric_unit_display_label_by_code.find(unit_it->second);
-                if (label_it != snapshot.metric_unit_display_label_by_code.end()) {
-                    data.unit_label = label_it->second;
-                }
-            }
-            
-            current_state_.metrics[sanitize_metric_name(path)] = data;
-        }
+        };
+
+        // Process bool metrics
+        process_metrics(
+            snapshot.bool_metrics,
+            snapshot.bool_metric_timestamps,
+            static_cast<const std::map<std::string, int>*>(nullptr),  // no units for bool metrics
+            "Boolean metric from Tenstorrent Metal",  // TODO(kkfernandez): something more descriptive, per metric
+            [](bool v) { return std::to_string(v ? 1 : 0); });
+
+        // Process unsigned integer metrics
+        process_metrics(
+            snapshot.uint_metrics,
+            snapshot.uint_metric_timestamps,
+            &snapshot.uint_metric_units,
+            "Unsigned integer metric from Tenstorrent Metal",  // TODO(kkfernandez): something more descriptive, per
+                                                               // metric
+            [](auto v) { return std::to_string(v); });
+
+        // Process floating-point metrics
+        process_metrics(
+            snapshot.double_metrics,
+            snapshot.double_metric_timestamps,
+            &snapshot.double_metric_units,
+            "Floating-point metric from Tenstorrent Metal",  // TODO(kkfernandez): something more descriptive, per
+                                                             // metric
+            [](auto v) { return std::to_string(v); });
     }
-    
+
     std::string generate_prom_output() {
         std::lock_guard<std::mutex> lock(state_mutex_);
         std::stringstream output;
-        
+
         // Write header
         auto now = std::chrono::system_clock::now();
         auto now_c = std::chrono::system_clock::to_time_t(now);
         std::string time_str = std::ctime(&now_c);
         time_str.pop_back(); // Remove trailing newline
-        
+
         output << "# Tenstorrent Metal Telemetry Metrics\n";
+        output << "# Host: " << hostname_ << "\n";
         output << "# Generated at: " << time_str << "\n\n";
-        
+
         // Write all metrics with their metadata
         for (const auto& [metric_name, data] : current_state_.metrics) {
             // Write HELP and TYPE
             output << "# HELP " << metric_name << " " << data.help_text << "\n";
             output << "# TYPE " << metric_name << " gauge\n";
-            
+
             // Write metric line
             output << metric_name;
             if (!data.unit_label.empty()) {
@@ -157,50 +178,56 @@ private:
             }
             output << "\n\n";
         }
-        
+
         return output.str();
     }
-    
+
     // Get snapshot if one is ready
     std::shared_ptr<TelemetrySnapshot> get_next_snapshot(std::unique_lock<std::mutex>& lock) {
         if (pending_snapshots_.empty()) {
             return nullptr;
         }
-        
+
         auto snapshot = std::move(pending_snapshots_.front());
         pending_snapshots_.pop();
         return snapshot;
     }
-    
+
     // Writes metrics to file (complete overwrite)
-    bool write_metrics_to_file() {
+    bool try_write_metrics_to_file() {
         std::string content = generate_prom_output();
-        
+
         std::lock_guard<std::mutex> lock(file_mutex_);
-        
+
         // Write to temp file first, then rename (atomic operation)
         std::filesystem::path temp_path = prom_file_path_.string() + ".tmp";
         std::ofstream prom_file(temp_path, std::ios::out | std::ios::trunc);
-        
+
         if (!prom_file.is_open()) {
             log_error(tt::LogAlways, "Failed to open temporary Prometheus metrics file: {}", temp_path.string());
             return false;
         }
-        
+
         try {
             prom_file << content;
             prom_file.close();
-            
+
             if (prom_file.fail()) {
                 log_error(tt::LogAlways, "Write failed for Prometheus metrics file: {}", temp_path.string());
                 std::filesystem::remove(temp_path);
                 return false;
             }
-            
+
             // Atomically rename temp file to actual file
-            std::filesystem::rename(temp_path, prom_file_path_);
+            try {
+                std::filesystem::rename(temp_path, prom_file_path_);
+            } catch (const std::filesystem::filesystem_error& e) {
+                // If rename fails (e.g., across filesystems), fall back to copy+remove
+                std::filesystem::copy_file(
+                    temp_path, prom_file_path_, std::filesystem::copy_options::overwrite_existing);
+                std::filesystem::remove(temp_path);
+            }
             return true;
-            
         } catch (const std::exception& e) {
             log_error(tt::LogAlways, "Exception while writing to Prometheus metrics file: {}", e.what());
             try {
@@ -209,7 +236,7 @@ private:
             return false;
         }
     }
-    
+
     void process_telemetry() {
         while (running_) {
             // Wait until:
@@ -221,53 +248,50 @@ private:
             snapshot_cv_.wait_for(lock, snapshot_check_timeout_, [this]() {
                 return !pending_snapshots_.empty() || !running_;
             });
-            
+
             // Exit if not running
             if (!running_) {
                 break;
             }
-            
+
             // Process all pending snapshots
             while (!pending_snapshots_.empty()) {
                 auto snapshot = get_next_snapshot(lock);
                 lock.unlock();
-                
+
                 if (snapshot) {
                     try {
                         // Update internal state
                         update_state_from_snapshot(*snapshot);
-                        
+
                         // Write current complete state to file
-                        if (!write_metrics_to_file()) {
-                            // TODO(kkfernandez): Consider additional error handling if file write fails
-                        }
+                        try_write_metrics_to_file();
                     } catch (const std::exception& e) {
                         log_error(tt::LogAlways, "Error processing telemetry for Prometheus: {}", e.what());
                     }
                 }
-                
+
                 lock.lock();
             }
         }
     }
-    
-    void initialize_file() {
-        // Create an initial empty file
-        write_metrics_to_file();
-    }
-    
+
 public:
-    PromWriter(std::string_view file_path) : prom_file_path_(file_path) {
+    PromWriter(std::string_view file_path) : prom_file_path_(file_path), hostname_(get_hostname()) {
         // Ensure directory exists
         std::filesystem::create_directories(prom_file_path_.parent_path());
-        initialize_file();
+
+        // Create an initial empty file
+        if (!try_write_metrics_to_file()) {
+            throw std::runtime_error("Failed to initialize Prometheus metrics file at: " + prom_file_path_.string());
+        }
     }
-    
+
     void start() {
         running_ = true;
         processing_thread_ = std::thread(&PromWriter::process_telemetry, this);
     }
-    
+
     void stop() {
         running_ = false;
         snapshot_cv_.notify_one();
@@ -275,7 +299,7 @@ public:
             processing_thread_.join();
         }
     }
-    
+
     void on_telemetry_ready(std::shared_ptr<TelemetrySnapshot> telemetry) override {
         {
             std::lock_guard<std::mutex> lock(snapshot_mutex_);
@@ -283,7 +307,7 @@ public:
         }
         snapshot_cv_.notify_one();
     }
-    
+
     ~PromWriter() {
         stop();
     }
@@ -294,7 +318,7 @@ std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_prom_writ
     std::string_view file_path) {
     auto writer = std::make_shared<PromWriter>(file_path);
     auto subscriber = std::static_pointer_cast<TelemetrySubscriber>(writer);
-    
+
     auto future = std::async(std::launch::async, [writer]() {
         try {
             writer->start();

--- a/tt_telemetry/server/prom_writer.cpp
+++ b/tt_telemetry/server/prom_writer.cpp
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <atomic>
+#include <fstream>
+#include <mutex>
+#include <thread>
+#include <queue>
+#include <chrono>
+#include <memory>
+#include <filesystem>
+#include <string_view>
+#include <condition_variable>
+
+#include <telemetry/telemetry_subscriber.hpp>
+#include <server/prom_writer.hpp>
+
+class PromWriter : public TelemetrySubscriber {
+private:
+    std::filesystem::path prom_file_path_;
+    std::mutex file_mutex_;
+    std::thread processing_thread_;
+    std::atomic<bool> running_{false};
+    std::queue<std::shared_ptr<TelemetrySnapshot>> pending_snapshots_;
+    std::mutex snapshot_mutex_;
+    std::condition_variable snapshot_cv_;
+    std::unordered_set<std::string> documented_metrics_;
+    static constexpr std::chrono::milliseconds snapshot_check_timeout_{1000};
+
+    void add_metric_comments_once(std::ostream& out, std::string_view metric_name, std::string_view help_text) {
+        if (documented_metrics_.insert(std::string(metric_name)).second) {
+            // First time this metric is seen
+            out << "# HELP " << metric_name << " " << help_text << "\n"; // TODO(kkfernandez): for now these are highly uninformative
+            out << "# TYPE " << metric_name << " gauge\n";
+        }
+    }
+
+    std::string sanitize_metric_name(std::string_view path) {
+        // Prefix with a standard namespace
+        std::string sanitized_prefix = "tt_metal_";
+        
+        // Convert to valid Prometheus metric name
+        std::string sanitized_name;
+        
+        // Ensure first character is a letter or underscore
+        if (path.empty()) {
+            return sanitized_prefix + "unnamed_metric";
+        }
+        
+        // First character must be a letter or underscore
+        if (!std::isalpha(path[0]) && path[0] != '_') {
+            sanitized_name = '_';
+        }
+        
+        // Subsequent characters can be alphanumeric or underscore
+        for (char c : path) {
+            if (std::isalnum(c) || c == '_' || c == ':') {
+                sanitized_name += c;
+            } else {
+                // Replace unsupported characters with underscore
+                sanitized_name += '_';
+            }
+        }
+        
+        return sanitized_prefix + sanitized_name;
+    }
+
+    std::string format_metric_line(
+        std::string_view name, 
+        std::string_view value,
+        const std::unordered_map<std::string, uint64_t>& timestamps
+    ) {
+        std::string sanitized_name = sanitize_metric_name(name);
+        
+        // Check if we have a timestamp for this metric
+        auto timestamp_it = timestamps.find(std::string(name));
+        std::string timestamp_suffix = timestamp_it != timestamps.end() 
+            ? " " + std::to_string(timestamp_it->second) 
+            : "";
+        
+        return sanitized_name + " " + std::string(value) + timestamp_suffix + "\n";
+    }
+
+    std::string convert_to_prom_format(const TelemetrySnapshot& snapshot) {
+        std::stringstream prom_output;
+
+        for (const auto& [path, value] : snapshot.bool_metrics) {
+            write_prom_metric(
+                prom_output,
+                path,
+                std::to_string(value ? 1 : 0),
+                snapshot.bool_metric_timestamps,
+                "Boolean metric from Tenstorrent Metal",
+                ""  // No unit label
+            );
+        }
+
+        process_prom_metrics(snapshot.uint_metrics,
+                            snapshot.uint_metric_units,
+                            snapshot.uint_metric_timestamps,
+                            snapshot,
+                            prom_output,
+                            "Unsigned integer metric from Tenstorrent Metal");
+
+        process_prom_metrics(snapshot.double_metrics,
+                            snapshot.double_metric_units,
+                            snapshot.double_metric_timestamps,
+                            snapshot,
+                            prom_output,
+                            "Floating-point metric from Tenstorrent Metal");
+
+        return prom_output.str();
+    }
+
+    void write_prom_metric(std::ostream& out,
+                        std::string_view path,
+                        std::string_view value_str,
+                        const std::unordered_map<std::string, uint64_t>& timestamps,
+                        std::string_view help_text,
+                        std::string_view label) {
+        std::string sanitized_name = sanitize_metric_name(path);
+        add_metric_comments_once(out, sanitized_name, help_text);
+
+        out << sanitized_name;
+        if (!label.empty()) {
+            out << "{" << label << "}";
+        }
+
+        out << " " << value_str;
+
+        auto it = timestamps.find(std::string(path));
+        if (it != timestamps.end()) {
+            out << " " << it->second;
+        }
+
+        out << "\n";
+    }
+
+    template <typename T>
+    void process_prom_metrics(const std::unordered_map<std::string, T>& metrics,
+                            const std::unordered_map<std::string, uint16_t>& metric_units,
+                            const std::unordered_map<std::string, uint64_t>& timestamps,
+                            const TelemetrySnapshot& snapshot,
+                            std::ostream& out,
+                            std::string_view help_text) {
+        for (const auto& [path, value] : metrics) {
+            std::string label;
+
+            auto unit_it = metric_units.find(path);
+            if (unit_it != metric_units.end()) {
+                auto label_it = snapshot.metric_unit_display_label_by_code.find(unit_it->second);
+                if (label_it != snapshot.metric_unit_display_label_by_code.end()) {
+                    label = "unit=\"" + label_it->second + "\"";
+                }
+            }
+
+            write_prom_metric(out, path, std::to_string(value), timestamps, help_text, label);
+        }
+    }
+
+    // Get snapshot if one is ready
+    std::shared_ptr<TelemetrySnapshot> get_next_snapshot(std::unique_lock<std::mutex>& lock) {
+        if (pending_snapshots_.empty()) {
+            return nullptr;
+        }
+        
+        auto snapshot = std::move(pending_snapshots_.front());
+        pending_snapshots_.pop();
+        return snapshot;
+    }
+
+    // Adds type info of the metrics to the file's header
+    bool ensure_metric_comments_exist() {
+        std::ifstream check_file(prom_file_path_);
+        std::string first_line;
+        std::getline(check_file, first_line);
+        
+        // If file is empty or doesn't have comments, add them
+        if (first_line.empty() || !first_line.starts_with("# HELP")) {
+            std::ofstream comments_file(prom_file_path_, std::ios::app);
+            comments_file << "# HELP tt_metal_bool_metrics Boolean metrics from Tenstorrent Metal\n";
+            comments_file << "# TYPE tt_metal_bool_metrics gauge\n";
+            
+            comments_file << "# HELP tt_metal_uint_metrics Unsigned integer metrics from Tenstorrent Metal\n";
+            comments_file << "# TYPE tt_metal_uint_metrics gauge\n";
+            
+            comments_file << "# HELP tt_metal_double_metrics Floating-point metrics from Tenstorrent Metal\n";
+            comments_file << "# TYPE tt_metal_double_metrics gauge\n";
+            
+            return true;
+        }
+        return false;
+    }
+
+    // Writes metrics to file
+    bool write_metrics_to_file(std::string_view metrics) {
+        ensure_metric_comments_exist();
+        
+        std::lock_guard<std::mutex> lock(file_mutex_);
+
+        if (!std::filesystem::exists(prom_file_path_)) {
+            log_warning(tt::LogAlways, "Prometheus metrics file not found. Recreating: {}", prom_file_path_.string());
+            initialize_file();
+        }
+    
+        // Open file in append mode
+        std::ofstream prom_file(prom_file_path_, std::ios::app | std::ios::out);
+
+        if (!prom_file.is_open()) {
+            log_error(tt::LogAlways, "Failed to open Prometheus metrics file: {}", prom_file_path_.string());
+            return false;
+        }
+
+        try {
+            // Write metrics
+            prom_file << metrics;
+            prom_file.flush();
+            
+            if (prom_file.fail()) {
+                log_error(tt::LogAlways, "Write failed for Prometheus metrics file: {}", prom_file_path_.string());
+                return false;
+            }
+            
+            return true;
+        } catch (const std::exception& e) {
+            log_error(tt::LogAlways, "Exception while writing to Prometheus metrics file: {}", e.what());
+            return false;
+        }
+    }
+
+    void process_telemetry() {
+        while (running_) {
+            // Wait until:
+            // 1. A snapshot is available
+            // 2. We're no longer running
+            // 3. Timeout occurs
+            // 4. Spurious wakeup
+            std::unique_lock<std::mutex> lock(snapshot_mutex_);
+            snapshot_cv_.wait_for(lock, snapshot_check_timeout_, [this]() {
+                return !pending_snapshots_.empty() || !running_;
+            });
+
+            // Exit if not running
+            if (!running_) {
+                break;
+            }
+
+            auto snapshot = get_next_snapshot(lock);
+            lock.unlock();
+
+            // Skip if no snapshot (spurious wakeup or woken on timeout)
+            if (!snapshot) {
+                continue;
+            }
+            
+            try {
+                // Convert to Prometheus format
+                auto prom_metrics = convert_to_prom_format(*snapshot);
+                
+                // Write to file
+                if (!write_metrics_to_file(prom_metrics)) {
+                    // TODO(kkfernandez): Consider additional error handling if file write fails
+                }
+            } catch (const std::exception& e) {
+                log_error(tt::LogAlways, "Error processing telemetry for Prometheus: {}", e.what());
+            }
+        }
+    }
+
+    void initialize_file() {
+        std::ofstream initial_file(prom_file_path_, std::ios::out);
+        if (!initial_file.is_open()) {
+            throw std::runtime_error("Unable to create Prometheus metrics file: " + prom_file_path_.string());
+        }
+
+        // Obtain human-readable timestamp
+        auto now = std::chrono::system_clock::now();
+        auto now_c = std::chrono::system_clock::to_time_t(now);
+        std::string time_str = std::ctime(&now_c);
+        time_str.pop_back(); // Remove trailing newline
+
+        // Write header
+        initial_file << "# Tenstorrent Metal Telemetry Metrics\n";
+        initial_file << "# Start Time: " << time_str << "\n\n";
+    }
+
+public:
+    PromWriter(std::string_view file_path) : prom_file_path_(file_path) {
+        // Ensure directory exists
+        std::filesystem::create_directories(prom_file_path_.parent_path());
+
+        initialize_file();
+    }
+
+    void start() {
+        running_ = true;
+        processing_thread_ = std::thread(&PromWriter::process_telemetry, this);
+    }
+
+    void stop() {
+        running_ = false;
+        if (processing_thread_.joinable()) {
+            processing_thread_.join();
+        }
+    }
+
+    void on_telemetry_ready(std::shared_ptr<TelemetrySnapshot> telemetry) override {
+        {
+            std::lock_guard<std::mutex> lock(snapshot_mutex_);
+            pending_snapshots_.emplace(std::move(telemetry));
+        }
+        snapshot_cv_.notify_one();
+    }
+
+    ~PromWriter() {
+        stop();
+    }
+};
+
+// Similar to other server creation functions
+std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_prom_writer(
+    std::string_view file_path) {
+    auto writer = std::make_shared<PromWriter>(file_path);
+    auto subscriber = std::static_pointer_cast<TelemetrySubscriber>(writer);
+    
+    auto future = std::async(std::launch::async, [writer]() {
+        try {
+            writer->start();
+            return true;
+        } catch (const std::exception& e) {
+            log_fatal(tt::LogAlways, "Prometheus writer error: {}", e.what());
+            return false;
+        }
+    });
+
+    return std::make_pair(std::move(future), subscriber);
+}

--- a/tt_telemetry/server/web_server.cpp
+++ b/tt_telemetry/server/web_server.cpp
@@ -107,6 +107,7 @@ private:
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 continue;
             }
+            print_snapshot(snapshot);
             telemetry_state_.merge_from(*snapshot);
             send_snapshot_to_clients(snapshot);
         }

--- a/tt_telemetry/server/web_server.cpp
+++ b/tt_telemetry/server/web_server.cpp
@@ -107,7 +107,6 @@ private:
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 continue;
             }
-            print_snapshot(snapshot);
             telemetry_state_.merge_from(*snapshot);
             send_snapshot_to_clients(snapshot);
         }


### PR DESCRIPTION
### Ticket
  Solves #30764.

### Problem description
  The telemetry server needed a way to export metrics in Prometheus format for integration with monitoring and observability tools. Previously, metrics were only available through WebSocket connections or the web UI, making it difficult to integrate with standard monitoring infrastructure that expects Prometheus-format metrics files.

### What's changed
  This PR implements a new `PromWriter` component that subscribes to telemetry snapshots and writes them to a file in Prometheus exposition format.

  **Key changes:**
  - **New `PromWriter` class** (`tt_telemetry/server/prom_writer.cpp`, `prom_writer.hpp`): Implements a telemetry subscriber that writes metrics to a `.prom` file
    - Asynchronous processing with queue-based snapshot handling
    - Atomic file writes using temp file + rename pattern to prevent partial reads
    - Metric name sanitization to comply with Prometheus naming conventions
    - State tracking to maintain current values of all metrics with timestamps and units

  - **CLI integration** (`tt_telemetry/server/main.cpp`):
    - Added `--use-prom-writer` flag to enable the Prometheus writer
    - Added `--prom-metrics-file` option to specify output file path (defaults to `<metal-src-dir>/tt_telemetry/output/metrics.prom`)
    - Improved `--metal-src-dir` handling with fallback to `TT_METAL_HOME` environment variable

  - **Debug utility** (`tt_telemetry/include/telemetry/telemetry_snapshot.hpp`):
    - Added `print_snapshot()` helper function for debugging telemetry snapshots

  - **Build system** (`tt_telemetry/CMakeLists.txt`):
    - Added `prom_writer.cpp` to build targets

  **Impact:**
  - Enables integration with Prometheus and other monitoring tools that can scrape or read `.prom` files
  - Provides a persistent, file-based view of current telemetry state
  - No impact on existing functionality when the feature is not enabled (opt-in via CLI flag)

### Checklist
  - [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
  - [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
  - [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
  - [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
  - [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See
  [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
  - [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
  - [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
  - [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on
  push to main)
  - [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required
   for release)
  - [ ] New/Existing tests provide coverage for changes