### PR TITLE
[skip ci] Bind find-changed-files action to a specific version to avoid rollout hazard

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -15,7 +15,7 @@ jobs:
       docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
     steps:
       - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
   pre-commit:
     name: Run Pre-commit Hooks
     runs-on: ubuntu-latest
@@ -190,7 +190,7 @@ jobs:
         submodules: recursive
     - name: Look for changed CMake files
       id: find-changes
-      uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+      uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
     - uses: lukka/get-cmake@b516803a3c5fac40e2e922349d15cdebdba01e60
       if: steps.find-changes.outputs.cmake-changed == 'true'
       with:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -40,7 +40,7 @@ jobs:
       do-scan: ${{ steps.compute-outputs.outputs.do-scan }}
     steps:
       - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
       - id: compute-outputs
         shell: bash

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -92,7 +92,7 @@ jobs:
       tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
     steps:
       - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -93,7 +93,7 @@ jobs:
       model-charts-changed: ${{ steps.find-changes.outputs.model-charts-changed }}
     steps:
       - id: find-changes
-        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   metalium-smoke-tests:
     needs: [ asan-build, find-changed-files ]


### PR DESCRIPTION
### Ticket
NA

### Problem description
- We have learned that it is not good practice to bind our actions to main
- Doing so, risks changing the action during a running workflow

### What's changed
- Bind current usages of find-changed-files to our most recent release tag.