### PR TITLE
More CCL Sweep test improvements

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -590,7 +590,7 @@ on:
           - BH-LoudBox
         default: "N150"
       log-level:
-        description: "Long sweeps on INFO log level may overwhelm the runner"
+        description: "Log level for sweep execution. INFO level may overwhelm runners for long sweeps."
         required: true
         type: choice
         options:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -605,8 +605,7 @@ on:
     - cron: "0 4 * * 3" # This cron schedule runs the workflow at 4:00 AM UTC on Wednesdays (comprehensive run)
     - cron: "0 5 * * 6" # This cron schedule runs the workflow at 5:00 AM UTC on Saturdays (comprehensive run)
 concurrency:
-  group: ttnn-sweeps-${{ github.ref }}-${{ github.event.inputs.arch || 'wormhole_b0' }}-${{ github.event.inputs['runner-label'] || 'N150' }}
-  cancel-in-progress: true
+  group: ttnn-sweeps-${{ github.ref }}-${{ github.event.inputs.arch || 'wormhole_b0' }}-${{ github.event.inputs.runner-label || 'N150' }}-${{ github.event.inputs.sweep_name }}
 
 jobs:
   build-artifact:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -589,7 +589,7 @@ on:
           - BH-DeskBox
           - BH-LoudBox
         default: "N150"
-      log_level:
+      log-level:
         description: "Long sweeps on INFO log level may overwhelm the runner"
         required: true
         type: choice
@@ -599,7 +599,6 @@ on:
           - WARNING
           - CRITICAL
         default: "INFO"
-
 
   schedule:
     - cron: "0 4 * * 1,2,4,5" # This cron schedule runs the workflow at 4:00 AM UTC on Mon, Tue, Thu, Fri (nightly runs)

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -589,6 +589,17 @@ on:
           - BH-DeskBox
           - BH-LoudBox
         default: "N150"
+      log_level:
+        description: "Long sweeps on INFO log level may overwhelm the runner"
+        required: true
+        type: choice
+        options:
+          - DEBUG
+          - INFO
+          - WARNING
+          - CRITICAL
+        default: "INFO"
+
 
   schedule:
     - cron: "0 4 * * 1,2,4,5" # This cron schedule runs the workflow at 4:00 AM UTC on Mon, Tue, Thu, Fri (nightly runs)
@@ -749,7 +760,8 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}
-        LOGURU_LEVEL: INFO
+        LOGURU_LEVEL: ${{ inputs.log-level }}
+        TT_LOGGER_LEVEL: ${{ inputs.log-level }}
         GITHUB_ACTIONS: true
         ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
         ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -795,7 +795,7 @@ jobs:
         with:
           name: sweeps-vectors
           path: /work/tests/sweep_framework/vectors_export/
-      - name: Run ttnn sweeps (single sweep)
+      - name: Run ttnn sweeps (single sweep) ${{ github.event.inputs.runner_label }} ${{ github.event.inputs.sweep_name }} ${{ github.event.inputs.suite_name }}
         run: |
           SKIP_ON_TIMEOUT_FLAG=""
           if [[ "${{ github.event.inputs.skip_on_timeout }}" == "true" ]]; then
@@ -807,7 +807,13 @@ jobs:
             DEVICE_PERF_FLAG="--device-perf"
           fi
 
-          python3 tests/sweep_framework/sweeps_runner.py --module-name ${{ github.event.inputs.sweep_name }} --vector-source vectors_export --result-dest results_export --tag ci-main --summary $SKIP_ON_TIMEOUT_FLAG $DEVICE_PERF_FLAG
+          python3 tests/sweep_framework/sweeps_runner.py \
+          --module-name ${{ github.event.inputs.sweep_name }} \
+          --vector-source vectors_export \
+          --result-dest results_export \
+          --tag ci-main \
+          --summary $SKIP_ON_TIMEOUT_FLAG $DEVICE_PERF_FLAG \
+          --suite-name ${{ github.event.inputs.suite_name }} \
       - name: Upload sweep results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/tests/sweep_framework/framework/sweeps_logger.py
