### PR TITLE
Remove gp references in lite fabric

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -277,6 +277,7 @@ foreach(ARCH IN LISTS ARCHS)
         "tdma_xmov.o:tt_metal/hw/firmware/src/tt-1xx/tdma_xmov.c"
         "noc.o:tt_metal/hw/firmware/src/${HW_VERSION_PATH}/${ARCH}/noc.c"
         "tmu-crt0.o:tt_metal/hw/toolchain/tmu-crt0.S"
+        "tmu-crt0-no-gp.o:tt_metal/hw/toolchain/tmu-crt0-no-gp.S"
     )
     set(ARCH_ALIAS ${ARCH})
 

--- a/tt_metal/hw/toolchain/tmu-crt0-no-gp.S
+++ b/tt_metal/hw/toolchain/tmu-crt0-no-gp.S
@@ -1,0 +1,31 @@
+.section .start,"ax",@progbits
+.global _start
+.type   _start, @function
+
+_start:
+	// set stack pointer, reserve 16 bytes for main's arguments
+	lui	sp, %hi(__stack_top - 16)
+	addi	sp, sp, %lo(__stack_top - 16)
+
+	// main is responsible for the rest of crt -- clear bss, copy data image, run global constructors
+
+  /* Pass in the tensix coordinates as argv[0][0] through argv[0][3].
+     argc = 1, envp = NULL. In memory, we'll have
+   * sp+0: argv[0] -> sp+8
+   * sp+4: argv[1] = NULL
+   * sp+8: s1
+   * sp+c: 0
+   */
+  addi    a0, sp, 8
+  sw      a0, 0(sp) // argv[0]
+  sw      zero, 4(sp) // argv[1]
+  sw      s1, 8(sp) // argv[0][0..3]
+  sw      zero, 12(sp) // argv[0][4..7]
+
+  li      a0, 1 // argc = 1
+  mv      a1, sp // argv
+  mv      a2, zero // env
+
+  call    main
+  tail    exit
+  .size  _start, .-_start

--- a/tt_metal/lite_fabric/build.cpp
+++ b/tt_metal/lite_fabric/build.cpp
@@ -181,7 +181,7 @@ int LinkFabricLite(
     link_oss << fmt::format("-T{} ", output_ld.string());  // Use preprocessed linker script
     link_oss << fmt::format("-Wl,-Map={}/lite_fabric.map ", out_dir.string());
     link_oss << fmt::format("-save-temps {}/lite_fabric.o ", out_dir.string());
-    link_oss << fmt::format("{}/runtime/hw/lib/blackhole/tmu-crt0.o ", root_dir.string());     // FIXME: hardcoded path
+    link_oss << fmt::format("{}/runtime/hw/lib/blackhole/tmu-crt0-no-gp.o ", root_dir.string());     // FIXME: hardcoded path
     link_oss << fmt::format("{}/runtime/hw/lib/blackhole/substitutes.o ", root_dir.string());  // FIXME: hardcoded path
     link_oss << fmt::format("-o {}", elf_out.string());
 

--- a/tt_metal/lite_fabric/toolchain/lite_fabric.ld
+++ b/tt_metal/lite_fabric/toolchain/lite_fabric.ld
@@ -46,9 +46,6 @@ SECTIONS
     . = ALIGN(ABSOLUTE(.) + 0, 16);
     __fw_export_text_end = ABSOLUTE(.);
 
-    /* Set up global pointer for efficient access to data */
-    PROVIDE(__global_pointer$ = LITE_FABRIC_DATA_START + 0x7f0);
-
     /* Data section starts at local memory base */
     .data LITE_FABRIC_DATA_START :
     {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Don't want to setup gp for lite fabric
- This can overwrite the gp of the existing program if we just want to launch lite fabric

### What's changed
- Added a tmu-crt0-no-gp.S which allows lite fabric to init without references to the global pointer

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/18850655448