### PR TITLE
#0: [skip ci] [produce data] Fix end timestamp handling for pytest results

### DIFF
--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -268,7 +268,12 @@ def get_pydantic_test_from_testcase_(testcase, default_timestamp=datetime.now(),
             # Check if properties is none to see if pytest recorded the timestamps
             if properties is not None:
                 test_start_ts = datetime.fromisoformat(properties["start_timestamp"])
-                test_end_ts = datetime.fromisoformat(properties["end_timestamp"])
+                if "end_timestamp" in properties:
+                    test_end_ts = datetime.fromisoformat(properties["end_timestamp"])
+                else:
+                    # When a setup error occurs in a pytest, the end timestamp may sometimes not be recorded
+                    # Set the end timestamp equal to the start timestamp since no test was executed
+                    test_end_ts = test_start_ts
             else:
                 # Check if there's a time attribute in the testcase
                 if "time" in testcase.attrib:


### PR DESCRIPTION
### Ticket
None

### Problem description
T3k test fails with an error in test setup: https://github.com/tenstorrent/tt-metal/actions/runs/18722308678/job/53398949144#step:5:197
This causes the end timestamp to not be recorded (as no test execution has occurred)
Results in a KeyError in produce data:
https://github.com/tenstorrent/tt-metal/actions/runs/18732778668/job/53433258321#step:10:249
```
Traceback (most recent call last):
  File "/home/runner/work/tt-metal/tt-metal/.github/scripts/data_analysis/create_pipeline_json.py", line 15, in <module>
    pipeline = create_cicd_json_for_data_analysis(
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/cicd.py", line 77, in create_cicd_json_for_data_analysis
    tests += get_tests_from_test_report_path(test_report_path)
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/github/workflows.py", line 433, in get_tests_from_test_report_path
    tests.append(get_pydantic_test(testcase))
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/github/workflows.py", line 271, in get_pydantic_test_from_testcase_
    test_end_ts = datetime.fromisoformat(properties["end_timestamp"])
KeyError: 'end_timestamp'
```

### What's changed
When no end timestamp is found, set end timestamp equal to start timestamp

### Checklist
- [x] Produce data:  https://github.com/tenstorrent/tt-metal/actions/runs/18753698448