### PR TITLE
[skip ci] set correct env

### DIFF
--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -30,6 +30,7 @@ jobs:
     # tt-train in N300 is timing out on CIv2-viommu: https://github.com/tenstorrent/tt-metal/issues/29443
     runs-on: >-
       tt-ubuntu-2204-N150-stable
+    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: harbor.ci.tenstorrent.net/${{ needs.build-artifact.outputs.dev-docker-image || 'docker-image-unresolved!' }}
       env:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Missed a crucial detail for my test.

### What's changed
Set the env to pick up the right secrets for RW to redis