### PR TITLE
#30912: SDXL comparison mode

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/conftest.py
+++ b/models/experimental/stable_diffusion_xl_base/conftest.py
@@ -40,10 +40,9 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--debug-mode",
-        action="store",
+        action="store_true",
         default=False,
-        type=bool,
-        help="Whether to run SDXL in debug mode (default: False)",
+        help="Run SDXL in debug mode (default: False)",
     )
 
 
@@ -100,7 +99,7 @@ def loop_iter_num(request):
 
 @pytest.fixture
 def debug_mode(request):
-    return int(request.config.getoption("--debug-mode"))
+    return request.config.getoption("--debug-mode")
 
 
 @pytest.fixture(scope="function")

--- a/models/experimental/stable_diffusion_xl_base/conftest.py
+++ b/models/experimental/stable_diffusion_xl_base/conftest.py
@@ -38,6 +38,13 @@ def pytest_addoption(parser):
         default=10,
         help="Number of iterations of denoising loop (default: 10)",
     )
+    parser.addoption(
+        "--debug-mode",
+        action="store",
+        default=False,
+        type=bool,
+        help="Whether to run SDXL in debug mode (default: False)",
+    )
 
 
 @pytest.fixture
@@ -89,6 +96,11 @@ def get_device_name():
 @pytest.fixture
 def loop_iter_num(request):
     return int(request.config.getoption("--loop-iter-num"))
