### PR TITLE
Wan2.2 defaults to ring topology on 6U

### DIFF
--- a/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -268,7 +268,7 @@ class WanAttention:
                     num_links=self.ccl_manager.num_links,
                     cluster_axis=self.parallel_config.sequence_parallel.mesh_axis,
                     mesh_device=self.mesh_device,
-                    topology=self.ccl_manager.topology,
+                    topology=ttnn.Topology.Linear,  # RJA always uses Linear topology
                     subdevice_id=self.ccl_manager.ccl_sub_device_id,
                     ccl_core_grid_offset=(0, self.sdpa_worker_grid[1]),
                 )

--- a/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
@@ -125,6 +125,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         boundary_ratio: Optional[float] = None,
         expand_timesteps: bool = False,  # Wan2.2 ti2v
         dynamic_load=False,
+        topology: ttnn.Topology = ttnn.Topology.Linear,
     ):
         super().__init__()
 
@@ -147,10 +148,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             "Wan-AI/Wan2.2-T2V-A14B-Diffusers", subfolder="transformer_2", trust_remote_code=True
         )
 
-        self.ccl_manager = CCLManager(
+        self.dit_ccl_manager = CCLManager(
             mesh_device=mesh_device,
             num_links=num_links,
-            topology=ttnn.Topology.Linear,
+            topology=topology,
+        )
+        self.vae_ccl_manager = CCLManager(
+            mesh_device=mesh_device,
+            num_links=num_links,
+            topology=ttnn.Topology.Linear,  # NOTE: VAE always uses Linear topology. TODO: enable ring if given.
         )
         self.parallel_config = parallel_config
         self.vae_parallel_config = vae_parallel_config
@@ -171,7 +177,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             out_channels=self.vae.config.out_channels,
             is_residual=self.vae.config.is_residual,
             mesh_device=self.mesh_device,
-            ccl_manager=self.ccl_manager,
+            ccl_manager=self.vae_ccl_manager,
             parallel_config=self.vae_parallel_config,
         )
 
@@ -197,7 +203,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             eps=self.torch_transformer.config.eps,
             rope_max_seq_len=self.torch_transformer.config.rope_max_seq_len,
             mesh_device=self.mesh_device,
-            ccl_manager=self.ccl_manager,
+            ccl_manager=self.dit_ccl_manager,
             parallel_config=self.parallel_config,
             is_fsdp=True,
         )
@@ -238,7 +244,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             eps=self.torch_transformer_2.config.eps,
             rope_max_seq_len=self.torch_transformer_2.config.rope_max_seq_len,
             mesh_device=self.mesh_device,
-            ccl_manager=self.ccl_manager,
+            ccl_manager=self.dit_ccl_manager,
             parallel_config=self.parallel_config,
             is_fsdp=True,
         )

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_attention_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_attention_wan.py
@@ -15,11 +15,12 @@ from ....parallel.manager import CCLManager
 from ....parallel.config import DiTParallelConfig, ParallelFactor
 from ....utils.padding import pad_vision_seq_parallel
 from ....utils.mochi import get_rot_transformation_mat, stack_cos_sin
