### PR TITLE
Rename notify_brisc_and_wait

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -64,7 +64,7 @@ uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 extern "C" uint32_t wh_iram_trampoline(uint32_t status, uint32_t first_argument);
 #endif
 
-inline __attribute__((always_inline)) void notify_brisc_and_wait() {
+inline __attribute__((always_inline)) void wait_for_brisc_notification() {
     while (true) {
         uint8_t run_value = *ncrisc_run;
         if (run_value == RUN_SYNC_MSG_GO || run_value == RUN_SYNC_MSG_LOAD) {
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
     DeviceProfilerInit();
     while (1) {
         WAYPOINT("W");
-        notify_brisc_and_wait();
+        wait_for_brisc_notification();
         DeviceZoneScopedMainN("NCRISC-FW");
 
         uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;


### PR DESCRIPTION
### Problem description
notify_brisc_and_wait is a confusing name, since the function doesn't actually notify the brisc of anything. This is a legacy of the grayskull implementation, where it notified the brisc that the core was ready to be reset.

### What's changed
Rename it to wait_for_brisc_notification.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes