### PR TITLE
Implement quiescing submeshes

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -230,13 +230,13 @@ TEST_P(MeshWorkloadTestSuiteSubmeshFixture, QuiesceSubmeshesAllowsAlternatingWor
     submesh->mesh_command_queue().enqueue_record_event();
 
     // 2) Quiesce all submeshes from the parent
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     // 3) Run on parent (non-blocking)
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), parent_workload, /*blocking=*/false);
 
     // 4) Quiesce again
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     // 5) Run again on the same submesh (non-blocking) and finish to ensure completion
     EnqueueMeshWorkload(submesh->mesh_command_queue(), submesh_workload, /*blocking=*/false);

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -208,7 +208,7 @@ TEST_P(MeshWorkloadTestSuiteSubmeshFixture, QuiesceSubmeshesAllowsAlternatingWor
 
     int submesh_index = GetParam();
     ASSERT_TRUE(submesh_index == 0 || submesh_index == 1);
-    auto submesh = submeshes[submesh_index];
+    auto& submesh = submeshes[submesh_index];
 
     // Single-core no-op program for submesh
     Program submesh_program = CreateProgram();

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <cmath>
 #include <cstdlib>
-#include <exception>
 #include <map>
 #include <memory>
 #include <optional>
@@ -181,6 +180,70 @@ void validate_sems(
 using MeshWorkloadTest2x4 = MeshDevice2x4Fixture;
 using MeshWorkloadTest4x8 = MeshDevice4x8Fixture;
 using MeshWorkloadTestSuite = GenericMeshDeviceFixture;
+
+// Parameterized: runs once with either submesh (index 0 or 1) executing the program.
+class MeshWorkloadTestSuiteSubmeshFixture : public MeshWorkloadTestSuite, public ::testing::WithParamInterface<int> {};
+
+// The test succeeds if it completes without hanging.
+TEST_P(MeshWorkloadTestSuiteSubmeshFixture, QuiesceSubmeshesAllowsAlternatingWorkloads) {
+    if (mesh_device_->num_devices() < 2) {
+        GTEST_SKIP() << "Requires at least 2 devices";
+    }
+
+    // Create two evenly sized submeshes (split along columns if possible, else rows).
+    MeshShape parent_shape = mesh_device_->shape();
+    std::optional<MeshShape> sub_shape;
+    if (parent_shape.dims() == 2 && (parent_shape[1] % 2 == 0)) {
+        sub_shape = MeshShape(parent_shape[0], parent_shape[1] / 2);
+    } else if (parent_shape.dims() == 2 && (parent_shape[0] % 2 == 0)) {
+        sub_shape = MeshShape(parent_shape[0] / 2, parent_shape[1]);
+    }
+
+    if (!sub_shape.has_value()) {
+        GTEST_SKIP() << "Mesh shape is not evenly splittable into two submeshes";
+    }
+
+    auto submeshes = mesh_device_->create_submeshes(*sub_shape);
+    ASSERT_EQ(submeshes.size(), 2u);
+
+    int submesh_index = GetParam();
+    ASSERT_TRUE(submesh_index == 0 || submesh_index == 1);
+    auto submesh = submeshes[submesh_index];
+
+    // Single-core no-op program for submesh
+    Program submesh_program = CreateProgram();
+    CoreCoord single_core = {0, 0};
+    CreateKernel(submesh_program, "tt_metal/kernels/compute/blank.cpp", single_core, ComputeConfig{});
+    MeshWorkload submesh_workload;
+    submesh_workload.add_program(MeshCoordinateRange(submesh->shape()), std::move(submesh_program));
+
+    // Single-core no-op program for parent mesh
+    Program parent_program = CreateProgram();
+    CreateKernel(parent_program, "tt_metal/kernels/compute/blank.cpp", single_core, ComputeConfig{});
+    MeshWorkload parent_workload;
+    parent_workload.add_program(MeshCoordinateRange(mesh_device_->shape()), std::move(parent_program));
+
+    // 1) Run on submesh (non-blocking)
+    EnqueueMeshWorkload(submesh->mesh_command_queue(), submesh_workload, /*blocking=*/false);
+
+    // Enqueue a record event to ensure the last event ID is higher on the submesh than on the parent mesh.
+    submesh->mesh_command_queue().enqueue_record_event();
+
+    // 2) Quiesce all submeshes from the parent
+    mesh_device_->quiesce_submeshes();
+
+    // 3) Run on parent (non-blocking)
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), parent_workload, /*blocking=*/false);
+
+    // 4) Quiesce again
+    mesh_device_->quiesce_submeshes();
+
+    // 5) Run again on the same submesh (non-blocking) and finish to ensure completion
+    EnqueueMeshWorkload(submesh->mesh_command_queue(), submesh_workload, /*blocking=*/false);
+    Finish(submesh->mesh_command_queue());
+}
+
+INSTANTIATE_TEST_SUITE_P(QuiesceSubmeshIndex, MeshWorkloadTestSuiteSubmeshFixture, ::testing::Values(0, 1));
 
 TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
     uint32_t num_workloads = 10;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -131,6 +131,11 @@ public:
     virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
+
+    // Internal function.
+    virtual void wait_for_completion(bool reset_launch_msg_state) {}
+    // May only be called after wait_for_completion has been called on both command queues on the device.
+    virtual void finish_and_reset_in_use() {}
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -133,7 +133,7 @@ public:
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
 
     // Internal function.
-    virtual void wait_for_completion(bool reset_launch_msg_state) {}
+    virtual void wait_for_completion(bool) {}
     // May only be called after wait_for_completion has been called on both command queues on the device.
     virtual void finish_and_reset_in_use() {}
 };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -302,16 +302,15 @@ public:
     std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
 
     /**
-     * @brief Synchronize with all submeshes created from this mesh.
+     * @brief Synchronize with all devices derived from this mesh (including submeshes).
      *
-     * Blocks until all in-flight work enqueued on every submesh derived from this mesh has completed.  Use this to
-     * insert a barrier between phases that use overlapping submeshes on the same physical devices.  After this call
+     * Blocks until all in-flight work enqueued on every submesh derived from this mesh has completed. Use this to
+     * insert a barrier between phases that use overlapping submeshes on the same physical devices. After this call
      * returns, it is safe to enqueue new work on this mesh or any submesh derived from this mesh that may overlap with
      * submeshes that were previously active. All submeshes must be using the default subdevice manager when this is
      * called.
-     *
      */
