### PR TITLE
#0: Fixes for UBB BH validation

### DIFF
--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -310,24 +310,24 @@ public:
 
         // Add LINKING_BOARD_1 connections
         auto* const lb1_connections = get_port_connections(&node, "LINKING_BOARD_1");
-        add_connection(lb1_connections, 1, 1, 2, 1);
-        add_connection(lb1_connections, 1, 2, 2, 2);
-        add_connection(lb1_connections, 3, 1, 4, 1);
-        add_connection(lb1_connections, 3, 2, 4, 2);
+        add_connection(lb1_connections, 1, 1, 3, 1);
+        add_connection(lb1_connections, 1, 2, 3, 2);
+        add_connection(lb1_connections, 2, 1, 4, 1);
+        add_connection(lb1_connections, 2, 2, 4, 2);
 
         // Add LINKING_BOARD_2 connections
         auto* const lb2_connections = get_port_connections(&node, "LINKING_BOARD_2");
-        add_connection(lb2_connections, 1, 1, 2, 1);
-        add_connection(lb2_connections, 1, 2, 2, 2);
-        add_connection(lb2_connections, 3, 1, 4, 1);
-        add_connection(lb2_connections, 3, 2, 4, 2);
+        add_connection(lb2_connections, 1, 1, 3, 1);
+        add_connection(lb2_connections, 1, 2, 3, 2);
+        add_connection(lb2_connections, 2, 1, 4, 1);
+        add_connection(lb2_connections, 2, 2, 4, 2);
 
         // Add LINKING_BOARD_3 connections
         auto* const lb3_connections = get_port_connections(&node, "LINKING_BOARD_3");
-        add_connection(lb3_connections, 1, 1, 3, 1);
-        add_connection(lb3_connections, 1, 2, 3, 2);
-        add_connection(lb3_connections, 2, 1, 4, 1);
-        add_connection(lb3_connections, 2, 2, 4, 2);
+        add_connection(lb3_connections, 1, 1, 2, 1);
+        add_connection(lb3_connections, 1, 2, 2, 2);
+        add_connection(lb3_connections, 3, 1, 4, 1);
+        add_connection(lb3_connections, 3, 2, 4, 2);
 
         // Add QSFP connections based on topology (one-hot encoded)
         if (static_cast<int>(topology) & static_cast<int>(BHGalaxyTopology::X_TORUS)) {  // X_TORUS bit

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -92,7 +92,8 @@ TrayID get_tray_id_for_chip(
 std::pair<TrayID, ASICLocation> get_asic_position(
     const std::unique_ptr<tt::umd::Cluster>& cluster, tt::ARCH arch, ChipId chip_id, bool using_mock_cluster_desc) {
     auto cluster_desc = cluster->get_cluster_description();
-    if (cluster_desc->get_board_type(chip_id) == BoardType::UBB) {
+    if (cluster_desc->get_board_type(chip_id) == BoardType::UBB_WORMHOLE ||
+        cluster_desc->get_board_type(chip_id) == BoardType::UBB_BLACKHOLE) {
         constexpr std::string_view ubb_mobo_name = "S7T-MB";
 
         TT_FATAL(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
BH UBB linking board connections had the trays swapped (was using the WH tray positions).
Physical validation was not using the UBB path for BH UBB.

### What's changed
Update to use BH tray ids for linking board connections in node.cpp.
Use UBB path for both WH and BH in physical validation.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes