### PR TITLE
Fix llama-3.3-70B accuracy test

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
@@ -186,6 +186,7 @@ def test_tt_model_acc(
         weight_cache_path=model_args.weight_cache_path(dtype),
         paged_attention_config=paged_attention_config,
         enable_prefetcher_performance_mode=True,
+        decode_mode_only=True,
     )
     tt_sampling = TTSampling(
         args=model_args,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30919

### Problem description
Missed `decode_only` argument on model init.