### PR TITLE
Stamp version number in lite fabric binary

### DIFF
--- a/tt_metal/lite_fabric/host_util.cpp
+++ b/tt_metal/lite_fabric/host_util.cpp
@@ -257,4 +257,10 @@ void TerminateLiteFabric(tt::Cluster& cluster, const SystemDescriptor& desc) {
     SetResetState(cluster, desc, true);
 }
 
+tt::umd::tt_version GetLiteFabricVersion(tt::Cluster& cluster, const SystemDescriptor& desc) {
+    std::vector<uint8_t> version_check(3);
+    cluster.read_core(version_check.data(), 3, desc.tunnels_from_mmio[0].mmio_cxy_virtual(), LITE_FABRIC_VERSION_ADDR);
+    return tt::umd::tt_version(version_check[0], version_check[1], version_check[2]);
+}
+
 }  // namespace lite_fabric

--- a/tt_metal/lite_fabric/host_util.hpp
+++ b/tt_metal/lite_fabric/host_util.hpp
@@ -8,6 +8,7 @@
 
 #include "tt_cluster.hpp"
 #include "core_coord.hpp"
+#include <umd/device/types/cluster_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/control_plane.hpp>
 
@@ -69,5 +70,7 @@ void ResumeLiteFabric(
     tt::Cluster& cluster, const tt::tt_metal::Hal& hal, const SystemDescriptor& desc, HOST_INTERFACE& host_interface);
 
 void TerminateLiteFabric(tt::Cluster& cluster, const SystemDescriptor& desc);
+
+tt::umd::tt_version GetLiteFabricVersion(tt::Cluster& cluster, const SystemDescriptor& desc);
 
 }  // namespace lite_fabric

--- a/tt_metal/lite_fabric/hw/inc/lf_dev_mem_map.hpp
+++ b/tt_metal/lite_fabric/hw/inc/lf_dev_mem_map.hpp
@@ -10,6 +10,10 @@
 
 #define LITE_FABRIC_BARRIER 12
 
+#define LITE_FABRIC_VERSION_MAJOR 0x1
+#define LITE_FABRIC_VERSION_MINOR 0x0
+#define LITE_FABRIC_VERSION_PATCH 0x0
+
 // NOTE: Base firmware data is starting at 0x70000.
 // We need to ensure that the Lite Fabric memory does not overlap with it or Metal
 #define MEM_LITE_FABRIC_MEMORY_BASE 0x6A000
@@ -20,6 +24,10 @@
 /* Text (firmware code) section */
 #define LITE_FABRIC_TEXT_START MEM_LITE_FABRIC_MEMORY_BASE
 #define LITE_FABRIC_TEXT_SIZE 0x2000
+
+/* Version at fixed address at end of text region (host must read from this fixed address) */
+#define LITE_FABRIC_VERSION_SIZE 32
+#define LITE_FABRIC_VERSION_ADDR (LITE_FABRIC_TEXT_START + LITE_FABRIC_TEXT_SIZE - LITE_FABRIC_VERSION_SIZE)
 
 /* Data section (in L1) */
 #define LITE_FABRIC_DATA_START (LITE_FABRIC_TEXT_START + LITE_FABRIC_TEXT_SIZE)

--- a/tt_metal/lite_fabric/hw/src/lite_fabric.cpp
+++ b/tt_metal/lite_fabric/hw/src/lite_fabric.cpp
@@ -18,11 +18,16 @@
 #include "tt_metal/lite_fabric/hw/inc/channel_util.hpp"
 #include "tt_metal/lite_fabric/hw/inc/header.hpp"
 #include "tt_metal/lite_fabric/hw/inc/types.hpp"
+#include "tt_metal/lite_fabric/hw/inc/lf_dev_mem_map.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 
 #if !defined(tt_l1_ptr)
 #define tt_l1_ptr __attribute__((rvtt_l1_ptr))
 #endif
+
+__attribute__((section(".version"), used, retain))
+const volatile uint8_t lite_fabric_version[] =
+    {LITE_FABRIC_VERSION_MAJOR, LITE_FABRIC_VERSION_MINOR, LITE_FABRIC_VERSION_PATCH};
 
 /////////////////////
 // Metal globals -- Mainly to make it compile

--- a/tt_metal/lite_fabric/toolchain/lite_fabric.ld
+++ b/tt_metal/lite_fabric/toolchain/lite_fabric.ld
@@ -36,6 +36,11 @@ SECTIONS
         . = ALIGN(4);
     } :text
 
+    .version LITE_FABRIC_VERSION_ADDR :
+    {
+        KEEP(*(.version))
+    } :text
+
     .empty.init.fini :
     {
         /* Check that these sections are empty */


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28765

### Problem description
- Adding a version number is useful to figure out which lite fabric binary is loaded onto the erisc core

### What's changed
- Add the version number of the binary file
- Add a test to ensure this version number can be read

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/18794088649