### PR TITLE
Provide int32 support for division

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -9,6 +9,25 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
+def create_full_range_tensor(input_shape, dtype, value_ranges):
+    num_elements = torch.prod(torch.tensor(input_shape)).item()
+
+    num_ranges = len(value_ranges)
+    elements_per_range = num_elements // num_ranges
+    remainder = num_elements % num_ranges
+
+    segments = []
+    for i, (low, high) in enumerate(value_ranges):
+        range_elements = elements_per_range + (1 if i < remainder else 0)
+
+        segment = torch.linspace(low, high, steps=range_elements, dtype=dtype)
+        segments.append(segment)
+
+    in_data = torch.cat(segments)
+    in_data = in_data.reshape(input_shape)
+    return in_data
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     [
@@ -659,41 +678,51 @@ def test_comp_ops_edge_cases(ttnn_op, device):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ],
-)
-@pytest.mark.parametrize(
-    "low_a, high_a, low_b, high_b",
-    [
-        (-300, 300, -250, 250),
-        (-500, 500, -750, 750),
-        (-1000, 1000, -500, 1000),
-        (-1e4, 1e4, -5e3, 5e3),
-        (-1e5, 1e5, -5e4, 5e4),
-        (-1e7, 1e7, -1e6, 1e6),
-        (2e9, 2077000000, 2e9, 2147483647),  # large positive input
-        (-2147483647, -2e9, -2077000000, -2e9),  # large negative input
-        (-2147483647, 2147483647, -2147483647, 2147483647),  # full range
-        (-2147483647, 2147483647, -10, 10),  # large numerator, small denominator
-        (-10, 10, -2147483647, 2147483647),  # small numerator, large denominator
-        # -2147483648 is not supported because the input is typecasted to float32 and ttnn.typecast rounds -2147483648 to 0.
-    ],
+    ((torch.Size([1, 2, 32, 128])),),
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_div_int32(input_shapes, low_a, high_a, low_b, high_b, use_legacy, device):
-    num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
-    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
-    torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(input_shapes)
+def test_binary_div_int32_full_range(input_shapes, use_legacy, device):
+    value_ranges_a = [
+        (-300, 300),
+        (-500, 500),
+        (-1000, 1000),
+        (-1e4, 1e4),
+        (-1e5, 1e5),
+        (-1e7, 1e7),
+        (2e9, 2077000000),  # large positive input
+        (-2147483647, -2e9),  # large negative input
+        (-2147483647, 2147483647),  # full range
+        (-2147483647, 2147483647),  # large numerator
+        (-10, 10),  # small numerator
+    ]
 
-    torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
-    torch_input_tensor_b = torch_input_tensor_b[:num_elements].reshape(input_shapes)
+    value_ranges_b = [
+        (-250, 250),
+        (-750, 750),
+        (-500, 1000),
+        (-5e3, 5e3),
+        (-5e4, 5e4),
+        (-1e6, 1e6),
+        (2e9, 2147483647),  # large positive input
+        (-2077000000, -2e9),  # large negative input
+        (-2147483647, 2147483647),  # full range
+        (-10, 10),  # small denominator
+        (-2147483647, 2147483647),  # large denominator
+    ]
+
+    torch_input_tensor_a = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
+    )
+    torch_input_tensor_b = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
+    )
 
     torch_input_tensor_b[
         torch_input_tensor_b == 0
     ] = 1  # avoid division by zero since nan and inf are not representable in int32