+
+
+@pytest.fixture
+def debug_mode(request):
+    return int(request.config.getoption("--debug-mode"))
 
 
 @pytest.fixture(scope="function")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -34,6 +34,7 @@ def test_crossattndown(
     out_dim,
     down_block_id,
     pcc,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -59,6 +60,7 @@ def test_crossattndown(
         num_attn_heads,
         out_dim,
         down_block_id == 1,
+        debug_mode=debug_mode,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -29,6 +29,7 @@ def test_crossattnmid(
     query_dim,
     num_attn_heads,
     out_dim,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -53,6 +54,7 @@ def test_crossattnmid(
         query_dim,
         num_attn_heads,
         out_dim,
+        debug_mode=debug_mode,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -53,6 +53,7 @@ def test_crossattnup(
     out_dim,
     block_id,
     pcc,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -78,6 +79,7 @@ def test_crossattnup(
         num_attn_heads,
         out_dim,
         True,
+        debug_mode=debug_mode,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
@@ -21,7 +21,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_downblock2d(device, temb_shape, input_shape, is_ci_env, reset_seeds):
+def test_downblock2d(device, temb_shape, input_shape, debug_mode, is_ci_env, reset_seeds):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -35,7 +35,7 @@ def test_downblock2d(device, temb_shape, input_shape, is_ci_env, reset_seeds):
     torch_downblock = unet.down_blocks[0]
 
     model_config = ModelOptimisations()
-    tt_downblock = TtDownBlock2D(device, state_dict, f"down_blocks.0", model_config=model_config)
+    tt_downblock = TtDownBlock2D(device, state_dict, f"down_blocks.0", model_config=model_config, debug_mode=debug_mode)
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
@@ -31,6 +31,7 @@ def test_downsample2d(
     stride,
     padding,
     dilation,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -57,6 +58,7 @@ def test_downsample2d(
         dilation,
         groups,
         model_config=model_config,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -43,6 +43,7 @@ def test_resnetblock2d(
     split_in,
     block,
     pcc,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -71,6 +72,7 @@ def test_resnetblock2d(
         model_config,
         conv_shortcut,
         split_in,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -75,6 +75,7 @@ def run_unet_model(
     encoder_shape,
     temb_shape,
     time_ids_shape,
+    debug_mode,
     is_ci_env,
     is_ci_v2_env,
     model_location_generator,
@@ -107,6 +108,7 @@ def run_unet_model(
         state_dict,
         "unet",
         model_config=model_config,
+        debug_mode=debug_mode,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_timestep_tensor = torch_random(timestep_shape, -0.1, 0.1, dtype=torch.float32)
@@ -206,6 +208,7 @@ def test_unet(
     encoder_shape,
     temb_shape,
     time_ids_shape,
+    debug_mode,
     is_ci_env,
     is_ci_v2_env,
     model_location_generator,
@@ -218,6 +221,7 @@ def test_unet(
         encoder_shape,
         temb_shape,
         time_ids_shape,
+        debug_mode,
         is_ci_env,
         is_ci_v2_env,
         model_location_generator,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -32,6 +32,7 @@ def test_upblock(
     temb_shape,
     residuals,
     block_id,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -48,7 +49,9 @@ def test_upblock(
     torch_crosattn = unet.up_blocks[block_id]
 
     model_config = ModelOptimisations()
-    tt_crosattn = TtUpBlock2D(device, state_dict, f"up_blocks.{block_id}", model_config=model_config)
+    tt_crosattn = TtUpBlock2D(
+        device, state_dict, f"up_blocks.{block_id}", model_config=model_config, debug_mode=debug_mode
+    )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
@@ -30,6 +30,7 @@ def test_upsample2d(
     stride,
     padding,
     dilation,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -56,6 +57,7 @@ def test_upsample2d(
         dilation,
         groups,
         model_config=model_config,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -112,7 +112,7 @@ def run_torch_denoising(
 
 
 @torch.no_grad()
-def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
+def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, debug_mode):
     torch.manual_seed(0)
 
     if isinstance(prompts, str):
@@ -139,6 +139,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
         pipeline.unet.state_dict(),
         "unet",
         model_config=tt_model_config,
+        debug_mode=debug_mode,
     )
     tt_scheduler = TtEulerDiscreteScheduler(
         ttnn_device,
@@ -287,29 +288,31 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
         compile_run=True,
     )
 
-    prepare_input_tensors(
-        [
-            tt_latents,
-            *tt_prompt_embeds[0],
-            tt_add_text_embeds[0][0],
-            tt_add_text_embeds[0][1],
-        ],
-        [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
-    )
-    tid, _, _, _ = run_tt_denoising(
-        ttnn_device=ttnn_device,
-        tt_latents_device=tt_latents_device,
-        tt_latents_output=None,
-        tt_unet=tt_unet,
-        tt_scheduler=tt_scheduler,
-        input_shape=[B, C, H, W],
-        ttnn_prompt_embeds=tt_prompt_embeds_device,
-        ttnn_add_text_embeds=tt_text_embeds_device,
-        ttnn_add_time_ids=tt_time_ids_device,
-        guidance_scale=guidance_scale,
-        extra_step_kwargs=extra_step_kwargs,
-        tid=None,
-    )
+    tid = None
+    if not debug_mode:
+        prepare_input_tensors(
+            [
+                tt_latents,
+                *tt_prompt_embeds[0],
+                tt_add_text_embeds[0][0],
+                tt_add_text_embeds[0][1],
+            ],
+            [tt_latents_device, *tt_prompt_embeds_device, *tt_text_embeds_device],
+        )
+        tid, _, _, _ = run_tt_denoising(
+            ttnn_device=ttnn_device,
+            tt_latents_device=tt_latents_device,
+            tt_latents_output=None,
+            tt_unet=tt_unet,
+            tt_scheduler=tt_scheduler,
+            input_shape=[B, C, H, W],
+            ttnn_prompt_embeds=tt_prompt_embeds_device,
+            ttnn_add_text_embeds=tt_text_embeds_device,
+            ttnn_add_time_ids=tt_time_ids_device,
+            guidance_scale=guidance_scale,
+            extra_step_kwargs=extra_step_kwargs,
+            tid=None,
+        )
 
     ttnn.synchronize_device(ttnn_device)
     pcc_per_iter = []
@@ -340,6 +343,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
                 guidance_scale=guidance_scale,
                 extra_step_kwargs=extra_step_kwargs,
                 tid=tid,
+                compile_run=debug_mode,
             )
             latents = run_torch_denoising(
                 latents=latents,
@@ -367,7 +371,8 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps):
             pcc_per_iter.append(float(pcc_message))
 
         tt_scheduler.set_step_index(0)
-    ttnn.release_trace(ttnn_device, tid)
+    if tid is not None:
+        ttnn.release_trace(ttnn_device, tid)
     if not is_ci_env:
         plt.plot(pcc_per_iter, marker="o")
         plt.title("PCC per iteration")
@@ -395,5 +400,6 @@ def test_unet_loop(
     is_ci_env,
     prompt,
     loop_iter_num,
+    debug_mode,
 ):
-    return run_unet_inference(device, is_ci_env, prompt, loop_iter_num)
+    return run_unet_inference(device, is_ci_env, prompt, loop_iter_num, debug_mode)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattndownblock2d.py
@@ -20,6 +20,7 @@ class TtCrossAttnDownBlock2D(LightweightModule):
         num_attn_heads,
         out_dim,
         has_downsample=False,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -44,7 +45,12 @@ class TtCrossAttnDownBlock2D(LightweightModule):
         for i in range(num_layers):
             self.resnets.append(
                 TtResnetBlock2D(
-                    device, state_dict, f"{module_path}.resnets.{i}", model_config=model_config, conv_shortcut=(i == 0)
+                    device,
+                    state_dict,
+                    f"{module_path}.resnets.{i}",
+                    model_config=model_config,
+                    conv_shortcut=(i == 0),
+                    debug_mode=debug_mode,
                 )
             )
 
@@ -58,6 +64,7 @@ class TtCrossAttnDownBlock2D(LightweightModule):
                 (1, 1),
                 1,
                 model_config=model_config,
+                debug_mode=debug_mode,
             )
             if has_downsample
             else None

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
@@ -17,6 +17,7 @@ class TtUNetMidBlock2DCrossAttn(LightweightModule):
         query_dim,
         num_attn_heads,
         out_dim,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -40,7 +41,9 @@ class TtUNetMidBlock2DCrossAttn(LightweightModule):
 
         for i in range(num_layers_resn):
             self.resnets.append(
-                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", model_config=model_config)
+                TtResnetBlock2D(
+                    device, state_dict, f"{module_path}.resnets.{i}", model_config=model_config, debug_mode=debug_mode
+                )
             )
 
     def forward(self, input_tensor, input_shape, temb=None, encoder_hidden_states=None, attention_mask=None):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -20,6 +20,7 @@ class TtCrossAttnUpBlock2D(LightweightModule):
         num_attn_heads,
         out_dim,
         has_upsample=False,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -49,12 +50,21 @@ class TtCrossAttnUpBlock2D(LightweightModule):
                     f"{module_path}.resnets.{i}",
                     model_config=model_config,
                     conv_shortcut=True,
+                    debug_mode=debug_mode,
                 )
             )
 
         self.upsamplers = (
             TtUpsample2D(
-                device, state_dict, f"{module_path}.upsamplers.0", (1, 1), (1, 1), (1, 1), 1, model_config=model_config
+                device,
+                state_dict,
+                f"{module_path}.upsamplers.0",
+                (1, 1),
+                (1, 1),
+                (1, 1),
+                1,
+                model_config=model_config,
+                debug_mode=debug_mode,
             )
             if has_upsample
             else None

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downblock2d.py
@@ -9,7 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_downsample2d import TtDo
 
 
 class TtDownBlock2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config):
+    def __init__(self, device, state_dict, module_path, model_config, debug_mode=False):
         super().__init__()
 
         num_layers = 2
@@ -17,7 +17,9 @@ class TtDownBlock2D(LightweightModule):
 
         for i in range(num_layers):
             self.resnets.append(
-                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", model_config=model_config)
+                TtResnetBlock2D(
+                    device, state_dict, f"{module_path}.resnets.{i}", model_config=model_config, debug_mode=debug_mode
+                )
             )
 
         self.downsamplers = TtDownsample2D(
@@ -29,6 +31,7 @@ class TtDownBlock2D(LightweightModule):
             (1, 1),
             1,
             model_config=model_config,
+            debug_mode=debug_mode,
         )
 
     def forward(self, hidden_states, input_shape, temb):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
@@ -9,7 +9,9 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtDownsample2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, stride, padding, dilation, groups, model_config):
+    def __init__(
+        self, device, state_dict, module_path, stride, padding, dilation, groups, model_config, debug_mode=False
+    ):
         super().__init__()
 
         self.device = device
@@ -17,6 +19,7 @@ class TtDownsample2D(LightweightModule):
         self.padding = padding
         self.dilation = dilation
         self.groups = groups
+        self.debug_mode = debug_mode
 
         weights = state_dict[f"{module_path}.conv.weight"]
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
@@ -33,7 +36,7 @@ class TtDownsample2D(LightweightModule):
     def forward(self, hidden_states, input_shape):
         B, C, H, W = input_shape
 
-        [hidden_states, [H, W], [self.tt_weights, self.tt_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_weights, tt_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_weights,
             in_channels=self.conv_params["input_channels"],
@@ -57,6 +60,9 @@ class TtDownsample2D(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_weights = tt_weights
+            self.tt_bias = tt_bias
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -26,6 +26,7 @@ class TtResnetBlock2D(LightweightModule):
         conv_shortcut=False,
         split_in=1,
         split_out=1,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -34,6 +35,7 @@ class TtResnetBlock2D(LightweightModule):
         self.split_conv = split_in > 1 or split_out > 1
         self.split_in = split_in
         self.split_out = split_out
+        self.debug_mode = debug_mode
 
         # fixed for ResnetBlock
         self.stride = (1, 1)
@@ -180,7 +182,7 @@ class TtResnetBlock2D(LightweightModule):
                 hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
             else:
                 hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
-            hidden_states, [C, H, W], [self.tt_conv1_weights, self.tt_conv1_bias] = split_conv2d(
+            hidden_states, [C, H, W], [tt_conv1_weights, tt_conv1_bias] = split_conv2d(
                 device=self.device,
                 hidden_states=hidden_states,
                 input_shape=[B, C, H, W],
@@ -198,7 +200,7 @@ class TtResnetBlock2D(LightweightModule):
                 groups=self.groups,
             )
         else:
-            [hidden_states, [H, W], [self.tt_conv1_weights, self.tt_conv1_bias]] = ttnn.conv2d(
+            [hidden_states, [H, W], [tt_conv1_weights, tt_conv1_bias]] = ttnn.conv2d(
                 input_tensor=hidden_states,
                 weight_tensor=self.tt_conv1_weights,
                 in_channels=self.conv1_params["input_channels"],
@@ -222,6 +224,9 @@ class TtResnetBlock2D(LightweightModule):
                 dtype=self.conv_output_dtype,
             )
             C = self.conv1_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_conv1_weights = tt_conv1_weights
+            self.tt_conv1_bias = tt_conv1_bias
 
         # ToDo: move to implace version or even better fuse iwth conv2d.
         # Currently both optinos have pcc issues.
@@ -265,7 +270,7 @@ class TtResnetBlock2D(LightweightModule):
 
         ttnn.silu(hidden_states, output_tensor=hidden_states)
 
-        [hidden_states, [H, W], [self.tt_conv2_weights, self.tt_conv2_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_conv2_weights, tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_conv2_weights,
             in_channels=self.conv2_params["input_channels"],
@@ -289,6 +294,9 @@ class TtResnetBlock2D(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv2_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_conv2_weights = tt_conv2_weights
+            self.tt_conv2_bias = tt_conv2_bias
 
         if self.tt_conv3_weights is not None:
             input_tensor_pre_conv = input_tensor

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
@@ -8,7 +8,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtR
 
 
 class TtUpBlock2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config):
+    def __init__(self, device, state_dict, module_path, model_config, debug_mode=False):
         super().__init__()
 
         num_layers = 3
@@ -22,6 +22,7 @@ class TtUpBlock2D(LightweightModule):
                     f"{module_path}.resnets.{i}",
                     model_config,
                     True,
+                    debug_mode=debug_mode,
                 )
             )
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
@@ -21,6 +21,7 @@ class TtUpsample2D(LightweightModule):
         dilation,
         groups,
         model_config,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -31,6 +32,7 @@ class TtUpsample2D(LightweightModule):
         self.dilation = dilation
         self.groups = groups
         self.scale_factor = 2  # fixed number for now
+        self.debug_mode = debug_mode
 
         weights = state_dict[f"{module_path}.conv.weight"]
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
@@ -60,7 +62,7 @@ class TtUpsample2D(LightweightModule):
         hidden_states, input_shape = self.interpolate(hidden_states)
         B, C, H, W = input_shape
 
-        [hidden_states, [H, W], [self.tt_weights, self.tt_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_weights, tt_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_weights,
             in_channels=self.conv_params["input_channels"],
@@ -84,6 +86,9 @@ class TtUpsample2D(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_weights = tt_weights
+            self.tt_bias = tt_bias
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -25,7 +25,9 @@ from loguru import logger
     ids=("test_decode", "test_encode"),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae(device, input_shape, vae_block, pcc, is_ci_env, reset_seeds, is_ci_v2_env, model_location_generator):
+def test_vae(
+    device, input_shape, vae_block, pcc, debug_mode, is_ci_env, reset_seeds, is_ci_v2_env, model_location_generator
+):
     model_location = model_location_generator(
         "stable-diffusion-xl-base-1.0/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -41,7 +43,7 @@ def test_vae(device, input_shape, vae_block, pcc, is_ci_env, reset_seeds, is_ci_
 
     logger.info("Loading weights to device")
     model_config = ModelOptimisations()
-    tt_vae = TtAutoencoderKL(device, state_dict, model_config)
+    tt_vae = TtAutoencoderKL(device, state_dict, model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -23,7 +23,7 @@ from loguru import logger
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_decoder(device, input_shape, pcc, is_ci_env, reset_seeds):
+def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -38,7 +38,7 @@ def test_vae_decoder(device, input_shape, pcc, is_ci_env, reset_seeds):
 
     logger.info("Loading weights to device")
     model_config = ModelOptimisations()
-    tt_vae = TtDecoder(device, state_dict, model_config=model_config)
+    tt_vae = TtDecoder(device, state_dict, model_config=model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
@@ -24,7 +24,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_downblock2d(device, block_id, input_shape, pcc, is_ci_env, reset_seeds):
+def test_downblock2d(device, block_id, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -45,6 +45,7 @@ def test_downblock2d(device, block_id, input_shape, pcc, is_ci_env, reset_seeds)
         model_config=model_config,
         has_downsample=block_id < 3,
         has_shortcut=block_id > 0 and block_id < 3,
+        debug_mode=debug_mode,
     )
     logger.info("Loaded weights")
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downsample2d.py
@@ -33,6 +33,7 @@ def test_downsample2d(
     stride,
     padding,
     dilation,
+    debug_mode,
     is_ci_env,
     reset_seeds,
 ):
@@ -59,6 +60,7 @@ def test_downsample2d(
         dilation,
         groups,
         model_config=model_config,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
@@ -23,7 +23,7 @@ from loguru import logger
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_decoder(device, input_shape, pcc, is_ci_env, reset_seeds):
+def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -38,7 +38,7 @@ def test_vae_decoder(device, input_shape, pcc, is_ci_env, reset_seeds):
 
     logger.info("Loading weights to device")
     model_config = ModelOptimisations()
-    tt_vae = TtEncoder(device, state_dict, model_config=model_config)
+    tt_vae = TtEncoder(device, state_dict, model_config=model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -27,7 +27,7 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_midblock(device, input_shape, block_name, is_ci_env, reset_seeds):
+def test_vae_midblock(device, input_shape, block_name, debug_mode, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -44,7 +44,9 @@ def test_vae_midblock(device, input_shape, block_name, is_ci_env, reset_seeds):
         torch_midblock = vae.decoder.mid_block
 
     model_config = ModelOptimisations()
-    tt_midblock = TtUNetMidBlock2D(device, state_dict, f"{block_name}.mid_block", model_config=model_config)
+    tt_midblock = TtUNetMidBlock2D(
+        device, state_dict, f"{block_name}.mid_block", model_config=model_config, debug_mode=debug_mode
+    )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
 
     torch_output_tensor = torch_midblock(torch_input_tensor, temb=None)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -32,7 +32,9 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_resnetblock2d(device, input_shape, block_id, resnet_id, conv_shortcut, block, pcc, is_ci_env, reset_seeds):
+def test_vae_resnetblock2d(
+    device, input_shape, block_id, resnet_id, conv_shortcut, block, pcc, debug_mode, is_ci_env, reset_seeds
+):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -57,7 +59,12 @@ def test_vae_resnetblock2d(device, input_shape, block_id, resnet_id, conv_shortc
 
     model_config = ModelOptimisations()
     tt_resnet = TtResnetBlock2D(
-        device, state_dict, f"{vae_block}.{block}.resnets.{resnet_id}", model_config, conv_shortcut
+        device,
+        state_dict,
+        f"{vae_block}.{block}.resnets.{resnet_id}",
+        model_config,
+        conv_shortcut,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -23,7 +23,7 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_upblock(device, input_shape, block_id, pcc, is_ci_env, reset_seeds):
+def test_vae_upblock(device, input_shape, block_id, pcc, debug_mode, is_ci_env, reset_seeds):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -44,6 +44,7 @@ def test_vae_upblock(device, input_shape, block_id, pcc, is_ci_env, reset_seeds)
         model_config,
         has_upsample=block_id < 3,
         conv_shortcut=block_id > 1,
+        debug_mode=debug_mode,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
@@ -24,7 +24,9 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, is_ci_env, reset_seeds):
+def test_vae_upsample2d(
+    device, input_shape, up_block_id, stride, padding, dilation, debug_mode, is_ci_env, reset_seeds
+):
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -48,6 +50,7 @@ def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilat
         padding,
         dilation,
         groups,
+        debug_mode=debug_mode,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_autoencoder_kl.py
@@ -18,6 +18,7 @@ class TtAutoencoderKL(LightweightModule):
         device,
         state_dict,
         model_config,
+        debug_mode=False,
     ):
         super().__init__()
 
@@ -33,12 +34,14 @@ class TtAutoencoderKL(LightweightModule):
             device,
             state_dict,
             model_config,
+            debug_mode=debug_mode,
         )
 
         self.encoder = TtEncoder(
             device,
             state_dict,
             model_config,
+            debug_mode=debug_mode,
         )
 
         quant_conv_weights = state_dict[f"quant_conv.weight"].squeeze()

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -18,7 +18,7 @@ from loguru import logger
 
 
 class TtDecoder(LightweightModule):
-    def __init__(self, device, state_dict, model_config):
+    def __init__(self, device, state_dict, model_config, debug_mode=False):
         super().__init__()
 
         self.device = device
@@ -30,10 +30,11 @@ class TtDecoder(LightweightModule):
         self.padding = (1, 1)
         self.dilation = (1, 1)
         self.groups = 1
+        self.debug_mode = debug_mode
 
         num_up_blocks = 4
 
-        self.mid_block = TtUNetMidBlock2D(device, state_dict, "decoder.mid_block", model_config)
+        self.mid_block = TtUNetMidBlock2D(device, state_dict, "decoder.mid_block", model_config, debug_mode=debug_mode)
         self.up_blocks = []
         for block_id in range(num_up_blocks):
             self.up_blocks.append(
@@ -44,6 +45,7 @@ class TtDecoder(LightweightModule):
                     model_config,
                     has_upsample=block_id < 3,
                     conv_shortcut=block_id > 1,
+                    debug_mode=debug_mode,
                 )
             )
 
@@ -109,7 +111,7 @@ class TtDecoder(LightweightModule):
         B, C, H, W = input_shape
         hidden_states = sample
 
-        [hidden_states, [H, W], [self.tt_conv_in_weights, self.tt_conv_in_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_conv_in_weights, tt_conv_in_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_conv_in_weights,
             in_channels=self.conv_in_params["input_channels"],
@@ -133,6 +135,9 @@ class TtDecoder(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv_in_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_conv_in_weights = tt_conv_in_weights
+            self.tt_conv_in_bias = tt_conv_in_bias
 
         logger.info("Starting mid-block")
         hidden_states, [C, H, W] = self.mid_block.forward(hidden_states, [B, C, H, W])
@@ -167,7 +172,7 @@ class TtDecoder(LightweightModule):
 
         hidden_states = ttnn.silu(hidden_states)
 
-        [hidden_states, [H, W], [self.tt_conv_out_weights, self.tt_conv_out_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_conv_out_weights, tt_conv_out_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_conv_out_weights,
             in_channels=self.conv_out_params["input_channels"],
@@ -191,5 +196,8 @@ class TtDecoder(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv_out_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_conv_out_weights = tt_conv_out_weights
+            self.tt_conv_out_bias = tt_conv_out_bias
 
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downblock2d.py
@@ -8,7 +8,9 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_downsample2d import 
 
 
 class TtDownEncoderBlock2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config, has_downsample=False, has_shortcut=False):
+    def __init__(
+        self, device, state_dict, module_path, model_config, has_downsample=False, has_shortcut=False, debug_mode=False
+    ):
         super().__init__()
 
         num_layers = 2
@@ -22,6 +24,7 @@ class TtDownEncoderBlock2D(LightweightModule):
                     f"{module_path}.resnets.{i}",
                     model_config=model_config,
                     conv_shortcut=(i == 0) and has_shortcut,
+                    debug_mode=debug_mode,
                 )
             )
 
@@ -35,6 +38,7 @@ class TtDownEncoderBlock2D(LightweightModule):
                 (1, 1),
                 1,
                 model_config=model_config,
+                debug_mode=debug_mode,
             )
             if has_downsample
             else None

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
@@ -10,7 +10,9 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_
 
 
 class TtDownsample2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, stride, padding, dilation, groups, model_config):
+    def __init__(
+        self, device, state_dict, module_path, stride, padding, dilation, groups, model_config, debug_mode=False
+    ):
         super().__init__()
 
         self.device = device
@@ -35,7 +37,7 @@ class TtDownsample2D(LightweightModule):
     def forward(self, hidden_states, input_shape):
         B, C, H, W = input_shape
 
-        [hidden_states, [H, W], [self.tt_weights, self.tt_bias]] = ttnn.conv2d(
+        [hidden_states, [H, W], [tt_weights, tt_bias]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.tt_weights,
             in_channels=self.conv_params["input_channels"],
@@ -59,5 +61,8 @@ class TtDownsample2D(LightweightModule):
             dtype=self.conv_output_dtype,
         )
         C = self.conv_params["output_channels"]
+        if not self.debug_mode:
+            self.tt_weights = tt_weights
+            self.tt_bias = tt_bias
 
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
@@ -20,6 +20,7 @@ class TtDownsample2D(LightweightModule):
         self.padding = padding
         self.dilation = dilation
         self.groups = groups
+        self.debug_mode = debug_mode
 
         weights = state_dict[f"{module_path}.conv.weight"]
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
@@ -8,7 +8,7 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import
 
 
 class TtUNetMidBlock2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config):
+    def __init__(self, device, state_dict, module_path, model_config, debug_mode=False):
         super().__init__()
 
         num_layers_attn = 1
@@ -22,7 +22,9 @@ class TtUNetMidBlock2D(LightweightModule):
             )
 
         for i in range(num_layers_resn):
-            self.resnets.append(TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", model_config))
+            self.resnets.append(
+                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", model_config, debug_mode=debug_mode)
+            )
 
     def forward(self, input_tensor, input_shape):
         B, C, H, W = input_shape

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
@@ -9,7 +9,9 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import Tt
 
 
 class TtUpDecoderBlock2D(LightweightModule):
-    def __init__(self, device, state_dict, module_path, model_config, has_upsample=False, conv_shortcut=False):
+    def __init__(
+        self, device, state_dict, module_path, model_config, has_upsample=False, conv_shortcut=False, debug_mode=False
+    ):
         super().__init__()
 
         num_layers = 3
@@ -24,11 +26,22 @@ class TtUpDecoderBlock2D(LightweightModule):
                     f"{module_path}.resnets.{i}",
                     model_config,
                     conv_shortcut=conv_shortcut and (i == 0),
+                    debug_mode=debug_mode,
                 )
             )
 
         self.upsamplers = (
-            TtUpsample2D(device, state_dict, f"{module_path}.upsamplers.0", model_config, (1, 1), (1, 1), (1, 1), 1)
+            TtUpsample2D(
+                device,
+                state_dict,
+                f"{module_path}.upsamplers.0",
+                model_config,
+                (1, 1),
+                (1, 1),
+                (1, 1),
+                1,
+                debug_mode=debug_mode,
+            )
             if has_upsample
             else None
         )


### PR DESCRIPTION
### Ticket
#30912 

### What's changed
This PR enables running SDXL loop and unit tests in comparison mode. To enable this modules were modified to reuse conv weights when not in `debug_mode`. Test mode is set through a pytest fixture, which is `False` by default.

To run a test like this successfully user should set `debug_mode` to `True` like so:
`pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --debug-mode`

### Checklist
- [X] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18747224364) CI passes
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/18747240633) CI passes
- [X] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/18747258741) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/18747280532) CI passes