### PR TITLE
reduce deepseek galaxy test time

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "(Galaxy) DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 130, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "(Galaxy) DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 95, owner_id: U03HY7MK4BT}, # Mark O'Connor
         ]
     runs-on:
       - arch-wormhole_b0

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -11,6 +11,7 @@ from transformers import AutoConfig
 
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
+from models.demos.deepseek_v3.utils.test_utils import load_state_dict
 from tests.scripts.common import get_updated_device_params
 
 RESET_WEIGHT_CACHE_OPTION = "--recalculate-weights"
@@ -80,6 +81,11 @@ def hf_config(model_path):
     """Load DeepSeek config for testing"""
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     return config
+
+
+@pytest.fixture(scope="session")
+def state_dict(model_path):
+    return load_state_dict(model_path, "")
 
 
 @pytest.fixture(scope="session")

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -46,7 +46,6 @@ def generate_reference_io(
 ):
     reference_model = DeepseekV3DecoderLayer(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
     if module_path is not None:
-        # state_dict = load_state_dict(model_path, module_path)
         state_dict = sub_state_dict(state_dict, module_path + ".")
         reference_model.load_state_dict(dequantize_state_dict(state_dict, hf_config))
     else:

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -12,13 +12,13 @@ from torch.nn import Embedding as EmbeddingReference
 import ttnn
 from models.demos.deepseek_v3.tt.embedding.embedding1d import Embedding1D
 from models.demos.deepseek_v3.tt.embedding.embedding2d import Embedding2D
+from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
     get_model_config,
     get_test_weight_config,
     load_reference_io_tensors_for_module,
-    load_state_dict,
     run_module_forward,
 )
 
@@ -59,6 +59,7 @@ def test_embedding_forward_pass(
     cache_path,
     force_recalculate_weight_config,
     set_deterministic_env,
+    state_dict,
 ):
     logger.info("Setting up reference IO")
     module_path = "model.embed_tokens"
