### PR TITLE
Fix sharded_to_interleaved oob writes

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sharded_to_interleaved_oob.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, comp_pcc
+
+
+def test_s2i_dram_height_sharded(device):
+    torch_weight_tensor = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand([1, 1, 320, 32], dtype=torch.bfloat16)
+
+    core_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 7)),
+        }
+    )
+    input_shard_shape = (32, 32)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+    )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=input_memory_config
+    )
+
+    # Allocate a dummy tensor so we can put weight after in DRAM
+    output_tensor = ttnn.from_torch(
+        torch_input_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )  # Alternatively: ttnn.sharded_to_interleaved(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+    weight_tensor = ttnn.from_torch(
+        torch_weight_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )  # This will be allocated after output tensor in DRAM
+
+    # Deallocated output to create slot and then reshard from L1 again
+    ttnn.deallocate(output_tensor)
+    output_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+
+    output_passed, output_message = comp_pcc(torch_input_tensor, ttnn.to_torch(output_tensor), 1.0)
+    weight_passed, weight_message = comp_pcc(torch_weight_tensor, ttnn.to_torch(weight_tensor), 1.0)
+
+    assert (
+        output_passed and weight_passed
+    ), f"Output result: (passed?={output_passed}, pcc={round(output_message, 4)}) - Weight result: (passed?={weight_passed}, pcc={round(weight_message, 4)})"

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -154,7 +154,8 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
     uint32_t curr_idx_w = 0;
 
 
-    for (const auto& core : cores) {
+    for (uint32_t core_idx = 0; core_idx < num_cores_unpadded; core_idx++) {
+        const auto& core = cores[core_idx];
         uint32_t shard_height = num_units_per_shard_height;
         uint32_t shard_width = input.layout() == Layout::TILE ? num_units_per_shard_width : output_unit_size;
         if (input.layout() == Layout::TILE) {
@@ -252,7 +253,7 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
         }
     }
     auto override_runtime_arguments_callback =
-        [unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cores, num_slices](
+        [unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cores, num_slices, num_cores_unpadded](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -278,7 +279,8 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
             }
             // TODO: Make these common args instead
             auto& runtime_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
-            for (const auto& core : cores) {
+            for (uint32_t core_idx = 0; core_idx < num_cores_unpadded; core_idx++) {
+                const auto& core = cores[core_idx];
                 auto& runtime_args = runtime_args_by_core[core.x][core.y];
                 runtime_args[0] = dst_buffer->address();
                 if (partial_op) {


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/30909
https://github.com/tenstorrent/tt-metal/issues/29932

### Problem description
Sharded to interleaved op is writing out of bound

### What's changed
The op is using more cores than needed for some cases. These extra cores are writing out of bound. This PR fixed the cores used in the program factory of the op

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18751769145
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes