### PR TITLE
[tt-train] Add galaxy configuration for 2-tier and 3-tier architecture training

### DIFF
--- a/tt-train/configs/training_shakespeare_nanogpt_3tier_fabric_5galaxies_2tier.yaml
+++ b/tt-train/configs/training_shakespeare_nanogpt_3tier_fabric_5galaxies_2tier.yaml
@@ -1,0 +1,40 @@
+training_config:
+  project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
+  seed: 5489
+  model_save_interval: 500
+  batch_size: 64
+  num_epochs: 1
+  max_steps: 5000
+  learning_rate: 0.0003
+  weight_decay: 0.01
+  use_moreh_adamw: true
+  use_kahan_summation: false
+  use_clip_grad_norm: false
+  clip_grad_norm_max_norm: 1.0
+  transformer_config:
+    num_heads: 6
+    embedding_dim: 384
+    dropout_prob: 0.2
+    num_blocks: 6
+    vocab_size: 96
+    max_sequence_length: 256
+    positional_embedding_type: trainable
+    runner_type: default
+    experimental:
+      use_composite_layernorm: false
+
+multihost_config:
+  enabled: true
+  num_workers: 4
+  socket_type: fabric
+
+eval_config:
+  repetition_penalty: 1.0
+  temperature: 0.7
+  top_k: 50
+  top_p: 1.0
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [1, 32]

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/hosts.txt
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/hosts.txt
@@ -1,0 +1,5 @@
+wh-glx-a03u02 slots=1
+wh-glx-a03u08 slots=1
+wh-glx-a03u14 slots=1
+wh-glx-a04u08 slots=1
+wh-glx-a04u14 slots=1

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/mgd.yaml
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/mgd.yaml
@@ -1,0 +1,63 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+Board: [
+  { name: galaxy,
+    type: Mesh,
+    topology: [1, 32]}
+]
+
+Mesh: [
+  {
+    id: 0,
+    board: galaxy,
+    device_topology: [1, 32],
+    host_topology: [1, 1],
+
+  },
+  {
+    id: 1,
+    board: galaxy,
+    device_topology: [1, 32],
+    host_topology: [1, 1],
+
+  },
+  {
+    id: 2,
+    board: galaxy,
+    device_topology: [1, 32],
+    host_topology: [1, 1],
+  },
+  {
+    id: 3,
+    board: galaxy,
+    device_topology: [1, 32],
+    host_topology: [1, 1],
+  },
+  {
+    id: 4,
+    board: galaxy,
+    device_topology: [1, 32],
+    host_topology: [1, 1],
+  }
+]
+
+RelaxedGraph: [
+  [M0, M1, 4],
+  [M0, M2, 4],
+  [M0, M3, 4],
+  [M0, M4, 4],
+  [M1, M2, 4],
+  [M1, M3, 4],
+  [M1, M4, 4],
+  [M2, M3, 4],
+  [M2, M4, 4],
+  [M3, M4, 4],
+]

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/rank_bindings.yaml
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/rank_bindings.yaml
@@ -1,0 +1,15 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 1
+  - rank: 1
+    mesh_id: 0
+  - rank: 2
+    mesh_id: 2
+  - rank: 3
+    mesh_id: 3
+  - rank: 4
+    mesh_id: 4
+
+global_env:
+  TT_METAL_HOME: "/home/local-rfurko/git/tt-metal"
+mesh_graph_desc_path: "configurations/5galaxies/mgd.yaml"

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/requirements.txt
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/requirements.txt
@@ -3,3 +3,4 @@ transformers
 tqdm
 numpy
 loguru
+pydantic

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/runner.sh
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/runner.sh
@@ -1,11 +1,18 @@
-USER="ttuser"
-CONFIG_FILE="training_shakespeare_tinyllama_tensor_parallel_3tier_fabric.yaml"
-HOST_FILE=${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/hosts.txt
-RANK_BINDINGS_FILE=${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/rank_bindings.yaml
+# Default profile
+PROFILE="loudboxes"
+USER=""
+CONFIG_FILE=""
+HOST_FILE=""
+RANK_BINDINGS_FILE=""
+MPI_EXTRA_ARGS=""
 
-# Allow overrides via environment or CLI args (with defaults above)
+# Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --profile)
+            shift
+            PROFILE="$1"
+            ;;
         --hostfile)
             shift
             HOST_FILE="$1"
@@ -22,13 +29,35 @@ while [[ "$#" -gt 0 ]]; do
             shift
             CONFIG_FILE="$1"
             ;;
+        --mpi-extra-args)
+            shift
+            MPI_EXTRA_ARGS="$1"
+            ;;
         *)
             echo "Unknown argument: $1"
+            echo "Usage: $0 [--profile loudboxes|galaxies] [--user USER] [--hostfile PATH] [--rank-bindings PATH] [--config CONFIG_FILE] [--mpi-extra-args ARGS]"
             exit 1
             ;;
     esac
     shift
 done
+
+# Set defaults based on profile if not explicitly provided
+if [[ "$PROFILE" == "loudboxes" ]]; then
+    USER="${USER:-ttuser}"
+    CONFIG_FILE="${CONFIG_FILE:-training_shakespeare_tinyllama_tensor_parallel_3tier_fabric.yaml}"
+    HOST_FILE="${HOST_FILE:-${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/hosts.txt}"
+    RANK_BINDINGS_FILE="${RANK_BINDINGS_FILE:-${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/rank_bindings.yaml}"
+elif [[ "$PROFILE" == "galaxies" ]]; then
+    USER="${USER:-local-rfurko}"
+    CONFIG_FILE="${CONFIG_FILE:-training_shakespeare_nanogpt_3tier_fabric_5galaxies_2tier.yaml}"
+    HOST_FILE="${HOST_FILE:-${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/hosts.txt}"
+    RANK_BINDINGS_FILE="${RANK_BINDINGS_FILE:-${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5galaxies/rank_bindings.yaml}"
+    MPI_EXTRA_ARGS="${MPI_EXTRA_ARGS:---allow-run-as-root --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0}"
+else
+    echo "Error: Unknown profile '$PROFILE'. Use 'loudboxes' or 'galaxies'."
+    exit 1
+fi
 
 # copy all files to all machines (pass user and hostfile)
 ${TT_METAL_HOME}/tt-train/sources/examples/nano_gpt/3tier/all_machines_copy.sh --run --sync --user "$USER" --hostfile "$HOST_FILE"
@@ -38,4 +67,4 @@ mpirun --hostfile ${HOST_FILE} --tag-output pip install -r ${TT_METAL_HOME}/tt-t
 
 CMD="python3 ${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py -c ${CONFIG_FILE}"
 # use tt-run to run the training script across all machines
-${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py --rank-binding ${RANK_BINDINGS_FILE} --mpi-args "--hostfile ${HOST_FILE} --tag-output" ${CMD}
+${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py --rank-binding ${RANK_BINDINGS_FILE} --mpi-args "--hostfile ${HOST_FILE} ${MPI_EXTRA_ARGS} --tag-output" ${CMD}


### PR DESCRIPTION
### Problem description
Extend script and add default configuration for galaxies so everyone can run 2-tier and 3-tier architecture training. 

### What's changed
* Add configurations folder
* Modify runner script
* Add 2-tier config 

### How to run 
```
cd git/tt-metal/tt-train/sources/examples/python/multihost/hierarchical_parallel
./runner.sh --profile galaxies
```

### Checklist
- [x] New/Existing tests provide coverage for changes