### PR TITLE
Enable fold+Matmul for conv2d where kernel==stride

### DIFF
--- a/models/experimental/swin_s/tt/common.py
+++ b/models/experimental/swin_s/tt/common.py
@@ -74,7 +74,7 @@ class Conv:
         if self.act_block_h is not None:
             conv_config.act_block_h_override = self.act_block_h
 
-        # Enabling kernel stride folding lands in to matmul where is fails because of
+        # Enabling kernel stride folding lands in to matmul where it fails because of
         # dimensionality mismatch. Disabling it to avoid the issue. Once #31313 is fixed, this can be re-enabled.
         conv_config.enable_kernel_stride_folding = False
         [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(

--- a/models/experimental/swin_s/tt/common.py
+++ b/models/experimental/swin_s/tt/common.py
@@ -74,6 +74,9 @@ class Conv:
         if self.act_block_h is not None:
             conv_config.act_block_h_override = self.act_block_h
 
+        # Enabling kernel stride folding lands in to matmul where is fails because of
+        # dimensionality mismatch. Disabling it to avoid the issue. Once #31313 is fixed, this can be re-enabled.
+        conv_config.enable_kernel_stride_folding = False
         [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(
             input_tensor=input_tensor,
             weight_tensor=self.weights,

--- a/models/experimental/swin_v2/tt/common.py
+++ b/models/experimental/swin_v2/tt/common.py
@@ -57,7 +57,7 @@ class Conv:
         if self.act_block_h is not None:
             self.conv_config.act_block_h_override = self.act_block_h
 
-        # Enabling kernel stride folding lands in to matmul where is fails because of
+        # Enabling kernel stride folding lands in to matmul where it fails because of
         # dimensionality mismatch. Disabling it to avoid the issue. Once #31313 is fixed, this can be re-enabled.
         self.conv_config.enable_kernel_stride_folding = False
         [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(

--- a/models/experimental/swin_v2/tt/common.py
+++ b/models/experimental/swin_v2/tt/common.py
@@ -57,6 +57,9 @@ class Conv:
         if self.act_block_h is not None:
             self.conv_config.act_block_h_override = self.act_block_h
 
+        # Enabling kernel stride folding lands in to matmul where is fails because of
+        # dimensionality mismatch. Disabling it to avoid the issue. Once #31313 is fixed, this can be re-enabled.
+        self.conv_config.enable_kernel_stride_folding = False
         [output_tensor, [_out_height, _out_width], [self.weights, self.bias]] = ttnn.conv2d(
             input_tensor=input_tensor,
             dtype=self.dtype,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -227,6 +227,7 @@ Result conv2d_DRAM(
         in_channels,
         kernel_size,
         stride,
+        dilation,
         padding_n4,
         mm_conv,
         conv_config);
@@ -466,6 +467,7 @@ Result conv2d_L1(
         in_channels,
         kernel_size,
         stride,
+        dilation,
         padding_n4,
         mm_conv,
         conv_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -443,11 +443,16 @@ void py_bind_conv2d(py::module& module) {
     py_conv_config.def_readwrite("enable_kernel_stride_folding", &Conv2dConfig::enable_kernel_stride_folding, R"doc(
         ===================== EXPERIMENTAL FEATURE ======================
 
-        Enables tensor folding optimization when strides match kernel dimensions.
+        Enables tensor folding optimization that transforms convolution operations by reshaping tensors
+        and adjusting stride patterns for improved computational efficiency.
 
-        This feature is under development and may change without notice.
-        Use with caution in production environments (Issue: #22378).
+        Args:
+            enable_kernel_stride_folding (Optional[bool]):
+                - None (default): Automatic enablement based on optimal conditions
+                - True: Force enable the optimization
+                - False: Disable the optimization
 
+        Behavior:
         When enabled, this optimization reshapes tensors as follows:
 
         * Input tensor (NHWC format):
@@ -457,15 +462,33 @@ void py_bind_conv2d(py::module& module) {
         * Weight tensor:
           - From: (OC, IC, kernel[0], kernel[1])
           - To: (1, 1, IC * (kernel[0] + pad_h) * (kernel[1] + pad_w), OC)
-          Note: The zero padding applied to the weight tensor is implicit and not passed by the user via the padding argument,
-          where pad_h = kernel[0] % stride[0] and pad_w = kernel[1] % stride[1].
+          where pad_h = kernel[0] % stride[0] and pad_w = kernel[1] % stride[1]
 
-        Note: This optimization is currently only applied when all of the following conditions are met:
-        1. The input tensor is stored in DRAM memory.
-        2. The input tensor's height and width are divisible by the stride dimensions.
-        3. Stride values are equal to or less than the kernel dimensions.
-        4. Input tensor's padding must be zero.
-        5. Input tensor data type is not BFLOAT8_B.
+        * Stride: Becomes (1, 1) after folding
+
+        Automatic Enablement:
+        When set to None, automatically enabled when ALL conditions are met (transforms conv2d into Fold + MatMul):
+        1. Stride equals kernel size in both dimensions (stride == kernel_size)
+        2. Stride is greater than 1 in at least one dimension
+        3. No dilation applied (dilation == [1, 1])
+        4. Input height and width (after padding) are divisible by respective stride values
+        5. Input tensor memory: DRAM (all types except bfloat8_b) OR L1 Height-sharded (all types)
+
+        Manual Enablement:
+        Particularly beneficial for unaligned input channels (e.g., small channel counts like 3 RGB channels).
+
+        Requirements when forcing enable_kernel_stride_folding=True:
+        - Stride ≤ kernel size in both dimensions
+        - Input tensor supports folding (DRAM except bfloat8_b, or L1 Height-sharded)
+        - Input dimensions after padding are divisible by stride values
+
+        Example:
+        For small channel counts (like 3 RGB channels) with stride=2x2, kernel=7x7:
+        - Transforms 3 channels → 12 channels, stride 2x2 → 1x1
+        - Reduces required padding for alignment (3→12 uses alignment more efficiently)
+        - Kernel size reduces to kernel/stride (e.g., 7x7 kernel → 4x4 kernel with padding)
+
+        Note: The weight tensor padding is applied implicitly and not passed via the padding argument.
 
         ===============================================================
         )doc");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -609,6 +609,11 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
                     shard_layout = TensorMemoryLayout::BLOCK_SHARDED;
                 }
             }
+            // Additional check for mm convs to ensure shard height is multiple of TILE_HEIGHT since tiling requires
+            // that
+            if (is_mm_conv && input_shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0) {
+                needs_shard_or_reshard = true;
+            }
 
             if (conv_config.override_sharding_config) {
                 TT_FATAL(
@@ -1543,22 +1548,40 @@ bool conv2d::determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint3
 }
 
 bool auto_enable_kernel_folding(
+    const ttnn::MemoryConfig& input_memory_config,
+    const DataType& input_dtype,
     std::optional<bool> enable_folding_,
-    bool is_dram,
     uint32_t input_height,
     uint32_t input_width,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 2>& dilation,
     std::array<uint32_t, 4>& padding_n4) {
     if (!enable_folding_.has_value()) {
-        if (stride[0] == kernel_size[0] && stride[1] == kernel_size[1] && (input_height % stride[0] == 0) &&
-            (input_width % stride[1] == 0) &&
-            (padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0) && is_dram) {
-            log_debug(tt::LogOp, "Auto enabling kernel folding");
-            return true;
-        } else {
+        if (stride[0] != kernel_size[0] || stride[1] != kernel_size[1]) {
             return false;
         }
+        if (stride[0] == 1 && stride[1] == 1) {
+            return false;
+        }
+        if (dilation[0] != 1 || dilation[1] != 1) {
+            return false;
+        }
+        if (stride[0] > kernel_size[0] || stride[1] > kernel_size[1]) {
+            return false;
+        }
+        auto input_padded_height = input_height + padding_n4[0] + padding_n4[1];
+        auto input_padded_width = input_width + padding_n4[2] + padding_n4[3];
+
+        if (input_padded_height % stride[0] != 0 || input_padded_width % stride[1] != 0) {
+            return false;
+        }
+        if (!((input_memory_config.is_dram() && input_dtype != DataType::BFLOAT8_B) ||
+              (input_memory_config.is_l1() && input_memory_config.is_sharded() &&
+               input_memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED))) {
+            return false;
+        }
+        return true;
     } else {
         return enable_folding_.value();
     }
@@ -1571,18 +1594,21 @@ Tensor fold_input_tensor_if_required(
     uint32_t& in_channels,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 2>& dilation,
     std::array<uint32_t, 4>& padding_n4,
     bool& mm_conv,
     Conv2dConfig& conv_config) {
     // Conv DRAM would fold the input tensor, but conv_config.enable_kernel_stride_folding would stil be true as weights
     // also need to be folded.
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
+        input_tensor.memory_config(),
+        input_tensor.dtype(),
         conv_config.enable_kernel_stride_folding,
-        input_tensor.memory_config().is_dram(),
         input_height,
         input_width,
         kernel_size,
         stride,
+        dilation,
         padding_n4);
 
     if (conv_config.enable_kernel_stride_folding.value() && (stride[0] > 1 || stride[1] > 1)) {
@@ -1615,12 +1641,6 @@ ttnn::Tensor fold_tensor(
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 4> padding_n4) {
     // Validation checks
-    TT_FATAL(
-        !tensor.memory_config().is_l1(),
-        "Conv2D kernel stride folding: Input tensor must not be in L1 memory for folding");
-    TT_FATAL(
-        tensor.dtype() != tt::tt_metal::DataType::BFLOAT8_B,
-        "Conv2D kernel stride folding: Currently doesn't support BFLOAT8_B");
     TT_FATAL(
         stride[0] <= kernel_size[0] && stride[1] <= kernel_size[1],
         "Conv2D kernel stride folding: Stride must be less than or equal to kernel size");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1567,9 +1567,6 @@ bool auto_enable_kernel_folding(
         if (dilation[0] != 1 || dilation[1] != 1) {
             return false;
         }
-        if (stride[0] > kernel_size[0] || stride[1] > kernel_size[1]) {
-            return false;
-        }
         auto input_padded_height = input_height + padding_n4[0] + padding_n4[1];
         auto input_padded_width = input_width + padding_n4[2] + padding_n4[3];
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1576,7 +1576,7 @@ bool auto_enable_kernel_folding(
         }
         auto is_zero_padding = padding_n4[0] == 0 && padding_n4[1] == 0 && padding_n4[2] == 0 && padding_n4[3] == 0;
         return (
-            (input_memory_config.is_dram() && !(input_layout == Layout::TILE && is_zero_padding)) ||
+            (input_memory_config.is_dram() && (input_layout == Layout::ROW_MAJOR || is_zero_padding)) ||
             (input_memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED));
     } else {
         return enable_folding_.value();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -611,7 +611,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
             }
             // Additional check for mm convs to ensure shard height is multiple of TILE_HEIGHT since tiling requires
             // that
-            if (is_mm_conv && input_shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0) {
+            if (is_mm_conv && (input_shard_spec.shape[0] % tt::constants::TILE_HEIGHT != 0)) {
                 needs_shard_or_reshard = true;
             }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -193,12 +193,14 @@ shard_or_reshard_tensor_if_required(
     bool auto_shard);
 
 bool auto_enable_kernel_folding(
+    const ttnn::MemoryConfig& input_memory_config,
+    const DataType& input_dtype,
     std::optional<bool> enable_folding_,
-    bool is_dram,
     uint32_t input_height,
     uint32_t input_width,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 2>& dilation,
     std::array<uint32_t, 4>& padding_n4);
 
 Tensor fold_input_tensor_if_required(
@@ -209,6 +211,7 @@ Tensor fold_input_tensor_if_required(
     uint32_t& in_channels,
     std::array<uint32_t, 2>& kernel_size,
     std::array<uint32_t, 2>& stride,
+    std::array<uint32_t, 2>& dilation,
     std::array<uint32_t, 4>& padding_n4,
     bool& mm_conv,
     Conv2dConfig& conv_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -194,6 +194,7 @@ shard_or_reshard_tensor_if_required(
 
 bool auto_enable_kernel_folding(
     const ttnn::MemoryConfig& input_memory_config,
+    Layout input_layout,
     const DataType& input_dtype,
     std::optional<bool> enable_folding_,
     uint32_t input_height,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1115,12 +1115,14 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     auto orig_stride = stride;
     const bool is_conv1d = is_1d_conv(kernel_size[1], input_width);
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
+        input_memory_config,
+        input_dtype,
         conv_config.enable_kernel_stride_folding,
-        input_memory_config.is_dram(),
         input_height,
         input_width,
         kernel_size,
         stride,
+        dilation,
         padding_n4);
     if (conv_config.enable_kernel_stride_folding.value()) {
         auto folding_result = compute_kernel_stride_folding_params(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1116,6 +1116,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     const bool is_conv1d = is_1d_conv(kernel_size[1], input_width);
     conv_config.enable_kernel_stride_folding = auto_enable_kernel_folding(
         input_memory_config,
+        input_layout,
         input_dtype,
         conv_config.enable_kernel_stride_folding,
         input_height,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -453,9 +453,9 @@ Tensor FoldOperation::invoke(
                 ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
         }
 
-        // Convert to row-major if tiled since fold supports only row-major layout
+        // If processed tensor is tiled, convert to row-major.
         if (processed_tensor.layout() == Layout::TILE) {
-            processed_tensor = ttnn::untilize(processed_tensor, std::nullopt, true, true);
+            processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
         // Reshard if needed for optimal fold computation
         processed_tensor = reshard_if_needed(processed_tensor, stride_h, stride_w);


### PR DESCRIPTION
### Ticket
#22378

### Problem description
kernel stride folding where kernel==stride was not enabled by default.

### What's changed
Enable kernel stride folding eligibility with following constrains:
  - Extended support to L1 height-sharded tensors (previously DRAM-only)
  - Added dilation validation (must be 1x1) and improved stride/kernel validation
  - Enhanced dimension checks using padded input dimensions for accuracy

Improved fold operation robustness:
  - Auto-convert tiled tensors to row-major before folding.
  - Added L1 shard height validation for TILE_HEIGHT compatibility.

Model-specific control: Added escape hatch for swin_s model where folding causes
  downstream matmul dimensionality failures

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19126314852)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19097084256)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19097035165/job/54560175948) same as main
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/19097062405)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19126309073)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19126302406)