### PR TITLE
#31137: [skip ci] TTNN stress test: bump timeout and skip ccl test

### DIFF
--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 70
       docker-image:
         required: true
         type: string
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Stress Tests
         timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/stress_tests/
+        run: pytest tests/ttnn/stress_tests/ --ignore=tests/ttnn/stress_tests/test_ccl.py
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31137

### Problem description
TTNN stress tests timing out on BH llmbox and loudbox

### What's changed
Increase timeout and skip ccl tests (already covered by nightly multi-pcie unit tests) while investigating.

### Checklist
- [ ] BH nightly (stress tests only) https://github.com/tenstorrent/tt-metal/actions/runs/18784485704