### PR TITLE
[skip ci] one line fix to make parsing in bisect less fragile

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -214,7 +214,7 @@ jobs:
 
           # Parse commit range from combined input
           COMMIT_RANGE='${{ inputs.commit-range }}'
-          IFS=',' read -r GOOD_COMMIT BAD_COMMIT <<< "$COMMIT_RANGE"
+          IFS=', ' read -r GOOD_COMMIT BAD_COMMIT <<< "$COMMIT_RANGE"
 
           # Validate parsed values
           if [ -z "$GOOD_COMMIT" ] || [ -z "$BAD_COMMIT" ]; then


### PR DESCRIPTION
### Ticket
NA

### Problem description
Having a space between commits in the bisect tool causes validate inputs to break (e.g. "123abc, 789xyz" is invalid).

### What's changed
Made the parsing for commits strip whitespace

### Checklist
- [ ] [Bisect Dispatch](https://github.com/tenstorrent/tt-metal/actions/workflows/bisect-dispatch.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18842780312 https://github.com/tenstorrent/tt-metal/actions/runs/18843132705