### PR TITLE
#25340: Stricter warning logic for default op TensorTopology

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -368,6 +368,9 @@ get_output_placements_and_shape(
     bool has_sharded_tensors = false;
     tt::stl::reflection::visit_object_of_type<Tensor>(
         [&](const Tensor& tensor) {
+            if (has_sharded_tensors) {
+                return;
+            }
             if (!is_fully_replicated(tensor)) {
                 has_sharded_tensors = true;
             }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25340)

### Problem description
Warnings were spammed on resnet and other models because of sharding with 1D distribution shape on some tensors and fully replicating (2D) on other tensors.

### What's changed

- Max distribution rank determined only by sharded tensors if they exist, otherwise by fully replicated tensors
- Warning only displayed when 2+ sharded tensors have different distribution ranks (warnings still disabled though)
- Fixed bug with warning logging where it was logging duplicate shard dims on the same distribution dim

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18761913269))
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18784878543))