### PR TITLE
[skip ci] Bundle SFPI with tarball (again)

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -300,7 +300,7 @@ jobs:
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}
         run: |
-          ARTIFACT_PATHS="ttnn/ttnn/*.so build/lib build/programming_examples build/test build/tools runtime/hw"
+          ARTIFACT_PATHS="ttnn/ttnn/*.so build/lib build/programming_examples build/test build/tools runtime"
           if [[ "${{ inputs.skip-tt-train }}" != "true" ]]; then
             ARTIFACT_PATHS="$ARTIFACT_PATHS build/tt-train data"
           fi


### PR DESCRIPTION
### Ticket
NA

### Problem description
SFPI either doesn't exist, or is the wrong version on the remote machines in the multihost workflows.

### What's changed
Switch back to bundling the sfpi compiler along with the build tree.
In the multihost workflow, this effectively installs the current version of SFPI into the remote machines, because of shared NFS drive.

This PR will give us time to think through how to keep system dependencies homogeneous on all these machines in mutlihost workflows.
