### PR TITLE
[skip ci] fixing syntax error in run_t3000_model_perf_tests

### DIFF
--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -160,7 +160,7 @@ main() {
   cd $TT_METAL_HOME
   export PYTHONPATH=$TT_METAL_HOME
 
-  elif [[ "$pipeline_type" == "model_perf_t3000" ]]; then
+  if [[ "$pipeline_type" == "model_perf_t3000" ]]; then
     run_t3000_model_perf_tests
   else
     echo "$pipeline_type is invalid (supported: [ccl_perf_t3000_device, model_perf_t3000])" 2>&1


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31068)

### Problem description
A recent commit introduced a syntax error where an elif was written without an if before it, causing T3K model perf tests to deterministically fail.

### What's changed
elif -> if

### Checklist
- [ ] [T3K model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18755150039