+++ b/tests/sweep_framework/framework/sweeps_logger.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 from loguru import logger
 
@@ -19,11 +20,12 @@ sweeps_format = (
     "<level>{message}</level>"
 )
 
+LOGURU_ENV_VAR = "LOGURU_LEVEL"
+LOGURU_DEFAULT_LEVEL = "INFO"
+
+level = os.environ.get(LOGURU_ENV_VAR, LOGURU_DEFAULT_LEVEL)
+
 logger.remove()
-logger.add(
-    sys.stderr, level="INFO", format=logger_format, filter=lambda record: record["extra"].get("name") != "sweeps"
-)
-logger.add(
-    sys.stderr, level="INFO", format=sweeps_format, filter=lambda record: record["extra"].get("name") == "sweeps"
-)
+logger.add(sys.stderr, level=level, format=logger_format, filter=lambda record: record["extra"].get("name") != "sweeps")
+logger.add(sys.stderr, level=level, format=sweeps_format, filter=lambda record: record["extra"].get("name") == "sweeps")
 sweeps_logger = logger.bind(name="sweeps")

--- a/tests/sweep_framework/sweeps/ccl/generality/all_broadcast.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_broadcast.py
@@ -20,42 +20,52 @@ TIMEOUT = 45
 # Get the number of available devices to dynamically generate mesh shapes
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
 
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
+
+
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "cluster_axis": [
+        0,
+        1,
+    ],
+    "input_shape": [
+        [1, 1, 32, 32],
+        [1, 1, 32, 1280],
+        [1, 1, 32, 31],
+        [1, 1, 1, 32, 32],
+        [2, 32, 32],
+        [1, 1, 32, 16384],
+        [1, 1, 1, 2048],
+        [1, 1, 1, 4096],
+    ],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],  # , ttnn.bfloat8_b, ttnn.uint32],
+    "mem_config": [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
 # Define the parameter space for the sweep test
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "cluster_axis": [
-            0,
-            1,
-        ],
-        "input_shape": [
-            [1, 1, 32, 32],
-            [1, 1, 32, 1280],
-            [1, 1, 32, 31],
-            [1, 1, 1, 32, 32],
-            [2, 32, 32],
-            [1, 1, 32, 16384],
-            [1, 1, 1, 2048],
-            [1, 1, 1, 4096],
-        ],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],  # , ttnn.bfloat8_b, ttnn.uint32],
-        "mem_config": [
-            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
-            ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
-        ],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
 }
 
 

