### PR TITLE
[tt-train] Apply patch only if needed for dependencies

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -79,6 +79,7 @@ CPMAddPackage(
 
 CPMAddPackage(NAME nlohmann_json GITHUB_REPOSITORY nlohmann/json GIT_TAG v3.11.3 OPTIONS "JSON_BuildTests OFF")
 
+# gersemi: off
 CPMAddPackage(
     NAME xtl
     GITHUB_REPOSITORY xtensor-stack/xtl
@@ -111,7 +112,6 @@ CPMAddPackage(
 
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_cli11.cmake)
 
-# gersemi: off
 CPMAddPackage(
     NAME msgpack
     GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -83,8 +83,8 @@ CPMAddPackage(
     NAME xtl
     GITHUB_REPOSITORY xtensor-stack/xtl
     GIT_TAG 0.8.0
-    PATCHES
-        xtl.patch
+    PATCH_COMMAND
+        patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/xtl.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/xtl.patch
     OPTIONS
         "XTL_ENABLE_TESTS OFF"
 )
@@ -93,8 +93,8 @@ CPMAddPackage(
     NAME xtensor
     GITHUB_REPOSITORY xtensor-stack/xtensor
     GIT_TAG 0.26.0
-    PATCHES
-        xtensor.patch
+    PATCH_COMMAND
+        patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/xtensor.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/xtensor.patch
     OPTIONS
         "XTENSOR_ENABLE_TESTS OFF"
 )
@@ -103,8 +103,8 @@ CPMAddPackage(
     NAME xtensor-blas
     GITHUB_REPOSITORY xtensor-stack/xtensor-blas
     GIT_TAG 0.22.0
-    PATCHES
-        xtensor-blas.patch
+    PATCH_COMMAND
+        patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/xtensor-blas.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/xtensor-blas.patch
     OPTIONS
         "XTENSOR_ENABLE_TESTS OFF"
 )


### PR DESCRIPTION
### Problem description

```
1 out of 1 hunk ignored -- saving rejects to file test/CMakeLists.txt.rej
FAILED: xtl-populate-prefix/src/xtl-populate-stamp/xtl-populate-patch /home/ttuser/git/tt-metal/tt-train/build/_deps/xtl-subbuild/xtl-populate-prefix/src/xtl-populate-stamp/xtl-populate-patch 
cd /home/ttuser/git/tt-metal/tt-train/build/_deps/xtl-src && /usr/bin/patch -p1 < /home/ttuser/git/tt-metal/tt-train/cmake/xtl.patch && /usr/bin/cmake -E touch /home/ttuser/git/tt-metal/tt-train/build/_deps/xtl-subbuild/xtl-populate-prefix/src/xtl-populate-stamp/xtl-populate-patch
ninja: build stopped: subcommand failed.

CMake Error at /usr/share/cmake-4.1/Modules/FetchContent.cmake:1918 (message):
  Build step for xtl failed: 1
Call Stack (most recent call first):
  /usr/share/cmake-4.1/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
  /usr/share/cmake-4.1/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  /usr/share/cmake-4.1/Modules/FetchContent.cmake:2145 (cmake_language)
  /usr/share/cmake-4.1/Modules/FetchContent.cmake:2384 (__FetchContent_Populate)
  build/cmake/CPM_0.40.2.cmake:1114 (FetchContent_MakeAvailable)
  build/cmake/CPM_0.40.2.cmake:895 (cpm_fetch_package)
  cmake/dependencies.cmake:82 (CPMAddPackage)
  CMakeLists.txt:55 (include)
```

### What's changed
Apply patch only if needed. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18743028052) CI passes