+from ....utils.test import ring_params, line_params
 from diffusers import WanTransformer3DModel
 
 
 @pytest.mark.parametrize(
-    "mesh_device, sp_axis, tp_axis, num_links",
+    "mesh_device, sp_axis, tp_axis, num_links, device_params, topology",
     [
         # [(1, 1), 0, 1, 1],
         # [(1, 2), 0, 1, 1],
@@ -28,11 +29,11 @@ from diffusers import WanTransformer3DModel
         # [(2, 1), 1, 0, 1],
         # [(2, 2), 0, 1, 1],
         # [(2, 2), 1, 0, 1],
-        [(2, 4), 0, 1, 1],
-        [(2, 4), 1, 0, 1],
+        [(2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear],
         # [(1, 8), 1, 0, 1],
-        [(4, 8), 0, 1, 4],
-        [(4, 8), 1, 0, 4],
+        [(4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
     ],
     ids=[
         # "1x1sp0tp1",
@@ -48,7 +49,7 @@ from diffusers import WanTransformer3DModel
         "4x8sp0tp1",
         "4x8sp1tp0",
     ],
-    indirect=["mesh_device"],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(
     "T, H, W",
@@ -61,7 +62,6 @@ from diffusers import WanTransformer3DModel
 )
 @pytest.mark.parametrize("prompt_seq_len", [None, 26, 126], ids=["no_prompt", "short_prompt", "long_prompt"])
 @pytest.mark.parametrize("is_fsdp", [True], ids=["yes_fsdp"])
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_wan_attention(
     mesh_device: ttnn.MeshDevice,
     sp_axis: int,
@@ -72,6 +72,7 @@ def test_wan_attention(
     W: int,
     prompt_seq_len: int,
     is_fsdp: bool,
+    topology: ttnn.Topology,
 ) -> None:
     torch_dtype = torch.float32
 
@@ -113,7 +114,7 @@ def test_wan_attention(
     ccl_manager = CCLManager(
         mesh_device=mesh_device,
         num_links=num_links,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
     )
 
     parallel_config = DiTParallelConfig(

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -9,22 +9,22 @@ from models.experimental.tt_dit.parallel.config import DiTParallelConfig, VaeHWP
 from diffusers.utils import export_to_video
 import pytest
 import ttnn
+from ....utils.test import line_params, ring_params
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology",
     [
-        [(2, 4), (2, 4), 0, 1, 1, True],
-        [(4, 8), (4, 8), 1, 0, 4, False],
+        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring],
     ],
     ids=[
         "2x4sp0tp1",
         "4x8sp1tp0",
     ],
-    indirect=["mesh_device"],
+    indirect=["mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_pipeline_inference(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load):
+def test_pipeline_inference(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, topology):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
 
@@ -60,6 +60,7 @@ def test_pipeline_inference(mesh_device, mesh_shape, sp_axis, tp_axis, num_links
         use_cache=True,
         boundary_ratio=0.875,
         dynamic_load=dynamic_load,
+        topology=topology,
     )
 
     # Run inference

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -17,11 +17,12 @@ from ....parallel.config import DiTParallelConfig, ParallelFactor
 from ....utils.padding import pad_vision_seq_parallel
 from ....utils.cache import get_cache_path, get_and_create_cache_path, save_cache_dict, load_cache_dict
 from ....utils.mochi import get_rot_transformation_mat, stack_cos_sin
+from ....utils.test import ring_params, line_params
 from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology",
     [
         # [(1, 1), (1, 1), 0, 1, 1],
         # [(1, 2), (1, 2), 0, 1, 1],
@@ -30,10 +31,10 @@ from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
         # [(2, 1), (2, 1), 1, 0, 1],
         # [(2, 2), (2, 2), 0, 1, 1],
         # [(2, 2), (2, 2), 1, 0, 1],
-        [(2, 4), (2, 4), 0, 1, 1],
-        [(2, 4), (2, 4), 1, 0, 1],
-        [(4, 8), (4, 8), 0, 1, 4],
-        [(4, 8), (4, 8), 1, 0, 4],
+        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
     ],
     ids=[
         # "1x1sp0tp1",
@@ -48,7 +49,7 @@ from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
         "4x8sp0tp1",
         "4x8sp1tp0",
     ],
-    indirect=["mesh_device"],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(
     ("B, T, H, W, prompt_seq_len"),
@@ -60,7 +61,6 @@ from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
     ids=["5b-720p", "14b-480p", "14b-720p"],
 )
 @pytest.mark.parametrize("is_fsdp", [True], ids=["yes_fsdp"])
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_wan_transformer_block(
     mesh_device: ttnn.MeshDevice,
     mesh_shape: tuple[int, int],
@@ -73,6 +73,7 @@ def test_wan_transformer_block(
     W: int,
     prompt_seq_len: int,
     is_fsdp: bool,
+    topology: ttnn.Topology,
 ) -> None:
     torch_dtype = torch.float32
     parent_mesh_device = mesh_device
@@ -110,7 +111,7 @@ def test_wan_transformer_block(
     ccl_manager = CCLManager(
         mesh_device=mesh_device,
         num_links=num_links,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
     )
 
     parallel_config = DiTParallelConfig(
@@ -208,7 +209,7 @@ def test_wan_transformer_block(
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology",
     [
         # [(1, 1), (1, 1), 0, 1, 1],
         # [(1, 2), (1, 2), 0, 1, 1],
@@ -217,10 +218,10 @@ def test_wan_transformer_block(
         # [(2, 1), (2, 1), 1, 0, 1],
         # [(2, 2), (2, 2), 0, 1, 1],
         # [(2, 2), (2, 2), 1, 0, 1],
-        [(2, 4), (2, 4), 0, 1, 1],
-        [(2, 4), (2, 4), 1, 0, 1],
-        [(4, 8), (4, 8), 0, 1, 4],
-        [(4, 8), (4, 8), 1, 0, 4],
+        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
     ],
     ids=[
         # "1x1sp0tp1",
@@ -235,7 +236,7 @@ def test_wan_transformer_block(
         "4x8sp0tp1",
         "4x8sp1tp0",
     ],
-    indirect=["mesh_device"],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(
     ("B, T, H, W, prompt_seq_len"),
@@ -248,7 +249,6 @@ def test_wan_transformer_block(
     ids=["short_seq", "5b-720p", "14b-480p", "14b-720p"],
 )
 @pytest.mark.parametrize("load_cache", [True, False], ids=["yes_load_cache", "no_load_cache"])
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_wan_transformer_model(
     mesh_device: ttnn.MeshDevice,
     mesh_shape: tuple[int, int],
@@ -261,6 +261,7 @@ def test_wan_transformer_model(
     W: int,
     prompt_seq_len: int,
     load_cache: bool,
+    topology: ttnn.Topology,
 ) -> None:
     torch_dtype = torch.float32
 
@@ -294,7 +295,7 @@ def test_wan_transformer_model(
     ccl_manager = CCLManager(
         mesh_device=mesh_device,
         num_links=num_links,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
     )
 
     parallel_config = DiTParallelConfig(
@@ -374,25 +375,25 @@ def test_wan_transformer_model(
 
 
 @pytest.mark.parametrize(
-    "mesh_device, sp_axis, tp_axis, num_links",
+    "mesh_device, sp_axis, tp_axis, num_links, device_params, topology",
     [
-        [(2, 4), 0, 1, 1],
-        [(4, 8), 1, 0, 4],
+        [(2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
+        [(4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
     ],
     ids=[
         "2x4sp0tp1",
         "4x8sp1tp0",
     ],
-    indirect=["mesh_device"],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("subfolder", ["transformer", "transformer_2"], ids=["transformer_1", "transformer_2"])
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_wan_transformer_model_caching(
     mesh_device: ttnn.MeshDevice,
     sp_axis: int,
     tp_axis: int,
     num_links: int,
     subfolder: str,
+    topology: ttnn.Topology,
 ) -> None:
     torch_dtype = torch.float32
 
@@ -426,7 +427,7 @@ def test_wan_transformer_model_caching(
     ccl_manager = CCLManager(
         mesh_device=mesh_device,
         num_links=num_links,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
     )
 
     parallel_config = DiTParallelConfig(

--- a/models/experimental/tt_dit/utils/test.py
+++ b/models/experimental/tt_dit/utils/test.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import ttnn
 
 line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}

--- a/models/experimental/tt_dit/utils/test.py
+++ b/models/experimental/tt_dit/utils/test.py
@@ -1,0 +1,4 @@
+import ttnn
+
+line_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
+ring_params = {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}


### PR DESCRIPTION
Wan2.2 gets a performance uplift by using ring topology on 6U.
For 4x8sp1tp0 config, block latency improves from 157ms -> 153ms.