### PR TITLE
#30358: use fromPaddedShape in GroupNorm::compute_output_specs

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
@@ -194,7 +194,12 @@ std::vector<TensorSpec> GroupNorm::compute_output_specs(const std::vector<Tensor
             auto mem_config = this->output_mem_config;
             return {TensorSpec(
                 input_tensor.logical_shape(),
-                TensorLayout(program_config.out_data_format, PageConfig(program_config.output_layout), mem_config))};
+                TensorLayout::fromPaddedShape(
+                    program_config.out_data_format,
+                    PageConfig(program_config.output_layout),
+                    mem_config,
+                    input_tensor.logical_shape(),
+                    input_tensor.padded_shape()))};
         },
         this->program_config);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #30358

### Problem description
Input may be padded to beyond the immediate tile, and the output needs to match the input. Otherwise the output is truncated to what the code expects and out of bounds writes occur.

### What's changed
Use fromPaddedShape to match the output to the input. This is what is done in LayerNorm.

New tests have not been added due to this only appearing on special 5x4 BH grid.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18750830071 (not waiting for galaxy)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes