### PR TITLE
#0: [skip ci] Update FW, SMI, and KMD versions for BH and WH 6U instructions

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -28,8 +28,8 @@ chmod +x install.sh
 > TT-Installer automatically installs all latest versions. Wormhole Galaxy (6U) and Blackhole systems require the following versions:
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
-> | Galaxy               | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above       | N/A                          |
-> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                            |
+> | Galaxy               | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                          |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                          |
 
 - If required, add the following flags for specifying dependencies versions:
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -29,7 +29,7 @@ chmod +x install.sh
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
 > | Galaxy               | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                          |
-> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                          |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.4.1 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.31 or above      | N/A                          |
 
 - If required, add the following flags for specifying dependencies versions:
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -25,11 +25,11 @@ chmod +x install.sh
 ```
 
 > [!WARNING]
-> TT-Installer automatically installs all latest versions. Galaxy Wormhole 4U and Blackhole systems require the following versions:
+> TT-Installer automatically installs all latest versions. Wormhole Galaxy (6U) and Blackhole systems require the following versions:
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
-> | Galaxy (Wormhole 4U) | Ubuntu 22.04    | 3.10     | v1.33 or above     | fw_pack-80.10.1.0                          | v2.2.3 or lower       | v1.1.3, `mesh` config          |
-> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.1.0 or above    | fw_pack-18.7.0.fwbundle (v18.7.0)          | v3.0.20 or above      | N/A                            |
+> | Galaxy               | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above       | N/A                          |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.3.0 or above    | fw_pack-18.12.0.fwbundle (v18.12.0)         | v3.0.28 or above      | N/A                            |
 
 - If required, add the following flags for specifying dependencies versions:
 


### PR DESCRIPTION
### Ticket

Upgrade of TT deps for newer machines.

### Problem description

Always keep this up to date.

### What's changed

Update instruction versions.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes