### PR TITLE
#28085 Tensor accessor sharding mismatched cases work with and without broadcasting

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -3658,35 +3658,12 @@ def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
+    import itertools
 
-    input_combinations = (
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, a_sharded_config),
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, a_sharded_config),
-        (ttnn.DRAM_MEMORY_CONFIG, b_sharded_config, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, b_sharded_config, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.DRAM_MEMORY_CONFIG, b_sharded_config, a_sharded_config),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, a_sharded_config),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, a_sharded_config),
-        (ttnn.L1_MEMORY_CONFIG, b_sharded_config, ttnn.DRAM_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, b_sharded_config, ttnn.L1_MEMORY_CONFIG),
-        (ttnn.L1_MEMORY_CONFIG, b_sharded_config, a_sharded_config),
-        (a_sharded_config, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (a_sharded_config, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (a_sharded_config, ttnn.DRAM_MEMORY_CONFIG, a_sharded_config),
-        (a_sharded_config, ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
-        (a_sharded_config, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        (a_sharded_config, ttnn.L1_MEMORY_CONFIG, a_sharded_config),
-        (a_sharded_config, b_sharded_config, ttnn.DRAM_MEMORY_CONFIG),
-        (a_sharded_config, b_sharded_config, ttnn.L1_MEMORY_CONFIG),
-        (a_sharded_config, b_sharded_config, a_sharded_config),
+    input_combinations = itertools.product(
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, a_sharded_config],
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, b_sharded_config],
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, a_sharded_config],
     )
     for a_config, b_config, dst_config in input_combinations:
         a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(a_shape)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2550,15 +2550,14 @@ def test_binary_sharded_bcast_scalar_zero_dim(
 
 
 @pytest.mark.parametrize(
-    "input_shape",
-    (torch.Size([1, 1, 12 * 32, 32]),),
-)
-@pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_mixed_buffer_type(input_shape, dtype_pt, dtype_tt, device):
+def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     torch.manual_seed(0)
+    dram_grid_size = device.dram_grid_size()
+    input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
+
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(input_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(input_shape)
 
@@ -2568,7 +2567,6 @@ def test_binary_sharded_shardspec_mixed_buffer_type(input_shape, dtype_pt, dtype
     shard_spec = ttnn.ShardSpec(shard_grid, [(N * C * H) // n_cores, W], ttnn.ShardOrientation.ROW_MAJOR)
     a_config = ttnn.MemoryConfig(ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
 
-    dram_grid_size = device.dram_grid_size()
     print("dram_grid_size:", dram_grid_size.x * dram_grid_size.y)
     dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -2599,7 +2599,11 @@ def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (2, 3))})
     N, C, H, W = input_shape
     n_cores = 12
-    shard_spec = ttnn.ShardSpec(shard_grid, [(N * C * H) // n_cores, W], ttnn.ShardOrientation.ROW_MAJOR)
+    import math
+
+    shard_spec = ttnn.ShardSpec(
+        shard_grid, [math.ceil((N * C * H) / n_cores / 32) * 32, W], ttnn.ShardOrientation.ROW_MAJOR
+    )
     a_config = ttnn.MemoryConfig(ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
 
     print("dram_grid_size:", dram_grid_size.x * dram_grid_size.y)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -34,12 +34,12 @@ inline bool is_block_format(DataType dtype) {
     }
 }
 
-inline bool is_layout(const Tensor& input, Layout layout) { return input.layout() == layout; }
+inline bool is_layout_or_scalar(const Tensor& input, Layout layout) { return input.layout() == layout; }
 
-inline bool is_layout([[maybe_unused]] float input, [[maybe_unused]] Layout layout) { return true; }
+inline bool is_layout_or_scalar([[maybe_unused]] float input, [[maybe_unused]] Layout layout) { return true; }
 
 inline Tensor to_layout(const Tensor& input, Layout layout) {
-    if (detail::is_layout(input, layout)) {
+    if (detail::is_layout_or_scalar(input, layout)) {
         return input;
     }
 
@@ -370,10 +370,8 @@ inline auto invoke_binary_ng(
 
     // RM is never BFLOAT8 or BFLOAT4 so we can assume it goes in here.
     if (not typecast_a and not typecast_b) {
-        const auto input_a_rm = detail::is_layout(lhs, Layout::ROW_MAJOR);
-        // For scalar case, check if we need layout conversion
-        constexpr bool is_scalar_rhs = std::is_floating_point_v<std::decay_t<decltype(rhs)>>;
-        const auto input_b_rm = is_scalar_rhs ? false : detail::is_layout(rhs, Layout::ROW_MAJOR);
+        const auto input_a_rm = detail::is_layout_or_scalar(lhs, Layout::ROW_MAJOR);
+        const auto input_b_rm = detail::is_layout_or_scalar(rhs, Layout::ROW_MAJOR);
         const auto input_a = detail::to_layout(lhs, Layout::TILE);
         const auto input_b = detail::to_layout(rhs, Layout::TILE);
 
@@ -381,7 +379,8 @@ inline auto invoke_binary_ng(
             // we don't support to_layout with optional output tensor
             TT_FATAL(
                 !output_preallocated,
-                "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+                "Optional output tensor with Row Major input is not supported right now for Elementwise "
+                "operations");
         }
 
         auto result = ttnn::prim::binary_ng(
@@ -398,8 +397,7 @@ inline auto invoke_binary_ng(
         // if both inputs are in row major, convert the output to row major
         // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
         // since it leads to better perf
-        // For scalar case, only convert if lhs was ROW_MAJOR AND result can be safely converted
-        if (input_a_rm and (input_b_rm or is_scalar_rhs)) {
+        if (input_a_rm and input_b_rm) {
             return detail::to_layout(result, Layout::ROW_MAJOR);
         }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -372,7 +372,7 @@ inline auto invoke_binary_ng(
     if (not typecast_a and not typecast_b) {
         const auto input_a_rm = detail::is_layout(lhs, Layout::ROW_MAJOR);
         // For scalar case, check if we need layout conversion
-        constexpr bool is_scalar_rhs = !requires { rhs.dtype(); };
+        constexpr bool is_scalar_rhs = std::is_floating_point_v<std::decay_t<decltype(rhs)>>;
         const auto input_b_rm = is_scalar_rhs ? false : detail::is_layout(rhs, Layout::ROW_MAJOR);
         const auto input_a = detail::to_layout(lhs, Layout::TILE);
         const auto input_b = detail::to_layout(rhs, Layout::TILE);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -56,7 +56,9 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case BinaryOpType::BITWISE_XOR:
         case BinaryOpType::BITWISE_OR:
         case BinaryOpType::BITWISE_AND:
-            return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16) || (a == DataType::UINT32 && b == DataType::UINT32));
+            return (
+                (a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16) ||
+                (a == DataType::UINT32 && b == DataType::UINT32));
         case BinaryOpType::MAXIMUM:
         case BinaryOpType::MINIMUM:
         case BinaryOpType::XLOGY:
@@ -158,30 +160,46 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
         if (tensor_b_sharded) {
             TT_FATAL(
                 input_tensor_a.memory_config().memory_layout() == input_tensor_b->memory_config().memory_layout(),
-                "Error");
-            TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b->shard_spec().value(), "Error");
+                "Input tensor A and input tensor B must have the same memory layout");
+            TT_FATAL(
+                input_tensor_a.shard_spec().value() == input_tensor_b->shard_spec().value(),
+                "Input tensor A and input tensor B must have the same shard spec");
         }
         if (attributes.memory_config.is_sharded()) {
             TT_FATAL(
-                input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+                input_tensor_a.memory_config().memory_layout() == attributes.memory_config.memory_layout(),
+                "Input tensor A and output tensor must have the same memory layout");
         } else {
-            TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+            TT_FATAL(
+                attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "Output tensor must be interleaved");
         }
     } else if (tensor_b_sharded) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor A must be interleaved");
         if (attributes.memory_config.is_sharded()) {
             TT_FATAL(
-                input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(), "Error");
+                input_tensor_b->memory_config().memory_layout() == attributes.memory_config.memory_layout(),
+                "Input tensor B and output tensor must have the same memory layout");
         } else {
-            TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+            TT_FATAL(
+                attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "Output tensor must be interleaved");
         }
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor A must be interleaved");
         if (input_tensor_b.has_value()) {
-            TT_FATAL((input_tensor_b->memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED), "Error");
+            TT_FATAL(
+                input_tensor_b->memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "Input tensor B must be interleaved");
         }
         if (!attributes.memory_config.is_sharded()) {
-            TT_FATAL(attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+            TT_FATAL(
+                attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "Output tensor must be interleaved");
         }
     }
 
@@ -189,7 +207,7 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     std::visit(
         [&attributes](auto&& program_factory) {
             if constexpr (std::is_same_v<decltype(program_factory), ElementWiseMultiCore>) {
-                TT_FATAL(not attributes.activations.has_value(), "Error");
+                TT_FATAL(not attributes.activations.has_value(), "Activations are not supported for binary operations");
             }
         },
         program_factory);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -150,7 +150,7 @@ void validate_sharding(
     SubtileBroadcastType subtile_broadcast_type) {
     switch (subtile_broadcast_type) {
         case SubtileBroadcastType::NONE:
-            TT_FATAL(shard_spec_x == shard_spec_y, "Operands to eltwise binary need to have the same shard spec");
+            // TT_FATAL(shard_spec_x == shard_spec_y, "Operands to eltwise binary need to have the same shard spec");
             break;
         default:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -148,7 +148,8 @@ bool is_native_L1_sharding(const Tensor& a, const std::optional<Tensor>& b, cons
     }
 
     // a and b identical shape, no broadcast on any dimension
-    if (b.has_value() && (a.logical_shape() == b->logical_shape())) {
+    if (b.has_value() && (a.logical_shape() == b->logical_shape()) &&
+        (a.memory_config().memory_layout() == b->memory_config().memory_layout())) {
         if (is_uneven(a) || is_uneven(*b) || is_uneven(c)) {
             return false;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -492,8 +492,10 @@ void add_activation_defines(
         });
 }
 
-std::map<std::string, std::string> make_dataflow_defines(const DataType dtype, const DataType b_dtype) {
+std::map<std::string, std::string> make_dataflow_defines(
+    const DataType dtype, const std::optional<DataType> b_dtype_opt) {
     std::map<std::string, std::string> defines;
+    const auto b_dtype = b_dtype_opt.value_or(dtype);
     // to maintain backward compatibility, we need to support both dtype and b_dtype
     if (dtype == DataType::FLOAT32) {
         defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
@@ -585,6 +587,8 @@ ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_s
     uint32_t to_width = to_shape[-1];
 
     // Adjust shard shape based on full volume ratios
+    TT_FATAL(from_volume_except_width > 0, "Invalid from_shape: volume is zero");
+    TT_FATAL(from_width > 0, "Invalid from_shape: width dimension is zero");
     ret.shape[0] = std::max((ret.shape[0] * to_volume_except_width) / from_volume_except_width, 32u);
     ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
     return ret;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -33,7 +33,6 @@ struct fmt::formatter<ttnn::operations::binary_ng::Lowercase> : fmt::formatter<s
 namespace ttnn::operations::binary_ng {
 
 BinaryNgKernelConfig::BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type) {
-    // TODO: completely remove old kernels and its old kernel parameters
     switch (subtile_broadcast_type) {
         case SubtileBroadcastType::NONE:
             reader_kernel = KernelName::ReaderNoBcast;
@@ -563,4 +562,31 @@ uint32_t pack_scalar_runtime_arg(const float scalar, const DataType dtype, const
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>);
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>);
 
+ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    auto ret = shard_spec;
+
+    // Calculate volume of all dimensions EXCEPT the last (width)
+    // This is the "collapsed height" for sharding purposes
+    uint32_t from_volume_except_width = 1;
+    uint32_t to_volume_except_width = 1;
+
+    const int rank = std::max(from_shape.rank(), to_shape.rank());
+
+    // Accumulate all dimensions except the last
+    for (int i = 0; i < rank - 1; ++i) {
+        uint32_t from_dim = (i < from_shape.rank()) ? from_shape[i] : 1;
+        uint32_t to_dim = (i < to_shape.rank()) ? to_shape[i] : 1;
+        from_volume_except_width *= from_dim;
+        to_volume_except_width *= to_dim;
+    }
+
+    // Get width dimensions
+    uint32_t from_width = from_shape[-1];
+    uint32_t to_width = to_shape[-1];
+
+    // Adjust shard shape based on full volume ratios
+    ret.shape[0] = std::max((ret.shape[0] * to_volume_except_width) / from_volume_except_width, 32u);
+    ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
+    return ret;
+}
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -564,7 +564,8 @@ uint32_t pack_scalar_runtime_arg(const float scalar, const DataType dtype, const
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>, std::optional<DataType>);
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>, std::optional<DataType>);
 
-ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+tt::tt_metal::ShardSpec adjust_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
     auto ret = shard_spec;
 
     // Calculate volume of all dimensions EXCEPT the last (width)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -92,7 +92,8 @@ void add_activation_defines(
 
 uint32_t pack_scalar_runtime_arg(float scalar, DataType dtype, bool is_quant_op);
 
-std::map<std::string, std::string> make_dataflow_defines(DataType dtype, DataType b_dtype);
+std::map<std::string, std::string> make_dataflow_defines(
+    DataType dtype, std::optional<DataType> b_dtype = std::nullopt);
 
 struct AllShardSpecs {
     tt::tt_metal::ShardSpec a_shard_spec;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -94,4 +94,13 @@ uint32_t pack_scalar_runtime_arg(float scalar, DataType dtype, bool is_quant_op)
 
 std::map<std::string, std::string> make_dataflow_defines(DataType dtype, DataType b_dtype);
 
+struct AllShardSpecs {
+    tt::tt_metal::ShardSpec a_shard_spec;
+    tt::tt_metal::ShardSpec b_shard_spec;
+    tt::tt_metal::ShardSpec c_shard_spec;
+};
+
+tt::tt_metal::ShardSpec adjust_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
+
 }  // namespace ttnn::operations::binary_ng


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/28085)

### Problem description
This PR enables full binary op sharding generality support.

### What's changed
For C (mem config either specified or not) = A + B
For any following tensor mem config parameters, the tensor mem config for A, B, C are independent. There is no restriction for generality support.

Memory config:
	Layout Strategy (Interleaved / sharded (HEIGHT / WIDTH / BLOCK))
	If sharded, shard spec (shard shape, core grid, orientation (row / col))
	Buffer type (L1 / DRAM)
	Memory layout (row_major / tile)
Uneven shard is supported (with the only exception of row_major_layout)

For any broadcast type:
Subtile broadcast (row, col, scalar, row_col_mixed, higher dim than H W), scalar value, identical shapes.

Any combination of above.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes