### PR TITLE
[tt-train] Integrate AdamW to python training. Fix parameters reading for optimizer.

### DIFF
--- a/tt-train/sources/ttml/nanobind/nb_optimizers.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_optimizers.cpp
@@ -30,7 +30,8 @@ void py_module_types(nb::module_& m) {
     nb::class_<SGDConfig>(m, "SGDConfig");
     nb::class_<SGD, OptimizerBase>(m, "SGD");
     nb::class_<AdamWConfig>(m, "AdamWConfig");
-    nb::class_<MorehAdamW, OptimizerBase>(m, "AdamW");
+    nb::class_<AdamW, OptimizerBase>(m, "AdamW");
+    nb::class_<MorehAdamW, OptimizerBase>(m, "MorehAdamW");
     nb::class_<RemoteOptimizer, OptimizerBase>(m, "RemoteOptimizer");
 }
 
@@ -92,8 +93,14 @@ void py_module(nb::module_& m) {
     }
 
     {
-        auto py_adamw = static_cast<nb::class_<MorehAdamW, OptimizerBase>>(m.attr("AdamW"));
+        auto py_adamw = static_cast<nb::class_<AdamW, OptimizerBase>>(m.attr("AdamW"));
         py_adamw.def(
+            nb::init<serialization::NamedParameters, const AdamWConfig&>(), nb::arg("parameters"), nb::arg("config"));
+    }
+
+    {
+        auto py_moreh_adamw = static_cast<nb::class_<MorehAdamW, OptimizerBase>>(m.attr("MorehAdamW"));
+        py_moreh_adamw.def(
             nb::init<serialization::NamedParameters, const AdamWConfig&>(), nb::arg("parameters"), nb::arg("config"));
     }
 

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -58,7 +58,7 @@ def create_optimizer(model, yaml_config: dict):
         AdamW or MorehAdamW optimizer instance based on configuration
     """
     optimizer_config = yaml_config.get("training_config", {})
-    
+
     lr = optimizer_config.get("learning_rate", 0.0003)
     beta1 = optimizer_config.get("beta1", 0.9)
     beta2 = optimizer_config.get("beta2", 0.999)
@@ -73,7 +73,7 @@ def create_optimizer(model, yaml_config: dict):
         float(eps),
         float(weight_decay),
     )
-    
+
     if use_moreh_adamw:
         return ttml.optimizers.MorehAdamW(model.parameters(), adamw_cfg)
     else:

--- a/tt-train/sources/ttml/ttml/common/utils.py
+++ b/tt-train/sources/ttml/ttml/common/utils.py
@@ -48,20 +48,23 @@ def initialize_device(yaml_config: dict):
 
 
 def create_optimizer(model, yaml_config: dict):
-    """Create AdamW optimizer from configuration.
+    """Create AdamW or MorehAdamW optimizer from configuration.
 
     Args:
         model: Model to optimize
         yaml_config: Dictionary containing optimizer configuration
 
     Returns:
-        AdamW optimizer instance
+        AdamW or MorehAdamW optimizer instance based on configuration
     """
-    lr = yaml_config.get("learning_rate", 0.0003)
-    beta1 = yaml_config.get("beta1", 0.9)
-    beta2 = yaml_config.get("beta2", 0.999)
-    eps = yaml_config.get("eps", 1e-8)
-    weight_decay = yaml_config.get("weight_decay", 0.01)
+    optimizer_config = yaml_config.get("training_config", {})
+    
+    lr = optimizer_config.get("learning_rate", 0.0003)
+    beta1 = optimizer_config.get("beta1", 0.9)
+    beta2 = optimizer_config.get("beta2", 0.999)
+    eps = optimizer_config.get("eps", 1e-8)
+    weight_decay = optimizer_config.get("weight_decay", 0.01)
+    use_moreh_adamw = optimizer_config.get("use_moreh_adamw", False)
 
     adamw_cfg = ttml.optimizers.AdamWConfig.make(
         float(lr),
@@ -70,7 +73,11 @@ def create_optimizer(model, yaml_config: dict):
         float(eps),
         float(weight_decay),
     )
-    return ttml.optimizers.AdamW(model.parameters(), adamw_cfg)
+    
+    if use_moreh_adamw:
+        return ttml.optimizers.MorehAdamW(model.parameters(), adamw_cfg)
+    else:
+        return ttml.optimizers.AdamW(model.parameters(), adamw_cfg)
 
 
 class PerformanceMeter:


### PR DESCRIPTION
### Problem description
We previously exposed only fused AdamW which created confusion during debug phase. 
There is a bug to read optimizer parameters. 

### What's changed
Expose composite AdamW alongside with MorehAdamW. 
Fix config reading during optimizer creation phase.

### Checklist
- [x] Python training works and behavior verified