--- a/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_gather.py
@@ -25,12 +25,17 @@ TIMEOUT = 45
 
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
+
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
 LEAD_MODEL_SHARD_SPECS = [
     get_serializable_shard_specs(
@@ -53,28 +58,33 @@ LEAD_MODEL_SHARD_SPECS = [
     ),
 ]
 
+
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "input_shape": [
+        [1, 1, 32, 32],
+        [1, 1, 32, 31],
+        [1, 1, 1, 32, 32],
+        [2, 32, 32],
+        [1, 1, 32, 16384],
+        [1, 1, 1, 2048],
+    ],
+    "dim": [0, 1, 2, 3, 4],
+    "cluster_axis": [0, 1, None],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],
+    "buffer_type": [ttnn.BufferType.DRAM],
+    "shard_specs": [None],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "input_shape": [
-            [1, 1, 32, 32],
-            [1, 1, 32, 31],
-            [1, 1, 1, 32, 32],
-            [2, 32, 32],
-            [1, 1, 32, 16384],
-            [1, 1, 1, 2048],
-        ],
-        "dim": [0, 1, 2, 3, 4],
-        "cluster_axis": [0, 1, None],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],
-        "buffer_type": [ttnn.BufferType.DRAM],
-        "shard_specs": [None],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
     "lead_model_suite": {
         "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
         "fabric_config": FABRIC_CONFIGS,

--- a/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
@@ -105,38 +105,48 @@ LEAD_MODEL_SHARD_SPECS = [
 ]
 
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
 
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
+
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "input_shape": [
+        [1, 1, 32, 32],
+        [1, 1, 32, 1280],
+        [1, 1, 32, 31 * NUM_DEVICES],
+        [1, 1, 1, 32, 32],
+        [2, 32, 32],
+        [1, 1, 32, 16384],
+        [1, 1, 1, 2048],
+    ],
+    "cluster_axis": [0, 1, None],
+    "math_op": [ttnn.ReduceType.Sum],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],
+    "buffer_type": [ttnn.BufferType.DRAM],
+    "shard_specs": [None],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
 
 # Define the parameter space for the sweep test
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "input_shape": [
-            [1, 1, 32, 32],
-            [1, 1, 32, 1280],
-            [1, 1, 32, 31 * NUM_DEVICES],
-            [1, 1, 1, 32, 32],
-            [2, 32, 32],
-            [1, 1, 32, 16384],
-            [1, 1, 1, 2048],
-        ],
-        "cluster_axis": [0, 1, None],
-        "math_op": [ttnn.ReduceType.Sum],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],
-        "buffer_type": [ttnn.BufferType.DRAM],
-        "shard_specs": [None],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
     "lead_model_suite": {
         "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
         "fabric_config": FABRIC_CONFIGS,

--- a/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_reduce.py
@@ -187,7 +187,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not validate_serializable_shard_spec(test_vector["input_shape"], test_vector["shard_specs"], None, cluster_size):
         return True, "Invalid shard spec"
 
-    if cluster_axis and mesh_shape[cluster_axis] == 1:
+    if cluster_axis is not None and mesh_shape[cluster_axis] == 1:
         return True, "Unit cluster axis"
 
     if (

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all.py
@@ -32,29 +32,27 @@ FABRIC_CONFIGS_2D = [
 
 FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
-GENERALITY_PARAMETERS = (
-    {
-        "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "input_shape": [
-            [1, 1, 32, 32],
-            [1, 1, 32, 1280],
-            [1, 1, 32, 31],
-            [1, 1, 1, 32, 32],
-            [2, 32, 32],
-            [1, 1, 32, 16384],
-            [1, 1, 1, 2048],
-        ],
-        "in_dim": [0, 1, 2, 3, 4],
-        "out_dim": [0, 1, 2, 3, 4],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],
-        "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
-)
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "input_shape": [
+        [1, 1, 32, 32],
+        [1, 1, 32, 1280],
+        [1, 1, 32, 31],
+        [1, 1, 1, 32, 32],
+        [2, 32, 32],
+        [1, 1, 32, 16384],
+        [1, 1, 1, 2048],
+    ],
+    "in_dim": [0, 1, 2, 3, 4],
+    "out_dim": [0, 1, 2, 3, 4],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],
+    "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
 
 # Define the parameter space for the sweep test
 parameters = {

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all.py
@@ -20,16 +20,21 @@ TIMEOUT = 60
 # Get the number of available devices to dynamically generate mesh shapes
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
+    ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
 
-# Define the parameter space for the sweep test
-parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
+
+GENERALITY_PARAMETERS = (
+    {
+        "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
         "fabric_config": FABRIC_CONFIGS,
         "num_links": [1],
         "input_shape": [
@@ -49,6 +54,13 @@ parameters = {
         "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
         "num_iters": [1],
     },
+)
+
+# Define the parameter space for the sweep test
+parameters = {
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
 }
 
 

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all_combine.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all_combine.py
@@ -17,40 +17,49 @@ TIMEOUT = 45
 
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
+
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
 
 def _pd(val: int):
     return val * NUM_DEVICES
 
 
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "input_shape": [
+        [_pd(1), 1, 8, 32],
+        [_pd(1), 1, 2, 2880],  # GPT-OSS
+        [_pd(1), 1, 8, 31],
+        [_pd(8), 1, 2, 7168],
+        [_pd(16), 1, 2, 7168],
+        [_pd(1), 1, 2, 16384],
+    ],
+    "experts": [_pd(i) for i in [2, 4, 8]],
+    "select_experts_k": [2, 4, 8],
+    "local_reduce": [False, True],
+    "cluster_axis": [0, 1, None],
+    "num_links": [1, 2, 3],
+    "input_dtype": [ttnn.bfloat16],
+    "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "input_shape": [
-            [_pd(1), 1, 8, 32],
-            [_pd(1), 1, 2, 2880],  # GPT-OSS
-            [_pd(1), 1, 8, 31],
-            [_pd(8), 1, 2, 7168],
-            [_pd(16), 1, 2, 7168],
-            [_pd(1), 1, 2, 16384],
-        ],
-        "experts": [_pd(i) for i in [2, 4, 8]],
-        "select_experts_k": [2, 4, 8],
-        "local_reduce": [False, True],
-        "cluster_axis": [0, 1, None],
-        "num_links": [1, 2, 3],
-        "input_dtype": [ttnn.bfloat16],
-        "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
     "lead_model_suite": {
         "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
         "fabric_config": FABRIC_CONFIGS,

--- a/tests/sweep_framework/sweeps/ccl/generality/all_to_all_dispatch.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/all_to_all_dispatch.py
@@ -17,39 +17,49 @@ TIMEOUT = 60
 
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
+
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
 
 def _pd(val: int):
     return val * NUM_DEVICES
 
 
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "input_shape": [
+        [_pd(1), 1, 8, 32],
+        [_pd(1), 1, 32, 2880],  # GPT-OSS
+        [_pd(1), 1, 2, 31],
+        [_pd(8), 1, 2, 7168],
+        [_pd(16), 1, 2, 7168],
+        [_pd(1), 1, 2, 16384],
+    ],
+    "experts": [_pd(i) for i in [2, 4, 8]],
+    "select_experts_k": [2, 4, 8],
+    "cluster_axis": [0, 1, None],
+    "num_links": [1],
+    "input_dtype": [ttnn.bfloat16],
+    "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "input_shape": [
-            [_pd(1), 1, 8, 32],
-            [_pd(1), 1, 32, 2880],  # GPT-OSS
-            [_pd(1), 1, 2, 31],
-            [_pd(8), 1, 2, 7168],
-            [_pd(16), 1, 2, 7168],
-            [_pd(1), 1, 2, 16384],
-        ],
-        "experts": [_pd(i) for i in [2, 4, 8]],
-        "select_experts_k": [2, 4, 8],
-        "cluster_axis": [0, 1, None],
-        "num_links": [1],
-        "input_dtype": [ttnn.bfloat16],
-        "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
     "lead_model_suite": {
         "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
         "fabric_config": FABRIC_CONFIGS,

--- a/tests/sweep_framework/sweeps/ccl/generality/point_to_point.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/point_to_point.py
@@ -103,7 +103,7 @@ def _get_tensors(input_shape, coord0, dtype, layout, device):
 
     device_shard_shape = tuple(s * (num_devices if i == 0 else 1) for i, s in enumerate(input_shape))
     input_tensor_torch = torch.zeros(device_shard_shape).bfloat16()
-    input_tensor_torch[idx_start0:idx_end0, :, :, :] = torch.randn(input_shape).bfloat16()
+    input_tensor_torch[idx_start0:idx_end0] = torch.randn(input_shape).bfloat16()
 
     tt_input = ttnn.from_torch(
         input_tensor_torch,

--- a/tests/sweep_framework/sweeps/ccl/generality/point_to_point.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/point_to_point.py
@@ -18,12 +18,17 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 TIMEOUT = 45
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
     ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
+
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
 
 # heuristic to cut down on combinatorial explosion. Send/receive to/from the (up to) 4 corners of the mesh.
@@ -38,25 +43,30 @@ def _mesh_and_coords_iterator(num_devices, mesh_limit=None):
             yield mesh_shape, coords
 
 
+GENERALITY_PARAMETERS = {
+    "mesh_shape_and_coords": list(_mesh_and_coords_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "input_shape": [
+        [1, 1, 32, 32],
+        [1, 1, 32, 1280],
+        [1, 1, 32, 31],
+        [1, 1, 1, 32, 32],
+        [2, 32, 32],
+        [1, 1, 32, 16384],
+        [1, 1, 1, 2048],
+    ],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
+
 parameters = {
-    "generality_suite": {
-        "mesh_shape_and_coords": _mesh_and_coords_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "input_shape": [
-            [1, 1, 32, 32],
-            [1, 1, 32, 1280],
-            [1, 1, 32, 31],
-            [1, 1, 1, 32, 32],
-            [2, 32, 32],
-            [1, 1, 32, 16384],
-            [1, 1, 1, 2048],
-        ],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
 }
 
 

--- a/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
@@ -107,7 +107,6 @@ GENERALITY_PARAMETERS = {
     "num_iters": [1],
 }
 
-print(GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D})
 
 parameters = {
     "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},

--- a/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
+++ b/tests/sweep_framework/sweeps/ccl/generality/reduce_scatter.py
@@ -26,11 +26,17 @@ TIMEOUT = 45
 
 NUM_DEVICES = ttnn.get_num_devices()
 
-FABRIC_CONFIGS = [
+FABRIC_CONFIGS_1D = [
     ttnn.FabricConfig.FABRIC_1D,
     ttnn.FabricConfig.FABRIC_1D_RING,
+]
+
+FABRIC_CONFIGS_2D = [
+    ttnn.FabricConfig.FABRIC_2D,
     ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
 ]
+
+FABRIC_CONFIGS = FABRIC_CONFIGS_1D + FABRIC_CONFIGS_2D
 
 LEAD_MODEL_SHARD_SPECS = [
     get_serializable_shard_specs(
@@ -80,27 +86,33 @@ LEAD_MODEL_SHARD_SPECS = [
     ),
 ]
 
+GENERALITY_PARAMETERS = {
+    "mesh_shape": list(mesh_shape_iterator(NUM_DEVICES)),
+    "fabric_config": FABRIC_CONFIGS,
+    "num_links": [1],
+    "input_shape": [
+        [1, 1, 32, 256],
+        [1, 1, 32, 248],
+        [1, 1, 1, 32, 256],
+        [2, 32, 256],
+        [1, 1, 32, 16384],
+    ],
+    "dim": [0, 1, 2, 3, 4],
+    "cluster_axis": [0, 1, None],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    "input_dtype": [ttnn.bfloat16],
+    "buffer_type": [ttnn.BufferType.DRAM],
+    "shard_specs": [None],
+    "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
+    "num_iters": [1],
+}
+
+print(GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D})
+
 parameters = {
-    "generality_suite": {
-        "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
-        "fabric_config": FABRIC_CONFIGS,
-        "num_links": [1],
-        "input_shape": [
-            [1, 1, 32, 256],
-            [1, 1, 32, 248],
-            [1, 1, 1, 32, 256],
-            [2, 32, 256],
-            [1, 1, 32, 16384],
-        ],
-        "dim": [0, 1, 2, 3, 4],
-        "cluster_axis": [0, 1, None],
-        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_dtype": [ttnn.bfloat16],
-        "buffer_type": [ttnn.BufferType.DRAM],
-        "shard_specs": [None],
-        "topology": [ttnn.Topology.Linear, ttnn.Topology.Ring],
-        "num_iters": [1],
-    },
+    "generality_suite": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS},
+    "generality_suite_fabric_1d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_1D},
+    "generality_suite_fabric_2d": GENERALITY_PARAMETERS | {"fabric_config": FABRIC_CONFIGS_2D},
     "lead_model_suite": {
         "mesh_shape": mesh_shape_iterator(NUM_DEVICES),
         "fabric_config": FABRIC_CONFIGS,


### PR DESCRIPTION
### Ticket
NA

### Problem description
Still trying to get CCL sweeps to work in CI

### What's changed
- Add the option to quiet logs in CI sweep runs as they may overwhelm runners
- Split up fabric 1D, and 2D sweeps into separate suites to speed up individual runs.
- Sneak in a couple of test setup fixes to RS and P2P
- Tweak concurrency group so different single sweep runs don't nuke each other 
- Fix workflow to actually use suite name and improve job label

### Checklist
- [x]  N150 Sweep https://github.com/tenstorrent/tt-metal/actions/runs/18924958778
- [x] T3K Sweep https://github.com/tenstorrent/tt-metal/actions/runs/18944953530/job/54119273325