### PR TITLE
Enable op device perf reporting tests in TT Transformers

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -49,11 +49,11 @@ jobs:
             owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
-            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -151,11 +151,11 @@ jobs:
             owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
-            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -47,6 +47,14 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel ${{ inputs.num_devices }} --max_generated_tokens 22000
             owner_id: U03PUAKE719 # Miguel Tairum
+          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+            arch: blackhole
+            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+            arch: blackhole
+            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
       - "in-service"
@@ -141,6 +149,14 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U03PUAKE719 # Miguel Tairum
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+            arch: blackhole
+            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+            arch: blackhole
+            cmd: LLAMA_DIR=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
       - "in-service"

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -22,6 +22,7 @@ jobs:
       packages: write
     secrets: inherit
     with:
+      tracy: true
       build-wheel: true
       version: 22.04
   blackhole-multi-card-demo-tests:

--- a/conftest.py
+++ b/conftest.py
@@ -621,9 +621,13 @@ def clear_compile_cache():
 
 
 @pytest.fixture(autouse=True)
-def reset_default_device():
+def reset_default_device(request):
     import ttnn
 
+    # Skip applying the fixture logic for this test
+    if "no_reset_default_device" in request.keywords:
+        yield
+        return
     device = ttnn.GetDefaultDevice()
     yield
     ttnn.SetDefaultDevice(device)

--- a/models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py
@@ -371,6 +371,9 @@ def load_perf_targets(galaxy_type):
     return perf_targets
 
 
+# This pytest flag is necessary to ensure that we do NOT open the device in the main process for device perf tests that run
+# the test inside a subprocess since UMD does not allow multiple subprocesses opening the device at the same time.
+@pytest.mark.no_reset_device
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
@@ -778,6 +781,7 @@ def test_llama_TG_perf_device(
     assert all_passing
 
 
+@pytest.mark.no_reset_device
 @pytest.mark.timeout(900)
 @pytest.mark.models_device_performance_bare_metal
 # To update:

--- a/models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -8,6 +8,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 
 
+@pytest.mark.no_reset_device
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     ("op_name", "expected_kernel_duration_4u_us", "expected_kernel_duration_6u_us", "perf_margin"),

--- a/models/tt_transformers/demo/conftest.py
+++ b/models/tt_transformers/demo/conftest.py
@@ -59,3 +59,17 @@ def pytest_addoption(parser):
         type=bool,
         help="Whether to enable tracing",
     )
+    parser.addoption(
+        "--num_layers",
+        action="store",
+        default=None,
+        type=int,
+        help="Number of layers to use",
+    )
+    parser.addoption(
+        "--mode",
+        action="store",
+        default="full",
+        type=str,
+        help="Mode to use for full model demo tests (values can be 'prefill','decode','full')",
+    )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -204,6 +204,7 @@ def prepare_generator_args(
     max_seq_len,
     page_params,
     paged_attention,
+    num_layers,
 ):
     submesh_devices = create_submeshes(mesh_device, data_parallel)
     state_dict = None
@@ -232,6 +233,7 @@ def prepare_generator_args(
             paged_attention_config=paged_attention_config,
             dtype=ttnn.bfloat8_b,
             state_dict=state_dict,
+            num_layers=num_layers,
         )
         model_args.append(model_args_i)
         model.append(model_i)
