### PR TITLE
clean up split reader and conv 3.0 ifdef clauses

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -120,18 +120,7 @@ std::vector<CBInfo> get_cb_info(
 
     // Block dims
     if (!split_reader_enabled || is_1d_depthwise_conv) {
-        if (!conv_config.enable_activation_reuse) {
-            act_block_num_tiles = block_config.act_block_h_ntiles * block_config.act_block_w_ntiles;
-        } else {
-            act_block_num_tiles = calculate_act_cb_size_with_reuse(
-                block_config.act_block_h_ntiles,
-                block_config.act_block_w_ntiles,
-                output_image_width,
-                padded_in_channels,
-                kernel_size,
-                input_tile_size,
-                input_datatype);
-        }
+        act_block_num_tiles = block_config.act_block_h_ntiles * block_config.act_block_w_ntiles;
     } else {
         // Calculate split reader parameters
         uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -291,13 +291,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         pad_w = 0;
     }
 
-    // Activation reuse validation
-    if (enable_activation_reuse) {
-        TT_FATAL(!block_sharded, "Activation data reuse is not supported for block sharded");
-        TT_FATAL(dilation_h == 1 && dilation_w == 1, "Activation data reuse is not supported for dilation > 1");
-        TT_FATAL(stride_h == 1 && stride_w == 1, "Activation data reuse is not supported for stride > 1");
-    }
-
     const bool is_conv_1d_depthwise_conv =
         is_1d_deptwise_conv(groups, ashape[3], output_channels, filter_w, ashape[2], has_bias);
 
@@ -327,6 +320,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         per_core_out_matrix_height_ntiles / block_config.act_block_h_ntiles,
         per_core_out_matrix_height_ntiles,
         block_config.act_block_h_ntiles);
+
+    // Activation reuse validation
+    if (enable_activation_reuse) {
+        TT_FATAL(!block_sharded, "Activation data reuse is not supported for block sharded");
+        TT_FATAL(dilation_h == 1 && dilation_w == 1, "Activation data reuse is not supported for dilation > 1");
+        TT_FATAL(stride_h == 1 && stride_w == 1, "Activation data reuse is not supported for stride > 1");
+        TT_FATAL(enable_split_reader, "Activation data reuse requires split reader to be on");
+    }
 
     TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
     // check is for 16-byte alignment
@@ -800,7 +801,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index};
+        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
+        (uint32_t)enable_split_reader,
+        (uint32_t)enable_activation_reuse};
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -834,6 +837,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
 
         reader_compile_time_args.insert(
             reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+    } else if (height_sharded) {
+        // Add dummy activation reuse arguments when not enabled
+        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
+        reader_compile_time_args.insert(
+            reader_compile_time_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
     }
 
     if (split_reader_cb_shared) {
@@ -864,7 +872,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
     }
 
     if (enable_activation_reuse) {
-        compute_defines["ACTIVATION_REUSE"] = "1";
         reader_defines["ACTIVATION_REUSE"] = "1";
         writer_mcast_sender_defines["ACTIVATION_REUSE"] = "1";
         writer_defines["ACTIVATION_REUSE"] = "1";
@@ -899,71 +906,73 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         num_blocks_act_h_per_core,
         num_blocks_weight_w_per_core,
         out_conv_c_blocks,
-        (uint32_t)has_bias};
+        (uint32_t)has_bias,
+        (uint32_t)enable_split_reader,
+        (uint32_t)(enable_activation_reuse && height_sharded)};
 
-    if (enable_split_reader) {
-        std::vector<uint32_t> split_reader_args = {
-            (uint32_t)act_block_num_tiles_split_last,
-            (uint32_t)conv_act_c_read_bytes,
-            (uint32_t)filter_w,                       // weight_size_w
-            (uint32_t)(conv_act_size_w + pad_w),      // conv_act_size_w_padded
-            (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
-            (uint32_t)needs_act_block_zero_out,
-            (uint32_t)dilation_h,
-            (uint32_t)dilation_w,
-            (uint32_t)stride_w,
-            (uint32_t)filter_h};
+    std::vector<uint32_t> split_reader_args = {
+        (uint32_t)act_block_num_tiles_split_last,
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)filter_w,                       // weight_size_w
+        (uint32_t)(conv_act_size_w + pad_w),      // conv_act_size_w_padded
+        (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
+        (uint32_t)needs_act_block_zero_out,
+        (uint32_t)dilation_h,
+        (uint32_t)dilation_w,
+        (uint32_t)stride_w,
+        (uint32_t)filter_h};
 
-        if (block_sharded) {
-            split_reader_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
-        }
-        if (split_reader_cb_shared) {
-            const tt::DataFormat img2col_cb_df =
-                get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).data_format;
-
-            const uint32_t img2col_cb_tile_size = tt::tile_size(img2col_cb_df);
-            const uint32_t act_cb_id_stride =
-                skip_activation_mcast ? 1 : 1 + get_num_cores_channels_from_parallel_config(parallel_config);
-            // get total number of blocks in the ACT CB so that we can compute the loop around when moving write
-            // pointer in second reader
-            const uint32_t act_cb_block_cnt = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages /
-                                              (act_block_num_tiles_split + act_block_num_tiles_split_last);
-
-            // In cases where the overlapped buffer is double buffered and number of push_backs done on NCRISC is odd,
-            // there are two addresses that need to be written to on the BRISC side for the second reader.
-            const bool second_writer_two_addr = (act_cb_block_cnt > 1) && (act_cb_id_stride % 2 == 1);
-            const uint32_t act_write_offset = act_block_num_tiles_split * img2col_cb_tile_size;
-            const uint32_t act_write_offset_last =
-                second_writer_two_addr
-                    ? (act_block_num_tiles_split_last + 2 * act_block_num_tiles_split) * img2col_cb_tile_size
-                    : act_write_offset;
-            split_reader_args.push_back(act_split_reader_reserve_done_semaphore_id);
-            split_reader_args.push_back(act_split_reader_write_done_semaphore_id);
-            split_reader_args.push_back(act_write_offset);
-            split_reader_args.push_back(act_write_offset_last);
-        } else if (block_sharded) {
-            split_reader_args.push_back(0);
-            split_reader_args.push_back(0);
-            split_reader_args.push_back(0);
-            split_reader_args.push_back(0);
-        }
-
-        if (enable_activation_reuse && height_sharded) {
-            std::vector<uint32_t> activation_reuse_args = {
-                activation_reuse_config.act_cb_num_tiles_split_last,
-                act_block_w_ntiles,
-                static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
-                activation_reuse_config.image_width_tiles,
-                output_image_width,
-                activation_reuse_config.reuse_window_offset,
-                static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
-                static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
-            split_reader_args.insert(
-                split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
-        }
-        writer_compile_time_args.insert(
-            writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
+    if (block_sharded) {
+        split_reader_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
     }
+    if (split_reader_cb_shared) {
+        const tt::DataFormat img2col_cb_df = get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).data_format;
+
+        const uint32_t img2col_cb_tile_size = tt::tile_size(img2col_cb_df);
+        const uint32_t act_cb_id_stride =
+            skip_activation_mcast ? 1 : 1 + get_num_cores_channels_from_parallel_config(parallel_config);
+        // get total number of blocks in the ACT CB so that we can compute the loop around when moving write
+        // pointer in second reader
+        const uint32_t act_cb_block_cnt = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages /
+                                          (act_block_num_tiles_split + act_block_num_tiles_split_last);
+
+        // In cases where the overlapped buffer is double buffered and number of push_backs done on NCRISC is odd,
+        // there are two addresses that need to be written to on the BRISC side for the second reader.
+        const bool second_writer_two_addr = (act_cb_block_cnt > 1) && (act_cb_id_stride % 2 == 1);
+        const uint32_t act_write_offset = act_block_num_tiles_split * img2col_cb_tile_size;
+        const uint32_t act_write_offset_last =
+            second_writer_two_addr
+                ? (act_block_num_tiles_split_last + 2 * act_block_num_tiles_split) * img2col_cb_tile_size
+                : act_write_offset;
+        split_reader_args.push_back(act_split_reader_reserve_done_semaphore_id);
+        split_reader_args.push_back(act_split_reader_write_done_semaphore_id);
+        split_reader_args.push_back(act_write_offset);
+        split_reader_args.push_back(act_write_offset_last);
+    } else if (block_sharded) {
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+        split_reader_args.push_back(0);
+    }
+
+    if (enable_activation_reuse && height_sharded) {
+        std::vector<uint32_t> activation_reuse_args = {
+            activation_reuse_config.act_cb_num_tiles_split_last,
+            act_block_w_ntiles,
+            static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
+            activation_reuse_config.image_width_tiles,
+            output_image_width,
+            activation_reuse_config.reuse_window_offset,
+            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
+            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
+        split_reader_args.insert(split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
+    } else if (height_sharded) {
+        // Add dummy activation reuse arguments when not enabled
+        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
+        split_reader_args.insert(
+            split_reader_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
+    }
+    writer_compile_time_args.insert(writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
     tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(writer_compile_time_args);
 
@@ -1008,18 +1017,21 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         weight_block_w_ntiles <= 8,  // packer_untilize
         packer_l1_acc_en,
         has_bias,
-        static_cast<uint32_t>(split_reader_cb_shared)};
+        enable_split_reader,
+        enable_activation_reuse};
 
     if (enable_activation_reuse) {
         compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
         compute_kernel_args.push_back(activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-        if (enable_split_reader) {
-            compute_kernel_args.push_back(
-                activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-            compute_kernel_args.push_back(
-                activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-        }
+        compute_kernel_args.push_back(activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+        compute_kernel_args.push_back(
+            activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
+    } else {
+        std::vector<uint32_t> activation_reuse_dummy_args = {0, 0, 0, 0};
+        compute_kernel_args.insert(
+            compute_kernel_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
     }
+    compute_kernel_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
 
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
     const tt::tt_metal::NOC reader_noc =
@@ -1248,7 +1260,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
                      total_num_cores - 1,  // mcast_num_dests, mcast_num_cores
                      weights_mcast_sender_semaphore_id,
                      weights_mcast_receiver_semaphore_id});
-                if (enable_split_reader && enable_activation_reuse) {
+                if (enable_activation_reuse) {
                     uint32_t writer_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
                         writer_remaining_tiles_to_push =
@@ -1295,7 +1307,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
                     top_left_core_physical.y,
                     weights_mcast_sender_semaphore_id,
                     weights_mcast_receiver_semaphore_id};
-                if (enable_split_reader && enable_activation_reuse) {
+                if (enable_activation_reuse) {
                     uint32_t writer_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
                         writer_remaining_tiles_to_push =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -448,7 +448,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
         weight_block_w_ntiles <= 8,  // packer_untilize
         packer_l1_acc,
         has_bias,
-        static_cast<uint32_t>(false)};
+        false,  // enable_split_reader (not used in width sharded)
+        false,  // enable_activation_reuse (not used in width sharded)
+        0,
+        0,
+        0,
+        0,                              // activation reuse related arguments
+        static_cast<uint32_t>(false)};  // split_reader_cb_shared (not used in width sharded)
 
     std::vector<uint32_t> activation_kernel_compile_args = {
         (uint32_t)stride_w,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -40,7 +40,6 @@ void tilize_in(
     }
 }  // tilize_in()
 
-#ifdef ACTIVATION_REUSE
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
 inline void tilize_single_block() {
     cb_wait_front(in_cb_id, in_block_w);
@@ -59,43 +58,6 @@ inline void tilize_single_block_with_out_cb_update(uint32_t& out_cb_addr) {
     PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
     PACK((out_cb_addr += tilized_cb_row_offset));
     tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
-}
-
-template <
-    uint32_t in_cb_id,
-    uint32_t in_block_w,
-    uint32_t in_num_subblocks,
-    uint32_t out_cb_id,
-    uint32_t window_reuse_offset,
-    uint32_t image_width_in_tiles>
-inline void tilize_in_reuse(uint32_t in_cb_start_addr) {
-    fast_tilize_init_with_dt(in_cb_id, in_block_w, out_cb_id);
-
-    constexpr uint32_t num_image_rows = in_num_subblocks / image_width_in_tiles;
-    constexpr uint32_t last_row_columns = in_num_subblocks % image_width_in_tiles;
-    uint32_t in_cb_addr = in_cb_start_addr;
-
-    // full image rows
-    for (uint32_t image_row = 0; image_row < num_image_rows; ++image_row) {
-        // each time we start processing a new image row, we need to update the read pointer to the appropriate offset
-        // from the start of the CB to match the reader behavior
-        in_cb_addr = update_in_cb<in_cb_id, window_reuse_offset>(in_cb_addr);
-        for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
-            cb_reserve_back(out_cb_id, in_block_w);
-            tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
-            cb_push_back(out_cb_id, in_block_w);
-        }
-    }
-
-    // partial last image row
-    in_cb_addr = update_in_cb<in_cb_id, window_reuse_offset>(in_cb_addr);
-    for (uint32_t image_col = 0; image_col < last_row_columns; ++image_col) {
-        cb_reserve_back(out_cb_id, in_block_w);
-        tilize_single_block<in_cb_id, in_block_w, out_cb_id>();
-        cb_push_back(out_cb_id, in_block_w);
-    }
-
-    fast_tilize_uninit(in_cb_id, out_cb_id);
 }
 
 template <
@@ -172,7 +134,6 @@ inline void tilize_in_reuse_split_reader(uint32_t act_cb_start_address, uint32_t
     cb_push_back(out_cb_id, out_cb_tiles);
     fast_tilize_uninit(in2_cb_id, out_cb_id);
 }
-#endif
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
@@ -241,16 +202,14 @@ void MAIN {
     constexpr bool packer_untilize = get_compile_time_arg_val(30);
     constexpr bool packer_l1_acc = get_compile_time_arg_val(31);
     constexpr bool fuse_bias = get_compile_time_arg_val(32);
-    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(33) == 1;
+    constexpr bool split_reader = get_compile_time_arg_val(33);
+    constexpr bool activation_reuse = get_compile_time_arg_val(34);
 
-#ifdef ACTIVATION_REUSE
-    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(34);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
-#ifdef SPLIT_READER
-    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(36);
-    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(37);
-#endif
-#endif
+    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(35);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
+    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(37);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(38);
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(39) == 1;
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;
@@ -265,14 +224,19 @@ void MAIN {
 
     constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
 
-#ifdef SPLIT_READER
-    constexpr bool split_reader = true;
-#else
-    constexpr bool split_reader = false;
-#endif
     constexpr uint32_t in0_num_subblocks_read_last =
         (split_reader && !split_reader_cb_shared) ? reader_num_h_subblocks / 2 : 0;
     constexpr uint32_t in0_num_subblocks_read = reader_num_h_subblocks - in0_num_subblocks_read_last;
+
+    // if activation reuse is enabled, we need to update read pointers of the act buffers
+    // each time we pass on to the new output image row to match the reader behavior
+    uint32_t act_cb_start_address = activation_reuse ? get_local_cb_interface(in0_cb_id).fifo_rd_ptr : 0;
+    const uint32_t out_cb_tiles =
+        activation_reuse ? in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last) : 0;
+    const uint32_t tilized_cb_start_address =
+        activation_reuse ? get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr : 0;
+    const uint32_t act_cb_second_reader_start_address =
+        activation_reuse ? get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr : 0;
 
     // For block sharded conv2d, compute kernels may be scheduled on cores that only need tilize
     // operations (input grid) while actual matmul occurs on different cores (output grid).
@@ -282,16 +246,6 @@ void MAIN {
     if constexpr (check_skip_compute) {
         skip_compute = (bool)get_arg_val<uint32_t>(0);
     }
-#ifdef ACTIVATION_REUSE
-    // if activation reuse is enabled, we need to update read pointers of the act buffers
-    // each time we pass on to the new output image row to match the reader behavior
-    uint32_t act_cb_start_address = get_local_cb_interface(in0_cb_id).fifo_rd_ptr;
-#ifdef SPLIT_READER
-    const uint32_t out_cb_tiles = in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last);
-    const uint32_t tilized_cb_start_address = get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr;
-    const uint32_t act_cb_second_reader_start_address = get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr;
-#endif
-#endif
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -356,37 +310,31 @@ void MAIN {
                         pack_reconfig_l1_acc(0);
                     }
 
-#ifndef ACTIVATION_REUSE
-                    tilize_in<true, !split_reader>(in0_cb_id, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
-#ifdef SPLIT_READER
-                    tilize_in<false, true>(
-                        in0_cb_second_reader_id, in0_block_w, in0_num_subblocks_read_last, tilized_in0_cb_id);
-#endif
-#else
-#ifndef SPLIT_READER
-                    tilize_in_reuse<
-                        in0_cb_id,
-                        in0_block_w,
-                        in0_num_subblocks_read,
-                        tilized_in0_cb_id,
-                        window_reuse_offset,
-                        image_width_in_tiles>(act_cb_start_address);
-#else
-                    PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
-                    tilize_in_reuse_split_reader<
-                        in0_cb_id,
-                        in0_cb_second_reader_id,
-                        in0_block_w,
-                        in0_num_subblocks_read,
-                        in0_num_subblocks_read_last,
-                        tilized_in0_cb_id,
-                        out_cb_tiles,
-                        window_reuse_offset,
-                        tilized_cb_row_offset,
-                        tilized_cb_second_reader_offset,
-                        image_width_in_tiles>(act_cb_start_address, act_cb_second_reader_start_address);
-#endif
-#endif
+                    if constexpr (!activation_reuse) {
+                        tilize_in<true, !split_reader>(
+                            in0_cb_id, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
+                    }
+
+                    if constexpr (split_reader) {
+                        if constexpr (!activation_reuse) {
+                            tilize_in<false, true>(
+                                in0_cb_second_reader_id, in0_block_w, in0_num_subblocks_read_last, tilized_in0_cb_id);
+                        } else {
+                            PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
+                            tilize_in_reuse_split_reader<
+                                in0_cb_id,
+                                in0_cb_second_reader_id,
+                                in0_block_w,
+                                in0_num_subblocks_read,
+                                in0_num_subblocks_read_last,
+                                tilized_in0_cb_id,
+                                out_cb_tiles,
+                                window_reuse_offset,
+                                tilized_cb_row_offset,
+                                tilized_cb_second_reader_offset,
+                                image_width_in_tiles>(act_cb_start_address, act_cb_second_reader_start_address);
+                        }
+                    }
 
                     mm_block_init_short_with_both_dt(
                         mm_in0_cb_id,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -74,7 +74,6 @@ FORCE_INLINE void read_kernel_w(uint32_t& l1_write_addr_act, uint32_t& act_l1_of
     act_l1_offset += stride_h_bytes;
 }
 
-#ifdef ACTIVATION_REUSE
 template <uint32_t cb_id_act, uint32_t act_cb_tiles, uint32_t window_reuse_offset>
 FORCE_INLINE void pass_to_the_next_image_width(
     uint32_t& l1_write_addr_act,
@@ -333,7 +332,7 @@ FORCE_INLINE void read_sticks_activation_reuse(
             packed_reader_indices_ptr, reader_idx, start_ind, end_ind, new_batch_image_rows_to_fill);
     }
 }
-#endif
+
 template <uint32_t dram_addr_index, uint32_t page_size_index, uint32_t tensor_args_index, uint32_t cb_reader_index>
 void load_config_tensor_if_in_dram(uint32_t core_index) {
 #ifdef CONFIG_TENSOR_IN_DRAM

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -25,26 +25,26 @@ void kernel_main() {
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
 
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(27);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(28);
+
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
     uint32_t runtime_arg_idx = 0;
     uint32_t core_index = get_arg_val<uint32_t>(runtime_arg_idx++);
-    load_config_tensor_if_in_dram<27, 28, 29, cb_reader_indices>(core_index);
-
-#ifdef ACTIVATION_REUSE
-    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(30);
-    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(31);
-    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(32) == 1;
-    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(33);
-    constexpr uint32_t output_image_width = get_compile_time_arg_val(34);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
-    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(36) == 1;
-    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(37) == 1;
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(core_index);
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(32);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(33);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(34) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(35);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(36);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(37);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(38) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(39) == 1;
 
     uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(runtime_arg_idx++);
-#endif
-
 
     if constexpr (needs_act_block_zero_out) {
         zero_out_tiles<cb_id_act>();
@@ -77,68 +77,69 @@ void kernel_main() {
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     uint32_t start_reader_idx = 0;
+    uint32_t l1_write_addr_act = 0;
     const uint32_t cb_start_addr = get_write_ptr(cb_id_act);
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
-#ifdef ACTIVATION_REUSE
-        uint32_t l1_write_addr_act = cb_start_addr;
-        get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
-#endif
+        if constexpr (activation_reuse_enabled) {
+            l1_write_addr_act = cb_start_addr;
+            get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+        }
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {
             reader_idx = start_reader_idx;
 
-#ifndef ACTIVATION_REUSE
-            cb_reserve_back(cb_id_act, act_block_num_tiles);
-            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
+            if constexpr (!activation_reuse_enabled) {
+                cb_reserve_back(cb_id_act, act_block_num_tiles);
+                l1_write_addr_act = get_write_ptr(cb_id_act);
 
-            read_sticks<
-                dilation_w,
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                stride_w_bytes,
-                weight_size_w,
-                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                read_sticks<
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w,
+                    stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
 
-            noc_async_read_barrier();
-            cb_push_back(cb_id_act, act_block_num_tiles);
-            reader_offset += window_outer_offset;
-#else
-            read_sticks_activation_reuse<
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                window_outer_offset,
-                weight_size_w,
-                stride_w,
-                weight_size_h,
-                cb_id_act,
-                act_reuse_cb_tiles,
-                act_block_w_tiles,
-                readers_process_full_image_widths,
-                image_width_tiles,
-                output_image_width,
-                window_reuse_offset,
-                single_core_processes_multiple_batches>(
-                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
-
-#endif
+                noc_async_read_barrier();
+                cb_push_back(cb_id_act, act_block_num_tiles);
+                reader_offset += window_outer_offset;
+            } else {
+                read_sticks_activation_reuse<
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    window_outer_offset,
+                    weight_size_w,
+                    stride_w,
+                    weight_size_h,
+                    cb_id_act,
+                    act_reuse_cb_tiles,
+                    act_block_w_tiles,
+                    readers_process_full_image_widths,
+                    image_width_tiles,
+                    output_image_width,
+                    window_reuse_offset,
+                    single_core_processes_multiple_batches>(
+                    packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+            }
         }
 
         start_reader_idx = reader_idx;
-#ifdef SPLIT_READER
-        // Increment reader index for the next number of segments (number of segments for other reader)
-        start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
-#endif
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+        }
     }
 
-#ifdef ACTIVATION_REUSE
-    // Last core sometimes has less work to do, but we still need to push the same number of tiles
-    // to avoid blocking compute kernels
-    if constexpr (need_to_push_remaining_tiles) {
-        push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(remaining_tiles_to_push, cb_start_addr);
+    if constexpr (activation_reuse_enabled) {
+        // Last core sometimes has less work to do, but we still need to push the same number of tiles
+        // to avoid blocking compute kernels
+        if constexpr (need_to_push_remaining_tiles) {
+            push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(
+                remaining_tiles_to_push, cb_start_addr);
+        }
     }
-#endif
 
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -23,30 +23,30 @@ void kernel_main() {
 
     constexpr bool fuse_bias = get_compile_time_arg_val(18);
 
-    // Split reader args
-#ifdef SPLIT_READER
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(19);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
-    constexpr uint32_t weights_size_h = get_compile_time_arg_val(28);
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(20);
 
-#ifdef ACTIVATION_REUSE
-    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(29);
-    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(30);
-    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(31) == 1;
-    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(32);
-    constexpr uint32_t output_image_width = get_compile_time_arg_val(33);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(34);
-    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(35) == 1;
-    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(36) == 1;
-#endif
-#endif
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(30);
+
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(32);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(35);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(37) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(38) == 1;
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i++);
@@ -55,11 +55,11 @@ void kernel_main() {
         return;
     }
 
-#ifdef SPLIT_READER
-    if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_second_reader>();
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>();
+        }
     }
-#endif
 
     // mcast args
     const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
@@ -72,93 +72,95 @@ void kernel_main() {
     const uint64_t weights_mcast_sender_semaphore_noc_addr =
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
-#ifdef SPLIT_READER
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
         cb_wait_front(cb_reader_indices, 1);
 #endif
-#ifdef ACTIVATION_REUSE
-    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
-#endif
+    }
     constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+                             : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-    // coalesce reads along weight_size_w
-    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-    const uint32_t cb_start_addr = get_write_ptr(cb_id_act_second_reader);
-#endif
+    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
+    uint32_t start_reader_idx =
+        split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1 : 0;
+    const uint32_t cb_start_addr = split_reader_enabled ? get_write_ptr(cb_id_act_second_reader) : 0;
 
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
-
+    uint32_t l1_write_addr_act = 0;
+    uint32_t reader_offset = 0;
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
         // MCAST RECEIVE WEIGHTS
         // read weight blocks inner dim
         // read weight slice - 1 block of weights in width dim and full weight matrix height
         // read slice only once for all activation blocks
 
-#ifdef SPLIT_READER
-#ifdef ACTIVATION_REUSE
-        uint32_t l1_write_addr_act = cb_start_addr;
-        get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
-#endif
-        uint32_t reader_offset = act_l1_read_addr;
-#endif
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+            }
+            reader_offset = act_l1_read_addr;
+        }
         for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-#ifdef SPLIT_READER
-            // Do the second half of the reads for act
-            noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-            reader_idx = start_reader_idx;
+            if constexpr (split_reader_enabled) {
+                // Do the second half of the reads for act
+                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                reader_idx = start_reader_idx;
 
-#ifndef ACTIVATION_REUSE
-            cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-            read_sticks<
-                dilation_w,
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                stride_w_bytes,
-                weight_size_w,
-                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+                if constexpr (!activation_reuse_enabled) {
+                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+                    l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
-            reader_offset += window_outer_offset;
-#else
-            read_sticks_activation_reuse<
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                window_outer_offset,
-                weight_size_w,
-                stride_w,
-                weights_size_h,
-                cb_id_act_second_reader,
-                act_reuse_cb_tiles,
-                act_block_w_tiles,
-                readers_process_full_image_widths,
-                image_width_tiles,
-                output_image_width,
-                window_reuse_offset,
-                single_core_processes_multiple_batches>(
-                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
-            if constexpr (need_to_push_remaining_tiles) {
-                if (block_weight_h == num_blocks_weight_h - 1) {
-                    // Last core sometimes has less work to do, but we still need to push the same number of tiles
-                    // to avoid blocking compute kernels
-                    push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                        remaining_tiles_to_push, cb_start_addr);
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
                 }
             }
-#endif
-#endif
 
             // Receive weights
             cb_reserve_back(cb_id_weight, weight_block_num_tiles);
@@ -195,10 +197,10 @@ void kernel_main() {
             }
         }
 
-#ifdef SPLIT_READER
-        // Increment reader index for the next number of segments (number of segments for other reader)
-        start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-#endif
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
     }  // out_num_blocks_h
 
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -28,36 +28,32 @@ void kernel_main() {
 
     constexpr bool fuse_bias = get_compile_time_arg_val(18);
 
-#ifdef SPLIT_READER
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(19);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
-    constexpr uint32_t weights_size_h = get_compile_time_arg_val(28);
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+    constexpr bool activation_reuse_enabled = get_compile_time_arg_val(20);
 
-#ifdef ACTIVATION_REUSE
-    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(29);
-    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(30);
-    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(31) == 1;
-    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(32);
-    constexpr uint32_t output_image_width = get_compile_time_arg_val(33);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(34);
-    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(35) == 1;
-    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(36) == 1;
-    constexpr uint32_t ct_arg_idx = 37;
-#else
-    constexpr uint32_t ct_arg_idx = 29;
-#endif
-#else
-    constexpr uint32_t ct_arg_idx = 19;
-#endif
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weights_size_h = get_compile_time_arg_val(30);
 
-    constexpr auto s_weight_args = TensorAccessorArgs<ct_arg_idx>();
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_compile_time_arg_val(31);
+    constexpr uint32_t act_block_w_tiles = get_compile_time_arg_val(32);
+    constexpr bool readers_process_full_image_widths = get_compile_time_arg_val(33) == 1;
+    constexpr uint32_t image_width_tiles = get_compile_time_arg_val(34);
+    constexpr uint32_t output_image_width = get_compile_time_arg_val(35);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(36);
+    constexpr bool need_to_push_remaining_tiles = get_compile_time_arg_val(37) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_compile_time_arg_val(38) == 1;
+
+    constexpr auto s_weight_args = TensorAccessorArgs<39>();
     constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
 
     uint32_t i = 0;
@@ -68,11 +64,11 @@ void kernel_main() {
     const uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i++);
     const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i++);
 
-#ifdef SPLIT_READER
-    if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_second_reader>();
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>();
+        }
     }
-#endif
 
     // mcast args
     const uint32_t weights_mcast_dest_noc_start_x = get_arg_val<uint32_t>(i++);
@@ -84,28 +80,29 @@ void kernel_main() {
     const uint32_t weights_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
     const uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i++));
 
-#ifdef SPLIT_READER
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg_val<uint32_t>(i++) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
         cb_wait_front(cb_reader_indices, 1);
 #endif
-#ifdef ACTIVATION_REUSE
-    uint32_t remaining_tiles_to_push = get_arg_val<uint32_t>(i++);
-#endif
-    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    }
 
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+                             : nullptr;
     uint32_t reader_idx = 0;
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
     constexpr uint32_t coalesced_read_bytes =
         ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
-
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+    uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
     // coalesce reads along weight_size_w
-    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
-    const uint32_t cb_start_addr = get_write_ptr(cb_id_act_second_reader);
+    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+    uint32_t cb_start_addr = split_reader_enabled ? get_write_ptr(cb_id_act_second_reader) : 0;
     uint32_t reader_offset = act_l1_read_addr;
-#endif
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -139,6 +136,7 @@ void kernel_main() {
     constexpr uint32_t weight_inner_block_stride_h =
         weight_next_block_stride_h / weight_block_height_num_outer;  // TODO: Pass as args
 
+    uint32_t l1_write_addr_act = 0;
     for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
         // READ WEIGHTS + MCAST SEND WEIGHTS
         // read weight blocks inner dim
@@ -148,64 +146,64 @@ void kernel_main() {
 
         uint32_t weight_current_block_start_tile_id = 0;
 
-#ifdef SPLIT_READER
-#ifdef ACTIVATION_REUSE
-        uint32_t l1_write_addr_act = cb_start_addr;
-        get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
-#endif
-        uint32_t reader_offset = act_l1_read_addr;
-#endif
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+            }
+            reader_offset = act_l1_read_addr;
+        }
 
         for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
-#ifdef SPLIT_READER
-            // Do the second half of the reads for act
-            noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-            reader_idx = start_reader_idx;
+            if constexpr (split_reader_enabled) {
+                // Do the second half of the reads for act
+                noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                reader_idx = start_reader_idx;
 
-#ifndef ACTIVATION_REUSE
-            cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
-            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
-            read_sticks<
-                dilation_w,
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                stride_w_bytes,
-                weight_size_w,
-                stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
+                if constexpr (!activation_reuse_enabled) {
+                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
+                    l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
-            reader_offset += window_outer_offset;
-#else
-            read_sticks_activation_reuse<
-                coalesced_read_bytes,
-                conv_act_c_read_bytes,
-                act_block_w_extra_align_bytes,
-                window_outer_offset,
-                weight_size_w,
-                stride_w,
-                weights_size_h,
-                cb_id_act_second_reader,
-                act_reuse_cb_tiles,
-                act_block_w_tiles,
-                readers_process_full_image_widths,
-                image_width_tiles,
-                output_image_width,
-                window_reuse_offset,
-                single_core_processes_multiple_batches>(
-                packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        packed_reader_indices_ptr, act_l1_read_addr, l1_write_addr_act, reader_idx, cb_start_addr);
 
-            if constexpr (need_to_push_remaining_tiles) {
-                if (block_weight_h == num_blocks_weight_h - 1) {
-                    // Last core sometimes has less work to do, but we still need to push the same number of tiles
-                    // to avoid blocking compute kernels
-                    push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
-                        remaining_tiles_to_push, cb_start_addr);
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
                 }
             }
-#endif
-#endif
 
             // Do weights read + mcast
             cb_reserve_back(cb_id_weight, weight_block_num_tiles);
@@ -335,9 +333,9 @@ void kernel_main() {
                 load_bias = false;
             }
         }
-#ifdef SPLIT_READER
-        // Increment reader index for the next number of segments (number of segments for other reader)
-        start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-#endif
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
     }  // out_num_blocks_h
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -28,44 +28,47 @@ void kernel_main() {
 
     constexpr bool fuse_bias = get_compile_time_arg_val(18);
 
-#ifdef SPLIT_READER
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+
+    // Split reader args
     constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
     constexpr uint32_t window_outer = get_compile_time_arg_val(6);  // num_blocks_act_w
     constexpr bool sliced_inner_dim = window_outer > 1;             // Derived like block sharded reader
-    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(19);  // This is what factory passes
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
-    constexpr uint32_t weight_size_h = get_compile_time_arg_val(28);  // Input filter window height
+    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(30);
 
     // When the split reader CB is shared, both readers write to the same circular buffer.
     // Synchronization is required: the main reader signals when CB space is reserved,
     // and the second reader signals when it has finished writing its portion.
-    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(29) == 1;
-    const uint32_t act_split_reader_reserve_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(30)) : 0;
-    const uint32_t act_split_reader_write_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(31)) : 0;
-    constexpr uint32_t act_write_offset = get_compile_time_arg_val(32);
-    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(33);
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(31) == 1;
+    const uint32_t act_split_reader_reserve_done_semaphore_addr =
+        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(32)) : 0;
+    const uint32_t act_split_reader_write_done_semaphore_addr =
+        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(33)) : 0;
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
     volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
     volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
 
-    const uint32_t split_reader_cb_write_addr = get_write_ptr(cb_id_act_second_reader) + act_write_offset;
+    const uint32_t split_reader_cb_write_addr =
+        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
-    const uint32_t split_reader_cb_write_addr_last = get_write_ptr(cb_id_act_second_reader) + act_write_offset_last;
+    const uint32_t split_reader_cb_write_addr_last =
+        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
-#else
-    const uint32_t split_reader_cb_write_addr = 0;
-#endif
 
     // mcast args
     uint32_t i = 0;
@@ -80,18 +83,22 @@ void kernel_main() {
     const uint64_t weights_mcast_sender_semaphore_noc_addr =
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
-#ifdef SPLIT_READER
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-    cb_wait_front(cb_reader_indices, 1);
+        cb_wait_front(cb_reader_indices, 1);
 #endif
-    if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_second_reader>();
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>();
+        }
     }
+
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+                             : nullptr;
 
     // Initial setup for second reader (starting from second reader's data)
-    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
+    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
     uint32_t reader_idx = start_reader_idx;
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
@@ -100,10 +107,7 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-
-    uint32_t cb_ind_offset = 0;
-#endif
+    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
     // read in bias if enabled (done only once for all batches)
     bool load_bias = true;
 
@@ -111,55 +115,56 @@ void kernel_main() {
     // Write out col major blocks in row major layout to output
     uint32_t l1_write_addr_act = split_reader_cb_write_addr;
     uint32_t prev_addr = 0;
+    uint32_t reader_offset = 0;
     for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
         for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
-#ifdef SPLIT_READER
-            // Read activation data using block sharded pattern (for second reader)
-            uint32_t reader_offset = act_l1_read_addr;
-#endif
+            if constexpr (split_reader_enabled) {
+                // Read activation data using block sharded pattern (for second reader)
+                reader_offset = act_l1_read_addr;
+            }
             for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
-#ifdef SPLIT_READER
-                reader_idx = start_reader_idx;
-                if constexpr (!split_reader_cb_shared) {
-                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
-                }
+                if constexpr (split_reader_enabled) {
+                    reader_idx = start_reader_idx;
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                    }
 
-                if (is_sender_core) {
-                    if constexpr (split_reader_cb_shared) {
-                        wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
-                        prev_addr = l1_write_addr_act;
-                    } else {
-                        l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                    if (is_sender_core) {
+                        if constexpr (split_reader_cb_shared) {
+                            wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                            prev_addr = l1_write_addr_act;
+                        } else {
+                            l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                        }
+                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                        read_activation_data<
+                            sliced_inner_dim,
+                            dilation_w,
+                            coalesced_read_bytes,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes,
+                            stride_w_bytes,
+                            weight_size_w,
+                            stride_w,
+                            weight_size_h,
+                            window_outer_offset>(
+                            packed_reader_indices_ptr,
+                            reader_offset,
+                            l1_write_addr_act,
+                            reader_idx,
+                            act_l1_read_addr,
+                            stride_h_bytes);
+                        if constexpr (split_reader_cb_shared) {
+                            // in case of shared cb we update the write address (it will remain the same if double
+                            // buffering is not enabled)
+                            l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                            signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                        }
                     }
-                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                    read_activation_data<
-                        sliced_inner_dim,
-                        dilation_w,
-                        coalesced_read_bytes,
-                        conv_act_c_read_bytes,
-                        act_block_w_extra_align_bytes,
-                        stride_w_bytes,
-                        weight_size_w,
-                        stride_w,
-                        weight_size_h,
-                        window_outer_offset>(
-                        packed_reader_indices_ptr,
-                        reader_offset,
-                        l1_write_addr_act,
-                        reader_idx,
-                        act_l1_read_addr,
-                        stride_h_bytes);
-                    if constexpr (split_reader_cb_shared) {
-                        // in case of shared cb we update the write address (it will remain the same if double buffering
-                        // is not enabled)
-                        l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
-                        signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
                     }
                 }
-                if constexpr (!split_reader_cb_shared) {
-                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
-                }
-#endif
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
                      weight_tile_h_outer_i++) {
                     // MCAST RECEIVE WEIGHTS
@@ -179,10 +184,11 @@ void kernel_main() {
                     cb_push_back(cb_id_weight, weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
-#ifdef SPLIT_READER
-            // Update reader index for next iteration (split reader increment)
-            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-#endif
+            if constexpr (split_reader_enabled) {
+                // Update reader index for next iteration (split reader increment)
+                start_reader_idx =
+                    reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+            }
             if constexpr (fuse_bias) {
                 if (load_bias) {
                     cb_reserve_back(bias_cb_id, bias_ntiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -34,49 +34,50 @@ void kernel_main() {
 
     constexpr bool fuse_bias = get_compile_time_arg_val(18);
 
-#ifdef SPLIT_READER
-    constexpr bool split_reader_enabled = true;
+    constexpr bool split_reader_enabled = get_compile_time_arg_val(19);
+
+    // Split reader args
     constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(3);
     constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(4);
     constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(5);
     constexpr uint32_t window_outer = get_compile_time_arg_val(6);  // num_blocks_act_w
     constexpr bool sliced_inner_dim = num_blocks_weight_h > 1;      // Derived like block sharded reader
-    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(19);  // This is what factory passes
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(20);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(21);
-    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(22);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(23);
-    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(24) == 1;
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(25);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(26);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(27);
-    constexpr uint32_t weight_size_h = get_compile_time_arg_val(28);  // Input filter window height
-    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(29) == 1;
+    constexpr uint32_t act_block_num_tiles_split_last = get_compile_time_arg_val(21);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(22);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(23);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(24);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(25);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(27);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(28);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(29);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(30);  // Input filter window height
+
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(31) == 1;
 
     // When the split reader CB is shared, both readers write to the same circular buffer.
     // Synchronization is required: the main reader signals when CB space is reserved,
     // and the second reader signals when it has finished writing its portion.
-    const uint32_t act_split_reader_reserve_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(30)) : 0;
-    const uint32_t act_split_reader_write_done_semaphore_addr = (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(31)) : 0;
-    constexpr uint32_t act_write_offset = get_compile_time_arg_val(32);
-    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(33);
+    const uint32_t act_split_reader_reserve_done_semaphore_addr =
+        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(32)) : 0;
+    const uint32_t act_split_reader_write_done_semaphore_addr =
+        (split_reader_cb_shared) ? get_semaphore(get_compile_time_arg_val(33)) : 0;
+    constexpr uint32_t act_write_offset = get_compile_time_arg_val(34);
+    constexpr uint32_t act_write_offset_last = get_compile_time_arg_val(35);
 
     volatile tt_l1_ptr uint32_t* act_split_reader_reserve_done_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_reserve_done_semaphore_addr);
     volatile tt_l1_ptr uint32_t* act_split_reader_write_done_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_split_reader_write_done_semaphore_addr);
 
-    const uint32_t split_reader_cb_write_addr = get_write_ptr(cb_id_act_second_reader) + act_write_offset;
+    const uint32_t split_reader_cb_write_addr =
+        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset : 0;
     // In case of double buffering the split reader can write to two different addresses
-    const uint32_t split_reader_cb_write_addr_last = get_write_ptr(cb_id_act_second_reader) + act_write_offset_last;
+    const uint32_t split_reader_cb_write_addr_last =
+        (split_reader_cb_shared) ? get_write_ptr(cb_id_act_second_reader) + act_write_offset_last : 0;
     const uint32_t split_reader_cb_write_addr_sum = split_reader_cb_write_addr + split_reader_cb_write_addr_last;
-    constexpr uint32_t ct_arg_idx = 34;
-#else
-    constexpr bool split_reader_enabled = false;
-    const uint32_t split_reader_cb_write_addr = 0;
-    constexpr uint32_t ct_arg_idx = 19;
-#endif
 
+    constexpr uint32_t ct_arg_idx = 36;
     constexpr auto s_weight_args = TensorAccessorArgs<ct_arg_idx>();
     constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
 
@@ -103,18 +104,21 @@ void kernel_main() {
         return;
     }
 
-#ifdef SPLIT_READER
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
 #ifdef CONFIG_TENSOR_IN_DRAM
-    cb_wait_front(cb_reader_indices, 1);
+        cb_wait_front(cb_reader_indices, 1);
 #endif
-    if constexpr (needs_act_block_zero_out) {
-        zero_out_tiles<cb_id_act_second_reader>();
+        if constexpr (needs_act_block_zero_out) {
+            zero_out_tiles<cb_id_act_second_reader>();
+        }
     }
-    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices))
+                             : nullptr;
     // Initial setup for second reader (starting from second reader's data)
-    uint32_t start_reader_idx = (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1;
+    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
     uint32_t reader_idx = start_reader_idx;
 
     constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
@@ -123,11 +127,7 @@ void kernel_main() {
     constexpr uint32_t window_outer_offset = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
     constexpr uint32_t stride_h_bytes = padded_conv_act_size_w * conv_act_c_read_bytes * dilation_h;
 
-    const uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-
-    uint32_t cb_ind_offset = 0;
-
-#endif
+    const uint32_t act_l1_read_addr = split_reader_enabled ? get_read_ptr(cb_id_sharded_act) : 0;
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -165,59 +165,60 @@ void kernel_main() {
 
     // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
     // Write out col major blocks in row major layout to output
+    uint32_t reader_offset = 0;
     uint32_t weight_start_tile_id = out_start_tile_id_w;
     uint32_t l1_write_addr_act = split_reader_cb_write_addr;
     uint32_t prev_addr = 0;
     for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
         for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
-#ifdef SPLIT_READER
-            uint32_t reader_offset = act_l1_read_addr;
-#endif
+            if constexpr (split_reader_enabled) {
+                reader_offset = act_l1_read_addr;
+            }
             for (uint32_t height_block_index = 0; height_block_index < num_blocks_weight_h; height_block_index++) {
-#ifdef SPLIT_READER
-                reader_idx = start_reader_idx;
-                if constexpr (!split_reader_cb_shared) {
-                    cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
-                }
-                if (is_sender_core) {
-                    if constexpr (split_reader_cb_shared) {
-                        wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
-                        prev_addr = l1_write_addr_act;
-                    } else {
-                        l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                if constexpr (split_reader_enabled) {
+                    reader_idx = start_reader_idx;
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
                     }
-                    noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
-                    read_activation_data<
-                        sliced_inner_dim,
-                        dilation_w,
-                        coalesced_read_bytes,
-                        conv_act_c_read_bytes,
-                        act_block_w_extra_align_bytes,
-                        stride_w_bytes,
-                        weight_size_w,
-                        stride_w,
-                        weight_size_h,
-                        window_outer_offset>(
-                        packed_reader_indices_ptr,
-                        reader_offset,
-                        l1_write_addr_act,
-                        reader_idx,
-                        act_l1_read_addr,
-                        stride_h_bytes);
-                    if constexpr (split_reader_cb_shared) {
-                        // in case of shared cb we update the write address (it will remain the same if double buffering
-                        // is not enabled)
-                        l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
-                        signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                    if (is_sender_core) {
+                        if constexpr (split_reader_cb_shared) {
+                            wait_reserve_done(act_split_reader_reserve_done_semaphore_addr_ptr);
+                            prev_addr = l1_write_addr_act;
+                        } else {
+                            l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
+                        }
+                        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+                        read_activation_data<
+                            sliced_inner_dim,
+                            dilation_w,
+                            coalesced_read_bytes,
+                            conv_act_c_read_bytes,
+                            act_block_w_extra_align_bytes,
+                            stride_w_bytes,
+                            weight_size_w,
+                            stride_w,
+                            weight_size_h,
+                            window_outer_offset>(
+                            packed_reader_indices_ptr,
+                            reader_offset,
+                            l1_write_addr_act,
+                            reader_idx,
+                            act_l1_read_addr,
+                            stride_h_bytes);
+                        if constexpr (split_reader_cb_shared) {
+                            // in case of shared cb we update the write address (it will remain the same if double
+                            // buffering is not enabled)
+                            l1_write_addr_act = split_reader_cb_write_addr_sum - prev_addr;
+                            signal_write_done(act_split_reader_write_done_semaphore_addr_ptr);
+                        }
+                    }
+                    if constexpr (!split_reader_cb_shared) {
+                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
+                    }
+                    if (skip_work) {
+                        continue;
                     }
                 }
-                if constexpr (!split_reader_cb_shared) {
-                    cb_push_back(cb_id_act_second_reader, act_block_num_tiles_split_last);
-                }
-                if (skip_work) {
-                    continue;
-                }
-#endif
                 // Compute height block offset once per outer loop iteration
                 const uint32_t height_block_offset = height_block_index * height_stride_factor;
                 for (uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer;
@@ -281,13 +282,14 @@ void kernel_main() {
                     cb_push_back(cb_id_weight, weight_block_num_tiles);
                 }  // for weight_block_height_num_outer
             }
-#ifdef SPLIT_READER
-            // Update reader index for next iteration (split reader increment)
-            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
-            if (skip_work) {
-                continue;
+            if constexpr (split_reader_enabled) {
+                // Update reader index for next iteration (split reader increment)
+                start_reader_idx =
+                    reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+                if (skip_work) {
+                    continue;
+                }
             }
-#endif
             if constexpr (fuse_bias) {
                 if (load_bias) {
                     cb_reserve_back(bias_cb_id, bias_ntiles);


### PR DESCRIPTION
### Ticket
#30676

### What's changed
- Removed single reader conv 3.0 path - heuristic sets split reader to true if activation reuse is enabled ([done in this commit](https://github.com/tenstorrent/tt-metal/commit/18bbf94b848b1241b1f8ac25c64a2cf706267881)). Activation reuse makes sense only when we are im2col bound, so it makes sense to always use these two together.
- Replaced ifdefs with if constexpr blocks in compute and dm kernels

### Checklist

- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/18868547645
- [x] BPC: https://github.com/tenstorrent/tt-metal/actions/runs/18868553025
- [X] Nightly L2: https://github.com/tenstorrent/tt-metal/actions/runs/18847484623
- [X] Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/18847465313

To trigger later APC, BPC