### PR TITLE
#31141 Add attention sink support to sdpa 

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -33,7 +33,7 @@ def fa_rand(*shape):
     return normal_1 + normal_2 * bernoulli
 
 
-def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window, is_causal=True):
+def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window=0, is_causal=True):
     """
     Create attention mask for sliding window attention in prefill mode.
 
@@ -54,7 +54,7 @@ def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window, is_causal
             if is_causal:
                 # Causal sliding window: spans from (q_pos - sliding_window + 1) to q_pos (inclusive)
                 window_end = q_pos + 1  # exclusive (causal constraint)
-                window_start = max(0, window_end - sliding_window)
+                window_start = max(0, window_end - sliding_window) if sliding_window > 0 else 0
 
                 # Mask positions before sliding window start
                 if window_start > 0:
@@ -65,7 +65,7 @@ def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window, is_causal
                     attn_mask[i, :, q_pos, q_pos + 1 :] = torch.finfo(torch.float32).min
             else:
                 # Non-causal sliding window: centered on diagonal with half before and half after
-                half_window = sliding_window // 2
+                half_window = sliding_window // 2 if sliding_window > 0 else seq_len // 2
                 window_start = max(0, q_pos - half_window)
                 window_end = min(seq_len, q_pos + half_window + 1)  # exclusive
 
@@ -1190,4 +1190,447 @@ def test_sdpa_sliding_window(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_ch
     rmse_threshold = 0.01
     run_test_sdpa_sliding_window(
         device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sliding_window, rmse_threshold=rmse_threshold
+    )
+
+
+def reference_sdpa_with_attention_sinks(Q, K, V, S, is_causal=True, sliding_window=0):
+    """
+    Reference implementation of scaled dot product attention with attention sinks.
+
+    Args:
+        Q: Query tensor [b, nh, s, d]
+        K: Key tensor [b, nh, s, d]
+        V: Value tensor [b, nh, s, d]
+        S: Attention sink tensor [b, nh] - one sink value per head (broadcast to all queries)
+        is_causal: Whether to apply causal masking
+        sliding_window: Sliding window size (0 = no sliding window)
+    Returns:
+        Output tensor [b, nh, s, d]
+    """
+    b, nh, s, d = Q.shape
+    assert K.shape == (b, nh, s, d)
+    assert V.shape == (b, nh, s, d)
+    # assert S.shape == (b, nh), f"Expected S shape {(b, nh)}, got {S.shape}"
+
+    # Compute attention scores: QK = Q @ K^T
+    # Q: [b, nh, s, d], K: [b, nh, s, d] -> QK: [b, nh, s, s]
+    QK = torch.matmul(Q, K.transpose(-2, -1))
+
+    # Scale
+    sm_scale = 1.0 / math.sqrt(d)
+    QK = QK * sm_scale
+
+    # Apply causal mask if needed
+    if is_causal or sliding_window > 0:
+        mask = create_sliding_window_mask_prefill(b, nh, s, sliding_window, is_causal)
+        QK = QK + mask
+
+    if S is not None:
+        # Broadcast attention sink values to all query positions
+        # S: [b, nh] -> [b, nh, s, 1]
+        S_broadcast = S[:, :, None, None].expand(b, nh, s, 1)
+        S_broadcast = S_broadcast * sm_scale
+
+        # Concatenate attention sink scores
+        # QK: [b, nh, s, s], S_broadcast: [b, nh, s, 1] -> QK_with_sink: [b, nh, s, s+1]
+        QK = torch.cat([QK, S_broadcast], dim=-1)
+
+    # Apply softmax over extended dimension (including sink)
+    W = torch.softmax(QK, dim=-1)
+
+    if S is not None:
+        # Slice off attention sink weights (they don't contribute to output)
+        W = W[..., :-1]  # [b, nh, s, s]
+
+    # Compute final output
+    output = torch.matmul(W, V)  # [b, nh, s, d]
+
+    return output
+
+
+def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_size=32, k_chunk_size=32):
+    """
+    Flash Attention implementation with attention sinks using chunked processing.
+
+    Args:
+        Q: Query tensor [b, nh, s, d]
+        K: Key tensor [b, nh, s, d]
+        V: Value tensor [b, nh, s, d]
+        S: Attention sink tensor [b, nh] - one sink value per head (or None)
+        is_causal: Whether to apply causal masking
+        q_chunk_size: Size of Q chunks for tiling
+        k_chunk_size: Size of K chunks for tiling
+
+    Returns:
+        Output tensor [b, nh, s, d]
+    """
+    b, nh, s, d = Q.shape
+    assert K.shape == (b, nh, s, d)
+    assert V.shape == (b, nh, s, d)
+
+    # Compute scale
+    sm_scale = 1.0 / math.sqrt(d)
+
+    # Reshape tensors for easier processing: [b, nh, s, d]
+    # Already in the right format, no permutation needed
+
+    # Initialize output accumulator
+    output = torch.zeros_like(Q)
+
+    # Process in Q chunks
+    num_q_chunks = (s + q_chunk_size - 1) // q_chunk_size
+
+    for q_chunk_idx in range(num_q_chunks):
+        q_start = q_chunk_idx * q_chunk_size
+        q_end = min(q_start + q_chunk_size, s)
+        q_chunk_len = q_end - q_start
+
+        Q_chunk = Q[:, :, q_start:q_end, :]  # [b, nh, q_chunk_len, d]
+
+        # Initialize running statistics for this Q chunk
+        running_max = torch.full((b, nh, q_chunk_len, 1), float("-inf"), device=Q.device, dtype=Q.dtype)
+        running_sum = torch.zeros((b, nh, q_chunk_len, 1), device=Q.device, dtype=Q.dtype)
+        running_output = torch.zeros((b, nh, q_chunk_len, d), device=Q.device, dtype=Q.dtype)
+
+        # Process K chunks (all chunks up to and including current Q chunk for causal)
+        # For causal attention, we attend to all K positions up to each Q position
+        max_k_chunks = (
+            (q_end + k_chunk_size - 1) // k_chunk_size if is_causal else (s + k_chunk_size - 1) // k_chunk_size
+        )
+        for k_chunk_idx in range(max_k_chunks):
+            k_start = k_chunk_idx * k_chunk_size
+            k_end = min(k_start + k_chunk_size, s)
+            k_chunk_len = k_end - k_start
+
+            # Only process if this K chunk contains tokens that should be attended to (causal constraint)
+            if is_causal and k_start >= q_end:
+                break
+
+            K_chunk = K[:, :, k_start:k_end, :]  # [b, nh, k_chunk_len, d]
+            V_chunk = V[:, :, k_start:k_end, :]  # [b, nh, k_chunk_len, d]
+
+            # Compute attention scores for this QK chunk pair
+            QK = torch.matmul(Q_chunk, K_chunk.transpose(-2, -1)) * sm_scale  # [b, nh, q_chunk_len, k_chunk_len]
+
+            # Apply causal mask if needed
+            if is_causal:
+                q_indices = torch.arange(q_start, q_end, device=Q.device)[:, None]
+                k_indices = torch.arange(k_start, k_end, device=Q.device)[None, :]
+                causal_mask = q_indices < k_indices
+                QK = QK.masked_fill(causal_mask[None, None, :, :], float("-inf"))
+
+            # Compute max for this chunk (handling -inf properly)
+            chunk_max = QK.max(dim=-1, keepdim=True).values  # [b, nh, q_chunk_len, 1]
+
+            # Update running max
+            new_max = torch.maximum(running_max, chunk_max)
+
+            # Rescale previous statistics if we're not on the first K chunk
+            if k_chunk_idx > 0 or torch.any(running_max > float("-inf")):
+                exp_diff_prev = torch.exp(running_max - new_max)
+                # Handle -inf cases
+                exp_diff_prev = torch.nan_to_num(exp_diff_prev, nan=0.0, posinf=0.0, neginf=0.0)
+                running_sum = running_sum * exp_diff_prev
+                running_output = running_output * exp_diff_prev
+
+            # Compute softmax for current chunk
+            QK_exp = torch.exp(QK - new_max)
+            # Handle -inf cases (masked positions)
+            QK_exp = torch.nan_to_num(QK_exp, nan=0.0, posinf=0.0, neginf=0.0)
+
+            chunk_sum = QK_exp.sum(dim=-1, keepdim=True)
+
+            # Update running sum
+            running_sum = running_sum + chunk_sum
+
+            # Accumulate weighted values
+            running_output = running_output + torch.matmul(QK_exp, V_chunk)
+
+            # Update running max
+            running_max = new_max
+        if S is not None:
+            # Process attention sink as a virtual K chunk
+            # S shape: [b, nh] -> broadcast to [b, nh, q_chunk_len, 1]
+            S_scaled = S[:, :, None, None] * sm_scale  # [b, nh, 1, 1]
+            S_chunk = S_scaled.expand(b, nh, q_chunk_len, 1)  # [b, nh, q_chunk_len, 1]
+
+            # Update running max with sink values
+            new_max = torch.maximum(running_max, S_chunk)
+
+            # Rescale previous statistics
+            exp_diff_prev = torch.exp(running_max - new_max)
+            exp_diff_prev = torch.nan_to_num(exp_diff_prev, nan=0.0, posinf=0.0, neginf=0.0)
+            running_sum = running_sum * exp_diff_prev
+            running_output = running_output * exp_diff_prev
+
+            # Add sink contribution to sum (sink doesn't contribute to output)
+            sink_exp = torch.exp(S_chunk - new_max)
+            running_sum = running_sum + sink_exp
+
+            # Update running max for final normalization
+            running_max = new_max
+
+        # Final normalization
+        output[:, :, q_start:q_end, :] = running_output / running_sum
+
+    # Output is already in [b, nh, s, d] format
+    return output
+
+
+def run_test_sdpa_with_attention_sink(
+    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sink_values=None, rmse_threshold=None
+):
+    """Test SDPA with attention sinks using per-head sink values."""
+    torch.manual_seed(1234)
+
+    program_config = ttnn.SDPAProgramConfig(
+        # compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        compute_with_storage_grid_size=(1, 1),
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=True,
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    Q = fa_rand(b, nh, s, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+
+    # Create per-head attention sink values
+    # Shape: [b, nh] - one value per head, scaled appropriately
+    sm_scale = 1.0 / math.sqrt(d)
+    if sink_values is None:
+        S_per_head = torch.rand(1, nh) * 20.0  # Random values scaled by to make closer to real distribution
+    else:
+        S_per_head = torch.tensor(sink_values).reshape(1, nh)
+
+    # Prepare attention sink tensor for device: [b, nh, TILE_HEIGHT, TILE_WIDTH]
+    # The actual value is at position [b, nh, 0, 0]
+    TILE_HEIGHT = 32
+    TILE_WIDTH = 32
+    S_padded = S_per_head.reshape(1, nh, 1, 1)
+    # S_padded = S_padded.repeat(1, 1, TILE_HEIGHT, TILE_WIDTH)
+    # S_padded = torch.nn.functional.pad(S_padded, (0, TILE_WIDTH - 1, 0, TILE_HEIGHT - 1), "constant", 0.0)
+    # S_padded /= sm_scale  # Important!! GPT-OSS expects sink to not be scaled
+
+    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_S = ttnn.from_torch(S_padded, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+
+    # tt_S = None
+    # print("Entering tt sdpa now")
+    tt_back = ttnn.transformer.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=True,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        attention_sink=tt_S,
+    )
+    print("Finished running sdpa now")
+    print("TT back shape: ", tt_back.shape)
+    tt_back = ttnn.to_torch(tt_back)
+    print("TT back torch shape: ", tt_back.shape)
+    # Slice out any tile-padding
+    tt_back = tt_back[:, :, :s, :]
+
+    # Compute reference with GQA expansion
+    K_repeated = torch.cat([K[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+
+    # Compute reference output using per-head sink values
+    # S_per_head = None
+    gt = reference_sdpa_with_attention_sinks(
+        Q,
+        K_repeated,
+        V_repeated,
+        S_per_head,
+        is_causal=True,
+    )
+    gt_flash = reference_flash_attention_with_sinks(
+        Q,
+        K_repeated,
+        V_repeated,
+        S_per_head,
+        is_causal=True,
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+    )
+
+    out_pass, out_pcc = comp_pcc(gt, gt_flash, 0.99)
+    logger.debug(f"python vs python(flash): {out_pcc}")
+    rmse = torch.sqrt(((gt - gt_flash) ** 2).mean()).item()
+    logger.debug(f"rmse: {rmse}")
+    if rmse_threshold is not None:
+        assert rmse < rmse_threshold, f"RMSE {rmse} exceeds threshold {rmse_threshold}"
+    else:
+        assert out_pass, f"PCC check failed: {out_pcc}"
+
+    out_pass, out_pcc = comp_pcc(gt_flash, tt_back, 0.99)
+    logger.debug(f"pytorch vs tt: {out_pcc}")
+    rmse = torch.sqrt(((gt_flash - tt_back) ** 2).mean()).item()
+    logger.debug(f"rmse: {rmse}")
+
+    if rmse_threshold is not None:
+        assert rmse < rmse_threshold, f"RMSE {rmse} exceeds threshold {rmse_threshold}"
+    else:
+        assert out_pass, f"PCC check failed: {out_pcc}"
+
+
+def run_test_sdpa_with_attention_sink_sliding_window(
+    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sliding_window, sink_values=None, rmse_threshold=None
+):
+    """Test SDPA with attention sinks using per-head sink values and sliding window."""
+    torch.manual_seed(1234)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=True,
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    Q = fa_rand(b, nh, s, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+
+    # Create per-head attention sink values
+    # Shape: [b, nh] - one value per head, scaled appropriately
+    sm_scale = 1.0 / math.sqrt(d)
+    if sink_values is None:
+        S_per_head = torch.rand(1, nh) * 4.0  # Random values scaled by to make closer to real distribution
+    else:
+        S_per_head = torch.tensor(sink_values).reshape(1, nh)
+
+    # Prepare attention sink tensor for device: [b, nh, TILE_HEIGHT, TILE_WIDTH]
+    # The actual value is at position [b, nh, 0, 0]
+    TILE_HEIGHT = 32
+    TILE_WIDTH = 32
+    S_padded = S_per_head.reshape(1, nh, 1, 1)
+    # S_padded = S_padded.repeat(1, 1, TILE_HEIGHT, TILE_WIDTH)
+    # S_padded = torch.nn.functional.pad(S_padded, (0, TILE_WIDTH - 1, 0, TILE_HEIGHT - 1), "constant", 0.0)
+    # S_padded /= sm_scale  # Important!! GPT-OSS expects sink to not be scaled
+
+    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_S = ttnn.from_torch(S_padded, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+
+    # tt_S = None
+    tt_back = ttnn.transformer.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=True,
+        sliding_window_size=sliding_window,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        attention_sink=tt_S,
+    )
+    tt_back = ttnn.to_torch(tt_back)
+    # Slice out any tile-padding
+    tt_back = tt_back[:, :, :s, :]
+
+    K_repeated = torch.cat([K[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+
+    # Compute reference output using per-head sink values
+    gt = reference_sdpa_with_attention_sinks(
+        Q,
+        K_repeated,
+        V_repeated,
+        S_per_head,
+        is_causal=True,
+        sliding_window=sliding_window,
+    )
+
+    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.99)
+    logger.debug(f"pytorch vs tt: {out_pcc}")
+    rmse = torch.sqrt(((gt - tt_back) ** 2).mean()).item()
+    logger.debug(f"rmse: {rmse}")
+
+    if rmse_threshold is not None:
+        assert rmse < rmse_threshold, f"RMSE {rmse} exceeds threshold {rmse_threshold}"
+    else:
+        assert out_pass, f"PCC check failed: {out_pcc}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("q_chunk_size", [32, 128], ids=["q32", "q128"])
+@pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d",
+    [
+        [1, 8, 1, 256, 32],  # Basic test
+        [1, 16, 1, 256, 128],  # Extra heads NB: this test currently hangs
+        [32, 8, 1, 256, 128],  # Batch size > 1
+        [1, 8, 1, 4096, 128],  # Long sequence
+        [1, 8, 1, 4096, 64],  # gpt-oss
+        [1, 8, 2, 128, 128],  # GQA
+    ],
+    # ids=["basic", "extra_heads", "multibatch", "long_sequence"],
+)
+def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_chunk_size):
+    """Test SDPA with per-head attention sinks on device."""
+    if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
+        pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
+    if nh % nkv != 0:
+        pytest.skip("nkv must divide nh")
+
+    ttnn.device.DisablePersistentKernelCache()
+    rmse_threshold = 0.015  # Slightly higher threshold due to sink approximation
+    run_test_sdpa_with_attention_sink(
+        device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("q_chunk_size", [32, 128], ids=["q32", "q128"])
+@pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, sliding_window",
+    [
+        [1, 8, 1, 4096, 64, 128],  # gpt-oss
+        [1, 4, 1, 4096, 128, 1024],  # gemma this also hangs with q_chunk_size=128
+    ],
+    ids=["gpt-oss", "gemma"],
+)
+def test_sdpa_with_attention_sink_sliding_window(
+    device, b, nh, nkv, s, d, sliding_window, dtype, q_chunk_size, k_chunk_size
+):
+    """Test SDPA with per-head attention sinks on device."""
+    if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
+        pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
+    if nh % nkv != 0:
+        pytest.skip("nkv must divide nh")
+
+    ttnn.device.DisablePersistentKernelCache()
+    rmse_threshold = 0.015  # Slightly higher threshold due to sink approximation
+    run_test_sdpa_with_attention_sink_sliding_window(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        sliding_window=sliding_window,
+        rmse_threshold=rmse_threshold,
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -1210,7 +1210,7 @@ def reference_sdpa_with_attention_sinks(Q, K, V, S, is_causal=True, sliding_wind
     b, nh, s, d = Q.shape
     assert K.shape == (b, nh, s, d)
     assert V.shape == (b, nh, s, d)
-    # assert S.shape == (b, nh), f"Expected S shape {(b, nh)}, got {S.shape}"
+    assert S.shape == (1, nh, 1, 1), f"Expected S shape {(1, nh, 1, 1)}, got {S.shape}"
 
     # Compute attention scores: QK = Q @ K^T
     # Q: [b, nh, s, d], K: [b, nh, s, d] -> QK: [b, nh, s, s]
@@ -1228,7 +1228,8 @@ def reference_sdpa_with_attention_sinks(Q, K, V, S, is_causal=True, sliding_wind
     if S is not None:
         # Broadcast attention sink values to all query positions
         # S: [b, nh] -> [b, nh, s, 1]
-        S_broadcast = S[:, :, None, None].expand(b, nh, s, 1)
+        S_broadcast = S.repeat_interleave(b, dim=0)
+        S_broadcast = S_broadcast.repeat_interleave(s, dim=-2)
         S_broadcast = S_broadcast * sm_scale
 
         # Concatenate attention sink scores
@@ -1267,9 +1268,11 @@ def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_siz
     b, nh, s, d = Q.shape
     assert K.shape == (b, nh, s, d)
     assert V.shape == (b, nh, s, d)
+    assert S.shape == (1, nh, 1, 1), f"Expected S shape {(1, nh, 1, 1)}, got {S.shape}"
 
     # Compute scale
     sm_scale = 1.0 / math.sqrt(d)
+    S = S.repeat_interleave(b, dim=0)
 
     # Reshape tensors for easier processing: [b, nh, s, d]
     # Already in the right format, no permutation needed
@@ -1300,7 +1303,6 @@ def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_siz
         for k_chunk_idx in range(max_k_chunks):
             k_start = k_chunk_idx * k_chunk_size
             k_end = min(k_start + k_chunk_size, s)
-            k_chunk_len = k_end - k_start
 
             # Only process if this K chunk contains tokens that should be attended to (causal constraint)
             if is_causal and k_start >= q_end:
@@ -1350,9 +1352,9 @@ def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_siz
             running_max = new_max
         if S is not None:
             # Process attention sink as a virtual K chunk
-            # S shape: [b, nh] -> broadcast to [b, nh, q_chunk_len, 1]
-            S_scaled = S[:, :, None, None] * sm_scale  # [b, nh, 1, 1]
-            S_chunk = S_scaled.expand(b, nh, q_chunk_len, 1)  # [b, nh, q_chunk_len, 1]
+            # S shape: [b, nh, 1, 1] -> broadcast to [b, nh, q_chunk_len, 1]
+            S_scaled = S * sm_scale
+            S_chunk = S_scaled.repeat_interleave(q_chunk_len, dim=-2)  # [b, nh, q_chunk_len, 1]
 
             # Update running max with sink values
             new_max = torch.maximum(running_max, S_chunk)
@@ -1377,15 +1379,15 @@ def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_siz
     return output
 
 
+import time
+
+
 def run_test_sdpa_with_attention_sink(
     device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sink_values=None, rmse_threshold=None
 ):
     """Test SDPA with attention sinks using per-head sink values."""
-    torch.manual_seed(1234)
-
     program_config = ttnn.SDPAProgramConfig(
-        # compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
-        compute_with_storage_grid_size=(1, 1),
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=True,
@@ -1410,13 +1412,8 @@ def run_test_sdpa_with_attention_sink(
     else:
         S_per_head = torch.tensor(sink_values).reshape(1, nh)
 
-    # Prepare attention sink tensor for device: [b, nh, TILE_HEIGHT, TILE_WIDTH]
-    # The actual value is at position [b, nh, 0, 0]
-    TILE_HEIGHT = 32
-    TILE_WIDTH = 32
+    # Prepare attention sink tensor for device: [1, nh, 1, 1]
     S_padded = S_per_head.reshape(1, nh, 1, 1)
-    # S_padded = S_padded.repeat(1, 1, TILE_HEIGHT, TILE_WIDTH)
-    # S_padded = torch.nn.functional.pad(S_padded, (0, TILE_WIDTH - 1, 0, TILE_HEIGHT - 1), "constant", 0.0)
     # S_padded /= sm_scale  # Important!! GPT-OSS expects sink to not be scaled
 
     tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
@@ -1424,8 +1421,6 @@ def run_test_sdpa_with_attention_sink(
     tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
     tt_S = ttnn.from_torch(S_padded, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
 
-    # tt_S = None
-    # print("Entering tt sdpa now")
     tt_back = ttnn.transformer.scaled_dot_product_attention(
         tt_Q,
         tt_K,
@@ -1435,10 +1430,7 @@ def run_test_sdpa_with_attention_sink(
         compute_kernel_config=compute_kernel_config,
         attention_sink=tt_S,
     )
-    print("Finished running sdpa now")
-    print("TT back shape: ", tt_back.shape)
     tt_back = ttnn.to_torch(tt_back)
-    print("TT back torch shape: ", tt_back.shape)
     # Slice out any tile-padding
     tt_back = tt_back[:, :, :s, :]
 
@@ -1447,19 +1439,18 @@ def run_test_sdpa_with_attention_sink(
     V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
 
     # Compute reference output using per-head sink values
-    # S_per_head = None
     gt = reference_sdpa_with_attention_sinks(
         Q,
         K_repeated,
         V_repeated,
-        S_per_head,
+        S_padded,
         is_causal=True,
     )
     gt_flash = reference_flash_attention_with_sinks(
         Q,
         K_repeated,
         V_repeated,
-        S_per_head,
+        S_padded,
         is_causal=True,
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
@@ -1489,8 +1480,6 @@ def run_test_sdpa_with_attention_sink_sliding_window(
     device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sliding_window, sink_values=None, rmse_threshold=None
 ):
     """Test SDPA with attention sinks using per-head sink values and sliding window."""
-    torch.manual_seed(1234)
-
     program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
@@ -1510,20 +1499,13 @@ def run_test_sdpa_with_attention_sink_sliding_window(
     V = fa_rand(b, nkv, s, d)
 
     # Create per-head attention sink values
-    # Shape: [b, nh] - one value per head, scaled appropriately
-    sm_scale = 1.0 / math.sqrt(d)
+    # Shape: [1, nh, 1, 1] - one value per head, scaled appropriately
     if sink_values is None:
         S_per_head = torch.rand(1, nh) * 4.0  # Random values scaled by to make closer to real distribution
     else:
         S_per_head = torch.tensor(sink_values).reshape(1, nh)
 
-    # Prepare attention sink tensor for device: [b, nh, TILE_HEIGHT, TILE_WIDTH]
-    # The actual value is at position [b, nh, 0, 0]
-    TILE_HEIGHT = 32
-    TILE_WIDTH = 32
     S_padded = S_per_head.reshape(1, nh, 1, 1)
-    # S_padded = S_padded.repeat(1, 1, TILE_HEIGHT, TILE_WIDTH)
-    # S_padded = torch.nn.functional.pad(S_padded, (0, TILE_WIDTH - 1, 0, TILE_HEIGHT - 1), "constant", 0.0)
     # S_padded /= sm_scale  # Important!! GPT-OSS expects sink to not be scaled
 
     tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
@@ -1554,7 +1536,7 @@ def run_test_sdpa_with_attention_sink_sliding_window(
         Q,
         K_repeated,
         V_repeated,
-        S_per_head,
+        S_padded,
         is_causal=True,
         sliding_window=sliding_window,
     )
@@ -1577,7 +1559,7 @@ def run_test_sdpa_with_attention_sink_sliding_window(
     "b, nh, nkv, s, d",
     [
         [1, 8, 1, 256, 32],  # Basic test
-        [1, 16, 1, 256, 128],  # Extra heads NB: this test currently hangs
+        [1, 16, 1, 256, 128],  # Extra heads
         [32, 8, 1, 256, 128],  # Batch size > 1
         [1, 8, 1, 4096, 128],  # Long sequence
         [1, 8, 1, 4096, 64],  # gpt-oss
@@ -1585,7 +1567,7 @@ def run_test_sdpa_with_attention_sink_sliding_window(
     ],
     # ids=["basic", "extra_heads", "multibatch", "long_sequence"],
 )
-def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_chunk_size):
+def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_chunk_size, reset_seeds):
     """Test SDPA with per-head attention sinks on device."""
     if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
@@ -1593,7 +1575,7 @@ def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size,
         pytest.skip("nkv must divide nh")
 
     ttnn.device.DisablePersistentKernelCache()
-    rmse_threshold = 0.015  # Slightly higher threshold due to sink approximation
+    rmse_threshold = 0.02
     run_test_sdpa_with_attention_sink(
         device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold
     )
@@ -1611,7 +1593,7 @@ def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size,
     ids=["gpt-oss", "gemma"],
 )
 def test_sdpa_with_attention_sink_sliding_window(
-    device, b, nh, nkv, s, d, sliding_window, dtype, q_chunk_size, k_chunk_size
+    device, b, nh, nkv, s, d, sliding_window, dtype, q_chunk_size, k_chunk_size, reset_seeds
 ):
     """Test SDPA with per-head attention sinks on device."""
     if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
@@ -1620,7 +1602,7 @@ def test_sdpa_with_attention_sink_sliding_window(
         pytest.skip("nkv must divide nh")
 
     ttnn.device.DisablePersistentKernelCache()
-    rmse_threshold = 0.015  # Slightly higher threshold due to sink approximation
+    rmse_threshold = 0.01
     run_test_sdpa_with_attention_sink_sliding_window(
         device,
         b,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -159,52 +159,6 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, bool 
     cb_push_back(reduce_cb, rows);
 }
 
-template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
-void sub_exp_block_bcast_cols_inplace2(uint32_t in1_cb, uint32_t reduce_cb) {
-    // Precondition: in0_cb has rows*cols produced
-    // Precondition: in1_cb has rows produced
-    // Postcondition: in1_cb has rows produced
-    sub_bcast_cols_init_short(in0_cb, in1_cb);
-
-    exp_tile_init<true, true, scale_fp32>();
-    cb_wait_front(in0_cb, rows * cols);
-    cb_wait_front(in1_cb, rows);
-    cb_reserve_back(reduce_cb, rows);
-
-    constexpr uint32_t dst_tiles = (cols < SUB_EXP_GRANULARITY) ? cols : SUB_EXP_GRANULARITY;
-    constexpr uint32_t granularity = (cols >= SUB_EXP_GRANULARITY) ? (cols >> LOG2_SUB_EXP_GRANULARITY) : 1;
-    uint32_t in0_index = 0;
-    for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t u = 0; u < granularity; u++) {
-            tile_regs_acquire();
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                sub_tiles_bcast_cols(in0_cb, in1_cb, in0_index, i, j);
-                exp_tile<true, true>(j);
-                in0_index++;
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-
-            // While we have results in DST, take advantage of L1 accumulation
-            // to reduce row x cols tiles to rows x 1 tiles.
-            if (u > 0) {
-                // If on the same row, keep accumulating
-                PACK((llk_pack_reconfig_l1_acc(1)));
-            }
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                pack_tile<true>(j, reduce_cb, i);
-                if (u == 0 && j == 0) {
-                    // If this was the first tile of a row, start accumulating
-                    PACK((llk_pack_reconfig_l1_acc(1)));
-                }
-            }
-            tile_regs_release();
-            PACK((llk_pack_reconfig_l1_acc(0)));
-        }
-    }
-    cb_push_back(reduce_cb, rows);
-}
-
 template <uint32_t rows, uint32_t cols>
 void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, bool pack_accumulate = false) {
     // Precondition: in0_cb has rows*cols produced

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -23,8 +23,8 @@ template <uint32_t num_tiles>
 void max_block_inplace(uint32_t in0, uint32_t in1) {
     // inputs come in full, outputs go out full
     copy_tile_to_dst_init_short(in0);
+    copy_tile_to_dst_init_short(in1);
     max_tile_init();
-
     constexpr uint32_t dst_reg_0 = 0;
     constexpr uint32_t dst_reg_1 = 1;
     cb_wait_front(in0, num_tiles);
@@ -102,7 +102,7 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 }
 
 template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
-void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
+void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, bool write_result_inplace = true) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
@@ -114,8 +114,8 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
     cb_wait_front(in1_cb, rows);
     cb_reserve_back(reduce_cb, rows);
 
-    constexpr uint32_t dst_tiles = SUB_EXP_GRANULARITY;
-    constexpr uint32_t granularity = cols >> LOG2_SUB_EXP_GRANULARITY;
+    constexpr uint32_t dst_tiles = (cols < SUB_EXP_GRANULARITY) ? cols : SUB_EXP_GRANULARITY;
+    constexpr uint32_t granularity = (cols >= SUB_EXP_GRANULARITY) ? (cols >> LOG2_SUB_EXP_GRANULARITY) : 1;
     uint32_t in0_index = 0;
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t u = 0; u < granularity; u++) {
@@ -128,8 +128,10 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
             tile_regs_commit();
             tile_regs_wait();
 
-            for (uint32_t j = 0; j < dst_tiles; ++j) {
-                pack_tile(j, in0_cb);
+            if (write_result_inplace) {
+                for (uint32_t j = 0; j < dst_tiles; ++j) {
+                    pack_tile(j, in0_cb);
+                }
             }
 
             // While we have results in DST, take advantage of L1 accumulation
@@ -149,9 +151,57 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb) {
             PACK((llk_pack_reconfig_l1_acc(0)));
         }
     }
-    cb_pop_front(in0_cb, rows * cols);
-    cb_reserve_back(in0_cb, rows * cols);
-    cb_push_back(in0_cb, rows * cols);
+    if (write_result_inplace) {
+        cb_pop_front(in0_cb, rows * cols);
+        cb_reserve_back(in0_cb, rows * cols);
+        cb_push_back(in0_cb, rows * cols);
+    }
+    cb_push_back(reduce_cb, rows);
+}
+
+template <uint32_t in0_cb, uint32_t rows, uint32_t cols, uint32_t scale_fp32>
+void sub_exp_block_bcast_cols_inplace2(uint32_t in1_cb, uint32_t reduce_cb) {
+    // Precondition: in0_cb has rows*cols produced
+    // Precondition: in1_cb has rows produced
+    // Postcondition: in1_cb has rows produced
+    sub_bcast_cols_init_short(in0_cb, in1_cb);
+
+    exp_tile_init<true, true, scale_fp32>();
+    cb_wait_front(in0_cb, rows * cols);
+    cb_wait_front(in1_cb, rows);
+    cb_reserve_back(reduce_cb, rows);
+
+    constexpr uint32_t dst_tiles = (cols < SUB_EXP_GRANULARITY) ? cols : SUB_EXP_GRANULARITY;
+    constexpr uint32_t granularity = (cols >= SUB_EXP_GRANULARITY) ? (cols >> LOG2_SUB_EXP_GRANULARITY) : 1;
+    uint32_t in0_index = 0;
+    for (uint32_t i = 0; i < rows; ++i) {
+        for (uint32_t u = 0; u < granularity; u++) {
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                sub_tiles_bcast_cols(in0_cb, in1_cb, in0_index, i, j);
+                exp_tile<true, true>(j);
+                in0_index++;
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+
+            // While we have results in DST, take advantage of L1 accumulation
+            // to reduce row x cols tiles to rows x 1 tiles.
+            if (u > 0) {
+                // If on the same row, keep accumulating
+                PACK((llk_pack_reconfig_l1_acc(1)));
+            }
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                pack_tile<true>(j, reduce_cb, i);
+                if (u == 0 && j == 0) {
+                    // If this was the first tile of a row, start accumulating
+                    PACK((llk_pack_reconfig_l1_acc(1)));
+                }
+            }
+            tile_regs_release();
+            PACK((llk_pack_reconfig_l1_acc(0)));
+        }
+    }
     cb_push_back(reduce_cb, rows);
 }
 
@@ -165,8 +215,8 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, boo
     // Postcondition: out_cb has rows*cols produced
 
     constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t dst_tiles = DHT_GRANULARITY;
-    constexpr uint32_t granularity = cols >> LOG2_DHT_GRANULARITY;
+    constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+    constexpr uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
     PACK((llk_pack_reconfig_l1_acc(pack_accumulate)));
     cb_wait_front(in0_cb, num_tiles);
@@ -210,8 +260,8 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
     // Postcondition: in1_cb has rows consumed
 
     constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t dst_tiles = DHT_GRANULARITY;
-    constexpr uint32_t granularity = cols >> LOG2_DHT_GRANULARITY;
+    constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+    constexpr uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, rows);
@@ -426,6 +476,7 @@ void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
             const_20_fp32 /*threshold*/,
             (int)VectorMode::C)));
         // Negate the output of softplus
+        negative_tile_init();
         negative_tile(0);
         pack_tile(0, out_cb);
         release_dst();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -272,7 +272,6 @@ void MAIN {
                 }
                 /**
                  * Performs final row-reduction on the partial sum.
-                 * The sum now includes contributions from both real tokens and attention sink.
                  */
                 matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -44,6 +44,7 @@ void MAIN {
     constexpr uint32_t is_chunked = get_compile_time_arg_val(26) == 1;
     constexpr uint32_t scale_fp32 = get_compile_time_arg_val(27);
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(28);
+    constexpr uint32_t use_attention_sink = get_compile_time_arg_val(29) == 1;
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(1);
@@ -71,6 +72,7 @@ void MAIN {
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
+    constexpr uint32_t cb_attention_sink = tt::CBIndex::c_4;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_7;
 
@@ -203,7 +205,6 @@ void MAIN {
                         cb_identity_scale_in,
                         Sq_chunk_t,
                         Sk_chunk_t>(alias_cur_max, alias_prev_max, k_chunk > 0);
-
                     /**
                      * sub_exp fuses a few operations.
                      * In-place it performs `QK = exp((QK - cur_max) * scale)`
@@ -269,15 +270,67 @@ void MAIN {
                     std::swap(alias_mm2_prev_out, alias_mm2_cur_out);
                     std::swap(alias_prev_max, alias_cur_max);
                 }
-
                 /**
                  * Performs final row-reduction on the partial sum.
+                 * The sum now includes contributions from both real tokens and attention sink.
                  */
                 matmul_reduce<Sq_chunk_t>(cb_col_identity, alias_prev_sum);
+
+                /**
+                 * Process attention sink as a virtual K chunk.
+                 * The attention sink provides additional logits that are included in the softmax
+                 * denominator but don't contribute to the output (no S @ V computation).
+                 * This effectively allows some attention probability to be "absorbed" by the sink,
+                 * reducing attention weights on actual tokens.
+                 *
+                 * Shape of attention_sink: [Sq_chunk_t, 1] tiles
+                 * Each head has one sink logit value that is broadcast to all query positions in the chunk.
+                 * The reader kernel replicates the per-head value across all Sq_chunk_t positions.
+                 */
+                if constexpr (use_attention_sink) {
+                    // Treat attention_sink as scores (already scaled)
+                    // Shape: [Sq_chunk_t, 1] tiles - same per-head sink value broadcast to all query positions
+
+                    // 1. Update running max: cur_max = max(prev_max, attention_sink)
+                    //    This compares the previous max with the sink logit
+                    reconfig_data_format(cb_attention_sink, cb_identity_scale_in);
+
+                    reduce_c<
+                        PoolType::MAX,
+                        ReduceDim::REDUCE_ROW,
+                        cb_attention_sink,
+                        cb_identity_scale_in,
+                        Sq_chunk_t,
+                        1>(alias_cur_max, alias_prev_max, true);
+
+                    // 2. Compute exp((prev_max - cur_max) * scale) to rescale previous statistics
+                    sub_exp_block<scale_fp32>(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);
+                    cb_pop_front(alias_prev_max, Sq_chunk_t);
+
+                    // 3. Rescale previous sum: prev_sum *= exp(prev_max - cur_max)
+                    mul_tiles_bcast_cols_inplace(alias_prev_sum, cb_exp_max_diff, Sq_chunk_t);
+                    // 4. Compute exp((attention_sink - cur_max) * scale) and accumulate in cur_sum
+                    //    This adds the attention sink's contribution to the softmax denominator
+                    sub_exp_block_bcast_cols_inplace<cb_attention_sink, Sq_chunk_t, 1, scale_fp32>(
+                        alias_cur_max, alias_cur_sum, false);
+
+                    // 5. Add rescaled previous sum to current sum: cur_sum += prev_sum
+                    add_block_inplace(alias_cur_sum, alias_prev_sum, Sq_chunk_t);
+
+                    // 6. Update running statistics for final normalization
+                    std::swap(alias_prev_sum, alias_cur_sum);
+                    std::swap(alias_prev_max, alias_cur_max);
+
+                    // 7. Rescale accumulated output: mm2_prev_out *= exp(prev_max - cur_max)
+                    //    Note: We do NOT compute attention_sink @ V, so output only has real token contributions
+                    //    But we need to rescale it due to the updated max
+                    mul_block_bcast_cols<Sq_chunk_t, vDHt>(
+                        alias_mm2_prev_out, cb_exp_max_diff, alias_mm2_cur_out, false);
+                    std::swap(alias_mm2_prev_out, alias_mm2_cur_out);
+                }
                 /* cb_cur_sum = 1.0 / cb_cur_sum */
                 recip_block_inplace(alias_prev_sum, Sq_chunk_t);
 
-                /* cb_out_accumulate_im *= cb_cur_sum */
                 pack_reconfig_data_format(cb_out);
                 mul_block_bcast_cols<Sq_chunk_t, vDHt>(alias_mm2_prev_out, alias_prev_sum, cb_out, false);
 
@@ -285,6 +338,7 @@ void MAIN {
                 // free up cb_prev_max after K chunks
                 cb_pop_front(alias_prev_max, Sq_chunk_t);
                 }
+                cb_pop_front(cb_attention_sink, Sq_chunk_t);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -330,6 +330,7 @@ void MAIN {
                 /* cb_cur_sum = 1.0 / cb_cur_sum */
                 recip_block_inplace(alias_prev_sum, Sq_chunk_t);
 
+                /* cb_out_accumulate_im *= cb_cur_sum */
                 pack_reconfig_data_format(cb_out);
                 mul_block_bcast_cols<Sq_chunk_t, vDHt>(alias_mm2_prev_out, alias_prev_sum, cb_out, false);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -338,7 +338,9 @@ void MAIN {
                 // free up cb_prev_max after K chunks
                 cb_pop_front(alias_prev_max, Sq_chunk_t);
                 }
-                cb_pop_front(cb_attention_sink, Sq_chunk_t);
+                if constexpr (use_attention_sink) {
+                    cb_pop_front(cb_attention_sink, Sq_chunk_t);
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -215,7 +215,7 @@ void MAIN {
                      * Partial reduce_sum is used to push the final row_reduction within a tile
                      * outside of the loop over K chunks.
                      */
-                    sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, Sk_chunk_t, scale_fp32>(
+                    sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, Sk_chunk_t, scale_fp32, true>(
                         alias_cur_max, alias_cur_sum);
 
                     cb_wait_front(cb_qk_im, qk_chunk_tiles);
@@ -310,8 +310,8 @@ void MAIN {
                     mul_tiles_bcast_cols_inplace(alias_prev_sum, cb_exp_max_diff, Sq_chunk_t);
                     // 4. Compute exp((attention_sink - cur_max) * scale) and accumulate in cur_sum
                     //    This adds the attention sink's contribution to the softmax denominator
-                    sub_exp_block_bcast_cols_inplace<cb_attention_sink, Sq_chunk_t, 1, scale_fp32>(
-                        alias_cur_max, alias_cur_sum, false);
+                    sub_exp_block_bcast_cols_inplace<cb_attention_sink, Sq_chunk_t, 1, scale_fp32, false>(
+                        alias_cur_max, alias_cur_sum);
 
                     // 5. Add rescaled previous sum to current sum: cur_sum += prev_sum
                     add_block_inplace(alias_cur_sum, alias_prev_sum, Sq_chunk_t);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -27,12 +27,14 @@ void kernel_main() {
     constexpr uint32_t is_chunked = get_compile_time_arg_val(17) == 1;
     constexpr uint32_t block_size_t = get_compile_time_arg_val(18);
     constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(19);
+    constexpr uint32_t use_attention_sink = get_compile_time_arg_val(20) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<20>();
+    constexpr auto q_args = TensorAccessorArgs<21>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
     constexpr auto page_table_args = TensorAccessorArgs<mask_args.next_compile_time_args_offset()>();
+    constexpr auto attention_sink_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -40,6 +42,7 @@ void kernel_main() {
     const uint32_t v_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t mask_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t page_table_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t attention_sink_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t core_id = get_arg_val<uint32_t>(argidx++);
     const uint32_t local_batch_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t local_batch_end = get_arg_val<uint32_t>(argidx++);
@@ -70,6 +73,7 @@ void kernel_main() {
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
+    constexpr uint32_t cb_attention_sink = tt::CBIndex::c_4;
     constexpr uint32_t cb_id_page_table = tt::CBIndex::c_6;
 
     constexpr uint32_t onetile = 1;
@@ -77,6 +81,7 @@ void kernel_main() {
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
     constexpr uint32_t mask_tile_bytes = get_tile_size(cb_mask_in);
+    constexpr uint32_t attention_sink_tile_bytes = use_attention_sink ? get_tile_size(cb_attention_sink) : 0;
 
     constexpr uint32_t q_heads_per_kv = NQH / NKH;
 
@@ -86,11 +91,14 @@ void kernel_main() {
     const auto k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
     const auto v_reader = TensorAccessor(v_args, v_addr, v_tile_bytes);
     const auto mask_reader = TensorAccessor(mask_args, mask_addr, mask_tile_bytes);
+    const auto attention_sink_reader =
+        TensorAccessor(attention_sink_args, attention_sink_addr, attention_sink_tile_bytes);
 
     const auto q_tile_shape = TensorTileShape(B, NQH, valid_Sqt, DHt);
     const auto k_tile_shape = TensorTileShape(B, NKH, valid_Skt, DHt);
     const auto v_tile_shape = TensorTileShape(B, NKH, valid_Skt, DHt);
     const auto mask_tile_shape = TensorTileShape(B, 1, valid_Sqt, valid_Skt);
+    const auto attention_sink_tile_shape = TensorTileShape(B, NQH, 1, 1);
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
 
@@ -124,6 +132,25 @@ void kernel_main() {
 
             const uint32_t mask_batch_offset = nb * Sqt * Skt;
             for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+                // Read attention sink for this Q chunk if enabled
+                if constexpr (use_attention_sink) {
+                    cb_reserve_back(cb_attention_sink, Sq_chunk_t);
+                    uint32_t attention_sink_write_ptr = get_write_ptr(cb_attention_sink);
+
+                    // Attention sink has shape [1, NH, 1, 1] - single value per head
+                    // Read the single tile for this head into the first tile of the CB
+                    const uint32_t sink_tile_id =
+                        attention_sink_tile_shape.id_of(0, nq, 0, 0);  // batch=0 since shape is [1,NH,1,1]
+                    noc_async_read_tile(sink_tile_id, attention_sink_reader, attention_sink_write_ptr);
+                    noc_async_read_barrier();
+
+                    // Fill all Sq_chunk_t tiles in the CB by copying the first element of the source tile
+                    // to the first element of every row in each destination tile
+                    fill_attention_sink_tiles<attention_sink_tile_bytes>(
+                        cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
+
+                    cb_push_back(cb_attention_sink, Sq_chunk_t);
+                }
                 for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
                     /*
                     Read a chunk of Q. BALANCED_Q_PARALLEL evenly distributes Q chunks
@@ -134,141 +161,140 @@ void kernel_main() {
                     */
                     uint32_t q_chunk;
 #if defined BALANCED_Q_PARALLEL
-                uint32_t q_chunk_div_2 = q_chunks_per_core / 2;
-                if (q_iter < q_chunk_div_2) {  // bottom half
-                    q_chunk = local_q_start + q_iter;
-                } else {
-                    uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
-                    q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
-                }
+                    uint32_t q_chunk_div_2 = q_chunks_per_core / 2;
+                    if (q_iter < q_chunk_div_2) {  // bottom half
+                        q_chunk = local_q_start + q_iter;
+                    } else {
+                        uint32_t back_q_iter = q_iter - q_chunk_div_2;  // Back half should start at 0
+                        q_chunk = q_num_chunks - 1 - (local_q_start + back_q_iter);
+                    }
 #else
-                q_chunk = local_q_start + q_iter;
+                    q_chunk = local_q_start + q_iter;
 #endif
-                /*
-                Determine how many rows of Q will be read. Both start and end rows are
-                capped by valid_Sqt, since Sq padding is independent of Sk padding.
-                */
-                const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
-                const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
-                const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
-                const uint32_t q_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
-                read_chunk_with_padding<q_tile_bytes>(
-                    q_reader, cb_q_in, q_tile_id, q_row_tile_count, DHt, Sq_chunk_t, DHt, barrier_threshold);
-
-                q_chunk = chunked_q_chunk_offset + q_chunk;
-                uint32_t q_low_idx =
-                    q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
-                uint32_t q_high_idx;
-                if constexpr (is_causal) {
-                    q_high_idx = q_low_idx + Sq_chunk_t;
-                } else {
-                    q_high_idx = Skt;
-                }
-
-                const uint32_t kv_head = nq / q_heads_per_kv;
-
-                // loop while k_low < q_high
-                for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
-                    const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
-                    const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
-
-                    const uint32_t k_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
-                    const uint32_t k_row_end_tile = std::min(k_row_start_tile + Sk_chunk_t, valid_Skt_bound);
-                    const uint32_t k_row_tile_count = k_row_end_tile - k_row_start_tile;
-                    const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, kv_head, k_row_start_tile, 0);
-
-                    if constexpr (is_chunked) {
-                        // Use page table to read K chunk
-                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                        read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
-                            k_reader,
-                            cb_k_in,
-                            kv_head,
-                            k_chunk_start_row_num,
-                            k_row_tile_count,
-                            DHt,
-                            Sk_chunk_t,
-                            DHt,
-                            k_tile_bytes,
-                            barrier_threshold,
-                            page_table_ptr,
-                            true  // transpose=true for K reads
-                        );
+                    /*
+                    Determine how many rows of Q will be read. Both start and end rows are
+                    capped by valid_Sqt, since Sq padding is independent of Sk padding.
+                    */
+                    const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
+                    const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
+                    const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
+                    const uint32_t q_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
+                    read_chunk_with_padding<q_tile_bytes>(
+                        q_reader, cb_q_in, q_tile_id, q_row_tile_count, DHt, Sq_chunk_t, DHt, barrier_threshold);
+                    q_chunk = chunked_q_chunk_offset + q_chunk;
+                    uint32_t q_low_idx =
+                        q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
+                    uint32_t q_high_idx;
+                    if constexpr (is_causal) {
+                        q_high_idx = q_low_idx + Sq_chunk_t;
                     } else {
-                        read_chunk_with_padding<k_tile_bytes>(
-                            k_reader,
-                            cb_k_in,
-                            k_start_tile_id,
-                            k_row_tile_count,
-                            DHt,
-                            Sk_chunk_t,
-                            DHt,
-                            barrier_threshold,
-                            true  // transpose=true for K reads
-                        );
+                        q_high_idx = Skt;
                     }
 
-                    if constexpr (use_provided_mask) {
-                        // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
-                        // Q-range = [q_low, q_high)
-                        // K-range = [k_low, k_high)
-                        // does_overlap = not (q_low >= k_high or k_low >= q_high)
-                        // Due to loop bounds, we should never have k_low >= q_high. Can simplify this conditional check
-                        // Read mask chunk
-                        // When a mask is provided, there will be no padding on q or kv.
-                        cb_reserve_back(cb_mask_in, mask_chunk_tiles);
-                        uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
-                        barrier_count = 0;
-                        mask_tile_id = mask_batch_offset + q_chunk * Sq_chunk_t * Skt /*row_offset*/ + k_chunk * Sk_chunk_t /*col_offset*/;
-                        for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
-                            for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
-                                noc_async_read_tile(mask_tile_id, mask_reader, mask_write_ptr);
-                                mask_tile_id += 1;
-                                mask_write_ptr += mask_tile_bytes;
-                                if (++barrier_count == barrier_threshold) {
-                                    noc_async_read_barrier();
-                                    barrier_count = 0;
-                                }
-                            }
-                            // Strid along columns to get to next row
-                            mask_tile_id -= Sk_chunk_t;
-                            mask_tile_id += Skt;
+                    const uint32_t kv_head = nq / q_heads_per_kv;
+
+                    // loop while k_low < q_high
+                    for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
+                        const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
+                        const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
+
+                        const uint32_t k_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
+                        const uint32_t k_row_end_tile = std::min(k_row_start_tile + Sk_chunk_t, valid_Skt_bound);
+                        const uint32_t k_row_tile_count = k_row_end_tile - k_row_start_tile;
+                        const uint32_t k_start_tile_id = k_tile_shape.id_of(nb, kv_head, k_row_start_tile, 0);
+
+                        if constexpr (is_chunked) {
+                            // Use page table to read K chunk
+                            const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                            read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                                k_reader,
+                                cb_k_in,
+                                kv_head,
+                                k_chunk_start_row_num,
+                                k_row_tile_count,
+                                DHt,
+                                Sk_chunk_t,
+                                DHt,
+                                k_tile_bytes,
+                                barrier_threshold,
+                                page_table_ptr,
+                                true  // transpose=true for K reads
+                            );
+                        } else {
+                            read_chunk_with_padding<k_tile_bytes>(
+                                k_reader,
+                                cb_k_in,
+                                k_start_tile_id,
+                                k_row_tile_count,
+                                DHt,
+                                Sk_chunk_t,
+                                DHt,
+                                barrier_threshold,
+                                true  // transpose=true for K reads
+                            );
                         }
-                        noc_async_read_barrier();
-                        cb_push_back(cb_mask_in, mask_chunk_tiles);
-                    }
 
-                    if constexpr (is_chunked) {
-                        // Use page table to read V chunk
-                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                        read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
-                            v_reader,
-                            cb_v_in,
-                            kv_head,
-                            k_chunk_start_row_num,
-                            k_row_tile_count,
-                            vDHt,
-                            Sk_chunk_t,
-                            vDHt,
-                            v_tile_bytes,
-                            barrier_threshold,
-                            page_table_ptr,
-                            false,
-                            DHt - vDHt /* src_skip_cols */);
-                    } else {
-                        read_chunk_with_padding<v_tile_bytes>(
-                            v_reader,
-                            cb_v_in,
-                            k_start_tile_id,
-                            k_row_tile_count,
-                            vDHt,
-                            Sk_chunk_t,
-                            vDHt,
-                            barrier_threshold,
-                            false,
-                            DHt - vDHt /* src_skip_cols */);
+                        if constexpr (use_provided_mask) {
+                            // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
+                            // Q-range = [q_low, q_high)
+                            // K-range = [k_low, k_high)
+                            // does_overlap = not (q_low >= k_high or k_low >= q_high)
+                            // Due to loop bounds, we should never have k_low >= q_high. Can simplify this conditional
+                            // check Read mask chunk When a mask is provided, there will be no padding on q or kv.
+                            cb_reserve_back(cb_mask_in, mask_chunk_tiles);
+                            uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+                            barrier_count = 0;
+                            mask_tile_id = mask_batch_offset + q_chunk * Sq_chunk_t * Skt /*row_offset*/ +
+                                           k_chunk * Sk_chunk_t /*col_offset*/;
+                            for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
+                                for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
+                                    noc_async_read_tile(mask_tile_id, mask_reader, mask_write_ptr);
+                                    mask_tile_id += 1;
+                                    mask_write_ptr += mask_tile_bytes;
+                                    if (++barrier_count == barrier_threshold) {
+                                        noc_async_read_barrier();
+                                        barrier_count = 0;
+                                    }
+                                }
+                                // Strid along columns to get to next row
+                                mask_tile_id -= Sk_chunk_t;
+                                mask_tile_id += Skt;
+                            }
+                            noc_async_read_barrier();
+                            cb_push_back(cb_mask_in, mask_chunk_tiles);
+                        }
+
+                        if constexpr (is_chunked) {
+                            // Use page table to read V chunk
+                            const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                            read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                                v_reader,
+                                cb_v_in,
+                                kv_head,
+                                k_chunk_start_row_num,
+                                k_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                v_tile_bytes,
+                                barrier_threshold,
+                                page_table_ptr,
+                                false,
+                                DHt - vDHt /* src_skip_cols */);
+                        } else {
+                            read_chunk_with_padding<v_tile_bytes>(
+                                v_reader,
+                                cb_v_in,
+                                k_start_tile_id,
+                                k_row_tile_count,
+                                vDHt,
+                                Sk_chunk_t,
+                                vDHt,
+                                barrier_threshold,
+                                false,
+                                DHt - vDHt /* src_skip_cols */);
+                        }
                     }
-                }
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -210,13 +210,15 @@ operation::ProgramWithCallbacks ring_sdpa_multi_core(
         false,  //(std::uint32_t)use_padded_mask,
         false,  //(uint32_t)is_chunked,
         0,      // block_size_t,
-        0       // page_table_stick_size
+        0,      // page_table_stick_size
+        0       // use_attention_sink
     };
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs().append_to(reader_compile_time_args);  // mask tensor (not used in ring)
     TensorAccessorArgs().append_to(reader_compile_time_args);  // page table (not used in ring)
+    TensorAccessorArgs().append_to(reader_compile_time_args);  // attention sink (not used in ring)
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
@@ -274,6 +276,7 @@ operation::ProgramWithCallbacks ring_sdpa_multi_core(
         true,   //(uint32_t)is_chunked,
         scale_union.u,
         0,  //(uint32_t)sliding_window_size,
+        0,  //(std::uint32_t)use_attention_sink,
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
 
@@ -450,6 +453,7 @@ operation::ProgramWithCallbacks ring_sdpa_multi_core(
              v_addr,
              0,  // mask_addr,
              0,
+             0,  // attention sink addr,
              i,
              local_batch_start,
              local_batch_end,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -30,6 +30,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     const Tensor& output_tensor,
     const std::optional<const Tensor>& attn_mask,
     const std::optional<const Tensor>& page_table,
+    const std::optional<const Tensor>& attention_sink,
     const std::optional<int64_t>& chunk_start_idx,
     std::optional<float> scale,
     bool is_causal,
@@ -158,8 +159,11 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     auto k_buffer = input_tensor_k.buffer();
     auto v_buffer = use_mla ? input_tensor_k.buffer() : input_tensor_v.buffer();
     auto mask_buffer = attn_mask.has_value() ? attn_mask.value().buffer() : nullptr;
+    auto attention_sink_buffer = attention_sink.has_value() ? attention_sink.value().buffer() : nullptr;
 
     auto out0_buffer = output_tensor.buffer();
+
+    bool use_attention_sink = attention_sink.has_value();
 
     CoreCoord grid_size = program_config.has_value() ? program_config->compute_with_storage_grid_size
                                                      : device->compute_with_storage_grid_size();
@@ -213,6 +217,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     uint32_t out0_t = Sq_chunk_t * vDHt;
     uint32_t scale_tiles = 1;
     uint32_t statistics_tiles = Sq_chunk_t;  // Single column of values in each iteration
+    uint32_t attention_sink_tiles = use_attention_sink ? Sq_chunk_t : 0;  // One column vector per Q chunk
 
     // log all values
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);
@@ -223,6 +228,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     log_debug(tt::LogOp, "out0_t: {}", out0_t);
     log_debug(tt::LogOp, "scale_tiles: {}", scale_tiles);
     log_debug(tt::LogOp, "statistics_tiles: {}", statistics_tiles);
+    log_debug(tt::LogOp, "attention_sink_tiles: {}", attention_sink_tiles);
 
     // Host code is responsible for determining matmul configuration
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
@@ -345,13 +351,16 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                                                       (std::uint32_t)use_padded_mask,
                                                       (uint32_t)is_chunked,
                                                       block_size_t,
-                                                      page_table_stick_size};
+                                                      page_table_stick_size,
+                                                      (std::uint32_t)use_attention_sink};
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(attn_mask.has_value() ? attn_mask->buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(page_table.has_value() ? page_table->buffer() : nullptr).append_to(reader_compile_time_args);
+    TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
+        .append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
@@ -410,6 +419,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         (uint32_t)is_chunked,
         scale_union.u,
         sliding_window_size.value_or(0),
+        (std::uint32_t)use_attention_sink,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(compute_compile_time_args);
@@ -529,6 +539,19 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         CreateCircularBuffer(program, core_grid, c_in6_config);
     }
 
+    // Create attention sink buffer if provided
+    if (use_attention_sink) {
+        tt::DataFormat sink_df = tt::tt_metal::datatype_to_dataformat_converter(attention_sink.value().dtype());
+        uint32_t sink_tile_size = tt::tile_size(sink_df);
+        // cb_attention_sink (CBIndex::c_4)
+        log_debug(tt::LogOp, "attention_sink_tiles: {}", attention_sink_tiles);
+        log_debug(tt::LogOp, "sink_tile_size: {}", sink_tile_size);
+        log_debug(tt::LogOp, "sink_df: {}", sink_df);
+        auto c_in4_config = CircularBufferConfig(attention_sink_tiles * sink_tile_size, {{tt::CBIndex::c_4, sink_df}})
+                                .set_page_size(tt::CBIndex::c_4, sink_tile_size);
+        CreateCircularBuffer(program, core_grid, c_in4_config);
+    }
+
     // cb_qk_im
     auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{tt::CBIndex::c_24, im_df}})
                                   .set_page_size(tt::CBIndex::c_24, im_tile_size);
@@ -579,6 +602,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     uint32_t k_addr = k_buffer->address();
     uint32_t v_addr = v_buffer->address();
     uint32_t mask_addr = attn_mask.has_value() ? mask_buffer->address() : 0;
+    uint32_t attention_sink_addr = attention_sink.has_value() ? attention_sink_buffer->address() : 0;
     uint32_t out_addr = out0_buffer->address();
 
     uint32_t num_phases = 1;
@@ -625,6 +649,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                 v_addr,
                 mask_addr,
                 is_chunked ? page_table.value().buffer()->address() : 0,
+                attention_sink_addr,
                 i,
                 local_batch_start,
                 local_batch_end,
@@ -685,12 +710,16 @@ operation::ProgramWithCallbacks sdpa_multi_core(
             auto v_buffer = use_mla ? input_tensors.at(1).buffer() : input_tensors.at(2).buffer();
             auto mask_buffer =
                 optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer() : nullptr;
+            auto attention_sink_buffer = (optional_input_tensors.size() > 2 && optional_input_tensors.at(2).has_value())
+                                             ? optional_input_tensors.at(2).value().buffer()
+                                             : nullptr;
 
             auto out0_buffer = output_tensors.at(0).buffer();
             uint32_t q_addr = q_buffer->address();
             uint32_t k_addr = k_buffer->address();
             uint32_t v_addr = v_buffer->address();
             uint32_t mask_addr = mask_buffer != nullptr ? mask_buffer->address() : 0;
+            uint32_t attention_sink_addr = attention_sink_buffer != nullptr ? attention_sink_buffer->address() : 0;
             uint32_t out_addr = out0_buffer->address();
 
             uint32_t page_table_addr = 0;
@@ -716,7 +745,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                 reader_args[2] = v_addr;
                 reader_args[3] = mask_addr;
                 reader_args[4] = page_table_addr;
-                reader_args[13] = chunked_q_chunk_offset;
+                reader_args[5] = attention_sink_addr;
+                reader_args[14] = chunked_q_chunk_offset;
 
                 writer_args[0] = out_addr;
                 writer_args[9] = chunked_q_chunk_offset;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
@@ -17,6 +17,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sdpa_multi_core(
     const Tensor& output_tensor,
     const std::optional<const Tensor>& attn_mask,
     const std::optional<const Tensor>& page_table,
+    const std::optional<const Tensor>& attention_sink,
     const std::optional<int64_t>& chunk_start_idx,
     std::optional<float> scale,
     bool is_causal,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -25,7 +25,8 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
     std::optional<uint32_t> sliding_window_size,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<SDPAProgramConfig> program_config,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::Tensor>& attention_sink) {
     [[maybe_unused]] auto arch =
         input_tensor_q.storage_type() == StorageType::DEVICE
             ? input_tensor_q.device()->arch()
@@ -45,7 +46,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                    .head_dim_v = std::nullopt,
                    .sliding_window_size = sliding_window_size},
                {input_tensor_q, input_tensor_k, input_tensor_v},
-               {attn_mask},
+               {attn_mask, std::nullopt, attention_sink},
                {})
         .at(0);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -23,7 +23,8 @@ struct ExecuteScaledDotProductAttention {
         std::optional<uint32_t> sliding_window_size = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<SDPAProgramConfig> program_config = std::nullopt,
-        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<ttnn::Tensor>& attention_sink = std::nullopt);
 };
 
 struct ExecuteChunkedScaledDotProductAttention {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -34,6 +34,7 @@ void py_bind_sdpa(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
+            attention_sink (ttnn.Tensor, optional): Defaults to `None`. [1 x nqh x 1 x 1]. Single attention sink value per head. The kernel will efficiently replicate this value across all query positions.
 
 
         Returns:
@@ -57,7 +58,8 @@ void py_bind_sdpa(py::module& module) {
                std::optional<uint32_t> sliding_window_size,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+               std::optional<ttnn::Tensor> attention_sink) {
                 return self(
                     input_tensor_q,
                     input_tensor_k,
@@ -68,7 +70,8 @@ void py_bind_sdpa(py::module& module) {
                     sliding_window_size,
                     memory_config,
                     program_config,
-                    compute_kernel_config);
+                    compute_kernel_config,
+                    attention_sink);
             },
             py::arg("input_tensor_q").noconvert(),
             py::arg("input_tensor_k").noconvert(),
@@ -80,7 +83,8 @@ void py_bind_sdpa(py::module& module) {
             py::arg("sliding_window_size").noconvert() = std::nullopt,
             py::arg("memory_config").noconvert() = std::nullopt,
             py::arg("program_config").noconvert() = std::nullopt,
-            py::arg("compute_kernel_config").noconvert() = std::nullopt});
+            py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("attention_sink").noconvert() = std::nullopt});
 
     auto chunked_doc =
         R"doc(


### PR DESCRIPTION
### Ticket
#31141

### Problem description
We need to add support for attention sinks to our SDPA op for prefill in gpt-oss.

### What's changed
Added attention sinks to flash attention in sdpa compute kernel. Attention sinks are provided by the user as a DRAM tensor of shape `[1, nh, 1, 1]`. Reader kernel then efficiently replicates this into tile format for each q head. Q is processed in chunks by the compute kernel and we reuse the attention sinks tensor in a new attention_sink_cb. Attention sink values are just used to contribute to the softmax denominator so we avoid modifying the values in place and therefore allow reuse of the cb. 

Ring distributed sdpa program factory compiles the same kernel files as regular sdpa so we've updated to reflect the newly expected compile and runtime args for those kernels.

### Checklist
APC: https://github.com/tenstorrent/tt-metal/actions/runs/19052361546 
Blackhole PC: https://github.com/tenstorrent/tt-metal/actions/runs/19052367588
Single card perf: https://github.com/tenstorrent/tt-metal/actions/runs/19052370987
Single card demo: https://github.com/tenstorrent/tt-metal/actions/runs/19053670921
T3K unit: https://github.com/tenstorrent/tt-metal/actions/runs/19052381164
Galaxy quick: https://github.com/tenstorrent/tt-metal/actions/runs/19052383181
Galaxy demo: https://github.com/tenstorrent/tt-metal/actions/runs/19052387244