-    void quiesce_submeshes();
+    void quiesce_devices();
 
     std::shared_ptr<MeshDevice> create_submesh(
         const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -126,6 +126,8 @@ private:
     std::unique_ptr<program_cache::detail::ProgramCache> program_cache_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
+    // Recursively quiesce all submeshes.
+    void quiesce_internal();
 
     void mark_allocations_unsafe();
     void mark_allocations_safe();
@@ -298,6 +300,18 @@ public:
 
     const std::shared_ptr<MeshDevice>& get_parent_mesh() const;
     std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
+
+    /**
+     * @brief Synchronize with all submeshes created from this mesh.
+     *
+     * Blocks until all in-flight work enqueued on every submesh derived from this mesh has completed.  Use this to
+     * insert a barrier between phases that use overlapping submeshes on the same physical devices.  After this call
+     * returns, it is safe to enqueue new work on this mesh or any submesh derived from this mesh that may overlap with
+     * submeshes that were previously active. All submeshes must be using the default subdevice manager when this is
+     * called.
+     *
+     */
+    void quiesce_submeshes();
 
     std::shared_ptr<MeshDevice> create_submesh(
         const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1186,7 +1186,6 @@ void FDMeshCommandQueue::wait_for_completion(bool reset_launch_msg_state) {
         }
         cq_shared_state_->sub_device_cq_owner.clear();
         cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
-        in_use_ = true;
         for (auto device : mesh_device_->get_devices()) {
             program_dispatch::reset_worker_dispatch_state_on_device(
                 mesh_device_,

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1178,4 +1178,56 @@ void FDMeshCommandQueue::capture_expected_worker_count_reset_cmd(
     }
 }
 
+void FDMeshCommandQueue::wait_for_completion(bool reset_launch_msg_state) {
+    if (in_use_) {
+        size_t num_sub_devices = mesh_device_->num_sub_devices();
+        for (auto device : mesh_device_->get_devices()) {
+            TT_FATAL(!device->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
+        }
+        cq_shared_state_->sub_device_cq_owner.clear();
+        cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
+        in_use_ = true;
+        for (auto device : mesh_device_->get_devices()) {
+            program_dispatch::reset_worker_dispatch_state_on_device(
+                mesh_device_,
+                device->sysmem_manager(),
+                id_,
+                this->virtual_program_dispatch_core(),
+                expected_num_workers_completed_,
+                reset_launch_msg_state);
+        }
+        program_dispatch::reset_config_buf_mgrs_and_expected_workers(
+            config_buffer_mgr_,
+            expected_num_workers_completed_,
+            mesh_device_->num_sub_devices(),
+            mesh_device_->allocator()->get_config().l1_unreserved_base);
+        if (reset_launch_msg_state) {
+            std::for_each(
+                this->cq_shared_state_->worker_launch_message_buffer_state.begin(),
+                this->cq_shared_state_->worker_launch_message_buffer_state.begin() + num_sub_devices,
+                std::mem_fn(&LaunchMessageRingBufferState::reset));
+        }
+        finish();
+    }
+}
+
+void FDMeshCommandQueue::finish_and_reset_in_use() {
+    if (in_use_) {
+        auto lock = lock_api_function_();
+        uint32_t current_event = reference_sysmem_manager().get_current_event(id_);
+        for (auto device : mesh_device_->get_devices()) {
+            TT_ASSERT(
+                device->sysmem_manager().get_last_completed_event(id_) == current_event,
+                "Current event must be equal to last completed event");
+            bool is_reference_cq = &device->sysmem_manager() == &reference_sysmem_manager();
+            // Ensure the next command will be recorded as event 0
+            device->sysmem_manager().set_current_and_last_completed_event(
+                id_, is_reference_cq ? UINT32_MAX : 0, UINT32_MAX);
+        }
+        finish_nolock({});
+
+        in_use_ = false;
+    }
+}
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -271,6 +271,9 @@ public:
     std::pair<bool, size_t> query_prefetcher_cache(uint64_t workload_id, uint32_t lengthB);
     void reset_prefetcher_cache_manager();
     int get_prefetcher_cache_sizeB() const;
+
+    void wait_for_completion(bool reset_launch_msg_state) override;
+    void finish_and_reset_in_use() override;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1032,7 +1032,7 @@ void MeshDevice::quiesce_internal() {
         "Cannot quiesce when non-default sub-device manager is active");
     for (const auto& submesh : submeshes_) {
         if (auto submesh_ptr = submesh.lock()) {
-            submesh_ptr->quiesce_submeshes();
+            submesh_ptr->quiesce_devices();
         }
     }
     bool have_reset_launch_msg_state = false;
@@ -1045,7 +1045,7 @@ void MeshDevice::quiesce_internal() {
     }
 }
 
-void MeshDevice::quiesce_submeshes() {
+void MeshDevice::quiesce_devices() {
     quiesce_internal();
     for (auto& command_queue : mesh_command_queues_) {
         for (auto& device : get_devices()) {

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -35,6 +35,8 @@ public:
 
     uint32_t get_last_completed_event(uint8_t cq_id);
 
+    uint32_t get_current_event(uint8_t cq_id);
+
     void reset(uint8_t cq_id);
 
     void set_issue_queue_size(uint8_t cq_id, uint32_t issue_queue_size);
@@ -86,6 +88,10 @@ public:
 
     void fetch_queue_write(uint32_t command_size_B, uint8_t cq_id, bool stall_prefetcher = false);
 
+    // Boths CQs on the device must be idle when this is called.
+    void set_current_and_last_completed_event(
+        uint8_t cq_id, uint32_t current_event_id, uint32_t last_completed_event_id);
+
 private:
     ChipId device_id = 0;
     std::vector<uint32_t> completion_byte_addrs;
@@ -95,7 +101,7 @@ private:
     uint32_t channel_offset = 0;
     std::vector<uint32_t> cq_to_event;
     std::vector<uint32_t> cq_to_last_completed_event;
-    std::vector<std::mutex> cq_to_event_locks;
+    mutable std::vector<std::mutex> cq_to_event_locks;
     std::vector<tt_cxy_pair> prefetcher_cores;
     std::vector<umd::Writer> prefetch_q_writers;
     std::vector<umd::Writer> completion_q_writers;


### PR DESCRIPTION
### Ticket
#30692 

### Problem description
At the moment, there's no way to switch between overlapping submeshes when submitting commands; if that's attempted, the device is likely to hang or assert.. This is particularly limiting if someone wants to be able to submit commands to a submesh normally, but also submit CCLs to the entire mesh.

### What's changed
For now, add a new quiesce_submesh command that will cause the all submeshes of a mesh to reset the state of their devices, including

- launch message ring buffer state
- worker config buffer state
- Current event state
- expected num workers completed.

This is an expensive operation, potentially taking 100-150us, but it is useful for prototyping software that needs this workflow. Longer-term, we may want to use different approaches.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes