### PR TITLE
2D rank support for all gather, ND fixes for composite

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -1037,10 +1037,19 @@ NUM_ITERS = 2
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",
-    [[32, 32], [2, 2, 32, 32], [5, 32, 32], [2, 2, 2, 32, 32], [2, 2, 2, 2, 32, 32], [2, 2, 2, 16, 16], [2, 16, 16]],
+    [
+        [32, 32],
+        [2, 2, 32, 32],
+        [5, 32, 32],
+        [2, 2, 2, 32, 32],
+        [2, 2, 2, 2, 32, 32],
+        [2, 2, 2, 16, 16],
+        [2, 16, 16],
+        [16, 16],
+    ],
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("cluster_axis", [1])
 @pytest.mark.parametrize("topology", [ttnn.Topology.Linear])

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -1035,7 +1035,10 @@ NUM_ITERS = 2
 
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
-@pytest.mark.parametrize("input_shape", [[2, 2, 32, 32], [5, 32, 32], [2, 2, 2, 32, 32], [2, 2, 2, 2, 32, 32]])
+@pytest.mark.parametrize(
+    "input_shape",
+    [[32, 32], [2, 2, 32, 32], [5, 32, 32], [2, 2, 2, 32, 32], [2, 2, 2, 2, 32, 32], [2, 2, 2, 16, 16], [2, 16, 16]],
+)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_broadcast.py
@@ -245,6 +245,7 @@ def run_all_broadcast_impl(
         (8, 1, [10, 8320], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
         (2, 1, [11, 10, 32784], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
         (4, 1, [1, 2, 16300], ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+        (4, 1, [2, 2, 2, 16, 16], ttnn.TILE_LAYOUT, ttnn.bfloat16),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -29,6 +29,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor,
             dim,
@@ -37,6 +38,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
             subdevice_id,
             /*cluster_axis*/ std::nullopt);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -72,9 +74,11 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             persistent_output_buffer,
@@ -115,9 +119,11 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case = composite_common::use_all_gather_async_llama_sharded(
         input_tensors.at(0), memory_config.value_or(input_tensors.at(0).memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensors, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensors,
             persistent_output_buffer,
@@ -155,9 +161,11 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -192,6 +200,7 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor,
             dim,
@@ -200,6 +209,7 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
             subdevice_id,
             /*cluster_axis*/ std::nullopt);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -235,8 +245,10 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             persistent_output_buffer,
@@ -275,9 +287,11 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
+        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
+        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -29,7 +29,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor,
             dim,
@@ -38,7 +38,7 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
             subdevice_id,
             /*cluster_axis*/ std::nullopt);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -74,11 +74,11 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             persistent_output_buffer,
@@ -119,11 +119,11 @@ std::vector<ttnn::Tensor> ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case = composite_common::use_all_gather_async_llama_sharded(
         input_tensors.at(0), memory_config.value_or(input_tensors.at(0).memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensors, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensors,
             persistent_output_buffer,
@@ -161,11 +161,11 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -200,7 +200,7 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor,
             dim,
@@ -209,7 +209,7 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
             subdevice_id,
             /*cluster_axis*/ std::nullopt);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,
@@ -245,10 +245,10 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             persistent_output_buffer,
@@ -287,11 +287,11 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool all_gather_async_llama_sharded_case =
         composite_common::use_all_gather_async_llama_sharded(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
-        log_debug(tt::LogOp, "DEBUG: using composite_all_gather");
+        log_debug(tt::LogOp, "Using composite_all_gather");
         return composite_common::composite_all_gather(
             input_tensor, dim, num_preferred_links.value_or(1), memory_config, subdevice_id, cluster_axis);
     } else {
-        log_debug(tt::LogOp, "DEBUG: using minimal_all_gather_async");
+        log_debug(tt::LogOp, "Using minimal_all_gather_async");
         return ttnn::operations::experimental::ccl::all_gather_async(
             input_tensor,
             dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -135,8 +135,7 @@ void AllGatherAsync::validate_with_output_tensors(
         }
         TT_FATAL(input_tensor.logical_shape().rank() >= 2, "AllGatherAsync requires tensor of rank 2 or greater");
     } else {
-        TT_FATAL(
-            input_tensor.logical_shape().rank() == 4, "Llama specific all_gather requires tensor of rank 4 or greater");
+        TT_FATAL(input_tensor.logical_shape().rank() == 4, "Llama specific all_gather requires tensor of rank 4");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -29,8 +29,6 @@ void AllGatherAsync::validate_with_output_tensors(
         "by the fabric api");
     TT_FATAL(page_size % input_tensors[0].buffer()->alignment() == 0, "All Gather currently requires aligned pages");
 
-    TT_FATAL(input_tensor.logical_shape().rank() > 2, "AllGatherAsync requires tensor of rank 3 or greater");
-
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_gather need to be allocated in buffers on device!");
     TT_FATAL(this->num_links > 0, "Error, num_links should be more than 0 but has {}", this->num_links);
@@ -135,6 +133,10 @@ void AllGatherAsync::validate_with_output_tensors(
                 input_tensor.memory_config().buffer_type() == BufferType::L1,
                 "We don't support input DRAM block sharding");
         }
+        TT_FATAL(input_tensor.logical_shape().rank() >= 2, "AllGatherAsync requires tensor of rank 2 or greater");
+    } else {
+        TT_FATAL(
+            input_tensor.logical_shape().rank() == 4, "Llama specific all_gather requires tensor of rank 4 or greater");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -413,55 +413,64 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
+
+    auto map_nd_to_4d = [&]() {
+        // Here we do a couple of tricks so that the kernels can handle ND tensors
+        // implicitly reshape lower dims so it is treated as 4D
+        uint32_t batch_head_size =
+            std::accumulate(input_tensor_shape.cbegin(), input_tensor_shape.cend() - 2, 1, std::multiplies<uint32_t>());
+
+        auto [normalized_dim, rank_diff] = composite_common::normalize_dim_4d(dim, input_tensor_shape.rank());
+
+        // if the gather dim is 4D normalized to 0,2,3 we can proceed as if nothing has changed
+        // if not we have to roll up the lower dims from the gather dim up to 1 into C and gather on 1.
+        uint32_t c_includes_dim;
+        if (rank_diff >= 1 && dim <= rank_diff) {
+            // gather dim to rank-3 accumulated into C
+            c_includes_dim = dim;
+            normalized_dim = 1;
+        } else {
+            // C will be 4D normalized dim 1
+            c_includes_dim = 1 + rank_diff;
+        }
+
+        uint32_t input_tensor_C = std::accumulate(
+            input_tensor_shape.view().rbegin() + 2,
+            input_tensor_shape.view().rend() - c_includes_dim,
+            1,
+            std::multiplies<uint32_t>());
+
+        uint32_t output_tensor_C = std::accumulate(
+            output_tensor_shape.view().rbegin() + 2,
+            output_tensor_shape.view().rend() - c_includes_dim,
+            1,
+            std::multiplies<uint32_t>());
+
+        return std::make_tuple(normalized_dim, batch_head_size, input_tensor_C, output_tensor_C);
+    };
+
+    auto map_2d_to_4d = [&]() {
+        const uint32_t normalized_dim = std::get<0>(composite_common::normalize_dim_4d(dim, input_tensor_shape.rank()));
+        constexpr uint32_t input_tensor_C = 1, output_tensor_C = 1, batch_head_size = 1;
+
+        return std::make_tuple(normalized_dim, batch_head_size, input_tensor_C, output_tensor_C);
+    };
+
+    const auto [normalized_dim, batch_head_size, input_tensor_C, output_tensor_C] =
+        (input_tensor_shape.rank() == 2) ? map_2d_to_4d() : map_nd_to_4d();
+
+    uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
+    TT_FATAL(!(input_tensor_shape[-1] % TILE_WIDTH), "Input tensor width must be a multiple of TILE_WIDTH");
+    TT_FATAL(!(output_tensor_shape[-1] % TILE_WIDTH), "Output tensor width must be a multiple of TILE_WIDTH");
+    uint32_t TILE_WIDTH = 32;
+
+    uint32_t input_tensor_Wt = input_tensor_shape[-1] / TILE_WIDTH;
+    uint32_t input_tensor_Ht = input_tensor_shape[-2] / TILE_WIDTH;
+
+    uint32_t output_tensor_Wt = output_tensor_shape[-1] / TILE_WIDTH;
+    uint32_t output_tensor_Ht = output_tensor_shape[-2] / TILE_WIDTH;
+
     for (uint32_t link = 0; link < num_links; link++) {
-        auto map_nd_to_4d = [&]() {
-            // Here we do a couple of tricks so that the kernels can handle ND tensors
-            // implicitly reshape lower dims so it is treated as 4D
-            uint32_t batch_head_size = std::accumulate(
-                input_tensor_shape.cbegin(), input_tensor_shape.cend() - 2, 1, std::multiplies<uint32_t>());
-
-            auto [normalized_dim, rank_diff] = composite_common::normalize_dim_4d(dim, input_tensor_shape.rank());
-
-            // if the gather dim is 4D normalized to 0,2,3 we can proceed as if nothing has changed
-            // if not we have to roll up the lower dims from the gather dim up to 1 into C and gather on 1.
-            uint32_t c_includes_dim;
-            if (rank_diff >= 1 && dim <= rank_diff) {
-                // gather dim to rank-3 accumulated into C
-                c_includes_dim = dim;
-                normalized_dim = 1;
-            } else {
-                // C will be 4D normalized dim 1
-                c_includes_dim = 1 + rank_diff;
-            }
-
-            uint32_t input_tensor_C = std::accumulate(
-                input_tensor_shape.view().rbegin() + 2,
-                input_tensor_shape.view().rend() - c_includes_dim,
-                1,
-                std::multiplies<uint32_t>());
-
-            uint32_t output_tensor_C = std::accumulate(
-                output_tensor_shape.view().rbegin() + 2,
-                output_tensor_shape.view().rend() - c_includes_dim,
-                1,
-                std::multiplies<uint32_t>());
-
-            return std::make_tuple(normalized_dim, batch_head_size, input_tensor_C, output_tensor_C);
-        };
-
-        const auto [normalized_dim, batch_head_size, input_tensor_C, output_tensor_C] = map_nd_to_4d();
-
-        uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
-        TT_FATAL(!(input_tensor_shape[-1] % TILE_WIDTH), "Input tensor width must be a multiple of TILE_WIDTH");
-        TT_FATAL(!(output_tensor_shape[-1] % TILE_WIDTH), "Output tensor width must be a multiple of TILE_WIDTH");
-        uint32_t TILE_WIDTH = 32;
-
-        uint32_t input_tensor_Wt = input_tensor_shape[-1] / TILE_WIDTH;
-        uint32_t input_tensor_Ht = input_tensor_shape[-2] / TILE_WIDTH;
-
-        uint32_t output_tensor_Wt = output_tensor_shape[-1] / TILE_WIDTH;
-        uint32_t output_tensor_Ht = output_tensor_shape[-2] / TILE_WIDTH;
-
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             // Fabrix mux kernel
             uint32_t mux_core_offset = (link * num_cores_per_link) +


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25143

### Note on Base
~~This is branched off of [amorrison/nd-rs](https://github.com/tenstorrent/tt-metal/tree/amorrison/nd-rs) so this PR is currently pointing at that branch for ease of review. It will be redirected to `main` once the former has merged.~~

### Problem description
- all gather usage with 2D tensors was desired
- Composite all gather still had some problems with ND 

### What's changed
- Add 2D special case to ND minimal all gather
- Fix some issues with ND composite all gather, tweaks to ensure it works
- Small refactor of in minimal program factory

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes  https://github.com/tenstorrent/tt-metal/actions/runs/18726537267
- [x] Blackhole Multi-Card demo https://github.com/tenstorrent/tt-metal/actions/runs/18726548066
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/18726555935
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/18791811724
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/18791860560
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/18791903848
- [x] New/Existing tests provide coverage for changes