### PR TITLE
Wan - remove nlp create heads workaround

### DIFF
--- a/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -215,13 +215,10 @@ class WanAttention:
         k_1BNF = self.norm_k(k_1BNF, compute_kernel_config=self.rmsnorm_compute_kernel_config)
 
         def create_heads(inp):
-            # Unfortunate hack - we don't have a split_heads operation that takes unfused qkv
-            # Can pass None kv input and 0 KV heads to create_qkv_heads to create just Q heads, but it's suspicious
             out, _, _ = ttnn.experimental.nlp_create_qkv_heads(
                 inp,
-                ttnn.concat([inp, inp], dim=-1),
                 num_heads=self.n_local_heads,
-                num_kv_heads=self.n_local_heads,
+                num_kv_heads=0,
                 transpose_k_heads=False,
             )
             return out


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29838

### Problem description
We were doing an unnecessary, expensive workaround in Wan2.2 when creating heads. Bless the TM team for figuring out to remove the workaround.

### What's changed
Remove unnecessary KV concat and KV create_heads for each create_head on Q, K, V.