### PR TITLE
ND tensor support for all_reduce

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_reduce.py
+++ b/tests/nightly/t3000/ccl/test_all_reduce.py
@@ -221,24 +221,12 @@ def test_nd(mesh_device, input_shape, cluster_axis, dtype, memory_config, topolo
         input_shape, cluster_axis, tuple(mesh_device.shape), dtype, LAYOUT, memory_config, mesh_device
     )
 
-    compute_grid_size = mesh_device.compute_with_storage_grid_size()
-    ccl_sub_device_crs = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
-    )
-    # all_reduce_async requires 7(!) semaphores
-    semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(7)]
     for _ in range(NUM_ITERS):
-        tt_out_tensor = ttnn.experimental.all_reduce_async(
+        tt_out_tensor = ttnn.all_reduce(
             tt_input,
             cluster_axis=cluster_axis,
-            mesh_device=mesh_device,
-            barrier_semaphores=semaphores[:2],
-            rs_global_semaphores=semaphores[2:5],
-            ag_global_semaphores=semaphores[5:],
-            math_op=ttnn.ReduceType.Sum,
             memory_config=memory_config,
             topology=topology,
-            num_links=1,
         )
 
         tt_output_tensor = torch.cat([ttnn.to_torch(t) for t in ttnn.get_device_tensors(tt_out_tensor)])

--- a/tests/nightly/t3000/ccl/test_all_reduce.py
+++ b/tests/nightly/t3000/ccl/test_all_reduce.py
@@ -168,3 +168,79 @@ def test_ring_all_reduce_post_commit_2chip(
         cluster_axis=None,
         use_semaphore_free_all_reduce_impl=True,
     )
+
+
+def _get_tensors(input_shape, cluster_axis, mesh_shape, dtype, layout, memory_config, device):
+    """
+    Generates a replicated input tensor for the mesh and computes the golden reference tensor.
+    """
+    num_devices = math.prod(mesh_shape)
+
+    torch_inputs = [torch.rand(input_shape).bfloat16() for _ in range(num_devices)]
+    torch_input = torch.concat(torch_inputs, dim=0)
+
+    torch_reference = torch.reshape(torch_input, tuple(list(mesh_shape) + input_shape))
+    torch_reference = torch.sum(torch_reference, dim=cluster_axis)
+
+    torch_reference_copies = []
+    for x in range(mesh_shape[0]):
+        for y in range(mesh_shape[1]):
+            i, j = (x, y) if cluster_axis == 1 else (y, x)
+            torch_reference_copies.append(torch_reference[i])
+
+    torch_reference = torch.concat(torch_reference_copies, dim=0)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=layout,
+        mesh_mapper=ttnn.ShardTensorToMesh(device, dim=0),
+        memory_config=memory_config,
+        device=device,
+        dtype=dtype,
+    )
+
+    return tt_input, torch_reference
+
+
+MESH_SHAPE = (2, 4)
+LAYOUT = ttnn.TILE_LAYOUT
+NUM_ITERS = 2
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape", [[128, 128], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+def test_nd(mesh_device, input_shape, cluster_axis, dtype, memory_config, topology):
+    tt_input, torch_reference = _get_tensors(
+        input_shape, cluster_axis, tuple(mesh_device.shape), dtype, LAYOUT, memory_config, mesh_device
+    )
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    # all_reduce_async requires 7(!) semaphores
+    semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(7)]
+    for _ in range(NUM_ITERS):
+        tt_out_tensor = ttnn.experimental.all_reduce_async(
+            tt_input,
+            cluster_axis=cluster_axis,
+            mesh_device=mesh_device,
+            barrier_semaphores=semaphores[:2],
+            rs_global_semaphores=semaphores[2:5],
+            ag_global_semaphores=semaphores[5:],
+            math_op=ttnn.ReduceType.Sum,
+            memory_config=memory_config,
+            topology=topology,
+            num_links=1,
+        )
+
+        tt_output_tensor = torch.cat([ttnn.to_torch(t) for t in ttnn.get_device_tensors(tt_out_tensor)])
+        eq, mess = comp_pcc(torch_reference, tt_output_tensor)
+        assert eq, mess

--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -1068,20 +1068,12 @@ def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, t
         mesh_device,
     )
 
-    compute_grid_size = mesh_device.compute_with_storage_grid_size()
-    ccl_sub_device_crs = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
-    )
-    semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(2)]
-
     for i in range(NUM_ITERS):