@@ -78,7 +79,8 @@ def test_embedding_forward_pass(
         cache_path = tmp_path
         force_recalculate_weight_config = True
     else:
-        state_dict = load_state_dict(model_path, module_path)
+        # state_dict = load_state_dict(model_path, module_path)
+        state_dict = sub_state_dict(state_dict, module_path + ".")
         torch_input, reference_output = load_reference_io_tensors_for_module(
             mode, module_path, batch_size_or_seq_len, 1
         )

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -79,7 +79,6 @@ def test_embedding_forward_pass(
         cache_path = tmp_path
         force_recalculate_weight_config = True
     else:
-        # state_dict = load_state_dict(model_path, module_path)
         state_dict = sub_state_dict(state_dict, module_path + ".")
         torch_input, reference_output = load_reference_io_tensors_for_module(
             mode, module_path, batch_size_or_seq_len, 1

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -14,7 +14,7 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     add_inv_scale_to_state_dict,
@@ -22,7 +22,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     get_model_config,
     get_rope_tensors,
     get_test_weight_config,
-    load_state_dict,
     paged_cache_from_torch,
     run_reference_with_attention,
     torch_cache_from_paged,
@@ -55,6 +54,7 @@ def generate_reference_io(
     seq_len: int,
     batch_size: int,
     mode: str,
+    state_dict: dict[str, torch.Tensor],
 ) -> tuple[dict[str, torch.Tensor], torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     if module_path is None:
         reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
@@ -64,7 +64,8 @@ def generate_reference_io(
         )
     else:
         reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
-        state_dict = load_state_dict(model_path, module_path)
+        # state_dict = load_state_dict(model_path, module_path)
+        state_dict = sub_state_dict(state_dict, module_path + ".")
         dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
         reference_model.load_state_dict(dequantized_state_dict)
 
@@ -166,6 +167,7 @@ def run_test_forward_pass_mla1d(
     model_path,
     module_path,
     force_recalculate_weight_config,
+    state_dict,
 ):
     # Check params
     if mode == "prefill":
@@ -176,7 +178,7 @@ def run_test_forward_pass_mla1d(
     # Get reference IO
     logger.info("Setting up reference IO")
     state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
-        model_path, module_path, hf_config_short, layer_idx, seq_len, batch_size, mode
+        model_path, module_path, hf_config_short, layer_idx, seq_len, batch_size, mode, state_dict
     )
 
     # Set up page config
@@ -297,6 +299,7 @@ def run_test_forward_pass_mla2d(
     model_path,
     module_path,
     force_recalculate_weight_config,
+    state_dict,
 ):
     # Check params
     if mode == "prefill":
@@ -309,7 +312,7 @@ def run_test_forward_pass_mla2d(
     # Get reference IO
     logger.info("Setting up reference IO")
     state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
-        model_path, module_path, hf_config_short, layer_idx, seq_len, batch_size, mode
+        model_path, module_path, hf_config_short, layer_idx, seq_len, batch_size, mode, state_dict
     )
 
     # Set up page config
@@ -441,6 +444,7 @@ def test_forward_pass(
     force_recalculate_weight_config,
     test_closure,
     set_deterministic_env,
+    state_dict,
 ):
     # Hardcoded arguments; can later change them to test arguments if needed
     layer_idx = 0
@@ -462,6 +466,7 @@ def test_forward_pass(
         model_path,
         module_path,
         force_recalculate_weight_config,
+        state_dict,
     )
 
 

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -64,7 +64,6 @@ def generate_reference_io(
         )
     else:
         reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
-        # state_dict = load_state_dict(model_path, module_path)
         state_dict = sub_state_dict(state_dict, module_path + ".")
         dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
         reference_model.load_state_dict(dequantized_state_dict)

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -44,7 +44,6 @@ def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_devic
     [(NonExpert, "model.layers.0.mlp"), (SharedExpert, "model.layers.3.mlp.shared_experts")],
 )
 def test_convert_weights_for_dequantized_mlps(MLPClass, module_path, hf_config, tmp_path, mesh_device, state_dict):
-    # state_dict = load_state_dict(model_path, module_path)
     state_dict = sub_state_dict(state_dict, module_path + ".")
     run_weight_conversion_test(
         MLPClass=MLPClass,
@@ -149,7 +148,6 @@ def test_forward_pass(
         reference_model = reference_model.to(torch.float32)
         reference_output = reference_model(torch_input)
     else:
-        # state_dict = load_state_dict(model_path, module_path)
         state_dict = sub_state_dict(state_dict, module_path + ".")
         torch_input, reference_output = load_reference_io_tensors_for_module(
             mode, module_path, seq_len, num_module_layers

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import itertools
-
 import pytest
 import torch
 from loguru import logger
@@ -15,7 +13,7 @@ from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.model.row_pipelined_model import RowPipelinedModel
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     add_inv_scale_to_state_dict,
@@ -24,7 +22,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     get_model_config,
     get_rope_tensors,
     get_test_weight_config,
-    load_state_dict,
     paged_caches_from_torch,
     run_reference_with_attention,
     torch_cache_from_transformers,
@@ -38,6 +35,7 @@ def generate_reference_io(
     batch_size: int,
     hf_config: PretrainedConfig,
     model_path: str,
+    state_dict: dict[str, torch.Tensor],
 ):
     """Generate reference input and output for the given mode using either real or random weights."""
     # This needs to be disabled as deterministic way to quantize weights is not supported
@@ -46,15 +44,16 @@ def generate_reference_io(
     if use_real_weights:
         torch.use_deterministic_algorithms(False)
 
-        logger.info(f"Loading state dict from {model_path}")
-        state_dict = load_state_dict(model_path, "")
-        logger.info(f"State dict loaded")
-        state_dict = {
-            k: v
-            for k, v in state_dict.items()
-            for layer_idx_str in ["".join(itertools.takewhile(str.isdigit, k.removeprefix("model.layers.")))]
-            if not layer_idx_str or int(layer_idx_str) < hf_config.num_hidden_layers
-        }  # Trim the loaded state dict to not run out of memory
+        # logger.info(f"Loading state dict from {model_path}")
+        # state_dict = load_state_dict(model_path, "")
+        # logger.info(f"State dict loaded")
+        # state_dict = {
+        #     k: v
+        #     for k, v in state_dict.items()
+        #     for layer_idx_str in ["".join(itertools.takewhile(str.isdigit, k.removeprefix("model.layers.")))]
+        #     if not layer_idx_str or int(layer_idx_str) < hf_config.num_hidden_layers
+        # }  # Trim the loaded state dict to not run out of memory
+        state_dict = sub_state_dict(state_dict, "", hf_config.num_hidden_layers)
 
         logger.info(f"Creating reference model")
         # Create model on meta device (no weight initialization or memory allocation)
@@ -112,6 +111,7 @@ def run_test_forward_pass_ppmodel(
     model_path,
     ccl,
     force_recalculate_weight_config,
+    state_dict,
 ):
     # Check params
     if mode == "prefill":
@@ -122,7 +122,7 @@ def run_test_forward_pass_ppmodel(
     # Get reference IO
     logger.info("Setting up reference IO")
     state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
-        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path
+        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path, state_dict
     )
 
     # Set up page config
@@ -201,6 +201,7 @@ def run_test_forward_pass_dpmodel(
     model_path,
     ccl,
     force_recalculate_weight_config,
+    state_dict,
 ):
     # Check params
     if mode == "prefill":
@@ -213,7 +214,7 @@ def run_test_forward_pass_dpmodel(
     # Get reference IO
     logger.info("Setting up reference IO")
     state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
-        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path
+        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path, state_dict
     )
 
     # Set up page config
@@ -316,6 +317,7 @@ def test_forward_pass(
     force_recalculate_weight_config,
     test_closure,
     set_deterministic_env,
+    state_dict,
 ):
     # Set less layers and shorter max length for the sake of testing
     hf_config_short.num_hidden_layers = 8
@@ -335,6 +337,7 @@ def test_forward_pass(
         model_path,
         ccl,
         force_recalculate_weight_config,
+        state_dict,
     )
 
 

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -44,15 +44,6 @@ def generate_reference_io(
     if use_real_weights:
         torch.use_deterministic_algorithms(False)
 
-        # logger.info(f"Loading state dict from {model_path}")
-        # state_dict = load_state_dict(model_path, "")
-        # logger.info(f"State dict loaded")
-        # state_dict = {
-        #     k: v
-        #     for k, v in state_dict.items()
-        #     for layer_idx_str in ["".join(itertools.takewhile(str.isdigit, k.removeprefix("model.layers.")))]
-        #     if not layer_idx_str or int(layer_idx_str) < hf_config.num_hidden_layers
-        # }  # Trim the loaded state dict to not run out of memory
         state_dict = sub_state_dict(state_dict, "", hf_config.num_hidden_layers)
 
         logger.info(f"Creating reference model")

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -63,7 +63,6 @@ def create_combined_state_dict(module_path: str, model_path: Path, state_dict: d
     out_state_dict = {}
     for i in range(s, e + 1):
         module_path_i = f"{base_path}.{i}"
-        # state_dict_i = load_state_dict(model_path, module_path_i)
         state_dict_i = sub_state_dict(state_dict, module_path_i + ".")
         for k, v in state_dict_i.items():
             k_ = f"{base_path.split('.')[-1]}.{i}.{k}"

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -83,7 +83,6 @@ def test_forward_pass(
         cache_path = tmp_path
         force_recalculate_weight_config = True
     else:
-        # state_dict = load_state_dict(model_path, reference_layernorm_path)
         state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
         torch_input, reference_output = load_reference_io_tensors_for_module(
             mode, reference_layernorm_path, seq_len, num_module_layers

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -9,13 +9,13 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3RMSNorm
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm import RMSNorm
+from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
     get_model_config,
     get_test_weight_config,
     load_reference_io_tensors_for_module,
-    load_state_dict,
     run_module_forward,
 )
 
@@ -60,6 +60,7 @@ def test_forward_pass(
     ccl,
     force_recalculate_weight_config,
     set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
 ):
     num_module_layers, _ = mesh_device.shape
 
@@ -82,7 +83,8 @@ def test_forward_pass(
         cache_path = tmp_path
         force_recalculate_weight_config = True
     else:
-        state_dict = load_state_dict(model_path, reference_layernorm_path)
+        # state_dict = load_state_dict(model_path, reference_layernorm_path)
+        state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
         torch_input, reference_output = load_reference_io_tensors_for_module(
             mode, reference_layernorm_path, seq_len, num_module_layers
         )

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -572,9 +572,18 @@ def get_state_dicts(
     return torch.stack(tensors, dim=concat_dim)
 
 
-def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str):
+def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str, num_layers: int | None = None):
     """Get a subset of the state dict with a given prefix."""
-    return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
+    if num_layers is None:
+        return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
+    else:
+        return {
+            k[len(prefix) :]: v
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+            for layer_idx_str in ["".join(itertools.takewhile(str.isdigit, k.removeprefix("model.layers.")))]
+            if not layer_idx_str or int(layer_idx_str) < num_layers
+        }
 
 
 def sub_state_dicts(


### PR DESCRIPTION
Deepseek galaxy tests were frequently timing out after 2hr10m due to decreased i/o speeds. Tests are loading state dict from file each time which is slow. These changes refactor the state dict loading to happen once with a scope of the pytest session reducing the test time to ~90 mins.  

### Checklist
Deepseek tests: https://github.com/tenstorrent/tt-metal/actions/runs/18722303901/job/53398749828