### PR TITLE
MM Fused Activation - Add Hardsigmoid and Mish Support, Clean GELU

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -172,13 +172,15 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
 @pytest.mark.parametrize("k_size", [1024])
 @pytest.mark.parametrize("n_size", [1024])
 @pytest.mark.parametrize(
-    "activation", [None, "relu", "relu6", "silu", "gelu", "gelu_approx", "sigmoid", "sigmoid_approx"]
+    "activation",
+    [None, "relu", "relu6", "silu", "gelu", "gelu_approx", "sigmoid", "sigmoid_approx", "hardsigmoid", "mish"],
 )
 def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_size, activation):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.randn((k_size, n_size), dtype=torch.bfloat16)
+
     torch_output_tensor = torch_input_tensor_a @ torch_input_tensor_b
     if activation == "relu":
         torch_output_tensor = torch.relu(torch_output_tensor)
@@ -190,6 +192,10 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
         torch_output_tensor = torch.nn.functional.gelu(torch_output_tensor)
     elif activation in ["sigmoid", "sigmoid_approx"]:
         torch_output_tensor = torch.nn.functional.sigmoid(torch_output_tensor)
+    elif activation == "hardsigmoid":
+        torch_output_tensor = torch.nn.functional.hardsigmoid(torch_output_tensor)
+    elif activation == "mish":
+        torch_output_tensor = torch.nn.functional.mish(torch_output_tensor)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -843,6 +843,8 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::SIGMOID, {static_cast<float>(VecMode::RC), static_cast<float>(false)});
     } else if (name == "sigmoid_approx") {
         return UnaryWithParam(UnaryOpType::SIGMOID, {static_cast<float>(VecMode::RC), static_cast<float>(true)});
+    } else if (name == "hardsigmoid") {
+        return UnaryWithParam(UnaryOpType::HARDSIGMOID);
     } else if (name == "sqrt") {
         return UnaryWithParam(UnaryOpType::SQRT);
     } else if (name == "rsqrt") {
@@ -885,6 +887,8 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::ALT_COMPLEX_ROTATE90);
     } else if (name == "hardmish") {
         return UnaryWithParam(UnaryOpType::HARDMISH, static_cast<float>(true));
+    } else if (name == "mish") {
+        return UnaryWithParam(UnaryOpType::MISH);
     }
     TT_THROW("Unknown unary op: {}", name);
 }
@@ -904,7 +908,9 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
                 return "sigmoid_approx";
             }
             return "sigmoid";
+        case UnaryOpType::HARDSIGMOID: return "hardsigmoid";
         case UnaryOpType::SQRT: return "sqrt";
+        case UnaryOpType::RSQRT: return "rsqrt";
         case UnaryOpType::EXP: return "exp";
         case UnaryOpType::RECIP: return "recip";
         case UnaryOpType::LOG: return "log";
@@ -914,12 +920,16 @@ std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
         case UnaryOpType::LOG10: return "log10";
         case UnaryOpType::SIN: return "sin";
         case UnaryOpType::COS: return "cos";
+        case UnaryOpType::COSH: return "cosh";
+        case UnaryOpType::SINH: return "sinh";
         case UnaryOpType::ABS: return "abs";
         case UnaryOpType::ABS_INT32: return "abs_int32";
         case UnaryOpType::SIGN: return "sign";
         case UnaryOpType::SQUARE: return "square";
         case UnaryOpType::SOFTPLUS: return "softplus";
+        case UnaryOpType::SELU: return "selu";
         case UnaryOpType::ALT_COMPLEX_ROTATE90: return "alt_complex_rotate90";
