### PR TITLE
SDXL additional parameters fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -696,6 +696,7 @@ def run_tt_image_gen(
     capture_trace=False,
     use_cfg_parallel=False,
     guidance_rescale=0.0,
+    one_minus_guidance_rescale=1.0,
 ):
     assert not (capture_trace and num_steps != 1), "Trace should capture only 1 iteration"
     profiler.start("image_gen")
@@ -768,7 +769,7 @@ def run_tt_image_gen(
             noise_pred_rescaled = ttnn.mul(noise_pred, std_ratio)
 
             rescaled_term = ttnn.mul(noise_pred_rescaled, guidance_rescale)
-            original_term = ttnn.mul(noise_pred, (1.0 - guidance_rescale))
+            original_term = ttnn.mul(noise_pred, one_minus_guidance_rescale)
             ttnn.deallocate(noise_pred)
             noise_pred = ttnn.add(rescaled_term, original_term)
             ttnn.deallocate(std_text)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -888,6 +888,7 @@ def run_tt_image_gen_inpainting(
     capture_trace=False,
     use_cfg_parallel=False,
     guidance_rescale=0.0,
+    one_minus_guidance_rescale=1.0,
 ):
     assert not (capture_trace and num_steps != 1), "Trace should capture only 1 iteration"
     profiler.start("image_gen")
@@ -962,7 +963,7 @@ def run_tt_image_gen_inpainting(
             noise_pred_rescaled = ttnn.mul(noise_pred, std_ratio)
 
             rescaled_term = ttnn.mul(noise_pred_rescaled, guidance_rescale)
-            original_term = ttnn.mul(noise_pred, (1.0 - guidance_rescale))
+            original_term = ttnn.mul(noise_pred, one_minus_guidance_rescale)
             ttnn.deallocate(noise_pred)
             noise_pred = ttnn.add(rescaled_term, original_term)
             ttnn.deallocate(std_text)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -117,6 +117,15 @@ class TtSDXLPipeline(LightweightModule):
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
         )
 
+        self.one_minus_guidance_rescale = ttnn.from_torch(
+            torch.Tensor([1.0 - self.pipeline_config.guidance_rescale]),
+            dtype=ttnn.bfloat16,
+            device=self.ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
+        )
+
         compute_grid_size = self.ttnn_device.compute_with_storage_grid_size()
         ccl_sub_device_crs = ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
@@ -165,7 +174,14 @@ class TtSDXLPipeline(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
         )
+        host_one_minus_guidance_rescale = ttnn.from_torch(
+            torch.Tensor([1.0 - self.pipeline_config.guidance_rescale]),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
+        )
         ttnn.copy_host_to_device_tensor(host_guidance_rescale, self.guidance_rescale)
+        ttnn.copy_host_to_device_tensor(host_one_minus_guidance_rescale, self.one_minus_guidance_rescale)
 
     def set_crop_coords_top_left(self, crop_coords_top_left: tuple):
         self.pipeline_config.crop_coords_top_left = crop_coords_top_left
@@ -324,7 +340,8 @@ class TtSDXLPipeline(LightweightModule):
                 self.ag_semaphores,
                 capture_trace=False,
                 use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
-                guidance_rescale=self.pipeline_config.guidance_rescale,
+                guidance_rescale=self.guidance_rescale,
+                one_minus_guidance_rescale=self.one_minus_guidance_rescale,
             )
             ttnn.synchronize_device(self.ttnn_device)
             profiler.end("warmup_run")
@@ -587,7 +604,8 @@ class TtSDXLPipeline(LightweightModule):
             output_shape=self.output_shape,
             tid_vae=self.tid_vae if hasattr(self, "tid_vae") else None,
             use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
-            guidance_rescale=self.pipeline_config.guidance_rescale,
+            guidance_rescale=self.guidance_rescale,
+            one_minus_guidance_rescale=self.one_minus_guidance_rescale,
         )
         self._reset_num_inference_steps()
         return imgs
@@ -764,7 +782,8 @@ class TtSDXLPipeline(LightweightModule):
             self.ag_semaphores,
             capture_trace=True,
             use_cfg_parallel=self.pipeline_config.use_cfg_parallel,
-            guidance_rescale=self.pipeline_config.guidance_rescale,
+            guidance_rescale=self.guidance_rescale,
+            one_minus_guidance_rescale=self.one_minus_guidance_rescale,
         )
         ttnn.synchronize_device(self.ttnn_device)
         profiler.end("capture_model_trace")

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -724,8 +724,7 @@ class TtSDXLPipeline(LightweightModule):
             )
             tt_time_ids_host = ttnn.squeeze(tt_time_ids_host, dim=0)
 
-            for host_tensor, device_tensor in zip(tt_time_ids_host, self.tt_time_ids_device):
-                ttnn.copy_host_to_device_tensor(host_tensor, device_tensor)
+            ttnn.copy_host_to_device_tensor(tt_time_ids_host, self.tt_time_ids_device)
 
     def __create_user_tensors(self, latents, all_prompt_embeds_torch, torch_add_text_embeds):
         # Instantiation of user host input tensors for the TT model.


### PR DESCRIPTION
### Ticket
tenstorrent/tt-inference-server#933

### Problem description
On the inference server side, `crop_coords_top_left` and `guidance_rescale` were not properly handled on subsequent calls to the model.

### What's changed
Fix so they are set appropriately and used in runs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18755324534) CI passes 🟢 
- [x] [Single-Card Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18774816620) CI passes 🟢 
- [x] [L2 nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/18756867469) CI passes 🟢 