### PR TITLE
Improve clarity of fill_tile param0 argument description

### DIFF
--- a/tt_metal/include/compute_kernel_api/eltwise_unary/fill.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/fill.h
@@ -38,7 +38,7 @@ ALWI void fill_tile(uint32_t idst, float param0) { MATH((llk_math_eltwise_unary_
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | param0          | Value to fill tile with (unsigned integer)                                 | uint     |                                                       | True     |
+ * | param0          | Value to fill tile with (unsigned integer)                                 | uint32_t |                                                       | True     |
  */
 ALWI void fill_tile_int(uint32_t idst, uint param0) {
     MATH((llk_math_eltwise_unary_sfpu_fill_int<APPROX>(idst, param0)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/fill.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/fill.h
@@ -22,11 +22,24 @@ namespace ckernel {
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | param0          | The value the output is if the input is greater than 0                     | float    |                                                       | True     |
+ * | param0          | Value to fill tile with.                                                   | float    |                                                       | True     |
  */
 // clang-format on
 ALWI void fill_tile(uint32_t idst, float param0) { MATH((llk_math_eltwise_unary_sfpu_fill<APPROX>(idst, param0))); }
 
+// clang-format off
+/**
+ * Performs element-wise fill operation. The value to be filled in the tile is provided as const param0. The DST
+ * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | Value to fill tile with (unsigned integer)                                 | uint     |                                                       | True     |
+ */
 ALWI void fill_tile_int(uint32_t idst, uint param0) {
     MATH((llk_math_eltwise_unary_sfpu_fill_int<APPROX>(idst, param0)));
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`fill_tile` description suggests that `param0` must be > 0 even for float data type.
This is wrong, and created confusion among Kernel writers. 

What likely happened: `fill_tile` used to take param0 as `uint`, but got updated to take float argument. But description was not updated.

### What's changed
-  Fix argument description for `fill_tile`
- Add basic doc for `fill_tile_int`. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/18744234290 
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes