### PR TITLE
SDXL perf test fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -41,9 +41,10 @@ def test_unet(
         encoder_shape,
         temb_shape,
         time_ids_shape,
-        is_ci_env,
-        is_ci_v2_env,
-        model_location_generator,
+        debug_mode=False,
+        is_ci_env=is_ci_env,
+        is_ci_v2_env=is_ci_v2_env,
+        model_location_generator=model_location_generator,
         iterations=iterations,
     )
 

--- a/models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py
@@ -48,7 +48,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_143_350_098
+    expected_device_perf_cycles_per_iteration = 1_060_704_386
 
     command = f"pytest models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]


### PR DESCRIPTION
### What's changed
PR to fix broken UNet CI device perf test on main

### Checklist
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/188158455896) CI passes