### PR TITLE
[skip ci] Realize the truth: there is no wandcpp

### DIFF
--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -85,7 +85,6 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 45
         run: |
-          cp ./build/tt-train/3rd_party/wandb-cpp/libwandbcpp.so build/lib/
           cd /work/build/tt-train
           mkdir -p generated/test_reports
           ldd tests/ttml_tests || true

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -74,7 +74,6 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          cp ./build/tt-train/3rd_party/wandb-cpp/libwandbcpp.so build/lib/
           cd /work/build/tt-train
           mkdir -p generated/test_reports
           ldd tests/ttml_tests || true


### PR DESCRIPTION
### Ticket
N/A

### Problem description
APC is broken.  A dep was removed, but the YAML didn't get the memo.

### What's changed
Do not copy that which does not exist.