### PR TITLE
Add debug commands to multi-host workflow

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -54,6 +54,9 @@ jobs:
       - name: Create Python venv
         run: |
           ./create_venv.sh
+      - name: Install Dependencies
+        run: |
+          ./install_dependencies.sh || true
       - name: Capture runner's home directory
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
@@ -118,6 +121,9 @@ jobs:
       - name: Create Python venv
         run: |
           ./create_venv.sh
+      - name: Install Dependencies
+        run: |
+          ./install_dependencies.sh || true
       - name: Capture runner's home directory
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -56,7 +56,7 @@ jobs:
           ./create_venv.sh
       - name: Install Dependencies
         run: |
-          ./install_dependencies.sh || true
+          sudo ./install_dependencies.sh || true
       - name: Capture runner's home directory
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
@@ -123,7 +123,7 @@ jobs:
           ./create_venv.sh
       - name: Install Dependencies
         run: |
-          ./install_dependencies.sh || true
+          sudo ./install_dependencies.sh || true
       - name: Capture runner's home directory
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -78,6 +78,15 @@ jobs:
             --hostname=mpirun-host
           install_wheel: true
           run_args: |
+            whoami
+            ls -lart /opt/tenstorrent
+            echo "hey"
+            ls -lart /opt/tenstorrent/sfpi/
+            echo "ha"
+            ls -lart /opt/tenstorrent/sfpi/compiler/
+            echo "gee"
+            ls -lart /opt/tenstorrent/sfpi/compiler/bin/
+            echo "lala"
             ./tests/scripts/multihost/run_dual_t3k_tests.sh
 
   multi-host-galaxy:
@@ -133,4 +142,13 @@ jobs:
             --hostname=mpirun-host
           install_wheel: true
           run_args: |
+            whoami
+            ls -lart /opt/tenstorrent
+            echo "hey"
+            ls -lart /opt/tenstorrent/sfpi/
+            echo "ha"
+            ls -lart /opt/tenstorrent/sfpi/compiler/
+            echo "gee"
+            ls -lart /opt/tenstorrent/sfpi/compiler/bin/
+            echo "lala"
             ./tests/scripts/multihost/run_dual_galaxy_tests.sh


### PR DESCRIPTION
Added debugging commands to check directory contents and user.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes