### PR TITLE
Only update Cluster Descriptor in GSD when running live discovery

### DIFF
--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -264,7 +264,7 @@ int main(int argc, char* argv[]) {
         reset_ethernet_links(physical_system_descriptor, missing_asic_topology);
         links_reset = true;
         num_retrains++;
-        physical_system_descriptor.run_discovery(true);
+        physical_system_descriptor.run_discovery(true, true);
         missing_asic_topology = validate_connectivity(input_args, physical_system_descriptor);
     }
 

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -167,7 +167,7 @@ public:
     PhysicalSystemDescriptor& operator=(const PhysicalSystemDescriptor&) = delete;
     PhysicalSystemDescriptor& operator=(PhysicalSystemDescriptor&&) = delete;
 
-    void run_discovery(bool run_global_discovery = true);
+    void run_discovery(bool run_global_discovery = true, bool run_live_discovery = true);
     // ASIC Topology Query APIs
     std::vector<AsicID> get_asic_neighbors(AsicID asic_id) const;
     std::vector<EthConnection> get_eth_connections(AsicID src_asic_id, AsicID dst_asic_id) const;
@@ -214,7 +214,7 @@ public:
     void emit_to_text_proto(const std::optional<std::string>& path_to_text_proto = std::nullopt);
 
 private:
-    void run_local_discovery();
+    void run_local_discovery(bool run_live_discovery);
     void run_global_discovery();
     void clear();
     void merge(PhysicalSystemDescriptor&& other);


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- BH Nightly Stress Tests are timing out on main after this PR was merged: https://github.com/tenstorrent/tt-metal/pull/30963
- This is because `PhysicalSystemDescriptor::run_local_discovery()` currently creates a new cluster descriptor each time it's called unconditionally
- When executing tests on BH, Control Plane is reinitialized for each workload -> `PhysicalSystemDescriptor::run_local_discovery()` is called -> new cluster descriptor is created each time, which causes test runtime to increase

### What's changed
- Instead of creating a new cluster descriptor when the `PhysicalSystemDescriptor` ctor is called, only create a new one when `PhysicalSystemDescriptor::run_discovery()` is explicitly called with the `run_live_discovery` flag set to true
- Users now have the option of explicitly specifying if live state should be queried during discovery

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes