### PR TITLE
Remove CommandQueue::enqueue_program

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -55,8 +55,6 @@ public:
     // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
 
-    virtual void enqueue_program(Program& program, bool blocking) = 0;
-
     virtual void enqueue_read_buffer(
         const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         void* dst,

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -30,7 +30,6 @@
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include <tt-logger/tt-logger.hpp>
-// #include "program/program_device_map.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "trace/trace_node.hpp"
@@ -405,8 +404,6 @@ void HWCommandQueue::enqueue_write_to_core(
         this->finish(sub_device_ids);
     }
 }
-
-// Removed: HWCommandQueue::enqueue_program
 
 void HWCommandQueue::enqueue_record_event(
     const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids) {

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -88,7 +88,6 @@ HWCommandQueue::HWCommandQueue(
     num_entries_in_completion_q_(0),
     num_completed_completion_q_reads_(0),
     device_(device),
-    noc_index_(noc_index),
     prefetcher_dram_aligned_block_size_(MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
     prefetcher_cache_sizeB_(
         MetalContext::instance().dispatch_mem_map(this->get_dispatch_core_type()).ringbuffer_size()),

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -15,8 +15,6 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <algorithm>
-#include <array>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -32,7 +30,7 @@
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "program/program_device_map.hpp"
+// #include "program/program_device_map.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "trace/trace_node.hpp"
@@ -408,152 +406,7 @@ void HWCommandQueue::enqueue_write_to_core(
     }
 }
 
-void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
-    ZoneScopedN("HWCommandQueue_enqueue_program");
-    std::vector<SubDeviceId> sub_device_ids = {program.impl().determine_sub_device_ids(device_)};
-    TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
-
-    if (!this->manager_.get_bypass_mode()) {
-        auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
-        auto& sub_device = sub_device_cq_owner[*sub_device_ids[0]];
-        sub_device.take_ownership(sub_device_ids[0], this->id_);
-    }
-
-    // Finalize Program: Compute relative offsets for data structures (semaphores, kernel binaries, etc) in L1
-    program.impl().finalize_offsets(device_);
-
-    if (program.impl().get_program_binary_status(device_->id()) == ProgramBinaryStatus::NotSent) {
-        // Write program binaries to device if it hasn't previously been cached
-        program.impl().allocate_kernel_bin_buf_on_device(device_);
-        if (!program.impl().get_program_transfer_info().binary_data.empty()) {
-            const BufferRegion buffer_region(0, program.impl().get_kernels_buffer(device_)->size());
-            this->enqueue_write_buffer(
-                *program.impl().get_kernels_buffer(device_),
-                program.impl().get_program_transfer_info().binary_data.data(),
-                buffer_region,
-                false);
-        }
-        program.impl().set_program_binary_status(device_->id(), ProgramBinaryStatus::InFlight);
-    }
-
-    // Lower the program to device: Generate dispatch commands.
-    // Values in these commands will get updated based on kernel config ring
-    // buffer state at runtime.
-    auto program_sizeB = program.impl().kernel_bins_sizeB;
-    bool use_prefetcher_cache = program_sizeB and program_sizeB <= this->prefetcher_cache_sizeB_;
-    program.impl().generate_dispatch_commands(device_, use_prefetcher_cache);
-    program.impl().set_last_used_command_queue_for_testing(this);
-
-    if (this->manager_.get_bypass_mode()) {
-        this->trace_nodes_.push_back(
-            program_dispatch::create_trace_node(program.impl(), device_, use_prefetcher_cache));
-        return;
-    }
-
-    const auto sub_device_id = sub_device_ids[0];
-    const auto sub_device_index = *sub_device_id;
-
-    uint32_t num_additional_workers = 0;
-    if (program.impl().runs_on_noc_multicast_only_cores()) {
-        num_additional_workers +=
-            calculate_expected_workers_to_finish(device_, sub_device_id, HalProgrammableCoreType::TENSIX);
-    }
-    if (program.impl().runs_on_noc_unicast_only_cores()) {
-        num_additional_workers +=
-            calculate_expected_workers_to_finish(device_, sub_device_id, HalProgrammableCoreType::ACTIVE_ETH);
-    }
-
-    // Expected number of workers from the previous run. Used to generate the wait command in the EnqueueProgramCommand
-    const auto updated_worker_counts = program_dispatch::get_expected_num_workers_completed_updates(
-        expected_num_workers_completed_[sub_device_index], num_additional_workers);
-    if (updated_worker_counts.wrapped) {
-        program_dispatch::reset_expected_num_workers_completed_on_device(
-            device_, sub_device_id, expected_num_workers_completed_[sub_device_index], id());
-        get_config_buffer_mgr(*sub_device_id).mark_completely_full(0);
-    }
-    uint32_t expected_workers_completed = updated_worker_counts.previous;
-    expected_num_workers_completed_[sub_device_index] = updated_worker_counts.current;
-
-#ifdef DEBUG
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
-        TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
-        if (const auto buffer = program.impl().get_kernels_buffer(device_)) {
-            std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
-            const BufferRegion region(0, buffer->size());
-            this->enqueue_read_buffer(*buffer, read_data.data(), region, true);
-            TT_FATAL(
-                program.impl().get_program_transfer_info().binary_data == read_data,
-                "Binary for program to be executed is corrupted. Another program likely corrupted this binary");
-        }
-    }
-#endif
-
-    auto& worker_launch_message_buffer_state =
-        this->cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id];
-
-    // Dispatch metadata contains runtime information based on
-    // the kernel config ring buffer state
-    program_dispatch::ProgramDispatchMetadata dispatch_metadata;
-    if (use_prefetcher_cache) {
-        bool& is_cached = dispatch_metadata.prefetcher_cache_info.is_cached;
-        uint32_t& cache_offset = dispatch_metadata.prefetcher_cache_info.offset;
-        std::tie(is_cached, cache_offset) = this->query_prefetcher_cache(program.impl().get_id(), program_sizeB);
-        TT_ASSERT(
-            cache_offset + program_sizeB <= this->prefetcher_cache_sizeB_,
-            "Prefetcher cache overflow: offset: {}, program size: {}, cache size: {}",
-            cache_offset,
-            program_sizeB,
-            this->prefetcher_cache_sizeB_);
-        dispatch_metadata.prefetcher_cache_info.mesh_max_program_kernels_sizeB = program_sizeB;
-    } else {
-        // prefetcher cache will be overwritten, reset for next program
-        this->reset_prefetcher_cache_manager();
-    }
-
-    auto command = EnqueueProgramCommand(
-        this->id_,
-        this->device_,
-        this->noc_index_,
-        program,
-        this->virtual_enqueue_program_dispatch_core_,
-        this->manager_,
-        this->get_config_buffer_mgr(sub_device_index),
-        expected_workers_completed,
-        // The assembled program command will encode the location of the launch messages in the ring buffer
-        worker_launch_message_buffer_state.get_mcast_wptr(),
-        worker_launch_message_buffer_state.get_unicast_wptr(),
-        sub_device_id,
-        dispatch_metadata);
-    // Update wptrs for tensix and eth launch message in the device class
-    if (program.impl().runs_on_noc_multicast_only_cores()) {
-        worker_launch_message_buffer_state.inc_mcast_wptr(1);
-    }
-    if (program.impl().runs_on_noc_unicast_only_cores()) {
-        worker_launch_message_buffer_state.inc_unicast_wptr(1);
-    }
-    this->enqueue_command(command, blocking, sub_device_ids);
-
-#ifdef DEBUG
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
-        TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
-        if (const auto buffer = program.impl().get_kernels_buffer(device_)) {
-            std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
-            const BufferRegion region(0, buffer->size());
-            this->enqueue_read_buffer(*buffer, read_data.data(), region, true);
-            TT_FATAL(
-                program.impl().get_program_transfer_info().binary_data == read_data,
-                "Binary for program that executed is corrupted. This program likely corrupted its own binary.");
-        }
-    }
-#endif
-
-    log_trace(
-        tt::LogMetal,
-        "Created EnqueueProgramCommand (active_cores: {} bypass_mode: {} expected_workers_completed: {})",
-        program.impl().get_program_transfer_info().num_active_cores,
-        this->manager_.get_bypass_mode(),
-        expected_workers_completed);
-}
+// Removed: HWCommandQueue::enqueue_program
 
 void HWCommandQueue::enqueue_record_event(
     const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids) {

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -162,7 +162,6 @@ private:
 
     CoreCoord virtual_enqueue_program_dispatch_core_;
     CoreCoord completion_queue_writer_core_;
-    NOC noc_index_;
 
     const uint32_t prefetcher_dram_aligned_block_size_;
     const uint64_t prefetcher_cache_sizeB_;

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -79,8 +79,6 @@ public:
 
     // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
-
-    void enqueue_program(Program& program, bool blocking) override;
     void enqueue_read_buffer(
         const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         void* dst,

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -10,17 +10,8 @@
 #include <host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
-#include <chrono>
-#include <fstream>
 #include <functional>
 #include <memory>
-#include <string>
-#include <thread>
-#include <type_traits>
-#include <unordered_map>
-#include <utility>
-#include <variant>
-#include <vector>
 
 #include "command_queue.hpp"
 #include "device.hpp"
@@ -32,11 +23,9 @@
 #include <tt_stl/span.hpp>
 #include <tt_stl/overloaded.hpp>
 #include "system_memory_manager.hpp"
-#include "tracy/Tracy.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
-#include "tt_metal/impl/program/program_command_sequence.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -80,80 +69,6 @@ void ValidateBufferRegion(
 
 inline uint32_t get_packed_write_max_unicast_sub_cmds(IDevice* device) {
     return device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
-}
-
-EnqueueProgramCommand::EnqueueProgramCommand(
-    uint32_t command_queue_id,
-    IDevice* device,
-    NOC noc_index,
-    Program& program,
-    CoreCoord& dispatch_core,
-    SystemMemoryManager& manager,
-    WorkerConfigBufferMgr& config_buffer_mgr,
-    uint32_t expected_num_workers_completed,
-    uint32_t multicast_cores_launch_message_wptr,
-    uint32_t unicast_cores_launch_message_wptr,
-    SubDeviceId sub_device_id,
-    program_dispatch::ProgramDispatchMetadata& dispatch_md) :
-    command_queue_id(command_queue_id),
-    device(device),
-    program(program),
-    manager(manager),
-    config_buffer_mgr(config_buffer_mgr),
-    dispatch_core(dispatch_core),
-    dispatch_core_type(MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type()),
-    expected_num_workers_completed(expected_num_workers_completed),
-    packed_write_max_unicast_sub_cmds(get_packed_write_max_unicast_sub_cmds(this->device)),
-    multicast_cores_launch_message_wptr(multicast_cores_launch_message_wptr),
-    unicast_cores_launch_message_wptr(unicast_cores_launch_message_wptr),
-    sub_device_id(sub_device_id),
-    dispatch_metadata(dispatch_md) {}
-
-void EnqueueProgramCommand::process() {
-    // Compute the total number of workers this program uses
-    uint32_t num_workers = 0;
-    if (program.impl().runs_on_noc_multicast_only_cores()) {
-        num_workers += calculate_expected_workers_to_finish(device, sub_device_id, HalProgrammableCoreType::TENSIX);
-    }
-    if (program.impl().runs_on_noc_unicast_only_cores()) {
-        num_workers += calculate_expected_workers_to_finish(device, sub_device_id, HalProgrammableCoreType::ACTIVE_ETH);
-    }
-    // Reserve space for this program in the kernel config ring buffer
-    program_dispatch::reserve_space_in_kernel_config_buffer(
-        this->config_buffer_mgr,
-        program.impl().get_program_config_sizes(),
-        program.impl().get_program_binary_status(device->id()),
-        num_workers,
-        this->expected_num_workers_completed,
-        dispatch_metadata);
-
-    RecordProgramRun(program.impl().get_id());
-
-    // Access the program dispatch-command cache
-    uint64_t command_hash = *device->get_active_sub_device_manager_id();
-    auto& cached_program_command_sequence = program.impl().get_cached_program_command_sequences().at(command_hash);
-    // Update the generated dispatch commands based on the state of the CQ and the ring buffer
-    program_dispatch::update_program_dispatch_commands(
-        program.impl(),
-        cached_program_command_sequence,
-        this->multicast_cores_launch_message_wptr,
-        this->unicast_cores_launch_message_wptr,
-        this->expected_num_workers_completed,
-        this->dispatch_core,
-        this->dispatch_core_type,
-        this->sub_device_id,
-        dispatch_metadata,
-        program.impl().get_program_binary_status(device->id()));
-    // Issue dispatch commands for this program
-    program_dispatch::write_program_command_sequence(
-        cached_program_command_sequence,
-        this->manager,
-        this->command_queue_id,
-        this->dispatch_core_type,
-        dispatch_metadata.stall_first,
-        dispatch_metadata.stall_before_program);
-    // Kernel Binaries are committed to DRAM, the first time the program runs on device. Reflect this on host.
-    program.impl().set_program_binary_status(device->id(), ProgramBinaryStatus::Committed);
 }
 
 EnqueueTerminateCommand::EnqueueTerminateCommand(
@@ -233,7 +148,6 @@ std::ostream& operator<<(std::ostream& os, const EnqueueCommandType& type) {
     switch (type) {
         case EnqueueCommandType::ENQUEUE_READ_BUFFER: os << "ENQUEUE_READ_BUFFER"; break;
         case EnqueueCommandType::ENQUEUE_WRITE_BUFFER: os << "ENQUEUE_WRITE_BUFFER"; break;
-        case EnqueueCommandType::ENQUEUE_PROGRAM: os << "ENQUEUE_PROGRAM"; break;
         case EnqueueCommandType::ENQUEUE_RECORD_EVENT: os << "ENQUEUE_RECORD_EVENT"; break;
         case EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT: os << "ENQUEUE_WAIT_FOR_EVENT"; break;
         case EnqueueCommandType::FINISH: os << "FINISH"; break;

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -27,13 +27,6 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 
-namespace tt {
-namespace tt_metal {
-class WorkerConfigBufferMgr;
-enum NOC : uint8_t;
-}  // namespace tt_metal
-}  // namespace tt
-
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -5,26 +5,11 @@
 #pragma once
 
 #include <stdint.h>
-#include <algorithm>
-#include <chrono>
-#include <condition_variable>
-#include <fstream>
-#include <memory>
-#include <span>
-#include <thread>
-#include <utility>
-#include <vector>
+// pruned unused includes
 
-#include "core_coord.hpp"
-#include "device_command.hpp"
-#include "env_lib.hpp"
-#include "multi_producer_single_consumer_queue.hpp"
-#include "dispatch_settings.hpp"
+// pruned unused includes
 #include "tt-metalium/program.hpp"
-#include "sub_device_types.hpp"
-#include "trace/trace_buffer.hpp"
-#include "tt_metal/impl/program/program_command_sequence.hpp"
-#include "worker_config_buffer.hpp"
+// pruned unused includes
 #include "program/dispatch.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>
@@ -52,7 +37,6 @@ enum class EnqueueCommandType {
     GET_BUF_ADDR,
     ADD_BUFFER_TO_PROGRAM,
     SET_RUNTIME_ARGS,
-    ENQUEUE_PROGRAM,
     ENQUEUE_RECORD_EVENT,
     ENQUEUE_WAIT_FOR_EVENT,
     FINISH,
@@ -67,45 +51,6 @@ public:
     virtual ~Command() = default;
     virtual void process() {};
     virtual EnqueueCommandType type() = 0;
-};
-
-class EnqueueProgramCommand : public Command {
-private:
-    uint32_t command_queue_id;
-    IDevice* device;
-    Program& program;
-    SystemMemoryManager& manager;
-    WorkerConfigBufferMgr& config_buffer_mgr;
-    CoreCoord dispatch_core;
-    CoreType dispatch_core_type;
-    uint32_t expected_num_workers_completed;
-    uint32_t packed_write_max_unicast_sub_cmds;
-    uint32_t multicast_cores_launch_message_wptr = 0;
-    uint32_t unicast_cores_launch_message_wptr = 0;
-    // TODO: There will be multiple ids once programs support spanning multiple sub_devices
-    SubDeviceId sub_device_id = SubDeviceId{0};
-    program_dispatch::ProgramDispatchMetadata& dispatch_metadata;
-
-public:
-    EnqueueProgramCommand(
-        uint32_t command_queue_id,
-        IDevice* device,
-        NOC noc_index,
-        Program& program,
-        CoreCoord& dispatch_core,
-        SystemMemoryManager& manager,
-        WorkerConfigBufferMgr& config_buffer_mgr,
-        uint32_t expected_num_workers_completed,
-        uint32_t multicast_cores_launch_message_wptr,
-        uint32_t unicast_cores_launch_message_wptr,
-        SubDeviceId sub_device_id,
-        program_dispatch::ProgramDispatchMetadata& dispatch_md);
-
-    void process() override;
-
-    EnqueueCommandType type() override { return EnqueueCommandType::ENQUEUE_PROGRAM; }
-
-    constexpr bool has_side_effects() { return true; }
 };
 
 class EnqueueTerminateCommand : public Command {

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -5,22 +5,15 @@
 #pragma once
 
 #include <stdint.h>
-// pruned unused includes
 
-// pruned unused includes
 #include "tt-metalium/program.hpp"
-// pruned unused includes
-#include "program/dispatch.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt {
 namespace tt_metal {
 class IDevice;
-class Program;
 class SystemMemoryManager;
-class WorkerConfigBufferMgr;
-enum NOC : uint8_t;
 }  // namespace tt_metal
 }  // namespace tt
 

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -73,11 +73,7 @@ table ProgramConstructorCommand {
   global_id: uint32;
 }
 
-table EnqueueProgramCommand {
-  cq_global_id: uint32;       // reference to CommandQueue
-  program_global_id: uint32;  // Reference to Program
-  blocking: bool;
-}
+// Removed: EnqueueProgramCommand
 
 table CreateKernelCommand {
   global_id: uint32;          // Reference to Kernel
@@ -133,7 +129,6 @@ union CommandType {
   EnqueueReadBufferCommand,
   FinishCommand,
   ProgramConstructorCommand,
-  EnqueueProgramCommand,
   CreateKernelCommand,
   SetRuntimeArgsUint32Command,
   SetRuntimeArgsUint32VecPerCoreCommand,

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -73,8 +73,6 @@ table ProgramConstructorCommand {
   global_id: uint32;
 }
 
-// Removed: EnqueueProgramCommand
-
 table CreateKernelCommand {
   global_id: uint32;          // Reference to Kernel
   program_global_id: uint32;  // Reference to Program

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -7,13 +7,13 @@
 #include "impl/dispatch/command_queue.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program.hpp>
-#include "dispatch/system_memory_manager.hpp"
+// #include "dispatch/system_memory_manager.hpp"
 
 #include <kernel_types.hpp>
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include "command_generated.h"
 #include "lightmetal/lightmetal_capture.hpp"
-#include "flatbuffer/base_types_to_flatbuffer.hpp"
+// #include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
 
@@ -286,23 +286,7 @@ void CaptureProgramConstructor(Program& program) {
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::ProgramConstructorCommand, cmd.Union());
 }
 
-void CaptureEnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
-    auto& ctx = LightMetalCaptureContext::get();
-
-    // When Metal Trace is enabled, skip EnqueueProgram capture (replaced with LoadTrace + ReplayTrace)
-    if (cq.sysmem_manager().get_bypass_mode()) {
-        return;
-    }
-
-    uint32_t cq_global_id = cq.id();  // TODO (kmabee) - consider storing/getting CQ from global map instead.
-    uint32_t program_global_id = ctx.get_global_id(&program);
-    log_debug(
-        tt::LogMetalTrace, "{}: cq_global_id: {} program_global_id: {}", __FUNCTION__, cq_global_id, program_global_id);
-
-    auto cmd = tt::tt_metal::flatbuffer::CreateEnqueueProgramCommand(
-        ctx.get_builder(), cq_global_id, program_global_id, blocking);
-    CaptureCommand(tt::tt_metal::flatbuffer::CommandType::EnqueueProgramCommand, cmd.Union());
-}
+// Removed: CaptureEnqueueProgram
 
 void CaptureCreateKernel(
     KernelHandle kernel_id,

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -7,13 +7,11 @@
 #include "impl/dispatch/command_queue.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program.hpp>
-// #include "dispatch/system_memory_manager.hpp"
 
 #include <kernel_types.hpp>
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include "command_generated.h"
 #include "lightmetal/lightmetal_capture.hpp"
-// #include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
 
@@ -285,8 +283,6 @@ void CaptureProgramConstructor(Program& program) {
     auto cmd = tt::tt_metal::flatbuffer::CreateProgramConstructorCommand(ctx.get_builder(), program_global_id);
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::ProgramConstructorCommand, cmd.Union());
 }
-
-// Removed: CaptureEnqueueProgram
 
 void CaptureCreateKernel(
     KernelHandle kernel_id,

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-// #include "flatbuffers/flatbuffers.h"
 #include "lightmetal/lightmetal_capture.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "flatbuffers/flatbuffers.h"
+// #include "flatbuffers/flatbuffers.h"
 #include "lightmetal/lightmetal_capture.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
@@ -105,7 +105,6 @@ void CaptureEnqueueReadBuffer(
 
 void CaptureFinish(CommandQueue& cq, tt::stl::Span<const SubDeviceId> sub_device_ids);
 void CaptureProgramConstructor(Program& program);
-void CaptureEnqueueProgram(CommandQueue& cq, Program& program, bool blocking);
 
 void CaptureCreateKernel(
     KernelHandle kernel_id,

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -15,7 +15,7 @@
 #include "trace/trace_buffer.hpp"
 #include "impl/dispatch/command_queue.hpp"
 #include <tt-metalium/device.hpp>
-#include "flatbuffer/base_types_from_flatbuffer.hpp"
+// #include "flatbuffer/base_types_from_flatbuffer.hpp"
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
 
@@ -333,10 +333,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
             execute(command->cmd_as_ProgramConstructorCommand());
             break;
         }
-        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueProgramCommand: {
-            execute(command->cmd_as_EnqueueProgramCommand());
-            break;
-        }
+        // Removed: EnqueueProgramCommand
         case ::tt::tt_metal::flatbuffer::CommandType::CreateKernelCommand: {
             execute(command->cmd_as_CreateKernelCommand());
             break;
@@ -530,24 +527,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::ProgramConstr
     add_program_to_map(cmd->global_id(), std::make_shared<Program>());
 }
 
-void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::EnqueueProgramCommand* cmd) {
-    auto program = get_program_from_map(cmd->program_global_id());
-    TT_FATAL(
-        program,
-        "Attempted to EnqueueProgram() program w/ global_id: {} that was not previously created.",
-        cmd->program_global_id());
-
-    log_debug(
-        tt::LogMetalTrace,
-        "LightMetalReplay(EnqueueProgram) program_global_id: {} cq_global_id: {}",
-        cmd->program_global_id(),
-        cmd->cq_global_id());
-
-    // TODO (kmabee) - consider storing/getting CQ from global map instead.
-    // CommandQueue& cq = this->device_->command_queue(cmd->cq_global_id());
-    // Issue #24955: Enable after Light-Metal rearchitecture
-    // EnqueueProgram(cq, *program, cmd->blocking());
-}
+// Removed: execute(EnqueueProgramCommand)
 
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* cmd) {
     log_debug(

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -15,7 +15,6 @@
 #include "trace/trace_buffer.hpp"
 #include "impl/dispatch/command_queue.hpp"
 #include <tt-metalium/device.hpp>
-// #include "flatbuffer/base_types_from_flatbuffer.hpp"
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
 
@@ -333,7 +332,6 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
             execute(command->cmd_as_ProgramConstructorCommand());
             break;
         }
-        // Removed: EnqueueProgramCommand
         case ::tt::tt_metal::flatbuffer::CommandType::CreateKernelCommand: {
             execute(command->cmd_as_CreateKernelCommand());
             break;
@@ -526,8 +524,6 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::ProgramConstr
     log_debug(tt::LogMetalTrace, "LightMetalReplay(ProgramConstructor) global_id: {} ", cmd->global_id());
     add_program_to_map(cmd->global_id(), std::make_shared<Program>());
 }
-
-// Removed: execute(EnqueueProgramCommand)
 
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* cmd) {
     log_debug(


### PR DESCRIPTION
### Problem description
CommandQueue::enqueue_program is unused.

### What's changed
Remove it and various other pieces of code that it was using that aren't needed anymore.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes