### PR TITLE
[skip ci] Comparison mode doc: conv2d 

### DIFF
--- a/tech_reports/ttnn/comparison-mode.md
+++ b/tech_reports/ttnn/comparison-mode.md
@@ -22,3 +22,15 @@ export TTNN_CONFIG_OVERRIDES='{
 - `enable_comparison_mode`: When set to `true`, comparison mode is activated. Defaults to `false`.
 - `comparison_mode_should_raise_exception`: When set to `true`, comparison mode will raise an exception, ending op execution, when encountering an op that fails comparison checks. This is useful for localizing a failing operations when you are running a full model, or want to integrate comparison mode checks into a unit test. Defaults to `false`.
 - `comparison_mode_pcc`: Sets the PCC threshold used in comparison mode.
+
+## ttnn.conv2d and comparison mode
+
+`ttnn.conv2d` operates with weights in the channel-last folded format: `[1, 1, NHW, C]`.
+If a tensor passed to the operation resides on the host or is not already in this format, the operator internally prepares the weights tensor.
+
+When implementing CNN models on TT hardware, the standard practice is to retrieve and reuse these internally prepared tensors in subsequent runs to improve performance.
+
+However, weights reuse can cause comparison mode to fail when applied to such models. This happens because the conv2d golden function expects weights in the standard channel-first unfolded format.
+
+To enable debugging models in comparison mode, weights reuse must be disabled.
+The method for disabling reuse is left to the model writer. For example, in the `SDXL` model, this is controlled via a pytest fixture `debug_mode`, which—when enabled—prevents reuse of convolution weights.


### PR DESCRIPTION
### Problem description
Comparison mode doesn't work with `ttnn.conv2d` calls that have already prepared weights passed in. 

### What's changed
Based on @bbradelTT suggestion I'm documenting the reason behind this combination not working and what needs to be done to enable comparison mode debug of CNN models on TT hw.