### PR TITLE
Fix CI - Revert 2231dec

### DIFF
--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -5,8 +5,6 @@
 #pragma once
 
 #include <string>
-#include <set>
-#include <cabling_generator/cabling_generator.hpp>
 
 namespace tt::scaleout_tools {
 
@@ -19,11 +17,10 @@ namespace tt::scaleout_tools {
 //                        If false, only checks that GSD connections exist in FSD
 //   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
 //                                    If false, missing connections are logged without an error being thrown
-std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
+void validate_fsd_against_gsd(
     const std::string& fsd_filename,
     const std::string& gsd_filename,
     bool strict_validation = true,
-    bool assert_on_connection_mismatch = true,
-    bool log_output = true);
+    bool assert_on_connection_mismatch = true);
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -115,14 +115,12 @@ InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
 std::string get_factory_system_descriptor_path(const InputArgs& input_args) {
     std::string fsd_path;
     if (input_args.cabling_descriptor_path.has_value()) {
-        const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
         log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
         tt::scaleout_tools::CablingGenerator cabling_generator(
             input_args.cabling_descriptor_path.value(), input_args.deployment_descriptor_path.value());
-        std::string filename =
-            "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
-        fsd_path = input_args.output_path / filename;
+        fsd_path = input_args.output_path / "generated_factory_system_descriptor.textproto";
         cabling_generator.emit_factory_system_descriptor(fsd_path);
+
     } else {
         fsd_path = input_args.fsd_path.value();
     }
@@ -159,39 +157,18 @@ PhysicalSystemDescriptor generate_physical_system_descriptor(const InputArgs& in
     }
 }
 
-void cleanup_metadata(const InputArgs& input_args, const std::string& gsd_file, const std::string& fsd_file) {
-    // Remove GSD file
-    std::filesystem::remove(gsd_file);
-    if (!input_args.fsd_path.has_value()) {
-        // Remove FSD file
-        std::filesystem::remove(fsd_file);
-    } else {
-        TT_FATAL(fsd_file == input_args.fsd_path.value(), "Internal error: Expected FSD File Paths to match");
-    }
-}
-
-AsicTopology validate_connectivity(const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
+void validate_connectivity(const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
     if (!input_args.validate_connectivity) {
-        return {};
+        return;
     }
     // Set output path for the YAML file
-    auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-    std::string gsd_yaml_filename = "global_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".yaml";
-    std::string gsd_yaml_path = input_args.output_path / gsd_yaml_filename;
+    std::string gsd_yaml_path = input_args.output_path / "global_system_descriptor.yaml";
     // Dump the discovered system to YAML
     physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
     log_output_rank0("Validating Factory System Descriptor (Golden Representation) against Global System Descriptor");
-    bool log_output = *distributed_context.rank() == 0;
-    auto missing_physical_connections = tt::scaleout_tools::validate_fsd_against_gsd(
-        get_factory_system_descriptor_path(input_args), gsd_yaml_path, true, input_args.fail_on_warning, log_output);
+    tt::scaleout_tools::validate_fsd_against_gsd(
+        get_factory_system_descriptor_path(input_args), gsd_yaml_path, true, input_args.fail_on_warning);
     log_output_rank0("Factory System Descriptor (Golden Representation) Validation Complete");
-    // TODO (AS): We shouldn't need to dump files to disk for validation, once validate_fsd_against_gsd can support
-    // comparing string representations of the FSD and GSD. For now, each rank dumps a file to disk, which gets deleted
-    // post validation (for all ranks except rank 0).
-    if (*distributed_context.rank() != 0) {
-        cleanup_metadata(input_args, gsd_yaml_path, gsd_yaml_filename);
-    }
-    return generate_asic_topology_from_connections(missing_physical_connections, physical_system_descriptor);
 }
 
 void print_usage_info() {
@@ -247,28 +224,8 @@ int main(int argc, char* argv[]) {
     // Create physical system descriptor and discover the system
     auto physical_system_descriptor = generate_physical_system_descriptor(input_args);
 
-    AsicTopology missing_asic_topology = validate_connectivity(input_args, physical_system_descriptor);
-    bool links_reset = false;
-    // Ethernet Link Retraining through SW is currently only supported for Wormhole
-    bool link_retrain_supported = tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::WORMHOLE_B0;
-    constexpr uint32_t MAX_RETRAINS_BEFORE_FAILURE =
-        5;  // If links don't come up after 5 retrains, the system is in an unrecoverable state.
-    uint32_t num_retrains = 0;
-    while (!missing_asic_topology.empty() && link_retrain_supported && num_retrains < MAX_RETRAINS_BEFORE_FAILURE) {
-        reset_ethernet_links(physical_system_descriptor, missing_asic_topology);
-        links_reset = true;
-        num_retrains++;
-        physical_system_descriptor.run_discovery(true);
-        missing_asic_topology = validate_connectivity(input_args, physical_system_descriptor);
-    }
-
-    if (num_retrains == MAX_RETRAINS_BEFORE_FAILURE && !missing_asic_topology.empty()) {
-        TT_THROW("Encountered unrecoverable state. Please check the system and try again.");
-        return -1;
-    }
-    if (links_reset) {
-        log_output_rank0("Ethernet Links were Retrained. Please run the validation tool again to issue traffic.");
-        return 0;
+    if (*distributed_context.rank() == 0) {
+        validate_connectivity(input_args, physical_system_descriptor);
     }
 
     eth_connections_healthy = generate_link_metrics(
@@ -281,7 +238,7 @@ int main(int argc, char* argv[]) {
         input_args.data_size,
         input_args.output_path);
 
-    if (*distributed_context.rank() == 0 && input_args.print_connectivity) {
+    if (*distributed_context.rank() == 0) {
         print_ethernet_connectivity(input_args.print_connectivity, physical_system_descriptor);
     }
     distributed_context.barrier();

--- a/tools/scaleout/validation/schemas/ethernet_link_metrics.proto
+++ b/tools/scaleout/validation/schemas/ethernet_link_metrics.proto
@@ -10,8 +10,7 @@ message TrafficParams {
 message EthernetMetrics {
     uint32 retrain_count = 1;
     uint32 crc_error_count = 2;
-    uint64 corrected_codeword_count = 3;
-    uint64 uncorrected_codeword_count = 4;
+    uint32 uncorrected_codeword_count = 3;
 }
 
 message LinkStatus {
@@ -35,17 +34,4 @@ message EthernetLinkMetrics {
 
 message EthernetLinkMetricsList {
     repeated EthernetLinkMetrics link_metrics = 1;
-}
-
-message EthChannelIdentifierList {
-    repeated EthChannelIdentifier exit_nodes = 1;
-}
-
-message ResetPair {
-    uint32 src_rank = 1;
-    uint32 dst_rank = 2;
-}
-
-message ResetPairList {
-    repeated ResetPair reset_pairs = 1;
 }

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -89,8 +89,7 @@ void configure_local_kernels(
     std::unordered_map<ChipId, tt::tt_metal::Program>& programs,
     size_t packet_size_bytes,
     size_t packet_size_words,
-    size_t data_size,
-    bool fwd) {
+    size_t data_size) {
     const auto& host_name = physical_system_descriptor.my_host_name();
     const auto& asic_topology = physical_system_descriptor.get_asic_topology(host_name);
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -99,93 +98,78 @@ void configure_local_kernels(
     const size_t dst_eth_l1_byte_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
 
     std::unordered_map<ChipId, std::vector<CoreCoord>> kernel_coords;
-    std::vector<uint32_t> all_zeros(inputs.size(), 0);
 
     for (const auto& [asic_id, asic_connections] : asic_topology) {
-        auto curr_chip_id = asic_id_to_chip_id[*asic_id];
-        auto curr_chip = devices[curr_chip_id];
-        auto& curr_program = programs[curr_chip_id];
+        auto sender_chip_id = asic_id_to_chip_id[*asic_id];
+        auto sender_device = devices[sender_chip_id];
+        auto& sender_program = programs[sender_chip_id];
 
-        for (const auto& [neighbor_asic_id, eth_connections] : asic_connections) {
-            if (physical_system_descriptor.get_host_name_for_asic(neighbor_asic_id) != host_name) {
+        for (const auto& [dst_asic_id, eth_connections] : asic_connections) {
+            if (physical_system_descriptor.get_host_name_for_asic(dst_asic_id) != host_name) {
                 continue;
             }
-            auto neighbor_chip_id = asic_id_to_chip_id[*neighbor_asic_id];
-            auto neighbor_chip = devices[neighbor_chip_id];
-            auto& neighbor_program = programs[neighbor_chip_id];
+            auto receiver_chip_id = asic_id_to_chip_id[*dst_asic_id];
+            auto receiver_device = devices[receiver_chip_id];
+            auto& receiver_program = programs[receiver_chip_id];
 
             for (const auto& eth_connection : eth_connections) {
-                auto curr_chan = eth_connection.src_chan;
-                auto neighbor_chan = eth_connection.dst_chan;
+                auto src_chan = eth_connection.src_chan;
+                auto dst_chan = eth_connection.dst_chan;
 
-                const auto& curr_soc_desc = cluster.get_soc_desc(curr_chip_id);
-                const auto& neighbor_soc_desc = cluster.get_soc_desc(neighbor_chip_id);
-                auto curr_coord = curr_soc_desc.get_eth_core_for_channel(curr_chan, CoordSystem::LOGICAL);
-                auto neighbor_coord = neighbor_soc_desc.get_eth_core_for_channel(neighbor_chan, CoordSystem::LOGICAL);
+                const auto& sender_soc_desc = cluster.get_soc_desc(sender_chip_id);
+                const auto& receiver_soc_desc = cluster.get_soc_desc(receiver_chip_id);
+                auto sender_coord = sender_soc_desc.get_eth_core_for_channel(src_chan, CoordSystem::LOGICAL);
+                auto receiver_coord = receiver_soc_desc.get_eth_core_for_channel(dst_chan, CoordSystem::LOGICAL);
 
-                if (std::find(kernel_coords[curr_chip_id].begin(), kernel_coords[curr_chip_id].end(), curr_coord) ==
-                    kernel_coords[curr_chip_id].end()) {
+                if (std::find(
+                        kernel_coords[sender_chip_id].begin(), kernel_coords[sender_chip_id].end(), sender_coord) ==
+                    kernel_coords[sender_chip_id].end()) {
                     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-                        curr_chip_id,
-                        curr_chip->ethernet_core_from_logical_core(curr_coord),
-                        fwd ? inputs : all_zeros,
+                        sender_chip_id,
+                        sender_device->ethernet_core_from_logical_core(sender_coord),
+                        inputs,
                         src_eth_l1_byte_address);
-
+                    std::vector<uint32_t> all_zeros(inputs.size(), 0);
                     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-                        neighbor_chip_id,
-                        neighbor_chip->ethernet_core_from_logical_core(neighbor_coord),
-                        fwd ? all_zeros : inputs,
+                        receiver_chip_id,
+                        receiver_device->ethernet_core_from_logical_core(receiver_coord),
+                        all_zeros,
                         dst_eth_l1_byte_address);
 
-                    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(curr_chip_id);
-                    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(neighbor_chip_id);
+                    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(sender_chip_id);
+                    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(receiver_chip_id);
 
-                    auto sender_kernel_path =
-                        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_send.cpp";
-                    auto receiver_kernel_path =
-                        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_receive.cpp";
-                    std::vector<uint32_t> sender_compile_args = {packet_size_bytes, packet_size_words};
-                    std::vector<uint32_t> receiver_compile_args = {};
-                    auto curr_kernel = tt::tt_metal::CreateKernel(
-                        curr_program,
-                        fwd ? sender_kernel_path : receiver_kernel_path,
-                        curr_coord,
+                    auto sender_kernel = tt::tt_metal::CreateKernel(
+                        sender_program,
+                        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_send.cpp",
+                        sender_coord,
                         tt::tt_metal::EthernetConfig{
-                            .noc = tt::tt_metal::NOC::NOC_0,
-                            .compile_args = fwd ? std::vector<uint32_t>{packet_size_bytes, packet_size_words}
-                                                : std::vector<uint32_t>{}});
-
-                    auto neighbor_kernel = tt::tt_metal::CreateKernel(
-                        neighbor_program,
-                        fwd ? receiver_kernel_path : sender_kernel_path,
-                        neighbor_coord,
-                        tt::tt_metal::EthernetConfig{
-                            .noc = tt::tt_metal::NOC::NOC_0,
-                            .compile_args = fwd ? std::vector<uint32_t>{}
-                                                : std::vector<uint32_t>{packet_size_bytes, packet_size_words}});
+                            .noc = tt::tt_metal::NOC::NOC_0, .compile_args = {packet_size_bytes, packet_size_words}});
                     tt::tt_metal::SetRuntimeArgs(
-                        fwd ? curr_program : neighbor_program,
-                        fwd ? curr_kernel : neighbor_kernel,
-                        fwd ? curr_coord : neighbor_coord,
+                        sender_program,
+                        sender_kernel,
+                        sender_coord,
                         {src_eth_l1_byte_address, dst_eth_l1_byte_address, data_size});
 
-                    tt::tt_metal::SetRuntimeArgs(
-                        fwd ? neighbor_program : curr_program,
-                        fwd ? neighbor_kernel : curr_kernel,
-                        fwd ? neighbor_coord : curr_coord,
-                        {data_size});
-
-                    kernel_coords[curr_chip_id].push_back(curr_coord);
-                    kernel_coords[neighbor_chip_id].push_back(neighbor_coord);
+                    auto receiver_kernel = tt::tt_metal::CreateKernel(
+                        receiver_program,
+                        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_receive.cpp",
+                        receiver_coord,
+                        tt::tt_metal::EthernetConfig{
+                            .noc = tt::tt_metal::NOC::NOC_0,
+                        });
+                    tt::tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_coord, {data_size});
+                    kernel_coords[sender_chip_id].push_back(sender_coord);
+                    kernel_coords[receiver_chip_id].push_back(receiver_coord);
                 } else {
                     TT_FATAL(
                         std::find(
-                            kernel_coords[neighbor_chip_id].begin(),
-                            kernel_coords[neighbor_chip_id].end(),
-                            neighbor_coord) != kernel_coords[neighbor_chip_id].end(),
+                            kernel_coords[receiver_chip_id].begin(),
+                            kernel_coords[receiver_chip_id].end(),
+                            receiver_coord) != kernel_coords[receiver_chip_id].end(),
                         "Expected kernel to be populated for device {}, logical eth core {}",
-                        neighbor_chip_id,
-                        neighbor_coord.str());
+                        receiver_chip_id,
+                        receiver_coord.str());
                 }
             }
         }
@@ -200,22 +184,20 @@ void configure_cross_host_kernels(
     std::unordered_map<ChipId, tt::tt_metal::Program>& programs,
     size_t packet_size_bytes,
     size_t packet_size_words,
-    size_t data_size,
-    bool fwd) {
+    size_t data_size) {
     const auto& host_name = physical_system_descriptor.my_host_name();
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
     const size_t src_eth_l1_byte_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
     const size_t dst_eth_l1_byte_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
 
-    std::vector<uint32_t> all_zeros(inputs.size(), 0);
     for (const auto& host_neighbor : physical_system_descriptor.get_host_neighbors(host_name)) {
         const auto& exit_nodes = physical_system_descriptor.get_connecting_exit_nodes(host_name, host_neighbor);
         for (const auto& exit_node : exit_nodes) {
             auto my_asic = exit_node.src_exit_node;
             auto my_chip = asic_id_to_chip_id[*my_asic];
             auto neighbor_asic = exit_node.dst_exit_node;
-            bool sender = fwd ? (*my_asic > *neighbor_asic) : (*my_asic < *neighbor_asic);
+            bool sender = (*my_asic > *neighbor_asic);
             auto my_device = devices[my_chip];
             auto& my_program = programs[my_chip];
             const auto& my_soc_desc = cluster.get_soc_desc(my_chip);
@@ -234,6 +216,7 @@ void configure_cross_host_kernels(
                 tt::tt_metal::SetRuntimeArgs(
                     my_program, sender_kernel, my_coord, {src_eth_l1_byte_address, dst_eth_l1_byte_address, data_size});
             } else {
+                std::vector<uint32_t> all_zeros(inputs.size(), 0);
                 tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                     my_chip, my_device->ethernet_core_from_logical_core(my_coord), all_zeros, dst_eth_l1_byte_address);
                 tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(my_chip);
@@ -282,7 +265,7 @@ void execute_workloads(
 
 bool link_unhealthy(const std::vector<LinkStatus>& link_stats) {
     auto retrain_count_increasing = [&](const std::vector<LinkStatus>& link_stats) {
-        uint32_t prev_retrain_count = link_stats[0].metrics.retrain_count;
+        uint32_t prev_retrain_count = 0;
         for (const auto& dumped_stat : link_stats) {
             const auto& metric = dumped_stat.metrics;
             if (metric.retrain_count > prev_retrain_count) {
@@ -293,28 +276,10 @@ bool link_unhealthy(const std::vector<LinkStatus>& link_stats) {
         return false;
     };
 
-    auto zero_retrain_count = [&](const std::vector<LinkStatus>& link_stats) {
-        return std::any_of(link_stats.begin(), link_stats.end(), [&](const LinkStatus& dumped_stat) {
-            return dumped_stat.metrics.retrain_count == 0;
-        });
-    };
-
     auto crc_error_reported = [&](const std::vector<LinkStatus>& link_stats) {
         return std::any_of(link_stats.begin(), link_stats.end(), [&](const LinkStatus& dumped_stat) {
             return dumped_stat.metrics.crc_error_count > 0;
         });
-    };
-
-    auto uncorrected_codewords_increasing = [&](const std::vector<LinkStatus>& link_stats) {
-        uint32_t prev_uncorrected_codeword_count = link_stats[0].metrics.uncorrected_codeword_count;
-        for (const auto& dumped_stat : link_stats) {
-            const auto& metric = dumped_stat.metrics;
-            if (metric.uncorrected_codeword_count > prev_uncorrected_codeword_count) {
-                return true;
-            }
-            prev_uncorrected_codeword_count = metric.uncorrected_codeword_count;
-        }
-        return false;
     };
 
     auto uncorrected_codewords_detected = [&](const std::vector<LinkStatus>& link_stats) {
@@ -328,22 +293,9 @@ bool link_unhealthy(const std::vector<LinkStatus>& link_stats) {
             return dumped_stat.num_mismatched_words > 0;
         });
     };
-    bool retrain_count_increasing_ = retrain_count_increasing(link_stats);
-    bool crc_error_reported_ = crc_error_reported(link_stats);
-    bool uncorrected_codewords_detected_ = uncorrected_codewords_detected(link_stats);
-    bool uncorrected_codewords_increasing_ = uncorrected_codewords_increasing(link_stats);
-    bool data_mismatch_ = data_mismatch(link_stats);
-    bool zero_retrain_count_ = zero_retrain_count(link_stats);
 
-    // A link is considered unhealthy if:
-    // - The retrain count is increasing
-    // - A CRC error is reported
-    // - Uncorrected codewords are detected but no retrains were issued
-    // - Uncorrected codewords are increasing
-    // - A data mismatch is detected
-    return retrain_count_increasing_ || crc_error_reported_ ||
-           (zero_retrain_count_ && uncorrected_codewords_detected_) || uncorrected_codewords_increasing_ ||
-           data_mismatch_;
+    return retrain_count_increasing(link_stats) || crc_error_reported(link_stats) ||
+           uncorrected_codewords_detected(link_stats) || data_mismatch(link_stats);
 }
 
 LinkStatus get_first_failure(const std::vector<LinkStatus>& link_stats) {
@@ -469,7 +421,7 @@ void dump_link_stats(
     const auto& host_name = physical_system_descriptor.my_host_name();
     const auto& asic_topology = physical_system_descriptor.get_asic_topology(host_name);
     const auto& asic_descriptors = physical_system_descriptor.get_asic_descriptors();
-    auto local_ethernet_metrics = physical_system_descriptor.query_local_ethernet_metrics();
+    physical_system_descriptor.generate_local_ethernet_metrics();
 
     for (const auto& [asic_id, asic_connections] : asic_topology) {
         auto chip_id = asic_id_to_chip_id[*asic_id];
@@ -502,7 +454,7 @@ void dump_link_stats(
                                       .channel = src_chan,
                                   }]
                     .push_back(LinkStatus{
-                        .metrics = local_ethernet_metrics.at(asic_id).at(src_chan),
+                        .metrics = physical_system_descriptor.get_ethernet_metrics().at(asic_id).at(src_chan),
                         .traffic_params =
                             TrafficParams{
                                 .packet_size_bytes = packet_size_bytes,
@@ -574,7 +526,6 @@ LinkMetricsResult send_traffic_and_validate_links(
         tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config());
 
     std::unordered_map<EthChannelIdentifier, std::vector<LinkStatus>> statuses_per_link;
-    bool fwd = true;
     for (int i = 0; i < num_iterations; i++) {
         for (const auto& traffic_config : traffic_configs) {
             std::size_t pkt_size_bytes = traffic_config.packet_size_bytes;
@@ -583,6 +534,7 @@ LinkMetricsResult send_traffic_and_validate_links(
 
             std::unordered_map<ChipId, tt::tt_metal::Program> programs;
             auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, d_size / sizeof(uint32_t));
+
             configure_local_kernels(
                 physical_system_descriptor,
                 asic_id_to_chip_id,
@@ -591,8 +543,7 @@ LinkMetricsResult send_traffic_and_validate_links(
                 programs,
                 pkt_size_bytes,
                 pkt_size_words,
-                d_size,
-                fwd);
+                d_size);
 
             configure_cross_host_kernels(
                 physical_system_descriptor,
@@ -602,8 +553,7 @@ LinkMetricsResult send_traffic_and_validate_links(
                 programs,
                 pkt_size_bytes,
                 pkt_size_words,
-                d_size,
-                fwd);
+                d_size);
 
             execute_workloads(programs, devices);
 
@@ -615,7 +565,6 @@ LinkMetricsResult send_traffic_and_validate_links(
                 devices,
                 d_size,
                 pkt_size_bytes);
-            fwd = !fwd;  // Toggle direction to test bidirectional traffic across links
         }
     }
 
@@ -651,6 +600,10 @@ std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<uint8_t, PortType>> 
 
 void print_ethernet_connectivity(
     bool print_connectivity, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
+    if (print_connectivity) {
+        log_output_rank0("Generating Ethernet Connectivity Logs");
+    }
+
     auto port_types = generate_port_types(physical_system_descriptor);
 
     // Collect all connections and organize by: connection_type -> hostname -> port_type -> connections
@@ -659,22 +612,19 @@ void print_ethernet_connectivity(
         organized_connections;
 
     for (const auto& host : physical_system_descriptor.get_all_hostnames()) {
-        const auto& asic_connections = physical_system_descriptor.get_asic_topology(host);
-        for (auto asic_id : physical_system_descriptor.get_asics_connected_to_host(host)) {
-            auto tray_id = physical_system_descriptor.get_asic_descriptors().at(asic_id).tray_id;
-            auto asic_location = physical_system_descriptor.get_asic_descriptors().at(asic_id).asic_location;
+        for (const auto& [asic_id, channel_metrics] : physical_system_descriptor.get_ethernet_metrics()) {
+            if (physical_system_descriptor.get_host_name_for_asic(asic_id) == host) {
+                auto tray_id = physical_system_descriptor.get_asic_descriptors().at(asic_id).tray_id;
+                auto asic_location = physical_system_descriptor.get_asic_descriptors().at(asic_id).asic_location;
 
-            for (const auto& asic_connection : asic_connections.at(asic_id)) {
-                auto connected_asic_id = asic_connection.first;
-                auto connected_tray_id =
-                    physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).tray_id;
-                auto connected_asic_location =
-                    physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).asic_location;
-                const auto& connected_host = physical_system_descriptor.get_host_name_for_asic(connected_asic_id);
-
-                for (const auto& eth_connection : asic_connection.second) {
-                    auto channel = eth_connection.src_chan;
-                    auto connected_channel = eth_connection.dst_chan;
+                for (const auto& [channel, metrics] : channel_metrics) {
+                    auto [connected_asic_id, connected_channel] =
+                        physical_system_descriptor.get_connected_asic_and_channel(asic_id, channel);
+                    auto connected_tray_id =
+                        physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).tray_id;
+                    auto connected_asic_location =
+                        physical_system_descriptor.get_asic_descriptors().at(connected_asic_id).asic_location;
+                    const auto& connected_host = physical_system_descriptor.get_host_name_for_asic(connected_asic_id);
                     auto port_type_str = enchantum::to_string(port_types.at(asic_id).at(channel));
 
                     ConnectionInfo conn_info{
@@ -789,8 +739,7 @@ void log_link_metrics(
         TrafficParams traffic_params;
         uint32_t retrain_count;
         uint32_t crc_error_count;
-        uint64_t corrected_codeword_count;
-        uint64_t uncorrected_codeword_count;
+        uint32_t uncorrected_codeword_count;
         uint32_t num_mismatched_words;
     };
 
@@ -805,46 +754,52 @@ void log_link_metrics(
                  link.link_status.traffic_params,
                  link.link_status.metrics.retrain_count,
                  link.link_status.metrics.crc_error_count,
-                 link.link_status.metrics.corrected_codeword_count,
                  link.link_status.metrics.uncorrected_codeword_count,
                  link.link_status.num_mismatched_words});
         }
     } else {
-        // When logging failures: one row per link with all metrics and combined failure types
+        // When logging failures: one row per metric type with non-zero values
         for (const auto& link : link_metrics) {
-            std::vector<std::string> failure_types;
-
             if (link.link_status.metrics.retrain_count > 0) {
-                failure_types.push_back("Retrain");
+                metric_rows.push_back(
+                    {link.channel_identifier,
+                     "Retrain",
+                     link.link_status.traffic_params,
+                     link.link_status.metrics.retrain_count,
+                     0,
+                     0,
+                     0});
             }
             if (link.link_status.metrics.crc_error_count > 0) {
-                failure_types.push_back("CRC Error");
+                metric_rows.push_back(
+                    {link.channel_identifier,
+                     "CRC Error",
+                     link.link_status.traffic_params,
+                     0,
+                     link.link_status.metrics.crc_error_count,
+                     0,
+                     0});
             }
             if (link.link_status.metrics.uncorrected_codeword_count > 0) {
-                failure_types.push_back("Uncorrected CW");
+                metric_rows.push_back(
+                    {link.channel_identifier,
+                     "Uncorrected CW",
+                     link.link_status.traffic_params,
+                     0,
+                     0,
+                     link.link_status.metrics.uncorrected_codeword_count,
+                     0});
             }
             if (link.link_status.num_mismatched_words > 0) {
-                failure_types.push_back("Data Mismatch");
+                metric_rows.push_back(
+                    {link.channel_identifier,
+                     "Data Mismatch",
+                     link.link_status.traffic_params,
+                     0,
+                     0,
+                     0,
+                     link.link_status.num_mismatched_words});
             }
-
-            // Combine failure types with "+"
-            std::string combined_failure_type;
-            for (size_t i = 0; i < failure_types.size(); ++i) {
-                if (i > 0) {
-                    combined_failure_type += " + ";
-                }
-                combined_failure_type += failure_types[i];
-            }
-
-            metric_rows.push_back(
-                {link.channel_identifier,
-                 combined_failure_type,
-                 link.link_status.traffic_params,
-                 link.link_status.metrics.retrain_count,
-                 link.link_status.metrics.crc_error_count,
-                 link.link_status.metrics.corrected_codeword_count,
-                 link.link_status.metrics.uncorrected_codeword_count,
-                 link.link_status.num_mismatched_words});
         }
     }
 
@@ -867,22 +822,22 @@ void log_link_metrics(
         std::cout << "Total Links: " << link_metrics.size() << std::endl;
         std::cout << "Total Metric Entries: " << metric_rows.size() << std::endl << std::endl;
     } else {
-        std::cout << "Total Faulty Links: " << link_metrics.size() << std::endl << std::endl;
+        std::cout << "Total Faulty Link Occurrences: " << link_metrics.size() << std::endl;
+        std::cout << "Total Failure Instances: " << metric_rows.size() << std::endl << std::endl;
     }
 
     // Table header
     std::cout << std::left << std::setw(20) << "Host" << std::setw(6) << "Tray" << std::setw(6) << "ASIC"
               << std::setw(5) << "Ch" << std::setw(14) << "Unique ID" << std::setw(12) << "Retrains" << std::setw(14)
-              << "CRC Err" << std::setw(18) << "Corrected CW" << std::setw(18) << "Uncorrected CW" << std::setw(16)
-              << "Mismatch Words";
+              << "CRC Err" << std::setw(18) << "Uncorrected CW" << std::setw(16) << "Mismatch Words";
 
     if (!log_ethernet_metrics) {
-        std::cout << std::setw(40) << "Failure Type";
+        std::cout << std::setw(18) << "Failure Type";
     }
 
     std::cout << std::setw(12) << "Pkt Size" << std::setw(12) << "Data Size" << std::endl;
 
-    std::cout << std::string(log_ethernet_metrics ? 153 : 193, '-') << std::endl;
+    std::cout << std::string(log_ethernet_metrics ? 135 : 153, '-') << std::endl;
 
     // Table rows
     for (const auto& row : metric_rows) {
@@ -903,11 +858,6 @@ void log_link_metrics(
         crc_stream << "0x" << std::hex << row.crc_error_count;
         std::cout << std::left << std::setw(14) << crc_stream.str();
 
-        // Corrected codewords
-        std::stringstream corr_stream;
-        corr_stream << "0x" << std::hex << row.corrected_codeword_count;
-        std::cout << std::left << std::setw(18) << corr_stream.str();
-
         // Uncorrected codewords
         std::stringstream uncorr_stream;
         uncorr_stream << "0x" << std::hex << row.uncorrected_codeword_count;
@@ -918,14 +868,14 @@ void log_link_metrics(
 
         // Failure Type (only for faulty links report)
         if (!log_ethernet_metrics) {
-            std::cout << std::left << std::setw(40) << row.metric_type;
+            std::cout << std::left << std::setw(18) << row.metric_type;
         }
 
         std::cout << std::setw(12) << (std::to_string(row.traffic_params.packet_size_bytes) + " B") << std::setw(12)
                   << (std::to_string(row.traffic_params.data_size) + " B") << std::endl;
     }
 
-    std::cout << std::string(log_ethernet_metrics ? 153 : 193, '-') << std::endl << std::endl;
+    std::cout << std::string(log_ethernet_metrics ? 135 : 153, '-') << std::endl << std::endl;
 
     // Write CSV file
     std::filesystem::path csv_path =
@@ -939,8 +889,7 @@ void log_link_metrics(
             csv_file << ",Failure_Type";
         }
         csv_file << ",Packet_Size_Bytes,Data_Size_Bytes,"
-                 << "Retrain_Count,CRC_Error_Count,Corrected_Codeword_Count,Uncorrected_Codeword_Count,Mismatched_Words"
-                 << std::endl;
+                 << "Retrain_Count,CRC_Error_Count,Uncorrected_Codeword_Count,Mismatched_Words" << std::endl;
 
         // CSV rows
         for (const auto& row : metric_rows) {
@@ -953,7 +902,6 @@ void log_link_metrics(
             csv_file << "," << row.traffic_params.packet_size_bytes << "," << row.traffic_params.data_size << ","
                      << row.retrain_count << ","
                      << "0x" << std::hex << row.crc_error_count << std::dec << ","
-                     << "0x" << std::hex << row.corrected_codeword_count << std::dec << ","
                      << "0x" << std::hex << row.uncorrected_codeword_count << std::dec << ","
                      << row.num_mismatched_words << std::endl;
         }
@@ -963,302 +911,6 @@ void log_link_metrics(
     } else {
         log_output_rank0("✗ Warning: Could not open CSV file for writing: " + csv_path.string());
     }
-}
-
-void point_to_point_barrier(const ResetPair& reset_pair) {
-    auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-    TT_FATAL(
-        *distributed_context.rank() == reset_pair.src_rank || *distributed_context.rank() == reset_pair.dst_rank,
-        "Point-to-Point barrier for ranks {} and {} cannot be called on rank {}.",
-        reset_pair.src_rank,
-        reset_pair.dst_rank,
-        *distributed_context.rank());
-
-    uint32_t tag = (reset_pair.src_rank << 8) | reset_pair.dst_rank;
-
-    if (*distributed_context.rank() == reset_pair.src_rank) {
-        int sync_msg = 1;
-        distributed_context.ssend(
-            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sync_msg), sizeof(sync_msg)),
-            tt::tt_metal::distributed::multihost::Rank{reset_pair.dst_rank},
-            tt::tt_metal::distributed::multihost::Tag{tag});
-    } else {
-        int sync_msg = 0;
-        distributed_context.recv(
-            tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&sync_msg), sizeof(sync_msg)),
-            tt::tt_metal::distributed::multihost::Rank{reset_pair.src_rank},
-            tt::tt_metal::distributed::multihost::Tag{tag});
-    }
-}
-
-void reset_local_link(ChipId src_chip, ChipId dst_chip, uint8_t src_chan, uint8_t dst_chan) {
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    std::vector<uint32_t> set = {1};
-
-    const auto& sender_soc_desc = cluster.get_soc_desc(src_chip);
-    const auto& receiver_soc_desc = cluster.get_soc_desc(dst_chip);
-    auto logical_src_coord = sender_soc_desc.get_eth_core_for_channel(src_chan, CoordSystem::LOGICAL);
-    auto logical_dst_coord = receiver_soc_desc.get_eth_core_for_channel(dst_chan, CoordSystem::LOGICAL);
-    auto src_coord = cluster.get_virtual_coordinate_from_logical_coordinates(
-        src_chip, tt_xy_pair(logical_src_coord.x, logical_src_coord.y), CoreType::ETH);
-    auto dst_coord = cluster.get_virtual_coordinate_from_logical_coordinates(
-        dst_chip, tt_xy_pair(logical_dst_coord.x, logical_dst_coord.y), CoreType::ETH);
-
-    cluster.write_core(src_chip, src_coord, set, 0x1EFC);
-    cluster.write_core(dst_chip, dst_coord, set, 0x1EFC);
-
-    bool reset = false;
-    while (!reset) {
-        std::vector<uint32_t> reset_src = {0};
-        std::vector<uint32_t> reset_dst = {0};
-
-        cluster.read_core(reset_src, sizeof(uint32_t), tt_cxy_pair(src_chip, src_coord), 0x1EFC);
-        cluster.read_core(reset_dst, sizeof(uint32_t), tt_cxy_pair(dst_chip, dst_coord), 0x1EFC);
-        reset = !(reset_src[0] || reset_dst[0]);
-    }
-}
-
-void forward_link_reset_metadata_from_controller(
-    std::unordered_map<uint32_t, std::vector<EthChannelIdentifier>>& ordered_exit_nodes,
-    std::unordered_map<uint32_t, std::vector<ResetPair>>& ordered_reset_pairs,
-    std::vector<EthChannelIdentifier>& exit_nodes_to_reset,
-    std::vector<ResetPair>& reset_pairs) {
-    constexpr uint32_t CONTROLLER_RANK = 0;
-    auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-
-    if (*distributed_context.rank() == CONTROLLER_RANK) {
-        for (const auto& [rank, exit_nodes] : ordered_exit_nodes) {
-            if (rank == *distributed_context.rank()) {
-                continue;
-            }
-            auto serialized_exit_nodes = tt::scaleout::validation::serialize_eth_chan_identifiers_to_bytes(exit_nodes);
-            auto serialized_exit_nodes_size = serialized_exit_nodes.size();
-            auto serialized_reset_pairs =
-                tt::scaleout::validation::serialize_reset_pairs_to_bytes(ordered_reset_pairs[rank]);
-            auto serialized_reset_pairs_size = serialized_reset_pairs.size();
-
-            distributed_context.send(
-                tt::stl::Span<std::byte>(
-                    reinterpret_cast<std::byte*>(&serialized_exit_nodes_size), sizeof(serialized_exit_nodes_size)),
-                tt::tt_metal::distributed::multihost::Rank{rank},
-                tt::tt_metal::distributed::multihost::Tag{0});
-            distributed_context.send(
-                tt::stl::as_writable_bytes(
-                    tt::stl::Span<uint8_t>(serialized_exit_nodes.data(), serialized_exit_nodes.size())),
-                tt::tt_metal::distributed::multihost::Rank{rank},
-                tt::tt_metal::distributed::multihost::Tag{0});
-
-            distributed_context.send(
-                tt::stl::Span<std::byte>(
-                    reinterpret_cast<std::byte*>(&serialized_reset_pairs_size), sizeof(serialized_reset_pairs_size)),
-                tt::tt_metal::distributed::multihost::Rank{rank},
-                tt::tt_metal::distributed::multihost::Tag{0});
-            distributed_context.send(
-                tt::stl::as_writable_bytes(
-                    tt::stl::Span<uint8_t>(serialized_reset_pairs.data(), serialized_reset_pairs.size())),
-                tt::tt_metal::distributed::multihost::Rank{rank},
-                tt::tt_metal::distributed::multihost::Tag{0});
-        }
-        exit_nodes_to_reset = ordered_exit_nodes[*distributed_context.rank()];
-        reset_pairs = ordered_reset_pairs[*distributed_context.rank()];
-    } else {
-        std::size_t serialized_exit_nodes_size = 0;
-        distributed_context.recv(
-            tt::stl::Span<std::byte>(
-                reinterpret_cast<std::byte*>(&serialized_exit_nodes_size), sizeof(serialized_exit_nodes_size)),
-            tt::tt_metal::distributed::multihost::Rank{CONTROLLER_RANK},
-            tt::tt_metal::distributed::multihost::Tag{0});
-        std::vector<uint8_t> serialized_exit_nodes(serialized_exit_nodes_size);
-        distributed_context.recv(
-            tt::stl::as_writable_bytes(
-                tt::stl::Span<uint8_t>(serialized_exit_nodes.data(), serialized_exit_nodes.size())),
-            tt::tt_metal::distributed::multihost::Rank{CONTROLLER_RANK},
-            tt::tt_metal::distributed::multihost::Tag{0});
-        exit_nodes_to_reset =
-            tt::scaleout::validation::deserialize_eth_chan_identifiers_from_bytes(serialized_exit_nodes);
-        std::size_t serialized_reset_pairs_size = 0;
-        distributed_context.recv(
-            tt::stl::Span<std::byte>(
-                reinterpret_cast<std::byte*>(&serialized_reset_pairs_size), sizeof(serialized_reset_pairs_size)),
-            tt::tt_metal::distributed::multihost::Rank{CONTROLLER_RANK},
-            tt::tt_metal::distributed::multihost::Tag{0});
-        std::vector<uint8_t> serialized_reset_pairs(serialized_reset_pairs_size);
-        distributed_context.recv(
-            tt::stl::as_writable_bytes(
-                tt::stl::Span<uint8_t>(serialized_reset_pairs.data(), serialized_reset_pairs.size())),
-            tt::tt_metal::distributed::multihost::Rank{CONTROLLER_RANK},
-            tt::tt_metal::distributed::multihost::Tag{0});
-        reset_pairs = tt::scaleout::validation::deserialize_reset_pairs_from_bytes(serialized_reset_pairs);
-    }
-
-    TT_FATAL(
-        exit_nodes_to_reset.size() == reset_pairs.size(),
-        "Expected reset pairs to be the same size as the number of links to reset {} {} {}",
-        exit_nodes_to_reset.size(),
-        reset_pairs.size(),
-        *distributed_context.rank());
-}
-
-void reset_local_ethernet_links(
-    const PhysicalSystemDescriptor& physical_system_descriptor, const AsicTopology& asic_topology) {
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    std::unordered_map<uint64_t, ChipId> asic_id_to_chip_id;
-
-    for (const auto& [chip_id, asic_id] : cluster.get_unique_chip_ids()) {
-        asic_id_to_chip_id[asic_id] = chip_id;
-    }
-    std::vector<uint32_t> set = {1};
-    std::unordered_map<uint64_t, std::set<uint8_t>> reset_cores;
-
-    for (const auto& [asic_id, asic_connections] : asic_topology) {
-        if (physical_system_descriptor.get_host_name_for_asic(asic_id) != physical_system_descriptor.my_host_name()) {
-            continue;
-        }
-        auto src_chip_id = asic_id_to_chip_id[*asic_id];
-        for (const auto& [dst_asic_id, eth_connections] : asic_connections) {
-            if (physical_system_descriptor.get_host_name_for_asic(dst_asic_id) !=
-                physical_system_descriptor.my_host_name()) {
-                continue;
-            }
-            auto dst_chip_id = asic_id_to_chip_id[*dst_asic_id];
-            for (const auto& eth_connection : eth_connections) {
-                auto src_chan = eth_connection.src_chan;
-                auto dst_chan = eth_connection.dst_chan;
-
-                if (reset_cores[*dst_asic_id].find(dst_chan) != reset_cores[*dst_asic_id].end()) {
-                    TT_FATAL(
-                        reset_cores[*asic_id].find(src_chan) != reset_cores[*asic_id].end(),
-                        "Expected channel {} on ASIC {} to already be reset",
-                        src_chan,
-                        *asic_id);
-                    continue;
-                }
-                reset_cores[*asic_id].insert(src_chan);
-                reset_cores[*dst_asic_id].insert(dst_chan);
-                const auto& asic_descriptor = physical_system_descriptor.get_asic_descriptors().at(asic_id);
-                const auto& dst_asic_descriptor = physical_system_descriptor.get_asic_descriptors().at(dst_asic_id);
-                log_output_rank0(
-                    "Host: " + asic_descriptor.host_name + " Resetting Link " + std::to_string(src_chan) + " on " +
-                    " Tray: " + std::to_string(*asic_descriptor.tray_id) + " Location: " +
-                    std::to_string(*asic_descriptor.asic_location) + " and Link: " + std::to_string(dst_chan) + " on " +
-                    " Tray: " + std::to_string(*dst_asic_descriptor.tray_id) +
-                    " Location: " + std::to_string(*dst_asic_descriptor.asic_location));
-
-                reset_local_link(src_chip_id, dst_chip_id, src_chan, dst_chan);
-            }
-        }
-    }
-}
-
-void get_cross_node_ethernet_links_to_reset(
-    const PhysicalSystemDescriptor& physical_system_descriptor,
-    const AsicTopology& asic_topology,
-    std::vector<EthChannelIdentifier>& cross_node_links_to_reset,
-    std::vector<ResetPair>& cross_node_reset_pairs) {
-    constexpr uint32_t CONTROLLER_RANK = 0;
-
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-
-    std::unordered_map<uint32_t, std::vector<EthChannelIdentifier>> ordered_exit_nodes;
-    std::unordered_map<uint32_t, std::vector<ResetPair>> ordered_reset_pairs;
-    std::unordered_map<uint64_t, std::unordered_set<uint64_t>> paired_asic_ids;
-
-    for (const auto& host : physical_system_descriptor.get_all_hostnames()) {
-        ordered_exit_nodes[physical_system_descriptor.get_rank_for_hostname(host)] =
-            std::vector<EthChannelIdentifier>();
-        ordered_reset_pairs[physical_system_descriptor.get_rank_for_hostname(host)] = std::vector<ResetPair>();
-    }
-
-    if (*distributed_context.rank() == CONTROLLER_RANK) {
-        for (const auto& [asic_id, asic_connections] : asic_topology) {
-            auto src_host_rank = physical_system_descriptor.get_rank_for_hostname(
-                physical_system_descriptor.get_host_name_for_asic(asic_id));
-            for (const auto& [dst_asic_id, eth_connections] : asic_connections) {
-                // These links are being retrained for the second time if the current dst_asic was paired with the
-                // current src_asic in a previous iteration.
-                // In this case, we skip the link reset.
-                if (paired_asic_ids.find(*dst_asic_id) != paired_asic_ids.end() and
-                    paired_asic_ids[*dst_asic_id].find(*asic_id) != paired_asic_ids[*dst_asic_id].end()) {
-                    continue;
-                }
-                paired_asic_ids[*asic_id].insert(*dst_asic_id);
-                auto dst_host_rank = physical_system_descriptor.get_rank_for_hostname(
-                    physical_system_descriptor.get_host_name_for_asic(dst_asic_id));
-                if (src_host_rank == dst_host_rank) {
-                    continue;
-                }
-                for (const auto& eth_connection : eth_connections) {
-                    ordered_exit_nodes[src_host_rank].push_back(EthChannelIdentifier{
-                        physical_system_descriptor.get_host_name_for_asic(asic_id),
-                        asic_id,
-                        TrayID{0},
-                        ASICLocation{0},
-                        eth_connection.src_chan});
-                    ordered_exit_nodes[dst_host_rank].push_back(EthChannelIdentifier{
-                        physical_system_descriptor.get_host_name_for_asic(dst_asic_id),
-                        dst_asic_id,
-                        TrayID{0},
-                        ASICLocation{0},
-                        eth_connection.dst_chan});
-                    ordered_reset_pairs[src_host_rank].push_back(ResetPair{src_host_rank, dst_host_rank});
-                    ordered_reset_pairs[dst_host_rank].push_back(ResetPair{src_host_rank, dst_host_rank});
-                }
-            }
-        }
-    }
-    forward_link_reset_metadata_from_controller(
-        ordered_exit_nodes, ordered_reset_pairs, cross_node_links_to_reset, cross_node_reset_pairs);
-}
-
-void reset_cross_node_ethernet_links(
-    const PhysicalSystemDescriptor& physical_system_descriptor,
-    const std::vector<EthChannelIdentifier>& cross_node_links_to_reset,
-    const std::vector<ResetPair>& cross_node_reset_pairs) {
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    std::vector<uint32_t> set = {1};
-
-    std::unordered_map<uint64_t, ChipId> asic_id_to_chip_id;
-
-    for (const auto& [chip_id, asic_id] : cluster.get_unique_chip_ids()) {
-        asic_id_to_chip_id[asic_id] = chip_id;
-    }
-
-    for (size_t i = 0; i < cross_node_links_to_reset.size(); i++) {
-        const auto& link = cross_node_links_to_reset[i];
-        const auto& reset_pair = cross_node_reset_pairs[i];
-
-        auto src_chip_id = asic_id_to_chip_id[*link.asic_id];
-        const auto& src_soc_desc = cluster.get_soc_desc(src_chip_id);
-        auto logical_src_coord = src_soc_desc.get_eth_core_for_channel(link.channel, CoordSystem::LOGICAL);
-        auto src_coord = cluster.get_virtual_coordinate_from_logical_coordinates(
-            src_chip_id, tt_xy_pair(logical_src_coord.x, logical_src_coord.y), CoreType::ETH);
-        const auto& asic_descriptor = physical_system_descriptor.get_asic_descriptors().at(link.asic_id);
-        log_output_rank0(
-            "Resetting Cross-Node Link " + std::to_string(link.channel) + " on " + std::to_string(*link.asic_id) +
-            " Host: " + asic_descriptor.host_name + " Tray: " + std::to_string(*asic_descriptor.tray_id) +
-            " Location: " + std::to_string(*asic_descriptor.asic_location));
-        point_to_point_barrier(reset_pair);
-        cluster.write_core(src_chip_id, src_coord, set, 0x1EFC);
-        std::vector<uint32_t> reset = {1};
-        while (reset[0]) {
-            cluster.read_core(reset, sizeof(uint32_t), tt_cxy_pair(src_chip_id, src_coord), 0x1EFC);
-        }
-    }
-}
-
-void reset_ethernet_links(
-    const PhysicalSystemDescriptor& physical_system_descriptor, const AsicTopology& asic_topology) {
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-    // Reset All Local Ethernet Links, specified in the topology. Ethernet Links on Exit Nodes are reset separately.
-    reset_local_ethernet_links(physical_system_descriptor, asic_topology);
-    distributed_context.barrier();
-
-    // Reset All Cross-Node Ethernet Links, specified in the topology.
-    std::vector<EthChannelIdentifier> cross_node_links_to_reset;
-    std::vector<ResetPair> cross_node_reset_pairs;
-    get_cross_node_ethernet_links_to_reset(
-        physical_system_descriptor, asic_topology, cross_node_links_to_reset, cross_node_reset_pairs);
-    reset_cross_node_ethernet_links(physical_system_descriptor, cross_node_links_to_reset, cross_node_reset_pairs);
 }
 
 // ============================================================================
@@ -1305,45 +957,6 @@ bool generate_link_metrics(
     }
     log_link_metrics(result.unhealthy_links, output_path, false);
     return result.unhealthy_links.empty();
-}
-
-AsicTopology generate_asic_topology_from_connections(
-    const std::set<PhysicalChannelConnection>& physical_connections,
-    PhysicalSystemDescriptor& physical_system_descriptor) {
-    AsicTopology asic_topology;
-    std::unordered_map<tt_metal::AsicID, std::set<tt_metal::AsicID>> visited;
-    std::unordered_map<tt_metal::AsicID, std::unordered_map<tt_metal::AsicID, uint32_t>> visited_idx;
-    for (const auto& connection : physical_connections) {
-        auto src = connection.first;
-        auto dst = connection.second;
-        auto src_asic_id = physical_system_descriptor.get_asic_id(
-            src.hostname, tt_metal::TrayID(*src.tray_id), tt_metal::ASICLocation(src.asic_channel.asic_location));
-        auto dst_asic_id = physical_system_descriptor.get_asic_id(
-            dst.hostname, tt_metal::TrayID(*dst.tray_id), tt_metal::ASICLocation(dst.asic_channel.asic_location));
-        if (visited[src_asic_id].find(dst_asic_id) == visited[src_asic_id].end()) {
-            asic_topology[src_asic_id].push_back(
-                {dst_asic_id,
-                 {EthConnection(
-                     *src.asic_channel.channel_id, *dst.asic_channel.channel_id, src.hostname == dst.hostname)}});
-            visited[src_asic_id].insert(dst_asic_id);
-            visited_idx[src_asic_id][dst_asic_id] = asic_topology[src_asic_id].size() - 1;
-        } else {
-            asic_topology[src_asic_id][visited_idx[src_asic_id][dst_asic_id]].second.push_back(EthConnection(
-                *src.asic_channel.channel_id, *dst.asic_channel.channel_id, src.hostname == dst.hostname));
-        }
-        if (visited[dst_asic_id].find(src_asic_id) == visited[dst_asic_id].end()) {
-            asic_topology[dst_asic_id].push_back(
-                {src_asic_id,
-                 {EthConnection(
-                     *dst.asic_channel.channel_id, *src.asic_channel.channel_id, src.hostname == dst.hostname)}});
-            visited[dst_asic_id].insert(src_asic_id);
-            visited_idx[dst_asic_id][src_asic_id] = asic_topology[dst_asic_id].size() - 1;
-        } else {
-            asic_topology[dst_asic_id][visited_idx[dst_asic_id][src_asic_id]].second.push_back(EthConnection(
-                *dst.asic_channel.channel_id, *src.asic_channel.channel_id, src.hostname == dst.hostname));
-        }
-    }
-    return asic_topology;
 }
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -14,7 +14,6 @@
 #include "tt_metal/impl/context/metal_context.hpp"
 #include "tools/scaleout/validation/utils/ethernet_link_metrics.hpp"
 #include "board/board.hpp"
-#include <factory_system_descriptor/utils.hpp>
 
 namespace tt::scaleout_tools {
 
@@ -57,12 +56,5 @@ bool generate_link_metrics(
     uint32_t packet_size_bytes,
     uint32_t data_size,
     const std::filesystem::path& output_path);
-
-void reset_ethernet_links(
-    const PhysicalSystemDescriptor& physical_system_descriptor, const tt_metal::AsicTopology& asic_topology);
-
-tt_metal::AsicTopology generate_asic_topology_from_connections(
-    const std::set<PhysicalChannelConnection>& physical_connections,
-    PhysicalSystemDescriptor& physical_system_descriptor);
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
@@ -21,11 +21,6 @@ struct LinkStatus {
     uint32_t num_mismatched_words = 0;
 };
 
-struct ResetPair {
-    uint32_t src_rank = 0;
-    uint32_t dst_rank = 0;
-};
-
 struct EthChannelIdentifier {
     std::string host;
     tt::tt_metal::AsicID asic_id;

--- a/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.cpp
@@ -30,7 +30,6 @@ std::vector<uint8_t> serialize_link_metrics_to_bytes(const std::vector<::Etherne
         auto* proto_metrics = proto_link_status->mutable_ethernet_metrics();
         proto_metrics->set_retrain_count(link_metric.link_status.metrics.retrain_count);
         proto_metrics->set_crc_error_count(link_metric.link_status.metrics.crc_error_count);
-        proto_metrics->set_corrected_codeword_count(link_metric.link_status.metrics.corrected_codeword_count);
         proto_metrics->set_uncorrected_codeword_count(link_metric.link_status.metrics.uncorrected_codeword_count);
 
         // Serialize TrafficParams
@@ -81,7 +80,6 @@ std::vector<::EthernetLinkMetrics> deserialize_link_metrics_from_bytes(const std
         const auto& proto_metrics = proto_link_status.ethernet_metrics();
         link_metric.link_status.metrics.retrain_count = proto_metrics.retrain_count();
         link_metric.link_status.metrics.crc_error_count = proto_metrics.crc_error_count();
-        link_metric.link_status.metrics.corrected_codeword_count = proto_metrics.corrected_codeword_count();
         link_metric.link_status.metrics.uncorrected_codeword_count = proto_metrics.uncorrected_codeword_count();
 
         // Deserialize TrafficParams
@@ -96,94 +94,6 @@ std::vector<::EthernetLinkMetrics> deserialize_link_metrics_from_bytes(const std
     }
 
     return link_metrics;
-}
-
-std::vector<uint8_t> serialize_eth_chan_identifiers_to_bytes(const std::vector<::EthChannelIdentifier>& exit_nodes) {
-    EthChannelIdentifierList proto_list;
-
-    for (const auto& exit_node : exit_nodes) {
-        auto* proto_exit_node = proto_list.add_exit_nodes();
-        proto_exit_node->set_host(exit_node.host);
-        proto_exit_node->set_asic_id(*exit_node.asic_id);
-        proto_exit_node->set_tray_id(*exit_node.tray_id);
-        proto_exit_node->set_asic_location(*exit_node.asic_location);
-        proto_exit_node->set_channel(exit_node.channel);
-    }
-
-    // Serialize to bytes
-    size_t size = proto_list.ByteSizeLong();
-    std::vector<uint8_t> result(size);
-
-    if (!proto_list.SerializeToArray(result.data(), size)) {
-        throw std::runtime_error("Failed to serialize EthChannelIdentifierList to protobuf binary format");
-    }
-
-    return result;
-}
-
-std::vector<::EthChannelIdentifier> deserialize_eth_chan_identifiers_from_bytes(const std::vector<uint8_t>& data) {
-    EthChannelIdentifierList proto_list;
-
-    if (!proto_list.ParseFromArray(data.data(), data.size())) {
-        throw std::runtime_error("Failed to parse EthChannelIdentifierList from protobuf binary format");
-    }
-
-    std::vector<::EthChannelIdentifier> exit_nodes;
-    exit_nodes.reserve(proto_list.exit_nodes_size());
-
-    for (const auto& proto_exit_node : proto_list.exit_nodes()) {
-        ::EthChannelIdentifier exit_node;
-        exit_node.host = proto_exit_node.host();
-        exit_node.asic_id = tt::tt_metal::AsicID(proto_exit_node.asic_id());
-        exit_node.tray_id = tt::tt_metal::TrayID(proto_exit_node.tray_id());
-        exit_node.asic_location = tt::tt_metal::ASICLocation(proto_exit_node.asic_location());
-        exit_node.channel = static_cast<uint8_t>(proto_exit_node.channel());
-
-        exit_nodes.push_back(std::move(exit_node));
-    }
-
-    return exit_nodes;
-}
-
-std::vector<uint8_t> serialize_reset_pairs_to_bytes(const std::vector<::ResetPair>& reset_pairs) {
-    ResetPairList proto_list;
-
-    for (const auto& reset_pair : reset_pairs) {
-        auto* proto_reset_pair = proto_list.add_reset_pairs();
-        proto_reset_pair->set_src_rank(reset_pair.src_rank);
-        proto_reset_pair->set_dst_rank(reset_pair.dst_rank);
-    }
-
-    // Serialize to bytes
-    size_t size = proto_list.ByteSizeLong();
-    std::vector<uint8_t> result(size);
-
-    if (!proto_list.SerializeToArray(result.data(), size)) {
-        throw std::runtime_error("Failed to serialize ResetPairList to protobuf binary format");
-    }
-
-    return result;
-}
-
-std::vector<::ResetPair> deserialize_reset_pairs_from_bytes(const std::vector<uint8_t>& data) {
-    ResetPairList proto_list;
-
-    if (!proto_list.ParseFromArray(data.data(), data.size())) {
-        throw std::runtime_error("Failed to parse ResetPairList from protobuf binary format");
-    }
-
-    std::vector<::ResetPair> reset_pairs;
-    reset_pairs.reserve(proto_list.reset_pairs_size());
-
-    for (const auto& proto_reset_pair : proto_list.reset_pairs()) {
-        ::ResetPair reset_pair;
-        reset_pair.src_rank = proto_reset_pair.src_rank();
-        reset_pair.dst_rank = proto_reset_pair.dst_rank();
-
-        reset_pairs.push_back(reset_pair);
-    }
-
-    return reset_pairs;
 }
 
 }  // namespace tt::scaleout::validation

--- a/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.hpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.hpp
@@ -13,10 +13,4 @@ namespace tt::scaleout::validation {
 std::vector<uint8_t> serialize_link_metrics_to_bytes(const std::vector<::EthernetLinkMetrics>& link_metrics);
 std::vector<::EthernetLinkMetrics> deserialize_link_metrics_from_bytes(const std::vector<uint8_t>& data);
 
-std::vector<uint8_t> serialize_eth_chan_identifiers_to_bytes(const std::vector<::EthChannelIdentifier>& exit_nodes);
-std::vector<::EthChannelIdentifier> deserialize_eth_chan_identifiers_from_bytes(const std::vector<uint8_t>& data);
-
-std::vector<uint8_t> serialize_reset_pairs_to_bytes(const std::vector<::ResetPair>& reset_pairs);
-std::vector<::ResetPair> deserialize_reset_pairs_from_bytes(const std::vector<uint8_t>& data);
-
 }  // namespace tt::scaleout::validation

--- a/tools/tests/scaleout/global_system_descriptors/proto/4_lb_superpod_physical_desc.textproto
+++ b/tools/tests/scaleout/global_system_descriptors/proto/4_lb_superpod_physical_desc.textproto
@@ -2045,3 +2045,1171 @@ exit_node_connection_table {
     }
   }
 }
+ethernet_metrics {
+  asic_id: 14521786451
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 29839
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 64674
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 107
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 53
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819281
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 15687
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 34252
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 2992
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 1112
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 247
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 191862
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 111090
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 2844
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786532
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 12713
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1839560
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 12001
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 1389
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786376
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 482
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 2639
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 477
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819183
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 39532
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 51153
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 2312
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 2677
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 802
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 357
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 34953
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 896
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819080
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 24345
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 61347
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 1538
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 723
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 4926045
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 245354
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786534
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 13959
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1100
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 10
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 20357
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819236
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 45663
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 897157
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 23402
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3086
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 8129654
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 8656683
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 471895
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 53243
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786371
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 77054
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 457
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 681
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 2212
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786479
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 990
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 34
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 23484
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1624191
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786531
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 308756
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 42277
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2087373
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 14056
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786438
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 52
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 97847
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 6372
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 31675
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819075
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 27270
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 280621
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 3
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 222
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 29
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 23881
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 4708
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819251
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 20720
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 192700
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 171
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 110
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 23660
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1165512
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 37202
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 6538
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819133
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 260
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 12394
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 40
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 155863
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2061
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786539
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 16215
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 5276
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 11671
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 797
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819235
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 37
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 48
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 2
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 568
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 46425
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 63489
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819238
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 1027
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 57853
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 9193
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 15680
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 361
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 4292
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 465764
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 169452
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819129
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 444
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 184974
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3726
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 31000
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 322498
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 5514
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819275
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 91880
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 164880
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 152
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 4801
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 1132770
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 644043
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 173548
+    }
+  }
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 28566
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819216
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 86441
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 294973
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 301
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 35774
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 2023
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 16791
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 63186
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 2486039
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786525
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 507
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 13493
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 187
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 16589
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786425
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 6987
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 3088
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 28176
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 690549
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786571
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 55965
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 104
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 68146
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 28368
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786512
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 5517
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 6947
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 162721
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 90465
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819229
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 22843
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 56133
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 35
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 6006
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 73
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 3127
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1181951
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 1449625
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819142
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 444
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 50048
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 769
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 201
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 1479
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 913
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 1112
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 12579959
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786429
+  channel_metrics {
+    channel: 7
+    metrics {
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 9195
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 13646
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 30870
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786547
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 5276
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 61557
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 4440
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 36208
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819243
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 2638
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 88996
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 145
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 61248
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 45405
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 241938
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 173505
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 556
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 14521786577
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 542169
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 649791
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 205
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 3658
+    }
+  }
+}
+ethernet_metrics {
+  asic_id: 10226819155
+  channel_metrics {
+    channel: 8
+    metrics {
+      corrected_codeword_count: 8309
+    }
+  }
+  channel_metrics {
+    channel: 9
+    metrics {
+      corrected_codeword_count: 357854
+    }
+  }
+  channel_metrics {
+    metrics {
+      corrected_codeword_count: 129
+    }
+  }
+  channel_metrics {
+    channel: 1
+    metrics {
+      corrected_codeword_count: 6551
+    }
+  }
+  channel_metrics {
+    channel: 14
+    metrics {
+      corrected_codeword_count: 21
+    }
+  }
+  channel_metrics {
+    channel: 15
+    metrics {
+      corrected_codeword_count: 129
+    }
+  }
+  channel_metrics {
+    channel: 7
+    metrics {
+      corrected_codeword_count: 344292
+    }
+  }
+  channel_metrics {
+    channel: 6
+    metrics {
+      corrected_codeword_count: 56630
+    }
+  }
+}

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
-#include <umd/device/cluster_descriptor.hpp>
 #include <tt_stl/strong_type.hpp>
 #include <tt_stl/reflection.hpp>
 
@@ -32,14 +31,6 @@ namespace tt::tt_metal {
 
 class Hal;
 
-// Live Ethernet Link Metrics
-struct EthernetMetrics {
-    uint32_t retrain_count = 0;
-    uint32_t crc_error_count = 0;
-    uint64_t corrected_codeword_count = 0;
-    uint64_t uncorrected_codeword_count = 0;
-};
-
 using AsicID = tt::stl::StrongType<uint64_t, struct AsicIDTag>;
 using TrayID = tt::stl::StrongType<uint32_t, struct TrayIDTag>;
 using ASICLocation = tt::stl::StrongType<uint32_t, struct ASICLocationTag>;
@@ -47,7 +38,6 @@ using RackID = tt::stl::StrongType<uint32_t, struct RackIDTag>;
 using UID = tt::stl::StrongType<uint32_t, struct UIDTag>;
 using HallID = tt::stl::StrongType<uint32_t, struct HallIDTag>;
 using AisleID = tt::stl::StrongType<uint32_t, struct AisleIDTag>;
-using LocalEthernetMetrics = std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>>;
 
 // Specify Physical ASIC Attributes
 struct ASICDescriptor {
@@ -56,6 +46,14 @@ struct ASICDescriptor {
     BoardType board_type = BoardType::UNKNOWN;
     AsicID unique_id;
     std::string host_name;
+};
+
+// Live Ethernet Link Metrics
+struct EthernetMetrics {
+    uint32_t retrain_count = 0;
+    uint32_t crc_error_count = 0;
+    uint64_t corrected_codeword_count = 0;
+    uint64_t uncorrected_codeword_count = 0;
 };
 
 // Specify an ethernet connection between two ASICs
@@ -154,20 +152,12 @@ public:
         const std::shared_ptr<distributed::multihost::DistributedContext>& distributed_context,
         const Hal* hal,
         bool using_mock_cluster_descriptor,
-        bool run_discovery = true);
+        bool run_discovery);
     // Constructor generating a PhysicalSystemDescriptor based on a protobuf
     // descriptor (can be used entirely offline).
     PhysicalSystemDescriptor(const std::string& mock_proto_desc_path);
 
     ~PhysicalSystemDescriptor();
-
-    // Move constructor (move assignment not possible due to const reference member)
-    PhysicalSystemDescriptor(PhysicalSystemDescriptor&&) = default;
-
-    // Delete copy constructor, copy assignment, and move assignment operators
-    PhysicalSystemDescriptor(const PhysicalSystemDescriptor&) = delete;
-    PhysicalSystemDescriptor& operator=(const PhysicalSystemDescriptor&) = delete;
-    PhysicalSystemDescriptor& operator=(PhysicalSystemDescriptor&&) = delete;
 
     void run_discovery(bool run_global_discovery = true);
     // ASIC Topology Query APIs
@@ -178,7 +168,7 @@ public:
     ASICLocation get_asic_location(AsicID asic_id) const;
     std::vector<AsicID> get_asics_connected_to_host(const std::string& hostname) const;
     std::pair<AsicID, uint8_t> get_connected_asic_and_channel(AsicID asic_id, uint8_t chan_id) const;
-    AsicID get_asic_id(const std::string& hostname, TrayID tray_id, ASICLocation asic_location) const;
+
     // Host Topology Query APIs
     std::vector<std::string> get_host_neighbors(const std::string& hostname) const;
     std::vector<ExitNodeConnection> get_connecting_exit_nodes(
@@ -201,19 +191,27 @@ public:
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
     bool is_using_mock_cluster() const { return using_mock_cluster_desc_; }
-    LocalEthernetMetrics query_local_ethernet_metrics() const;
+    const std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>>& get_ethernet_metrics() const {
+        return ethernet_metrics_;
+    }
 
     PhysicalConnectivityGraph& get_system_graph() { return system_graph_; }
     std::unordered_map<AsicID, ASICDescriptor>& get_asic_descriptors() { return asic_descriptors_; }
     std::unordered_map<std::string, std::string>& get_host_mobo_name_map() { return host_to_mobo_name_; }
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
+    std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>>& get_ethernet_metrics() {
+        return ethernet_metrics_;
+    }
 
     static const std::unique_ptr<tt::umd::Cluster> null_cluster;
 
     // Utility APIs to Print Physical System Descriptor
     void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt);
     void emit_to_text_proto(const std::optional<std::string>& path_to_text_proto = std::nullopt);
+
+    // API to generate Ethernet Metrics
+    void generate_local_ethernet_metrics();
 
 private:
     void run_local_discovery();
@@ -228,8 +226,6 @@ private:
     void validate_graphs();
 
     const std::unique_ptr<tt::umd::Cluster>& cluster_;
-    std::unique_ptr<umd::ClusterDescriptor> cluster_desc_ = nullptr;
-
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
     const Hal* hal_;
     const bool using_mock_cluster_desc_;
@@ -238,6 +234,7 @@ private:
     std::unordered_map<std::string, std::string> host_to_mobo_name_;
     std::unordered_map<std::string, uint32_t> host_to_rank_;
     ExitNodeConnectionTable exit_node_connection_table_;
+    std::unordered_map<AsicID, std::unordered_map<uint8_t, EthernetMetrics>> ethernet_metrics_;
     bool all_hostnames_unique_ = true;
 };
 

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -2,6 +2,14 @@ syntax = "proto3";
 
 package tt.fabric.proto;
 
+// Live Ethernet Link Metrics
+message EthernetMetrics {
+    uint32 retrain_count = 1;
+    uint32 crc_error_count = 2;
+    uint64 corrected_codeword_count = 3;
+    uint64 uncorrected_codeword_count = 4;
+}
+
 // Ethernet connection between two ASICs
 message EthConnection {
     uint32 src_chan = 1;
@@ -90,6 +98,18 @@ message ExitNodeConnectionTable {
     repeated ExitNodeConnection exit_connections = 2;
 }
 
+// Map entry for ethernet metrics per channel
+message ChannelEthernetMetrics {
+    uint32 channel = 1;
+    EthernetMetrics metrics = 2;
+}
+
+// Map entry for ASIC ID to ethernet metrics
+message AsicEthernetMetrics {
+    uint64 asic_id = 1;
+    repeated ChannelEthernetMetrics channel_metrics = 2;
+}
+
 // Top-level Physical System Descriptor message
 message PhysicalSystemDescriptor {
     PhysicalConnectivityGraph system_graph = 1;
@@ -98,4 +118,5 @@ message PhysicalSystemDescriptor {
     repeated HostToRankMap host_to_rank = 4;
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
     bool mock_cluster = 6;
+    repeated AsicEthernetMetrics ethernet_metrics = 7;
 }

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -56,6 +56,24 @@ ExitNodeConnection proto_to_exit_node_connection(const tt::fabric::proto::ExitNo
     return exit_conn;
 }
 
+// Convert EthernetMetrics to protobuf
+void ethernet_metrics_to_proto(const EthernetMetrics& metrics, tt::fabric::proto::EthernetMetrics* proto_metrics) {
+    proto_metrics->set_retrain_count(metrics.retrain_count);
+    proto_metrics->set_crc_error_count(metrics.crc_error_count);
+    proto_metrics->set_corrected_codeword_count(metrics.corrected_codeword_count);
+    proto_metrics->set_uncorrected_codeword_count(metrics.uncorrected_codeword_count);
+}
+
+// Convert protobuf to EthernetMetrics
+EthernetMetrics proto_to_ethernet_metrics(const tt::fabric::proto::EthernetMetrics& proto_metrics) {
+    EthernetMetrics metrics;
+    metrics.retrain_count = proto_metrics.retrain_count();
+    metrics.crc_error_count = proto_metrics.crc_error_count();
+    metrics.corrected_codeword_count = proto_metrics.corrected_codeword_count();
+    metrics.uncorrected_codeword_count = proto_metrics.uncorrected_codeword_count();
+    return metrics;
+}
+
 // Convert AsicTopology to protobuf
 void asic_topology_to_proto(const AsicTopology& topology, tt::fabric::proto::HostAsicConnectivity* host_asic_conn) {
     for (const auto& [asic_id, connections] : topology) {
@@ -192,6 +210,18 @@ void physical_system_descriptor_to_proto(
 
     // Set mock cluster flag
     proto_desc->set_mock_cluster(descriptor.is_using_mock_cluster());
+
+    // Convert ethernet metrics
+    for (const auto& [asic_id, channel_metrics] : descriptor.get_ethernet_metrics()) {
+        auto* proto_asic_metrics = proto_desc->add_ethernet_metrics();
+        proto_asic_metrics->set_asic_id(*asic_id);
+
+        for (const auto& [channel, metrics] : channel_metrics) {
+            auto* proto_channel_metrics = proto_asic_metrics->add_channel_metrics();
+            proto_channel_metrics->set_channel(channel);
+            ethernet_metrics_to_proto(metrics, proto_channel_metrics->mutable_metrics());
+        }
+    }
 }
 
 // Convert protobuf to PhysicalSystemDescriptor
@@ -256,6 +286,20 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
         exit_node_connection_table[proto_table.host_name()] = std::move(exit_connections);
     }
 
+    // Convert ethernet metrics
+    auto& ethernet_metrics = descriptor->get_ethernet_metrics();
+    for (const auto& proto_asic_metrics : proto_desc.ethernet_metrics()) {
+        AsicID asic_id{proto_asic_metrics.asic_id()};
+        std::unordered_map<uint8_t, EthernetMetrics> channel_metrics;
+
+        for (const auto& proto_channel_metrics : proto_asic_metrics.channel_metrics()) {
+            uint8_t channel = static_cast<uint8_t>(proto_channel_metrics.channel());
+            channel_metrics[channel] = proto_to_ethernet_metrics(proto_channel_metrics.metrics());
+        }
+
+        ethernet_metrics[asic_id] = std::move(channel_metrics);
+    }
+
     return descriptor;
 }
 
@@ -303,7 +347,7 @@ PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_bytes(const
         throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from protobuf binary format");
     }
 
-    return std::move(*proto_to_physical_system_descriptor(proto_desc));
+    return *proto_to_physical_system_descriptor(proto_desc);
 }
 
 PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_file(
@@ -320,6 +364,6 @@ PhysicalSystemDescriptor deserialize_physical_system_descriptor_from_text_proto_
         throw std::runtime_error("Failed to parse PhysicalSystemDescriptor from text proto file: " + text_proto_file);
     }
 
-    return std::move(*proto_to_physical_system_descriptor(physical_system_descriptor));
+    return *proto_to_physical_system_descriptor(physical_system_descriptor);
 }
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#31137 

### Problem description
Matmul stress tests are taking 2x as long and are timing out, causing CI failures. Binary search on a QB points to commit 2231dec4013839950a56032fc76faea9bab5d732 causing the slowdown.

### What's changed
Revert 2231dec4013839950a56032fc76faea9bab5d732.

### Checklist
BH nightly stress test [run](https://github.com/tenstorrent/tt-metal/actions/runs/18791251885), matmul runs are sped up significantly compared to [without](https://github.com/tenstorrent/tt-metal/actions/runs/18773676821/job/53587163887) the revert