### PR TITLE
[skip ci] Optimize Initialize Containers step in code analysis workflow

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: tt-ubuntu-2204-xlarge-stable
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
-      image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
+      image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_REMOTE_ONLY: "true"
         CCACHE_TEMPDIR: /tmp/ccache

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -35,6 +35,8 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/cluster_types.hpp>
 
+// REVERT ME, NEED TO FORCE CLANG TIDY TO RUN
+
 namespace tt {
 namespace llrt {
 class RunTimeOptions;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -35,8 +35,6 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/cluster_types.hpp>
 
-// REVERT ME, NEED TO FORCE CLANG TIDY TO RUN
-
 namespace tt {
 namespace llrt {
 class RunTimeOptions;


### PR DESCRIPTION
### Ticket
NA

### Problem description
Code Analysis workflow was not using harbor (internal docker image cache).
It also was using the full developer container, and not the limited ci-build container.

### What's changed
- This should save ~5 minutes in every clang-tidy run

https://github.com/tenstorrent/tt-metal/actions/runs/18698318208