+
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -711,14 +740,27 @@ def test_div_int32(input_shapes, low_a, high_a, low_b, high_b, use_legacy, devic
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    golden_function = ttnn.get_golden_function(ttnn.div)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
-
     output_tensor = ttnn.div(input_tensor_a, input_tensor_b, use_legacy=use_legacy)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
+
+
+def test_div_int32_optional_output(device):
+    torch_input_tensor_a = torch.arange(-(2**23), 2**23, 1024, dtype=torch.int32)
+    torch_input_tensor_b = torch.arange(-(2**23) - 1, 2**23 - 1, 1024, dtype=torch.int32)
+    torch_input_tensor_b[torch_input_tensor_b == 0] = 1
+
+    golden_fn = ttnn.get_golden_function(ttnn.div)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b, device=device).to(torch.int32)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.div(input_tensor_a, input_tensor_b, dtype=ttnn.int32, use_legacy=True)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.max(torch.abs(torch_output_tensor - output_tensor)) <= 1
 
 
 @pytest.mark.parametrize(
@@ -793,7 +835,7 @@ def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round
     if round_mode is not None:
         # A maximum absolute difference of 1 is expected for round modes floor and trunc.
         # This minor deviation comes from accumulated FP32 division rounding errors.
-        # For example, (1000 / 1000) = 0.9999... (in FP32) rounds to 0 (in INT32) when floored or truncated.
+        # For example, (1000 / 500) = 1.9999... (in FP32) rounds to 1 (in INT32) when floored or truncated.
         assert torch.max(torch.abs(torch_output_tensor - output_tensor)) <= 1
     else:
         assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
@@ -850,7 +892,10 @@ def test_div_edge_cases(round_mode, device):
     output_tensor = ttnn.div(input_tensor_a, input_tensor_b, round_mode=round_mode, use_legacy=True)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
+    if round_mode is not None:
+        assert torch.max(torch.abs(torch_output_tensor - output_tensor)) <= 1
+    else:
+        assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-6, equal_nan=False)
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -34,12 +34,12 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
             return (
                 (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
                 (a == DataType::UINT16 && b == DataType::UINT16));
-        case BinaryOpType::DIV:
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:
         case BinaryOpType::LDEXP:
         case BinaryOpType::BIAS_GELU:
         case BinaryOpType::HYPOT: return (a == DataType::FLOAT32 && b == DataType::FLOAT32);
+        case BinaryOpType::DIV:
         case BinaryOpType::RSUB:
         case BinaryOpType::GT:
         case BinaryOpType::LT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -32,7 +32,6 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case LDEXP:
         case BIAS_GELU:
         case HYPOT: return (a == FLOAT32 && b == FLOAT32);
-        case DIV:
         case RSUB:
         case GT:
         case LT:
@@ -54,7 +53,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case MINIMUM:
         case XLOGY:
         case POWER: return true;
-        case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32);
+        case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32);
         default: return false;
     }
     return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -32,6 +32,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case LDEXP:
         case BIAS_GELU:
         case HYPOT: return (a == FLOAT32 && b == FLOAT32);
+        case DIV:
         case RSUB:
         case GT:
         case LT:


### PR DESCRIPTION
### Ticket
#18589 
#25112 
#22796 

### Problem description
ttnn.div does not support inputs of INT32 datatype.

### What's changed
In this PR, INT32 datatype is supported by typecasting the input to `FP32` and performing `FP32 division`. If rounding mode is specified as `floor` or `trunc`, the output is typecasted back to `INT32`. This behaviour is consistent with Torch behaviour.

**Torch Behaviour for `INT32` inputs:**
```
torch.div(input_a, input_b, round_mode=None) -> FP32 output
torch.div(input_a, input_b, round_mode='floor') -> INT32 output
torch.div(input_a, input_b, round_mode='trunc') -> INT32 output
```

This approach provides outputs with ULP delta < `2.0`

### Problems Faced:
- Supported Range: `[-2147483647, 2147483647]` -> `-2147483648` is not supported because `ttnn.typecast` rounds it to `0`. 

- A maximum absolute difference of `1` is observed when rounding modes `floor` and `trunc` are specified due to accumulated `FP32 division` rounding errors.
  For example, `(1000 / 500) = 1.9999...` (in `FP32`) rounds to `1` (in `INT32`) when floored or truncated.

- For rounding modes `floor` and `trunc`, if the numerator is large and the denominator is small, an error in output (absolute difference ~ 6) is observed due to `FP32` precision loss.
   For example, numerator = `2021531526` and denominator = `9`:
   ```
   torch.div([2021531526], [9], rounding_mode=None) = 224614608.0 -> division is computed in float32 precision
   torch.div([2021531526], [9], rounding_mode='trunc') = 224614614 -> division is computed in direct int32 precision
   ```
   Since `224614614 > 2**24`, the typecast approach effectively performs floor/trunc operation on `224614608.0` instead of `224614614.0` 

**To Do:** 
Provide a precise implementation for rounding modes `floor` and `trunc` in order to curb the inaccuracies caused by FP32 division especially for large numerator or small denominator cases.


### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/19131701236
- [ ] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/19131705215
- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/19109644146
- [x] New/Existing tests provide coverage for changes