@@ -262,11 +264,17 @@ def prepare_generator_args(
 # page_params (dict): Page parameters for paged attention (block_size, max_num_blocks) For smaller context lengths use block_size=32 and max_num_blocks=1024, for larger context use block_size=64 and max_num_blocks=2048
 # sampling_params (dict): Sampling parameters for decoding (temperature, top_p). If temperature is set to 0, argmax (greedy decode) is used.
 # stop_at_eos (bool): Whether to stop decoding when the model generates an EoS token
-#
+# ci_only (bool): Whether to run the demo in CI only mode
+# data_parallel (int): Number of data parallel groups to use
+# token_accuracy (bool): Whether to compute token accuracy
+# stress_test (bool): Whether to run the demo in stress test mode
+# enable_trace (bool): Whether to enable tracing
+# num_layers (int): Number of layers to use
+# mode (str): Mode to run the demo in (full, prefill, decode), full will run both prefill and decode
 # optimization (ModelOptimizations): Optimization level to use for the model (performance or accuracy)
 # MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy, stress_test, enable_trace",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy, stress_test, enable_trace, num_layers, mode",
     [
         (  # Batch-1 run (Latency) - single user, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -284,6 +292,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -301,6 +311,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # long-context-64k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -318,6 +330,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # Long-context-32k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -335,6 +349,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # Long-context-16k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -352,6 +368,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # reasoning-1 - single user, small prompt, long thinking time
             "models/tt_transformers/demo/input_data_questions_reasoning.json",  # input_prompts
@@ -372,6 +390,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-1 [CI-only] - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -389,6 +409,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-32 [CI-only] - Measures the performance of 32 users over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -406,6 +428,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # DP-4-b1 - single user, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -423,6 +447,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # DP-8-b1 - single user, data-parallel=8, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -440,6 +466,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # DP-4-b32 - 32 users, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -457,6 +485,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-b1-DP-4 [CI-Only] - single user, data-parallel=4, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -474,6 +504,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-b1-DP-8 [CI-Only] - single user, data-parallel=8, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -491,6 +523,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-b1-DP-16 [CI-Only] - single user, data-parallel=16, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -508,6 +542,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-b1-DP-32 [CI-Only] - single user, data-parallel=32, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -525,6 +561,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-stress-1 [CI-only] stress test - Runs a short prefill (128) and loops the same iteration over 50000 times
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -542,6 +580,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             True,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # CI Batch-1 run - Measures token matching accuracy of a single user over 500 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -559,6 +599,8 @@ def prepare_generator_args(
             True,  # token_accuracy
             False,  # stress_test
             False,  # enable_trace -> Teacher forcing does not work if it is on
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-eval-1 - 6 repeat batches with output comparison
             "models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch1.json",  # input_prompts
@@ -576,6 +618,8 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
         ),
         (  # ci-eval-32 - 32 users with 3 repeat batches and shifting prompts
             "models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch32.json",  # input_prompts
@@ -593,6 +637,27 @@ def prepare_generator_args(
             False,  # token_accuracy
             False,  # stress_test
             True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # device-perf - Measures device performance of a prefill or decode run (by default runs prefill but test_device_perf uses args to override defaults)
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            False,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            2,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            10,  # num_layers, if None -> defaults to all layers
+            "prefill",  # mode
         ),
     ],
     ids=[
@@ -615,6 +680,7 @@ def prepare_generator_args(
         "ci-token-matching",  # CI performs token accuracy matching with reference procomputed tokens
         "ci-eval-1",  # CI 6 repeat batches with output comparison
         "ci-eval-32",  # CI batch 32 with 3 repeat batches and output comparison
+        "device-perf",  # Device perf
     ],
 )
 @pytest.mark.parametrize(
@@ -667,7 +733,8 @@ def test_demo_text(
     token_accuracy,
     stress_test,
     enable_trace,
-    model_location_generator,
+    num_layers,
+    mode,
 ):
     """
     Simple demo with limited dependence on reference code.
@@ -706,6 +773,8 @@ def test_demo_text(
     token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
     stress_test = request.config.getoption("--stress_test") or stress_test
     enable_trace = request.config.getoption("--enable_trace") or enable_trace
+    num_layers = request.config.getoption("--num_layers") or num_layers
+    mode = request.config.getoption("--mode") or mode
 
     if stress_test and token_accuracy:
         pytest.skip("Stress test cannot be run with token accuracy mode")
@@ -798,6 +867,7 @@ def test_demo_text(
         max_seq_len=max_seq_len,
         page_params=page_params,
         paged_attention=paged_attention,
+        num_layers=num_layers,
     )
 
     # Skip ci-eval tests on P100 devices
@@ -869,29 +939,40 @@ def test_demo_text(
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
 
-        logger.info("Starting prefill warmup...")
-        profiler.start(f"compile_prefill", iteration=batch_idx)
+        if mode == "prefill" or mode == "full":
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
 
-        logits = generator.prefill_forward_text(
-            input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
-            page_table=page_table,
-            kv_cache=tt_kv_cache,
-            prompt_lens=decoding_pos,
-        )
-        profiler.end(f"compile_prefill", iteration=batch_idx)
-        logger.info("Finished prefill warmup")
+            logits = generator.prefill_forward_text(
+                input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+            )
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
 
-        logger.info(f"Starting prefill...")
-        profiler.start(f"inference_prefill", iteration=batch_idx)
-        logits = generator.prefill_forward_text(
-            input_tokens_prefill_pt,
-            page_table=page_table,
-            kv_cache=tt_kv_cache,
-            prompt_lens=decoding_pos,
-        )
-        prefilled_token = torch.argmax(logits, dim=-1)
-        profiler.end(f"inference_prefill", iteration=batch_idx)
-        logger.info(f"Prefill finished")
+            logger.info(f"Starting prefill...")
+            profiler.start(f"inference_prefill", iteration=batch_idx)
+            logits = generator.prefill_forward_text(
+                input_tokens_prefill_pt,
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+            )
+            prefilled_token = torch.argmax(logits, dim=-1)
+            profiler.end(f"inference_prefill", iteration=batch_idx)
+            logger.info(f"Prefill finished")
+        else:
+            # CI expects profiler to have these measurement keys so
+            # they must be inserted regardless of whether we run prefill or not
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            profiler.start(f"inference_prefill", iteration=batch_idx)
+            profiler.end(f"inference_prefill", iteration=batch_idx)
+            logger.info(f"Skipping prefill forward pass when decode mode is enabled")
+
+            prefilled_token = torch.zeros(global_batch_size, 1, 1)
 
         # Keep track of generated outputs to print out every iteration
         all_outputs = [encoded_prompts[b][: prefill_lens[b]] for b in range(global_batch_size)]
@@ -909,7 +990,7 @@ def test_demo_text(
             device_sampling_params = None
 
         # Initial positions
-        current_pos = torch.tensor([decoding_pos[b] for b in range(global_batch_size)])
+        current_pos = torch.tensor([decoding_pos[b] if mode == "full" else 0 for b in range(global_batch_size)])
 
         # Start decoding
         iteration = 0
@@ -921,7 +1002,17 @@ def test_demo_text(
 
         # Log total inference (accounting for compile_decode as well)
         profiler.start(f"inference_decode", iteration=batch_idx)
-        while users_decoding:
+
+        if mode == "prefill":
+            # CI expects profiler to have these measurement keys so
+            # they must be inserted regardless of whether we run decode or not
+            profiler.start(f"compile_decode", iteration=batch_idx)
+            profiler.end(f"compile_decode", iteration=batch_idx)
+            profiler.start(f"inference_decode_time_{1}", iteration=batch_idx)
+            profiler.end(f"inference_decode_time_{1}", iteration=batch_idx)
+            logger.info(f"Skipping decode forward pass when prefill mode is enabled")
+
+        while users_decoding and mode != "prefill":
             if iteration == 0:  # First iteration also accounts for compile time
                 profiler.start(f"compile_decode", iteration=batch_idx)
             else:
@@ -1062,23 +1153,30 @@ def test_demo_text(
     profiler.end("run")
 
     # Prepare profile benchmark metrics for the first repeat batch only
-    compile_prefill_time = profiler.get_duration("compile_prefill")
-    compile_decode_time = profiler.get_duration("compile_decode")
+    compile_prefill_time = profiler.get_duration("compile_prefill") if mode != "decode" else 0
+    compile_decode_time = profiler.get_duration("compile_decode") if mode != "prefill" else 0
 
-    total_inference_prefill_time = profiler.get_duration("inference_prefill")
+    total_inference_prefill_time = profiler.get_duration("inference_prefill") if mode != "decode" else 0
     total_inference_decode_time = 0
     for i in range(1, num_tokens_generated_decode[0]):  # Iteration 0 is the compile time
         total_inference_decode_time += profiler.get_duration(f"inference_decode_time_{i}")
 
     # Average prefill time for each user
     avg_time_to_first_token = total_inference_prefill_time / global_batch_size
-    # Average decode time per batch iteration
-    avg_decode_iteration_time = total_inference_decode_time / (num_tokens_generated_decode[0] - 1)
 
-    prefill_tok_s = prefill_lens[0] / total_inference_prefill_time * global_batch_size
-    decode_tok_s_user = (num_tokens_generated_decode[0] - 1) / total_inference_decode_time  # Remove the compile time
+    # Average decode time per batch iteration
+    avg_decode_iteration_time = (
+        total_inference_decode_time / (num_tokens_generated_decode[0] - 1) if iteration > 1 else 0
+    )
+
+    prefill_tok_s = prefill_lens[0] / total_inference_prefill_time * global_batch_size if mode != "decode" else 0
+    decode_tok_s_user = (
+        (num_tokens_generated_decode[0] - 1) / total_inference_decode_time if mode != "prefill" and iteration > 1 else 0
+    )  # Remove the compile time
     decode_tok_s = (
-        (num_tokens_generated_decode[0] - 1) / total_inference_decode_time * global_batch_size
+        ((num_tokens_generated_decode[0] - 1) / total_inference_decode_time * global_batch_size)
+        if mode != "prefill" and iteration > 1
+        else 0
     )  # Remove the compile time
 
     measurements = {
@@ -1097,7 +1195,9 @@ def test_demo_text(
     }
 
     # Decode performance for some specific tokens
-    tok_1_perf = profiler.get_duration(f"inference_decode_time_{1}")  # Iteration 0 is compile time
+    tok_1_perf = (
+        profiler.get_duration(f"inference_decode_time_{1}") if 1 < num_tokens_generated_decode[0] else 0
+    )  # Iteration 0 is compile time
     tok_128_perf = profiler.get_duration(f"inference_decode_time_{127}") if 127 < num_tokens_generated_decode[0] else 0
     tok_1024_perf = (
         profiler.get_duration(f"inference_decode_time_{1023}") if 1023 < num_tokens_generated_decode[0] else 0
@@ -1111,9 +1211,10 @@ def test_demo_text(
 
     logger.info("")
     logger.info(f"=== Performance metrics ===")
-    logger.info(
-        f"1st token decode time: {tok_1_perf*1000:.2f}ms [{round(1/tok_1_perf, 2)} t/s/u, {round((1/tok_1_perf)*global_batch_size, 2)} t/s]"
-    )
+    if tok_1_perf > 0:
+        logger.info(
+            f"1st token decode time: {tok_1_perf*1000:.2f}ms [{round(1/tok_1_perf, 2)} t/s/u, {round((1/tok_1_perf)*global_batch_size, 2)} t/s]"
+        )
     if tok_128_perf > 0:
         logger.info(
             f"128th token decode time: {tok_128_perf*1000:.2f}ms [{round(1/tok_128_perf, 2)} t/s/u, {round((1/tok_128_perf)*global_batch_size, 2)} t/s]"

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -50,15 +50,13 @@ from models.tt_transformers.tt.rope import RotarySetup
     "max_seq_len",
     (256,),  # For decode-only unit test, there's no need to run with large sequence lengths
 )
+@pytest.mark.parametrize(
+    "generation_length",
+    (10,),  # For decode-only unit test, there's no need to run with large sequence lengths
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_decoder_inference(
-    max_seq_len,
-    batch_size,
-    paged_attention,
-    page_params,
-    mesh_device,
-    reset_seeds,
-    ensure_gc,
+    max_seq_len, batch_size, paged_attention, page_params, mesh_device, reset_seeds, ensure_gc, generation_length
 ):
     dtype = ttnn.bfloat8_b
 
@@ -76,7 +74,6 @@ def test_decoder_inference(
     reference_model.load_state_dict(partial_state_dict)
 
     generation_start_pos = 0
-    generation_length = 10
     all_tests_pass = True
 
     # Setup RoPE transformation matrices

--- a/models/tt_transformers/tests/test_device_perf.py
+++ b/models/tt_transformers/tests/test_device_perf.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+
+import pandas as pd
+import pytest
+from loguru import logger
+
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from models.perf.device_perf_utils import run_device_perf
+from models.tt_transformers.tests.test_utils import (
+    merge_device_rows,
+    print_dict,
+    process_measurements,
+    split_compile_and_trace,
+    verify_value_within_margin,
+)
+from tools.tracy.process_model_log import get_latest_ops_log_filename
+
+
+# This pytest flag is necessary to ensure that we do NOT open the device in the main process for device perf tests that run
+# the test inside a subprocess since UMD does not allow multiple subprocesses opening the device at the same time.
+@pytest.mark.no_reset_default_device
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("export_measurements", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 32])
+@pytest.mark.parametrize("data_parallel", [1, 2, 4, 8])
+@pytest.mark.parametrize("num_layers", [10])
+@pytest.mark.parametrize("max_seq_len", [1024])
+@pytest.mark.parametrize("max_generated_tokens", [2])
+@pytest.mark.parametrize("model_name", ["llama3_70b", "llama3_8b"])  # Add more models here as needed
+@pytest.mark.parametrize(
+    "mode, num_runs",
+    [
+        ("prefill", 2),
+        ("decode", 4),
+    ],
+    ids=["prefill", "decode"],
+)
+def test_device_perf_one_iter(
+    num_layers,
+    model_name,
+    batch_size,
+    data_parallel,
+    max_seq_len,
+    mode,
+    num_runs,
+    max_generated_tokens,
+    export_measurements,
+):
+    cmd = f"pytest models/tt_transformers/demo/simple_text_demo.py -k performance-device-perf --num_layers {num_layers} --data_parallel {data_parallel} --max_seq_len {max_seq_len} --max_generated_tokens {max_generated_tokens} --paged_attention 1  --batch_size {batch_size} --mode {mode}"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+    device_analysis_types = ["device_kernel_duration", "device_kernel_first_to_last_start"]
+    subdir = f"ttt-device-perf-{mode}"
+    profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    profiler.start("run")
+    profiler.start("decoder-perf-op-metrics")
+
+    # Load perf targets
+    perf_targets = {}
+    try:
+        with open(f"models/tt_transformers/tests/perf_targets/device_perf_{mode}.json", "r") as f:
+            perf_targets = json.load(f)
+    except FileNotFoundError:
+        logger.error(
+            f"Perf targets file not found, device perf test will proceed without performance target comparison"
+        )
+
+    _ = run_device_perf(
+        cmd,
+        subdir,
+        num_iterations=1,
+        cols=cols,
+        batch_size=batch_size,
+        device_analysis_types=device_analysis_types,
+    )
+
+    profiler.end("decoder-perf-op-metrics")
+    profiler.end("run")
+
+    # Parse the latest ops CSV and aggregate per-op metrics
+    filename = get_latest_ops_log_filename(subdir)
+    df = pd.read_csv(filename)
+    df = df[df["OP TYPE"].isin(["tt_dnn_device"])]
+    df = merge_device_rows(df)
+
+    # Split compile and trace
+    (
+        df_model_compilation,
+        df_model_trace,
+        df_first_layer_compilation,
+        df_first_layer_trace,
+        df_mid_layers_compilation,
+        df_mid_layers_trace,
+        df_model_tail_compilation,
+        df_model_tail_trace,
+    ) = split_compile_and_trace(
+        df,
+        mode=mode,
+        num_runs=num_runs,
+        num_layers=num_layers,
+    )
+
+    (
+        kernel_agg_first_layer_compile,
+        dispatch_agg_first_layer_compile,
+        firstlast_agg_first_layer_compile,
+    ) = process_measurements(df_first_layer_compilation, 1)
+    (
+        kernel_agg_first_layer_trace,
+        dispatch_agg_first_layer_trace,
+        firstlast_agg_first_layer_trace,
+    ) = process_measurements(df_first_layer_trace, 1)
+
+    if num_layers > 1:
+        (
+            kernel_agg_mid_layers_compile,
+            dispatch_agg_mid_layers_compile,
+            firstlast_agg_mid_layers_compile,
+        ) = process_measurements(
+            df_mid_layers_compilation, num_layers - 1
+        )  # we dont count the first layer
+
+        (
+            kernel_agg_mid_layers_trace,
+            dispatch_agg_mid_layers_trace,
+            firstlast_agg_mid_layers_trace,
+        ) = process_measurements(df_mid_layers_trace, num_layers - 1)
+
+    if df_model_tail_compilation is not None:
+        (
+            kernel_agg_model_tail_compile,
+            dispatch_agg_model_tail_compile,
+            firstlast_agg_model_tail_compile,
+        ) = process_measurements(df_model_tail_compilation, 1)
+        (
+            kernel_agg_model_tail_trace,
+            dispatch_agg_model_tail_trace,
+            firstlast_agg_model_tail_trace,
+        ) = process_measurements(df_model_tail_trace, 1)
+
+    # Print measurements
+    print_dict(kernel_agg_first_layer_compile, "KERNEL AVERAGE DURATION FOR FIRST LAYER COMPILE")
+    print_dict(kernel_agg_first_layer_trace, "KERNEL AVERAGE DURATION FOR FIRST LAYER TRACE")
+
+    if num_layers > 1:
+        print_dict(kernel_agg_mid_layers_compile, "KERNEL AVERAGE DURATION FOR MID LAYERS COMPILE")
+        print_dict(kernel_agg_mid_layers_trace, "KERNEL AVERAGE DURATION FOR MID LAYERS TRACE")
+        print_dict(dispatch_agg_mid_layers_trace, "DISPATCH AVERAGE DURATION FOR MID LAYERS TRACE")
+        print_dict(firstlast_agg_mid_layers_trace, "FIRST TO LAST AVERAGE START TIME FOR MID LAYERS TRACE")
+
+    if df_model_tail_compilation is not None:
+        print_dict(kernel_agg_model_tail_compile, "KERNEL AVERAGE DURATION FOR MODEL TAIL COMPILE")
+        print_dict(kernel_agg_model_tail_trace, "KERNEL AVERAGE DURATION FOR MODEL TAIL TRACE")
+        print_dict(dispatch_agg_model_tail_trace, "DISPATCH AVERAGE DURATION FOR MODEL TAIL TRACE")
+        print_dict(firstlast_agg_model_tail_trace, "FIRST TO LAST AVERAGE START TIME FOR MODEL TAIL TRACE")
+
+    # Prefer trace for collectives, compile for others
+    def is_collective(op_code: str) -> bool:
+        return any(x in op_code for x in ("AllGather", "ReduceScatter", "AllReduce", "Matmul_RS"))
+
+    # Prepare export structure and default margins
+    perf_measurements_export: dict[str, dict[str, dict[str, float]]] = {}
+
+    # Export metrics for an op group (first layer, mid layers, model tail)
+    def export_group(
+        group_name: str,
+        kernel_agg_compile: dict,
+        kernel_agg_trace: dict,
+        dispatch_agg_trace: dict,
+        firstlast_agg_trace: dict | None,
+    ):
+        all_passing = True
+        perf_measurements_export[group_name] = {}
+        op_codes = set(list(kernel_agg_compile["avg"].keys()) + list(kernel_agg_trace["avg"].keys()))
+        for op_code in op_codes:
+            # kernel avg
+            k_avg_trace = kernel_agg_trace["avg"].get(op_code)
+            k_min_trace = kernel_agg_trace["min"].get(op_code)
+            k_max_trace = kernel_agg_trace["max"].get(op_code)
+            k_avg_comp = kernel_agg_compile["avg"].get(op_code)
+            k_min_comp = kernel_agg_compile["min"].get(op_code)
+            k_max_comp = kernel_agg_compile["max"].get(op_code)
+
+            if is_collective(op_code):
+                k_avg = k_avg_trace if k_avg_trace is not None else k_avg_comp
+                k_min = k_min_trace if k_min_trace is not None else k_min_comp
+                k_max = k_max_trace if k_max_trace is not None else k_max_comp
+            else:
+                k_avg = k_avg_comp if k_avg_comp is not None else k_avg_trace
+                k_min = k_min_comp if k_min_comp is not None else k_min_trace
+                k_max = k_max_comp if k_max_comp is not None else k_max_trace
+
+            if k_avg is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-kernel-avg", float(k_avg)
+                )
+            if k_min is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-kernel-min", float(k_min)
+                )
+            if k_max is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-kernel-max", float(k_max)
+                )
+
+            # Initialize export entry for this op
+            export_entry: dict[str, float] = {}
+            if k_avg is not None:
+                export_entry["kernel_duration"] = float(k_avg)
+
+            # Check that perf_targets, group_name, and op_code exist and keys exist
+            if perf_targets and group_name in perf_targets and op_code in perf_targets[group_name]:
+                passing = verify_value_within_margin(
+                    k_avg,
+                    perf_targets[group_name][op_code]["kernel_duration"],
+                    perf_targets[group_name][op_code]["kernel_duration_relative_margin"],
+                    op_code,
+                    "kernel",
+                )
+                all_passing = all_passing and passing
+            else:
+                logger.warning(f"Warning: {op_code}-{group_name}-kernel not found in perf_targets")
+            # dispatch from trace only
+            d_avg = dispatch_agg_trace["avg"].get(op_code)
+            d_min = dispatch_agg_trace["min"].get(op_code)
+            d_max = dispatch_agg_trace["max"].get(op_code)
+            if d_avg is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-op_to_op-avg", float(d_avg)
+                )
+            if d_min is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-op_to_op-min", float(d_min)
+                )
+            if d_max is not None:
+                benchmark_data.add_measurement(
+                    profiler, 0, "decoder-perf-op-metrics", f"{op_code}-{group_name}-op_to_op-max", float(d_max)
+                )
+
+            if d_avg is not None:
+                export_entry["op_to_op"] = float(d_avg)
+
+            if perf_targets and group_name in perf_targets and op_code in perf_targets[group_name]:
+                passing = verify_value_within_margin(
+                    d_avg,
+                    perf_targets[group_name][op_code]["op_to_op"],
+                    perf_targets[group_name][op_code]["op_to_op_duration_relative_margin"],
+                    op_code,
+                    "op_to_op",
+                )
+                all_passing = all_passing and passing
+            else:
+                logger.warning(f"Warning: {op_code}-{group_name}-op_to_op not found in perf_targets")
+
+            # first_to_last from trace only (if provided)
+            if firstlast_agg_trace is not None:
+                fl_avg = firstlast_agg_trace["avg"].get(op_code)
+                fl_min = firstlast_agg_trace["min"].get(op_code)
+                fl_max = firstlast_agg_trace["max"].get(op_code)
+                if fl_avg is not None:
+                    benchmark_data.add_measurement(
+                        profiler,
+                        0,
+                        "decoder-perf-op-metrics",
+                        f"{op_code}-{group_name}-first_to_last-avg",
+                        float(fl_avg),
+                    )
+                if fl_min is not None:
+                    benchmark_data.add_measurement(
+                        profiler,
+                        0,
+                        "decoder-perf-op-metrics",
+                        f"{op_code}-{group_name}-first_to_last-min",
+                        float(fl_min),
+                    )
+                if fl_max is not None:
+                    benchmark_data.add_measurement(
+                        profiler,
+                        0,
+                        "decoder-perf-op-metrics",
+                        f"{op_code}-{group_name}-first_to_last-max",
+                        float(fl_max),
+                    )
+
+                if fl_avg is not None:
+                    export_entry["first_to_last_start"] = float(fl_avg)
+
+                if perf_targets and group_name in perf_targets and op_code in perf_targets[group_name]:
+                    passing = verify_value_within_margin(
+                        fl_avg,
+                        perf_targets[group_name][op_code]["first_to_last_start"],
+                        perf_targets[group_name][op_code]["first_to_last_start_relative_margin"],
+                        op_code,
+                        "first_to_last_start",
+                    )
+                    all_passing = all_passing and passing
+                else:
+                    logger.warning(f"Warning: {op_code}-{group_name}-first_to_last not found in perf_targets")
+            # Save the entry for this op if we collected any metrics
+            if export_entry:
+                perf_measurements_export[group_name][op_code] = export_entry
+        return all_passing
+
+    # Export per-op metrics for each group
+    all_passing = True
+    all_passing = all_passing and export_group(
+        group_name=f"decoder-first",
+        kernel_agg_compile=kernel_agg_first_layer_compile,
+        kernel_agg_trace=kernel_agg_first_layer_trace,
+        dispatch_agg_trace=dispatch_agg_first_layer_trace,
+        firstlast_agg_trace=firstlast_agg_first_layer_trace,
+    )
+
+    if num_layers > 1:
+        all_passing = all_passing and export_group(
+            group_name=f"decoder-mid",
+            kernel_agg_compile=kernel_agg_mid_layers_compile,
+            kernel_agg_trace=kernel_agg_mid_layers_trace,
+            dispatch_agg_trace=dispatch_agg_mid_layers_trace,
+            firstlast_agg_trace=firstlast_agg_mid_layers_trace,
+        )
+    if df_model_tail_compilation is not None:
+        all_passing = all_passing and export_group(
+            group_name=f"model-tail",
+            kernel_agg_compile=kernel_agg_model_tail_compile,
+            kernel_agg_trace=kernel_agg_model_tail_trace,
+            dispatch_agg_trace=dispatch_agg_model_tail_trace,
+            firstlast_agg_trace=None,  # align with decoder tail export (no first_to_last)
+        )
+
+    # Write out current measurements in the perf-measurements JSON schema
+    if export_measurements:
+        try:
+            output_dir = os.path.join(os.path.dirname(__file__), "perf_measurements")
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(
+                output_dir,
+                f"device_perf_measurements_{model_name}_{mode}_bs{batch_size}_dp{data_parallel}_layers{num_layers}_seq{max_seq_len}.json",
+            )
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(perf_measurements_export, f, indent=4, sort_keys=True)
+            logger.info(f"Wrote perf measurements export to {output_path}")
+        except Exception as e:
+            logger.error(f"Failed to write perf measurements export: {e}")
+
+    # Save partial run
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type="ttnn_decoder_unit",
+        ml_model_name=f"{model_name}-{mode}-{data_parallel}dp-{num_layers}layers-{max_seq_len}seq",
+    )
+
+    # No strict assertions on perf; test succeeds if profiling and export ran
+    assert True

--- a/models/tt_transformers/tests/test_utils.py
+++ b/models/tt_transformers/tests/test_utils.py
@@ -2,7 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+from collections import defaultdict
+
+import pandas as pd
 import torch
+from loguru import logger
 
 from models.tt_transformers.tt.model_config import HfAttentionWrapper, HfDecoderWrapper, HfModelWrapper
 
@@ -58,3 +63,375 @@ def get_ref_model_dype(ref_model, model_name):
             return torch.bfloat16
 
     return default_dype
+
+
+### UTIL FUNCTIONS FOR DEVICE PERF
+def build_duration_dict(raw_dict, column_name):
+    """Build a dictionary of op codes to list of durations."""
+    op_code_dict = {}
+    for entry in raw_dict:
+        if column_name not in entry:
+            logger.warning(f"Warning: {entry} does not have column {column_name}")
+        op_code = entry["OP CODE"]
+        duration = entry[column_name]
+        if op_code not in op_code_dict:
+            op_code_dict[op_code] = []
+        op_code_dict[op_code].append(duration)
+    return op_code_dict
+
+
+def build_duration_per_instance_dict(input_dict, num_layers):
+    """Build a dictionary of op codes to list of durations per instance."""
+    per_instance_dict = {}
+    for op_code in input_dict:
+        num_ops_with_op_code = len(input_dict[op_code])
+        num_instances = num_ops_with_op_code // num_layers
+        if num_ops_with_op_code % num_layers != 0:
+            logger.warning(f"Warning: {op_code} has {num_ops_with_op_code} ops, not a multiple of {num_layers} layers")
+            print_dict(input_dict, "input_dict")
+            assert num_ops_with_op_code % num_layers == 0
+        for iteration_id in range(num_layers):
+            for instance_id in range(num_instances):
+                op_code_with_id = f"{op_code}_{instance_id}"
+                if op_code_with_id not in per_instance_dict:
+                    per_instance_dict[op_code_with_id] = []
+                per_instance_dict[op_code_with_id].append(
+                    input_dict[op_code][iteration_id * num_instances + instance_id]
+                )
+    return per_instance_dict
+
+
+def merge_device_rows(df):
+    """
+    Merges device rows from a DataFrame into a single row per device.
+
+    Args:
+        df: A DataFrame containing measurements.
+
+    Returns:
+        A DataFrame with merged rows.
+    """
+    block_by_device = defaultdict(list)
+
+    for _, row in df.iterrows():
+        op_name = row["OP CODE"]
+        op_type = row["OP TYPE"]
+
+        if op_type == "tt_dnn_device":
+            device_id = int(row["DEVICE ID"])
+            block_by_device[device_id].append((op_name, row.to_dict()))
+
+    device_ids = sorted(block_by_device.keys())
+    merged_blocks = []
+    global_index = 0
+    while max(len(block_by_device[device_id]) for device_id in device_ids) > 0:
+        blocks = []
+        op_name = None
+        missing_devices = []
+        for device_id in device_ids:
+            if not len(block_by_device[device_id]):
+                logger.warning(f"Warning: Device {device_id} is missing operation {op_name} at index {global_index}")
+                continue
+            if op_name is None:
+                op_name = block_by_device[device_id][0][0]
+            elif op_name != block_by_device[device_id][0][0]:
+                missing_devices.append(device_id)
+                continue
+
+            blocks.append(block_by_device[device_id].pop(0))
+
+        if missing_devices:
+            logger.warning(
+                f"Warning: {op_name} at index {global_index} not present in CSV for {len(missing_devices)} devices {missing_devices} - do not trust data for this op or directly subsequent ops with the same name"
+            )
+
+        if not blocks:
+            break
+
+        if "AllGather" in op_name or "ReduceScatter" in op_name or "AllReduce" in op_name or "Matmul_RS" in op_name:
+            # For collective ops, take the average duration over all rows within a block
+            device_kernel_durations = [
+                d["DEVICE KERNEL DURATION [ns]"]
+                for _, d in blocks
+                if "DEVICE KERNEL DURATION [ns]" in d and not math.isnan(d["DEVICE KERNEL DURATION [ns]"])
+            ]
+
+            average_duration = (
+                sum(device_kernel_durations) / len(device_kernel_durations) if device_kernel_durations else float("nan")
+            )
+            # Use the first block's data but update its duration with the average
+            base_block = blocks[0][1].copy()
+            base_block["DEVICE KERNEL DURATION [ns]"] = average_duration
+            merged_blocks.append(base_block)
+        else:
+            # For non-collective ops, take the row with maximum duration
+            max_duration_block = max(blocks, key=lambda x: x[1]["DEVICE KERNEL DURATION [ns]"])
+            merged_blocks.append(max_duration_block[1])
+
+        global_index += 1
+
+    return pd.DataFrame(merged_blocks)
+
+
+def process_measurements(df, num_layers):
+    """
+    Given a Dataframe containing op device perf measurements, return the average, min, and max durations per instance on kerne
+    dispatch, and first to last start.
+
+    Args:
+        df: A DataFrame containing measurements.
+        num_layers: The number of layers in the model.
+
+    Returns:
+        A dictionary of aggregated values.
+        - kernel_duration_per_instance_aggregate_dict: A dictionary of aggregated kernel durations per instance.
+        - dispatch_duration_per_instance_aggregate_dict: A dictionary of aggregated dispatch durations per instance.
+        - first_to_last_start_per_instance_aggregate_dict: A dictionary of aggregated first to last start durations per instance.
+    """
+    raw_dict = df[
+        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]", "DEVICE KERNEL FIRST TO LAST START [ns]"]
+    ].to_dict(orient="records")
+
+    # Kernel duration
+    kernel_duration_dict = build_duration_dict(raw_dict, "DEVICE KERNEL DURATION [ns]")
+    kernel_duration_per_instance_dict = build_duration_per_instance_dict(kernel_duration_dict, num_layers)
+    kernel_duration_per_instance_aggregate_dict = {
+        "avg": aggregate_per_instance_dict(kernel_duration_per_instance_dict, lambda v: sum(v) / len(v)),
+        "min": aggregate_per_instance_dict(kernel_duration_per_instance_dict, min),
+        "max": aggregate_per_instance_dict(kernel_duration_per_instance_dict, max),
+    }
+
+    # Dispatch duration
+    dispatch_duration_dict = build_duration_dict(raw_dict, "OP TO OP LATENCY [ns]")
+    dispatch_duration_per_instance_dict = build_duration_per_instance_dict(dispatch_duration_dict, num_layers)
+    dispatch_duration_per_instance_aggregate_dict = {
+        "avg": aggregate_per_instance_dict(dispatch_duration_per_instance_dict, lambda v: sum(v) / len(v)),
+        "min": aggregate_per_instance_dict(dispatch_duration_per_instance_dict, min),
+        "max": aggregate_per_instance_dict(dispatch_duration_per_instance_dict, max),
+    }
+    # First to last start
+    first_to_last_start_dict = build_duration_dict(raw_dict, "DEVICE KERNEL FIRST TO LAST START [ns]")
+    first_to_last_start_per_instance_dict = build_duration_per_instance_dict(first_to_last_start_dict, num_layers)
+    first_to_last_start_per_instance_aggregate_dict = {
+        "avg": aggregate_per_instance_dict(first_to_last_start_per_instance_dict, lambda v: sum(v) / len(v)),
+        "min": aggregate_per_instance_dict(first_to_last_start_per_instance_dict, min),
+        "max": aggregate_per_instance_dict(first_to_last_start_per_instance_dict, max),
+    }
+
+    return (
+        kernel_duration_per_instance_aggregate_dict,
+        dispatch_duration_per_instance_aggregate_dict,
+        first_to_last_start_per_instance_aggregate_dict,
+    )
+
+
+def print_dict(input_dict, dict_name):
+    # print dict as a readable python dict
+    logger.info(f"\n{dict_name} = {{")
+    for op_code_with_id in input_dict:
+        logger.info(f'"{op_code_with_id}": {input_dict[op_code_with_id]},')
+    logger.info("}")
+
+
+def aggregate_per_instance_dict(input_dict, agg_fn, default=0):
+    """
+    Aggregates a dictionary of values by a given function.
+
+    Args:
+        input_dict: A dictionary of values to aggregate.
+        agg_fn: A function to aggregate the values.
+        default: The default value to return if the dictionary is empty.
+
+    Returns:
+        A dictionary of aggregated values.
+    """
+    result = {}
+    for key, values in input_dict.items():
+        clean_values = [v if v is not None else 0 for v in values]
+        result[key] = agg_fn(clean_values) if clean_values else default
+    return result
+
+
+def find_repeated_runs(ops, num_runs):
+    """
+    Find the starting index of repeated operation runs in a list.
+
+    This function scans through a list of operations (`ops`) to find the
+    first index (`left`) such that the remaining portion of the list,
+    `ops[left:]`, can be evenly divided into `num_runs` contiguous segments
+    (runs), all of which are identical.
+    """
+
+    def check_ops(left):
+        n = len(ops) - left
+        if n % num_runs != 0:
+            return False  # Can't evenly split
+
+        run_length = n // num_runs
+        first = ops[left : left + run_length]
+        for i in range(1, num_runs):
+            if ops[left + i * run_length : left + (i + 1) * run_length] != first:
+                return False
+        return True
+
+    left = 0
+    while left < len(ops):
+        if check_ops(left):
+            return left
+        left += 1
+    return -1  # return -1 if not found
+
+
+def find_repeated_block(ops, min_repeat=2):
+    """
+    Detect a repeating block (pattern) of operations within a list.
+
+    This function scans through the list of operations `ops` to find a contiguous
+    sub-sequence (block) that repeats consecutively at least `min_repeat` times.
+    It returns information about the prefix (head) before the repeated region,
+    the size and count of the repeated block, and the suffix (tail) after it.
+
+    The function assumes that each block represents a "layer" or
+    repeating structure (e.g., neural network layer operations).
+    It tries multiple possible block sizes (starting from 10) to identify
+    the first valid repeated pattern.
+
+    """
+    n = len(ops)
+    for block_size in range(10, n // min_repeat + 1):  # ignore tiny blocks
+        for start in range(n - 2 * block_size):
+            block = ops[start : start + block_size]
+            next_block = ops[start + block_size : start + 2 * block_size]
+
+            if block == next_block:
+                # Found a repeating pattern
+                # Extend it as far as it repeats
+                i = start
+                while i + block_size <= n and ops[i : i + block_size] == block:
+                    i += block_size
+                repeat_count = (i - start) // block_size
+
+                head = ops[:start]
+                tail = ops[i:]
+                return {
+                    "num_head_ops": len(head),
+                    "num_layer_block_ops": len(block),
+                    "num_layers": repeat_count,
+                    "num_tail_ops": len(tail),
+                }
+    # No repetition found
+    return {
+        "head": ops,
+        "layer_block": [],
+        "num_layers": 0,
+        "tail": [],
+    }
+
+
+def split_compile_and_trace(
+    df: pd.DataFrame,
+    mode: str = "prefill",
+    num_runs: int = 1,
+    num_layers: int = None,
+):
+    """
+    Split a concatenated ops DataFrame into compile and runtime-trace segments,
+    and further partition those into first layer, mid layers, and model tail DataFrames.
+
+    The ops CSV typically contains three consecutive phases: compile, capture/trace,
+    and runtime trace. When an extra sampling compile pass is present (to enable
+    random sampling), it contributes a fixed number of rows that should not be used
+    to determine the thirds split.
+
+    Parameters:
+        df:                the input DataFrame (all ops)
+        mode:              the mode of the test (prefill or decode)
+        num_runs:          number of runs in the CSV (typically 3: compile, capture, trace)
+        num_layers:        number of core layers to partition (required for further splits)
+
+    Returns:
+        (
+            df_model_compilation, df_model_trace,
+            df_first_layer_compilation, df_first_layer_trace,
+            df_mid_layers_compilation, df_mid_layers_trace,
+            df_model_tail_compilation, df_model_tail_trace
+        )
+        Any of the additional outputs may be None if slicing arguments are not provided.
+    """
+    # Finds the first index such that ops[left:] contains num_runs of identical blocks of ops
+    first_run_start = find_repeated_runs(df["OP CODE"].tolist(), num_runs)
+    adjusted_len = (len(df) - first_run_start) // num_runs  # The number of ops in each run
+    first_run_end = first_run_start + adjusted_len
+    last_run_start = len(df) - adjusted_len
+    df_model_compilation = df[first_run_start:first_run_end]
+    df_model_trace = df[last_run_start:]
+
+    # Find the head and tail of the repeating region in the model compilation/ trace region of ops
+    head_tail_ops = find_repeated_block(df_model_compilation["OP CODE"].tolist(), num_layers)
+
+    # [op_start_index:op_end_index] = all core layers region
+    op_start_index = head_tail_ops["num_head_ops"]
+    op_end_index = len(df_model_compilation) - head_tail_ops["num_tail_ops"]
+    df_layers_compilation = df_model_compilation[op_start_index:op_end_index]
+    df_layers_trace = df_model_trace[op_start_index:op_end_index]
+
+    # First layer: always first 'len/num_layers'
+    split_point = int(len(df_layers_compilation) / num_layers)
+    df_first_layer_compilation = df_layers_compilation[:split_point]
+    df_first_layer_trace = df_layers_trace[:split_point]
+
+    # Mid layers: remainder of layers region
+    if num_layers > 1:
+        df_mid_layers_compilation = df_layers_compilation[split_point:]
+        df_mid_layers_trace = df_layers_trace[split_point:]
+    else:
+        df_mid_layers_compilation = None
+        df_mid_layers_trace = None
+
+    # Model tail ops (e.g. lmhead/sampling): [tail_start_index:]
+    if op_end_index is not None:
+        df_model_tail_compilation = df_model_compilation[op_end_index:]
+        df_model_tail_trace = df_model_trace[op_end_index:]
+    else:
+        df_model_tail_compilation = None
+        df_model_tail_trace = None
+
+    return (
+        df_model_compilation,
+        df_model_trace,
+        df_first_layer_compilation,
+        df_first_layer_trace,
+        df_mid_layers_compilation,
+        df_mid_layers_trace,
+        df_model_tail_compilation,
+        df_model_tail_trace,
+    )
+
+
+def verify_value_within_margin(value, target, margin, op_code_with_id, perf_type):
+    upper_limit = target + margin * target
+    lower_limit = target - margin * target
+
+    passing = True
+
+    if value > upper_limit:
+        passing = False
+        logger.warning(
+            f"{op_code_with_id} {perf_type}: {value} ns is larger than target "
+            f"({target}) ns, difference: "
+            f"{abs(value - upper_limit)} ns, margin: "
+            f"{margin}, "
+            f"relative margin to pass would be: "
+            f"{(abs(target - value) / target) if target != 0 else -1}"
+        )
+    elif value < lower_limit:
+        passing = False
+        logger.warning(
+            f"{op_code_with_id} {perf_type}: {value} ns is smaller than target "
+            f"({target}) ns, difference: "
+            f"{abs(value - lower_limit)} ns, margin: "
+            f"{margin}, "
+            f"relative margin to pass would be: "
+            f"{(abs(target - value) / target) if target != 0 else -1}"
+        )
+    return passing


### PR DESCRIPTION
### Problem description
There was previously no test to enable comprehensive testing and reporting of models run in TT Transformers, makes understanding op performance for models brought up using TTT very challenging. This PR adds a new test similar to `test_decoder_device_perf.py` used in the llama code base with extensive support for prefill and decode mode.

### What's changed
- Added a new test file `test_device_perf.py`, test will run `simple_text_demo.py` in a subprocess, prefill or decode mode can be specified as a pytest parameter (prefill and decode mode both only runs 2 iterations - 1 compile and 1 trace iteration)
- instead of hard coding the op indices the test will take the recorded op list and dynamically find the number of head ops and tail ops from the prefill or decode run
- Allows loading of  `num_layers` in simple_text_demo such that device perf test can run only a selected number of layers of a model to reduce op count for tracy profiling
- Updated conftest.py to accept new command line arguments for mode and num layers
- Added a flag in reset device pytest fixture that allows tests to skip the `reset_default_device` fixture which opens the device so subprocess that runs perf test can acquire the device lock 
- Utilize the pytest flag to skip opening device in llama model perf test (CI is currently failing because of this issue)
- added these device perf reporting tests to BH demo CI pipelines

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19053814253) CI passes
- [x] [BH multi card demo pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/19053106274)
- [ ] [Galaxy model perf pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/19053777596)