### PR TITLE
Fix issue #28509: hang in numeric stable large softmax kernel

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -32,9 +32,7 @@ def test_large_softmax(device, batch_size, h, w, dim):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
     input_tensor = ttnn.to_device(input_tensor, device)
-    # TODO: need to fix a hang, which occurs when numeric_stable is True
-    # See: issue #28509
-    output_tensor = ttnn.softmax(input_tensor, dim=dim, numeric_stable=False)
+    output_tensor = ttnn.softmax(input_tensor, dim=dim, numeric_stable=True)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -77,7 +77,6 @@ void MAIN {
     const uint32_t start_ht = get_arg_val<uint32_t>(4);
     const uint32_t mask_padded_data = get_arg_val<uint32_t>(5);
     const uint32_t cb_length_t = get_arg_val<uint32_t>(6);
-    const bool dest_fp_32 = get_arg_val<uint32_t>(6) == 1;
 
     // reserve one tile for zeros on cb_in2
     // We only do the reserve for the intermediates once and use pack_tile
@@ -108,7 +107,6 @@ void MAIN {
 #endif
 
     uint32_t num_cb_passes = 1 + ((Wt - 1) / cb_length_t);  // ceiling divide
-    uint32_t max_blk = dest_fp_32 ? 8 : 4;
 
     // First loop is to parse and find the sum
     uint32_t dst0 = 0;
@@ -131,7 +129,6 @@ void MAIN {
          */
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
-            // uint32_t blk = std::gcd(max_blk, cb_length_t);
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
@@ -168,7 +165,6 @@ void MAIN {
          */
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
-            // uint32_t blk = std::gcd(max_blk, cb_length_t);
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
@@ -238,7 +234,6 @@ void MAIN {
         cur_cb_length_t = cb_length_t;
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
-            // uint32_t blk = std::gcd(max_blk, cb_length_t);
 #if FUSED_SCALE_MASK
             apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
             apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -16,6 +16,9 @@
 #include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
 #include "compute_kernel_api/eltwise_unary/fill.h"
 #include "compute_kernel_api.h"
+
+#include "debug/assert.h"
+
 // clang-format off
 // 3 Loops in code
 // 1: Optional Max value for numerical stability
@@ -67,14 +70,14 @@ void reduce_cb(
     uint32_t cb_length_t);
 void apply_recip(uint32_t cb_in, uint32_t cb_recip, uint32_t cb_out, uint32_t cb_length_t, uint32_t blk);
 void MAIN {
-    uint32_t NCHt = get_arg_val<uint32_t>(0);
-    uint32_t Ht = get_arg_val<uint32_t>(1);
-    uint32_t Wt = get_arg_val<uint32_t>(2);
-    uint32_t blk = get_arg_val<uint32_t>(3);
-    uint32_t start_ht = get_arg_val<uint32_t>(4);
-    uint32_t mask_padded_data = get_arg_val<uint32_t>(5);
-    uint32_t cb_length_t = get_arg_val<uint32_t>(6);
-    bool dest_fp_32 = get_arg_val<uint32_t>(6) == 1;
+    const uint32_t NCHt = get_arg_val<uint32_t>(0);
+    const uint32_t Ht = get_arg_val<uint32_t>(1);
+    const uint32_t Wt = get_arg_val<uint32_t>(2);
+    const uint32_t blk = get_arg_val<uint32_t>(3);
+    const uint32_t start_ht = get_arg_val<uint32_t>(4);
+    const uint32_t mask_padded_data = get_arg_val<uint32_t>(5);
+    const uint32_t cb_length_t = get_arg_val<uint32_t>(6);
+    const bool dest_fp_32 = get_arg_val<uint32_t>(6) == 1;
 
     // reserve one tile for zeros on cb_in2
     // We only do the reserve for the intermediates once and use pack_tile
@@ -143,12 +146,12 @@ void MAIN {
                 cb_processed_input = cb_in0;
             }
 #endif
-            reduce_cb<PoolType::MAX>(cb_processed_input, tt::CBIndex::c_2, cb_prev_max, cb_max, use_prev_reduce, Wt);
+            reduce_cb<PoolType::MAX>(cb_processed_input, tt::CBIndex::c_2, cb_prev_max, cb_max, use_prev_reduce, cur_cb_length_t);
             use_prev_reduce = true;
             length_left_t -= cur_cb_length_t;
             cur_cb_length_t = std::min(cur_cb_length_t, length_left_t);
             if (cur_pass != num_cb_passes - 1) {
-                std::swap(cb_max, cb_prev_reduce);
+                std::swap(cb_max, cb_prev_max);
             }
         }
         use_prev_reduce = false;
@@ -386,6 +389,8 @@ void exp_cb(uint32_t cb_in, uint32_t cb_out, uint32_t cb_max, const uint32_t cb_
     //   blk is a divisor of cb_length_t
     //   Calculates e^cb_in for cb_length_t num of tiles
     //      Also if numeric stable calcs e^(cb_in- BCASTCOL(cb_max))
+    ASSERT(cb_length_t % blk == 0);
+
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 #ifdef NUMERIC_STABLE

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
@@ -813,9 +813,6 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
         im0_t = 80;
         im3_t = 80;
         TT_FATAL(!attributes.inplace, "Tensor is too large to run softmax inplace, please use standard softmax");
-        // TODO: fix the hang, which occurs when numeric_stable is true for large softmax
-        // See issue #28509
-        TT_FATAL(!attributes.numeric_stable, "For softmax, cannot enable both large_kernel and numeric_stable");
     }
     if (!use_large_kernel) {
         TT_FATAL(


### PR DESCRIPTION
### Ticket
[28509](https://github.com/tenstorrent/tt-metal/issues/28509)

### Problem description
The unit test test_large_softmax hangs when the softmax kernel is invoked with the numeric_stable parameter set to True

### What's changed
Root cause was found and fixed in the softmax kernel used for large input tensors (softmax_large_kernel.cpp)
Wrong size was given to reduce_cb function
Wrong cb index used in a swap operation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)