### PR TITLE
Upload single-card end-to-end performance data to Superset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -305,7 +305,7 @@ models/demos/vit @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat @tenstorr
 models/experimental/*yolo*/ @tenstorrent/cse-developer-ttnn @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/demos/yolo_eval @tenstorrent/cse-developer-ttnn @tenstorrent/metalium-codeowners-large-changes
 models/demos/segformer @arginugaTT @tenstorrent/cse-developer-ttnn @uaydonat @tenstorrent/metalium-codeowners-large-changes
-models/perf/ @yieldthought @uaydonat @tenstorrent/metalium-codeowners-large-changes
+models/perf/ @yieldthought @esmalTT @skhorasganiTT @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/perf/benchmarking_utils.py @skhorasganiTT @williamlyTT @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/demos/utils/llm_demo_utils.py @skhorasganiTT @mtairum @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/experimental/oft @bjanjicTT @mbezuljTT @pavlepopovic

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -278,6 +278,25 @@ jobs:
             env python3 models/perf/merge_perf_results.py CHECK
         if: ${{ !cancelled() }}
 
+      - name: Save environment data
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/docker-run
+        with:
+          docker_image: ${{ inputs.docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: ${{ env.DOCKER_OPTS }}
+          run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+
+      - name: Upload benchmark data
+        if: ${{ !cancelled() }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          path: ${{ github.workspace }}
+
       # TODO: Fix the pipeline before enabling notifications.
       #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
       #  if: ${{ failure() }}

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -210,20 +210,20 @@ def prep_perf_report(
 
     # Add measurements for the key performance metrics
     # Convert string values back to float for measurements
-    benchmark_data.add_measurement(profiler, 0, step_name, "Inference Time (sec)", inference_time)
-    benchmark_data.add_measurement(profiler, 0, step_name, "Compile Time (sec)", compile_time)
-    benchmark_data.add_measurement(profiler, 0, step_name, "Throughput (batch*inf/sec)", float(device_throughput))
-    benchmark_data.add_measurement(profiler, 0, step_name, "First Run (sec)", inference_and_compile_time)
-    benchmark_data.add_measurement(profiler, 0, step_name, "Expected Inference Time (sec)", expected_inference_time)
-    benchmark_data.add_measurement(profiler, 0, step_name, "Expected Compile Time (sec)", expected_compile_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "inference_time_s", inference_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "compile_time_s", compile_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "throughput_iter_per_s", float(device_throughput))
+    benchmark_data.add_measurement(profiler, 0, step_name, "first_run_s", inference_and_compile_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "expected_inference_time_s", expected_inference_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "expected_compile_time_s", expected_compile_time)
 
     if inference_time_cpu is not None:
-        benchmark_data.add_measurement(profiler, 0, step_name, "Inference Time CPU (sec)", inference_time_cpu)
+        benchmark_data.add_measurement(profiler, 0, step_name, "inference_time_cpu_s", inference_time_cpu)
         benchmark_data.add_measurement(
             profiler,
             0,
             step_name,
-            "Throughput CPU (batch*inf/sec)",
+            "throughput_cpu_iter_per_s",
             float(cpu_throughput) if cpu_throughput != "unknown" else 0.0,
         )
 

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -11,6 +11,8 @@ from os.path import isfile, join
 import git
 from loguru import logger
 
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
 today = time.strftime("%Y_%m_%d")
 
 
@@ -195,3 +197,39 @@ def prep_perf_report(
     model_name = model_name.replace("/", "_")
     csv_file = f"perf_{model_name}_{comments}_{today}.csv"
     write_dict_to_file(csv_file, dict_res)
+
+    # Dummy profiler to satisfy BenchmarkData's requirements
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
+    profiler.end("run")
+    step_name = "end_to_end_perf"
+    profiler.start(step_name)
+    profiler.end(step_name)
+
+    benchmark_data = BenchmarkData()
+
+    # Add measurements for the key performance metrics
+    # Convert string values back to float for measurements
+    benchmark_data.add_measurement(profiler, 0, step_name, "Inference Time (sec)", inference_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "Compile Time (sec)", compile_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "Throughput (batch*inf/sec)", float(device_throughput))
+    benchmark_data.add_measurement(profiler, 0, step_name, "First Run (sec)", inference_and_compile_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "Expected Inference Time (sec)", expected_inference_time)
+    benchmark_data.add_measurement(profiler, 0, step_name, "Expected Compile Time (sec)", expected_compile_time)
+
+    if inference_time_cpu is not None:
+        benchmark_data.add_measurement(profiler, 0, step_name, "Inference Time CPU (sec)", inference_time_cpu)
+        benchmark_data.add_measurement(
+            profiler,
+            0,
+            step_name,
+            "Throughput CPU (batch*inf/sec)",
+            float(cpu_throughput) if cpu_throughput != "unknown" else 0.0,
+        )
+
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type="end_to_end_perf",
+        ml_model_name=model_name,
+        batch_size=batch_size,
+    )


### PR DESCRIPTION
### Summary

This PR implements functionality to automatically upload single-card end-to-end performance metrics to Superset so we can monitor performance over time more easily.

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18696229367