### PR TITLE
[skip CI] Fix error message in validateSharding in page update cache op

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -177,10 +177,11 @@ void PagedUpdateCacheDeviceOperation::validate(
         if (input_tensor.is_sharded()) {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "Expect input_tensor to have memory layout WIDTH SHARDED");
+                "Expect input_tensor to NOT have memory layout WIDTH SHARDED");
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Expect input_tensor to have ");
+                "Expect input_tensor to have shard height equal to the last dimension of the input tensor padded "
+                "shape");
             TT_FATAL(
                 (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -180,8 +180,10 @@ void PagedUpdateCacheDeviceOperation::validate(
                 "Expect input_tensor to NOT have memory layout WIDTH SHARDED");
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Expect input_tensor to have shard height equal to the last dimension of the input tensor padded "
-                "shape");
+                "Expect input_tensor to have shard height ({}) equal to the last dimension of the input tensor padded "
+                "shape ({})",
+                input_tensor.shard_spec().value().shape[1],
+                input_tensor.padded_shape()[-1]);
             TT_FATAL(
                 (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -180,7 +180,7 @@ void PagedUpdateCacheDeviceOperation::validate(
                 "Expect input_tensor to NOT have memory layout WIDTH SHARDED");
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Expect input_tensor to have shard height ({}) equal to the last dimension of the input tensor padded "
+                "Expect input_tensor to have shard width ({}) equal to the last dimension of the input tensor padded "
                 "shape ({})",
                 input_tensor.shard_spec().value().shape[1],
                 input_tensor.padded_shape()[-1]);


### PR DESCRIPTION
### Ticket
#31077

### Problem description
There was an error in the error message in paged cache update op when validating sharding configuration of the input tensor. It was updated to reflect the conditional checks.

### What's changed
- updated the error message in the validate sharding function