### PR TITLE
[skip ci] Improve error message

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -68,6 +68,19 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
+    if (this->root_dir.empty()) {
+        log_critical(
+            tt::LogMetal,
+            "Failed to determine TT-Metal root directory. "
+            "Root directory must be set via one of the following methods:\n"
+            "1. Automatically determined when using a package install\n"
+            "2. Set TT_METAL_RUNTIME_ROOT environment variable to the path containing tt_metal/\n"
+            "3. Call RunTimeOptions::set_root_dir() API before creating RunTimeOptions\n"
+            "4. Run from the root of the repository\n"
+            "Current working directory: {}",
+            std::filesystem::current_path().string());
+    }
+
     TT_FATAL(!this->root_dir.empty(), "Root Directory is not set.");
 
     {


### PR DESCRIPTION
I chose to use log_critical directly, because it will give accurate line number in the log file, whereas TT_FATAL will not.