### PR TITLE
Fix shard spec in transpose pytest

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1292,18 +1292,16 @@ def test_transpose_29126(device):
     h = 8192
     w = 2048
 
-    dram_cores = 8
-    dram_weight_grid = ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(
-                ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(dram_cores - 1, 0),
-            )
-        }
+    num_cores_x = 8
+    num_cores_y = 1
+    if num_cores_x > device.core_grid.x:
+        num_cores_x = device.core_grid.x
+    shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
     )
     shard_spec = ttnn.ShardSpec(
-        dram_weight_grid,
-        (ttnn.core.roundup(ttnn.core.divup(h, dram_cores), ttnn.TILE_SIZE), w),
+        shard_grid,
+        (ttnn.core.roundup(ttnn.core.divup(h, num_cores_x * num_cores_y), ttnn.TILE_SIZE), w),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)


### PR DESCRIPTION
### Ticket
N/A
Failing pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/18708198375/job/53384618679#step:5:569

### Problem description
The number of DRAM cores was hardcoded.

### What's changed
- Correctly query the number of DRAM cores from `device`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18724653942)
- [x] [Nightly L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18728146017)