-        tt_out_tensor = ttnn.experimental.all_gather_async(
+        tt_out_tensor = ttnn.all_gather(
             tt_input,
             dim,
             cluster_axis=cluster_axis,
-            mesh_device=mesh_device,
             topology=topology,
-            multi_device_global_semaphore=semaphores,
         )
 
         tt_output_tensor = torch.cat([ttnn.to_torch(t) for t in ttnn.get_device_tensors(tt_out_tensor)])

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -24,7 +24,7 @@ void AllGatherDeviceOperation::validate_on_program_cache_miss(
     // Basic validations
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in buffer on device!");
-    TT_FATAL(input_tensor.logical_shape().rank() > 2, "AllGather requires tensor of rank 3 or greater");
+    TT_FATAL(input_tensor.logical_shape().rank() >= 2, "AllGather requires tensor of rank 2 or greater");
 
     uint32_t target_ring_size = ::ttnn::ccl::get_topological_dimension(input_tensor, operation_attributes.cluster_axis);
     TT_FATAL(target_ring_size > 1, "all_gather op will only work for num_devices > 1, but has {}", target_ring_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -35,7 +35,7 @@ uint32_t finding_scatter_dim(const ttnn::Tensor& input_tensor, size_t num_worker
     const auto layout = input_tensor.layout();
     const auto rank = padded_shape.rank();
 
-    TT_FATAL(rank >= 2, "Expected input tensor to have 4 dimensions");
+    TT_FATAL(rank >= 2, "Expected input tensor to be of at least rank 2");
 
     ttnn::SmallVector<uint32_t> shape_vec(padded_shape.cbegin(), padded_shape.cend());
     if (layout == Layout::TILE) {
@@ -410,7 +410,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool use_optimal_ccl_for_llama) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
 
-    log_debug(tt::LogOp, "DEBUG: using minimal all_reduce_async 1");
+    log_debug(tt::LogOp, "Using minimal all_reduce_async");
     return ttnn::operations::experimental::ccl::all_reduce_async(
         input_tensor,
         buffer_tensor,
@@ -441,7 +441,7 @@ std::vector<ttnn::Tensor> ExecuteAllReduceAsync::invoke(
     bool use_optimal_ccl_for_llama) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensors.at(0).memory_config());
 
-    log_debug(tt::LogOp, "DEBUG: using minimal all_reduce_async 1");
+    log_debug(tt::LogOp, "Using minimal all_reduce_async with multiple tensors");
     return ttnn::operations::experimental::ccl::all_reduce_async(
         input_tensors,
         buffer_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -27,39 +27,30 @@
 
 namespace ttnn::operations::experimental::ccl {
 
-uint32_t finding_scatter_dim(const ttnn::Shape& input_tensor_padded_shape, const Layout& layout, size_t num_workers) {
+namespace detail {
+uint32_t finding_scatter_dim(const ttnn::Tensor& input_tensor, size_t num_workers) {
     // iterate until we find a dimension that is divisible by num_workers
-    TT_FATAL(input_tensor_padded_shape.size() == 4, "Expected input tensor to have 4 dimensions");
+
+    const auto& padded_shape = input_tensor.padded_shape();
+    const auto layout = input_tensor.layout();
+    const auto rank = padded_shape.rank();
+
+    TT_FATAL(rank >= 2, "Expected input tensor to have 4 dimensions");
+
+    ttnn::SmallVector<uint32_t> shape_vec(padded_shape.cbegin(), padded_shape.cend());
     if (layout == Layout::TILE) {
-        ttnn::Shape input_tensor_shape_in_tiles{
-            input_tensor_padded_shape[0],
-            input_tensor_padded_shape[1],
-            input_tensor_padded_shape[2] / tt::constants::TILE_HEIGHT,
-            input_tensor_padded_shape[3] / tt::constants::TILE_WIDTH};
-        for (int dim = 3; dim >= 0; dim--) {
-            if (input_tensor_shape_in_tiles[dim] % num_workers == 0) {
-                log_debug(
-                    tt::LogOp,
-                    "Found scatter dimension {} for input tensor with padded shape {}",
-                    dim,
-                    input_tensor_padded_shape);
-                return dim;
-            }
-        }
-    } else {
-        for (int dim = 3; dim >= 0; dim--) {
-            if (input_tensor_padded_shape[dim] % num_workers == 0) {
-                log_debug(
-                    tt::LogOp,
-                    "Found scatter dimension {} for input tensor with padded shape {}",
-                    dim,
-                    input_tensor_padded_shape);
-                return dim;
-            }
-        }
+        const auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+        auto tile_shape_it = tile_shape.crbegin();
+        std::for_each(
+            shape_vec.rbegin(), shape_vec.rbegin() + 2, [&tile_shape_it](auto& x) { x /= *(tile_shape_it++); });
     }
-    return input_tensor_padded_shape.size();
+    auto dim_it = std::find_if(
+        shape_vec.crbegin(), shape_vec.crend(), [num_workers](const auto& x) { return x % num_workers == 0; });
+
+    auto end_it = shape_vec.crend();
+    return (dim_it == end_it) ? rank : end_it - dim_it - 1;  // forward index
 }
+}  // namespace detail
 
 Tensor local_sum(
     const ttnn::Tensor& gathered_tensor,
@@ -163,10 +154,8 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     std::optional<tt::tt_metal::SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
     bool input_is_sharded = input_tensor.memory_config().is_sharded();
-    uint32_t dim = finding_scatter_dim(
-        input_tensor.padded_shape(),
-        input_tensor.layout(),
-        ttnn::ccl::get_active_physical_devices(input_tensor).size());
+    uint32_t dim =
+        detail::finding_scatter_dim(input_tensor, ttnn::ccl::get_active_physical_devices(input_tensor).size());
 
     auto padded_tensor = input_tensor;
     auto initial_shape = input_tensor.logical_shape();
@@ -188,6 +177,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     if (composite_all_gather || composite_reduce_scatter || (dim != composite_dim) ||
         tt::tt_fabric::GetFabricConfig() == tt::tt_fabric::FabricConfig::FABRIC_2D) {
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
+
         // All reduce = all gather + local reduce
         composite_dim = 0;
         auto reshaped_tensor = ttnn::reshape(
@@ -212,7 +202,6 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
 
         return ttnn::reshape(sum_tensor, initial_shape);
     }
-
     // Reduce scatter + all gather
     bool use_llama_sharded = composite_common::use_all_gather_async_llama_sharded(padded_tensor, out_memory_config);
     padded_tensor.deallocate();
@@ -262,7 +251,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
     bool input_is_sharded = input_tensor.memory_config().is_sharded();
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
-    uint32_t dim = finding_scatter_dim(input_tensor.padded_shape(), input_tensor.layout(), num_devices);
+    uint32_t dim = detail::finding_scatter_dim(input_tensor, num_devices);
     auto padded_tensor = input_tensor;
     auto initial_shape = input_tensor.logical_shape();
 
@@ -285,9 +274,13 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
         log_debug(tt::LogOp, "Using composite all gather + local reduce");
         // All reduce = all gather + local reduce
         composite_dim = 0;
-        auto reshaped_tensor = ttnn::reshape(
-            interleaved_tensor,
-            ttnn::Shape({1, initial_shape[0] * initial_shape[1], initial_shape[2], initial_shape[3]}));
+
+        ttnn::SmallVector<uint32_t> ag_shape_vec(initial_shape.rank());
+        std::copy(initial_shape.cbegin() + 2, initial_shape.cend(), ag_shape_vec.begin() + 2);
+        ag_shape_vec[0] = 1;
+        ag_shape_vec[1] = initial_shape[0] * initial_shape[1];
+
+        auto reshaped_tensor = ttnn::reshape(interleaved_tensor, ttnn::Shape(ag_shape_vec));
         interleaved_tensor.deallocate();
         auto gather_tensor = composite_common::composite_all_gather(
             reshaped_tensor,
@@ -416,6 +409,8 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     bool use_noc1_only,
     bool use_optimal_ccl_for_llama) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
+
+    log_debug(tt::LogOp, "DEBUG: using minimal all_reduce_async 1");
     return ttnn::operations::experimental::ccl::all_reduce_async(
         input_tensor,
         buffer_tensor,
@@ -445,6 +440,8 @@ std::vector<ttnn::Tensor> ExecuteAllReduceAsync::invoke(
     bool use_noc1_only,
     bool use_optimal_ccl_for_llama) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensors.at(0).memory_config());
+
+    log_debug(tt::LogOp, "DEBUG: using minimal all_reduce_async 1");
     return ttnn::operations::experimental::ccl::all_reduce_async(
         input_tensors,
         buffer_tensor,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28533

### Note on Base
~~This is branched off of [amorrison/2d-ag](https://github.com/tenstorrent/tt-metal/pull/30998) so this PR is currently pointing at that branch for ease of review. It will be redirected to `main` once the former has merged.~~

### Problem description
- all reduce should support ND tensors for generality

### What's changed
- A couple of tweaks to dim finding and test coverage
Note: this PR enables ND support only for the composite versions of all_reduce. The "minimal" version is not the most general path.
- Yak shave: Update to `ttnn.all_gather` in that Ops ND test, and tweak the validation FATAL.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes  https://github.com/tenstorrent/tt-metal/actions/runs/18726537267
- [x] Blackhole Multi-Card demo https://github.com/tenstorrent/tt-metal/actions/runs/18726548066
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/18726555935
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/18791811724
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/18791860560
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/18791903848
- [x] New/Existing tests provide coverage for changes