+        case UnaryOpType::MISH: return "mish";
         case UnaryOpType::HARDMISH: return "hardmish";
         default: TT_THROW("Unsupported unary op type: {}", static_cast<int>(unary_op.op_type));
     }

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -156,12 +156,7 @@ ttnn::Tensor bound_matmul(
     }
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
-        const UnaryOpType& op_type = parameters.user_fused_activation.value().op_type;
-
-        // Gelu must have approximation disabled for model accuracy. Other activations are run as-is.
-        auto activation = (op_type == UnaryOpType::GELU)
-                              ? ttnn::operations::unary::EltwiseUnaryWithParam{op_type, static_cast<float>(false)}
-                              : ttnn::operations::unary::EltwiseUnaryWithParam{op_type};
+        const ttnn::operations::unary::EltwiseUnaryWithParam activation = parameters.user_fused_activation.value();
 
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
             output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -156,7 +156,7 @@ ttnn::Tensor bound_matmul(
     }
 
     if (parameters.user_fused_activation.has_value() && !has_user_grid) {
-        const ttnn::operations::unary::EltwiseUnaryWithParam activation = parameters.user_fused_activation.value();
+        const UnaryWithParam& activation = parameters.user_fused_activation.value();
 
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
             output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -169,6 +169,8 @@ def get_torch_act_func_from_string(activation):
         ttnn.UnaryOpType.SILU: torch.nn.functional.silu,
         ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
         ttnn.UnaryOpType.SIGMOID: torch.nn.functional.sigmoid,
+        ttnn.UnaryOpType.HARDSIGMOID: torch.nn.functional.hardsigmoid,
+        ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
         ttnn.UnaryOpType.TANH: torch.nn.functional.tanh,
         ttnn.UnaryOpType.LOG: torch.log,
         ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -170,7 +170,6 @@ def get_torch_act_func_from_string(activation):
         ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
         ttnn.UnaryOpType.SIGMOID: torch.nn.functional.sigmoid,
         ttnn.UnaryOpType.HARDSIGMOID: torch.nn.functional.hardsigmoid,
-        ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
         ttnn.UnaryOpType.TANH: torch.nn.functional.tanh,
         ttnn.UnaryOpType.LOG: torch.log,
         ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -31,6 +31,8 @@ def _get_golden_activation_function(activation):
         ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,
         ttnn.UnaryOpType.GELU: torch.nn.functional.gelu,
         ttnn.UnaryOpType.SQRT: torch.sqrt,
+        ttnn.UnaryOpType.HARDSIGMOID: torch.nn.functional.hardsigmoid,
+        ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
     }
 
     if activation in golden_activations_map:

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -26,13 +26,12 @@ def _get_golden_activation_function(activation):
         ttnn.UnaryOpType.SILU: torch.nn.functional.silu,
         ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
         ttnn.UnaryOpType.SIGMOID: torch.nn.functional.sigmoid,
+        ttnn.UnaryOpType.HARDSIGMOID: torch.nn.functional.hardsigmoid,
         ttnn.UnaryOpType.TANH: torch.nn.functional.tanh,
         ttnn.UnaryOpType.LOG: torch.log,
         ttnn.UnaryOpType.SOFTPLUS: torch.nn.functional.softplus,
         ttnn.UnaryOpType.GELU: torch.nn.functional.gelu,
         ttnn.UnaryOpType.SQRT: torch.sqrt,
-        ttnn.UnaryOpType.HARDSIGMOID: torch.nn.functional.hardsigmoid,
-        ttnn.UnaryOpType.MISH: torch.nn.functional.mish,
     }
 
     if activation in golden_activations_map:


### PR DESCRIPTION
### Ticket
#30973 

### Problem description
1. Vovnet needs to fuse conv and hardsigmoid. For convs that get lowered to MM, this causes an issue as hardsigmoid is not supported.

2. In https://github.com/tenstorrent/tt-metal/pull/30207, compound op GELU was forced to always be non-approx. Now that https://github.com/tenstorrent/tt-metal/pull/29322 is merged so that non-approx is the default "gelu", we can clean this up and rely on the parameters provided for the fused activation.

### What's changed
Added hardsigmoid support to the string/Unary conversions. Also added mish together with this change, since it will be needed for future MLIR dialect work.

Added some other missing activations that were in `string_to_unary_with_param` but missing in `unary_with_param_to_string` so they have parity.

Added hardsigmoid and mish to a fused linear test.

Remove non-approx GELU hacks and use the actual parameters.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18946999447)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18947005362)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18954388231) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18947012809)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [matches](https://github.com/tenstorrent/tt-metal/actions/runs/18973340412) main with [Yolov11 timeout](https://github.com/tenstorrent/tt-metal/actions/runs/18950638525/job/54115701278)
- [x] New/Existing tests provide coverage for changes
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18954092785)
- [x] Frequent Model & TTNN [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18947411539)