### PR TITLE
Fix tiny tiles feature on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -353,7 +353,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
     return padded_number
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #31385")
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1280])
 @pytest.mark.parametrize("has_bias", [False, True])

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -67,7 +67,6 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
     assert_with_pcc(torch_input_tensor, output_tensor, expected_pcc)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("n", [1])
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("m", [1024])
@@ -247,7 +246,6 @@ def test_matmul_reuse_config_sharded_fd_column(
     assert_with_pcc(pt_out, output_tensor, expected_pcc)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("b", [2])
 @pytest.mark.parametrize("h", [3])
 @pytest.mark.parametrize("m", [256])
@@ -793,7 +791,6 @@ def run_matmul_2d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
 @pytest.mark.parametrize("n", [768])
@@ -951,7 +948,6 @@ def run_matmul_1d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #29890")
 @pytest.mark.parametrize("m", [128])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1024])

--- a/tt_metal/hw/ckernels/blackhole/metal/common/chlkc_list.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/common/chlkc_list.h
@@ -18,6 +18,7 @@ using namespace ckernel;
 #include "chlkc_math_approx_mode.h"
 #include "chlkc_math_fidelity.h"
 #include "chlkc_unpack_data_format.h"
+#include "chlkc_unpack_tile_dims.h"
 #include "chlkc_math.cpp"
 // clang-format on
 #endif
@@ -27,6 +28,7 @@ using namespace ckernel;
 #include "chlkc_dst_accum_mode.h"
 #include "chlkc_dst_sync_mode.h"
 #include "chlkc_pack_data_format.h"
+#include "chlkc_pack_tile_dims.h"
 #include "chlkc_pack.cpp"
 // clang-format on
 #endif
@@ -36,6 +38,7 @@ using namespace ckernel;
 #include "chlkc_dst_accum_mode.h"
 #include "chlkc_dst_sync_mode.h"
 #include "chlkc_unpack_data_format.h"
