### PR TITLE
[Fabric] Test infra error handling

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -38,7 +38,6 @@ const std::
 };
 
 int main(int argc, char** argv) {
-    log_info(tt::LogTest, "Starting Test");
     std::vector<std::string> input_args(argv, argv + argc);
 
     auto fixture = std::make_shared<TestFixture>();
@@ -64,8 +63,14 @@ int main(int argc, char** argv) {
             physical_mesh_config = parsed_yaml.physical_mesh_config;
         }
     } else {
-        raw_test_configs = cmdline_parser.generate_default_configs();
+        log_error(
+            tt::LogTest,
+            "No YAML config file path specified. Please use --test_config <file_path> to specify the test config. Use "
+            "--help for more information.");
+        return 1;
     }
+
+    log_info(tt::LogTest, "Starting Test");
 
     fixture->init(physical_mesh_config);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -286,7 +286,6 @@ public:
     std::optional<std::string> get_yaml_config_path();
     bool check_filter(ParsedTestConfig& test_config, bool fine_grained);
     void apply_overrides(std::vector<ParsedTestConfig>& test_configs);
-    std::vector<ParsedTestConfig> generate_default_configs();
     std::optional<uint32_t> get_master_seed();
     bool dump_built_tests();
     std::string get_built_tests_dump_file_name(const std::string& default_file_name);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We were trying to generate a default test case when the users didnt specify the yaml config correctly. This led to some erroneous code-paths. Moreover, this is not the desired behavior either.

### What's changed
1. Exit early with a clean message showing that a test config yaml is needed. 
2. Deprecated the method to generate default test config
3. Also updated the help message to reflect these changes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/18793735437)
- [x] New/Existing tests provide coverage for changes