### PR TITLE
[skip ci] Run TTNN examples in PR Gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -237,6 +237,26 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-metalium
 
+  ttnn-examples:
+    needs: [ build, find-changed-files ]
+    if: ${{
+        github.ref_name == 'main' ||
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-nn-changed == 'true'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N150-viommu",
+        ]
+    uses: ./.github/workflows/sdk-examples.yaml
+    with:
+      docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
+      package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
+      product: tt-nn
+
   ttsim-integration-tests:
     needs: [ build ]
     strategy:

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -41,7 +41,14 @@ jobs:
           set -euo pipefail
           apt update
           DEBIAN_FRONTEND=noninteractive TZ=UTC apt install -y -q libprotobuf-dev # this is being installed for testing dependency conflicts with protobuf
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb
+          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb
+
+          if [ "${{ inputs.product }}" == "tt-metalium" ]; then
+            apt install -y ./pkgs/tt-metalium-examples_*.deb
+          fi
+          if [ "${{ inputs.product }}" == "tt-nn" ]; then
+            apt install -y ./pkgs/tt-nn_*.deb ./pkgs/tt-nn-dev_*.deb ./pkgs/tt-nn-examples_*.deb
+          fi
 
       - name: Run examples
         id: test


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We have an example of how to consume TTNN for CMake projects, but never actually lit it up in CI.

### What's changed
Light it up.

See: https://github.com/tenstorrent/tt-metal/actions/runs/18733628576/job/53436665507#step:6:31