+#include "chlkc_unpack_tile_dims.h"
 #include "chlkc_unpack.cpp"
 // clang-format on
 #endif

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -21,7 +21,9 @@ inline void llk_math_matmul_init(
     const std::uint32_t in0_id = get_operand_id(operandA);
     const std::uint32_t in1_id = get_operand_id(operandB);
 
-    const bool partial_face = get_operand_partial_face(in0_id);
+    // TODO: this flag is only for computing 8x32 tile shape, although current impl assumes the in0 tile is still
+    // 16x32. We should remove this flag in the future and add impl for 8x32 input tile shape
+    const bool partial_face = 0;
 
     const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);
     const std::uint32_t in0_tile_c_dim = get_operand_tile_c_dim(in0_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -21,8 +21,8 @@ inline void llk_math_matmul_init(
     const std::uint32_t in0_id = get_operand_id(operandA);
     const std::uint32_t in1_id = get_operand_id(operandB);
 
-    // TODO: this flag is only for computing 8x32 tile shape, although current impl assumes the in0 tile is still
-    // 16x32. We should remove this flag in the future and add impl for 8x32 input tile shape
+    // Issue #31387: this flag is only for computing 8x32 tile shape, although current impl assumes the in0 tile is
+    // still 16x32. We should remove this flag in the future and add impl for 8x32 input tile shape
     const bool partial_face = 0;
 
     const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -116,8 +116,8 @@ inline void llk_unpack_AB_matmul(
     const std::uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandA_id);  // In0/InA -> srcB
 
     // TODO: Review RT, use partial_face_b
-    const bool partial_face_a = get_operand_partial_face(operandA_id);
-    const bool partial_face_b = get_operand_partial_face(operandB_id);
+    const bool partial_face_a = get_operand_partial_face(operandB_id);
+    const bool partial_face_b = get_operand_partial_face(operandA_id);
 
     std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_operands.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_operands.h
@@ -12,14 +12,26 @@ inline const uint32_t get_operand_src_format(const std::uint32_t operand_id) { r
 
 inline const uint32_t get_operand_dst_format(const std::uint32_t operand_id) { return unpack_dst_format[operand_id]; }
 
-inline const uint32_t get_operand_num_faces(const std::uint32_t operand_id) { return 4; }
+inline const uint32_t get_operand_num_faces(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_tile_num_faces[operand_id];
+}
 
-inline const uint32_t get_operand_partial_face(const std::uint32_t operand_id) { return 0; }
+inline const uint32_t get_operand_partial_face(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_partial_face[operand_id];
+}
 
-inline const uint32_t get_operand_face_r_dim(const std::uint32_t operand_id) { return 16; }
+inline const uint32_t get_operand_face_r_dim(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_tile_face_r_dim[operand_id];
+}
 
-inline const uint32_t get_operand_narrow_tile(const std::uint32_t operand_id) { return 0; }
+inline const uint32_t get_operand_narrow_tile(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_narrow_tile[operand_id];
+}
 
-inline const uint32_t get_operand_tile_r_dim(const std::uint32_t operand_id) { return 32; }
+inline const uint32_t get_operand_tile_r_dim(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_tile_r_dim[operand_id];
+}
 
-inline const uint32_t get_operand_tile_c_dim(const std::uint32_t operand_id) { return 32; }
+inline const uint32_t get_operand_tile_c_dim(const std::uint32_t operand_id) {
+    return (uint32_t)unpack_tile_c_dim[operand_id];
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_outputs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_outputs.h
@@ -14,18 +14,30 @@ inline const uint32_t get_output_base_id() {
     return (OUTPUT_BASE_ID);
 }
 
-inline const uint32_t get_output_src_format(const std::uint32_t output_id) { return pack_src_format[output_id]; }
+inline const unsigned char get_output_src_format(const std::uint32_t output_id) { return pack_src_format[output_id]; }
 
-inline const uint32_t get_output_dst_format(const std::uint32_t output_id) { return pack_dst_format[output_id]; }
+inline const unsigned char get_output_dst_format(const std::uint32_t output_id) { return pack_dst_format[output_id]; }
 
-inline const uint32_t get_output_num_faces(const std::uint32_t output_id) { return 4; }
+inline const uint32_t get_output_num_faces(const std::uint32_t output_id) {
+    return (uint32_t)pack_tile_num_faces[output_id];
+}
 
-inline const uint32_t get_output_partial_face(const std::uint32_t output_id) { return 0; }
+inline const uint32_t get_output_partial_face(const std::uint32_t output_id) {
+    return (uint32_t)pack_partial_face[output_id];
+}
 
-inline const uint32_t get_output_face_r_dim(const std::uint32_t output_id) { return 16; }
+inline const uint32_t get_output_face_r_dim(const std::uint32_t output_id) {
+    return (uint32_t)pack_tile_face_r_dim[output_id];
+}
 
-inline const uint32_t get_output_narrow_tile(const std::uint32_t output_id) { return 0; }
+inline const uint32_t get_output_narrow_tile(const std::uint32_t output_id) {
+    return (uint32_t)pack_narrow_tile[output_id];
+}
 
-inline const uint32_t get_output_tile_r_dim(const std::uint32_t output_id) { return 32; }
+inline const uint32_t get_output_tile_r_dim(const std::uint32_t output_id) {
+    return (uint32_t)pack_tile_r_dim[output_id];
+}
 
-inline const uint32_t get_output_tile_c_dim(const std::uint32_t output_id) { return 32; }
+inline const uint32_t get_output_tile_c_dim(const std::uint32_t output_id) {
+    return (uint32_t)pack_tile_c_dim[output_id];
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -21,8 +21,8 @@ inline void llk_math_matmul_init(
     const std::uint32_t in0_id = get_operand_id(operandA);
     const std::uint32_t in1_id = get_operand_id(operandB);
 
-    // TODO: this flags is only for computing 8x32 tile shape, although current impl assumes the in0 tile is still
-    // 16x32. We should remove this flag in the furture and add impl for 8x32 input tile shape
+    // Issue #31387: this flag is only for computing 8x32 tile shape, although current impl assumes the in0 tile is
+    // still 16x32. We should remove this flag in the future and add impl for 8x32 input tile shape
     const bool partial_face = 0;
 
     const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);


### PR DESCRIPTION
### Ticket
#29890
### Problem description

The tests that used tiny tiles were broken on BH, resulting in assertion errors. So far, they were skipped for BH. 

### What's changed

Fixed the hard-coded values in `llk_operands.h`  and `llk_outputs.h`. 
The parameters indicating partial faces in the UNPACK path are switched for Operand A and Operand B. 
The parameter for partial face in MATH is set to 0, to match the WH version of the code. 

4/5 tiny tile tests are passing. The remaining test requires further investigation.

[BH Nightly passes
](https://github.com/tenstorrent/tt-metal/actions/runs/18747677493)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes
](https://github.com/tenstorrent/tt-metal/actions/runs/18747574852/job/53479382521)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) [CI with demo tests passes (if applicable)
](https://github.com/tenstorrent/tt-metal/actions/runs/18747632520)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes