### PR TITLE
Update `to_torch` to return `torch.uint16` tensors when input has 'DataType::UINT16'

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
@@ -41,7 +41,7 @@ def print_tiles(tiled_tensor, num_tiles_height, num_tiles_width):
 
 
 def get_tensor(shape, dtype):
-    if dtype in {torch.int16, torch.int32}:
+    if dtype in {torch.uint16, torch.int16, torch.uint32, torch.int32}:
         torch_tensor = torch.randint(0, 1024, shape, dtype=dtype)
     else:
         torch_tensor = torch.rand(shape, dtype=dtype)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -20,11 +20,11 @@ torch.manual_seed(0)
 
 def random_torch_tensor(dtype, shape):
     if dtype == ttnn.uint16:
-        return torch.randint(0, 2**15, shape, dtype=torch.int16)
+        return torch.randint(0, 2**16, shape, dtype=torch.uint16)
     if dtype == ttnn.int32:
         return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
     if dtype == ttnn.uint32:
-        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+        return torch.randint(0, 2**32, shape, dtype=torch.uint32)
     return torch.rand(shape).bfloat16().float()
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -695,6 +695,9 @@ def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dt
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)
+    # Convert output tensor to bool to match golden function output type for comparison
+    if golden_tensor.dtype == torch.bool:
+        output_tensor = output_tensor.bool()
     assert torch.equal(golden_tensor, output_tensor)
 
 

--- a/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
@@ -36,7 +36,7 @@ def test_tensor_conversion_with_tt_dtype(python_lib, shape, tt_dtype, convert_to
     if python_lib == torch:
         dtype = tt_dtype_to_torch_dtype[tt_dtype]
 
-        if dtype in {torch.uint8, torch.int16, torch.int32}:
+        if dtype in {torch.uint8, torch.uint16, torch.int16, torch.uint32, torch.int32}:
             py_tensor = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype)
         else:
             py_tensor = torch.rand(shape, dtype=dtype)
@@ -48,7 +48,7 @@ def test_tensor_conversion_with_tt_dtype(python_lib, shape, tt_dtype, convert_to
             pytest.skip("ttnn.bfloat16 dtype is not supported yet for numpy tensors!")
         dtype = tt_dtype_to_np_dtype[tt_dtype]
 
-        if dtype in {np.ubyte, np.int16, np.int32}:
+        if dtype in {np.ubyte, np.uint16, np.int16, np.uint32, np.int32}:
             py_tensor = np.random.randint(np.iinfo(dtype).min, np.iinfo(dtype).max, shape, dtype=dtype)
         else:
             py_tensor = np.random.random(shape).astype(dtype=dtype)
@@ -124,7 +124,7 @@ def test_tensor_conversion_with_python_dtype(python_lib, shape, python_dtype_str
     if python_lib == torch:
         dtype = string_to_torch_dtype[python_dtype_str]
 
-        if dtype in {torch.uint8, torch.int16, torch.int32, torch.int64}:
+        if dtype in {torch.uint8, torch.uint16, torch.int16, torch.uint32, torch.int32, torch.int64}:
             py_tensor = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype)
         else:
             py_tensor = torch.rand(shape, dtype=dtype)
@@ -136,7 +136,7 @@ def test_tensor_conversion_with_python_dtype(python_lib, shape, python_dtype_str
             pytest.skip("{} dtype is not supported yet for numpy tensors!".format(python_dtype_str))
         dtype = string_to_np_dtype[python_dtype_str]
 
-        if dtype in {np.ubyte, np.int16, np.int32, np.int64}:
+        if dtype in {np.ubyte, np.uint16, np.int16, np.uint32, np.int32, np.int64}:
             py_tensor = np.random.randint(np.iinfo(dtype).min, np.iinfo(dtype).max, shape, dtype=dtype)
         else:
             py_tensor = np.random.random(shape).astype(dtype=dtype)
@@ -154,7 +154,7 @@ def test_tensor_conversion_with_python_dtype(python_lib, shape, python_dtype_str
     elif python_lib == np:
         py_tensor_after_round_trip = tt_tensor.to_numpy()
 
-    if python_dtype_str in ("int64", "float16"):
+    if python_dtype_str in ("int16", "int64", "float16"):
         pytest.xfail(
             "{} dtype is incorrectly handled in ttnn tensors, so roundtrip tests are not working!".format(
                 python_dtype_str

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -18,8 +18,8 @@ import numpy as np
 # Dictionaries for converting dtypes
 tt_dtype_to_torch_dtype = {
     ttnn.uint8: torch.uint8,
-    ttnn.uint16: torch.int16,
-    ttnn.uint32: torch.int32,
+    ttnn.uint16: torch.uint16,
+    ttnn.uint32: torch.uint32,
     ttnn.int32: torch.int32,
     ttnn.float32: torch.float,
     ttnn.bfloat16: torch.bfloat16,
@@ -29,8 +29,8 @@ tt_dtype_to_torch_dtype = {
 
 tt_dtype_to_np_dtype = {
     ttnn.uint8: np.ubyte,
-    ttnn.uint16: np.int16,
-    ttnn.uint32: np.int32,
+    ttnn.uint16: np.uint16,
+    ttnn.uint32: np.uint32,
     ttnn.int32: np.int32,
     ttnn.float32: np.float32,
     ttnn.bfloat8_b: np.float32,

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -507,7 +507,7 @@ py::object convert_tt_tensor_to_torch_tensor(const RowMajorHostBuffer& row_major
     py::object torch_dtype = [&]() {
         switch (row_major_host_buffer.data_type) {
             case DataType::UINT8: return torch.attr("uint8");
-            case DataType::UINT16: return torch.attr("int16");
+            case DataType::UINT16: return torch.attr("uint16");
             case DataType::INT32:
             case DataType::UINT32: return torch.attr("int32");
             case DataType::BFLOAT16: return torch.attr("bfloat16");

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -508,8 +508,8 @@ py::object convert_tt_tensor_to_torch_tensor(const RowMajorHostBuffer& row_major
         switch (row_major_host_buffer.data_type) {
             case DataType::UINT8: return torch.attr("uint8");
             case DataType::UINT16: return torch.attr("uint16");
-            case DataType::INT32:
-            case DataType::UINT32: return torch.attr("int32");
+            case DataType::INT32: return torch.attr("int32");
+            case DataType::UINT32: return torch.attr("uint32");
             case DataType::BFLOAT16: return torch.attr("bfloat16");
             case DataType::BFLOAT8_B:
             case DataType::BFLOAT4_B:
@@ -544,9 +544,9 @@ py::object convert_tt_tensor_to_numpy_tensor(const RowMajorHostBuffer& row_major
     py::object np_dtype = [&]() {
         switch (row_major_host_buffer.data_type) {
             case DataType::UINT8: return np.attr("ubyte");
-            case DataType::UINT16: return np.attr("int16");
-            case DataType::INT32:
-            case DataType::UINT32: return np.attr("int32");
+            case DataType::UINT16: return np.attr("uint16");
+            case DataType::INT32: return np.attr("int32");
+            case DataType::UINT32: return np.attr("uint32");
             case DataType::BFLOAT16: TT_THROW("Bfloat16 is not supported for numpy!");
             case DataType::BFLOAT8_B:
             case DataType::BFLOAT4_B:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently `to_torch` converts uint16 tensors to int16 causing overflow / wrapping issues.

### What's changed
Updated `to_torch` to return uint16 for uint16.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:

- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:

- [ ] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:

- [ ] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:

- [ ] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:

- [x] New/Existing tests provide coverage for changes