### PR TITLE
Fix test path for Gemma3

### DIFF
--- a/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
+++ b/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
@@ -1,11 +1,24 @@
 {
-    "T3K": {
-        "model_forward_inference": 0.5988920000000001
+    "gemma-3-4b-it": {
+        "T3K": {
+            "model_forward_inference": 0.5988920000000001
+        },
+        "N150": {
+            "model_forward_inference": 0.7977291428571428
+        },
+        "N300": {
+            "model_forward_inference": 0.5401455714285713
+        }
     },
-    "N150": {
-        "model_forward_inference": 0.7977291428571428
-    },
-    "N300": {
-        "model_forward_inference": 0.5401455714285713
+    "gemma-3-27b-it": {
+        "T3K": {
+            "model_forward_inference": 0.5716122666666666
+        },
+        "N150": {
+            "model_forward_inference": 0.8444842666666666
+        },
+        "N300": {
+            "model_forward_inference": 0.5853735333333333
+        }
     }
 }

--- a/models/demos/gemma3/tests/test_ci_dispatch.py
+++ b/models/demos/gemma3/tests/test_ci_dispatch.py
@@ -28,7 +28,7 @@ def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_gene
         "models/demos/gemma3/tests/test_mmp.py",
     ]
     ci_v1_tests = [
-        "models/demos/gemma3/tests/test_benchmark_vision_cross_attention_transformer.py",
+        "models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py",
         "models/demos/siglip/tests/test_attention.py",
         "models/demos/gemma3/tests/test_patch_embedding.py",
         "models/demos/gemma3/tests/test_vision_attention.py",
@@ -56,8 +56,8 @@ def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_gene
 
     # Pass the exit code of pytest to proper keep track of failures during runtime
     exit_code = pytest.main(tests + ["-x"])
-    if exit_code == pytest.ExitCode.TESTS_FAILED:
+    if exit_code != pytest.ExitCode.OK:
         pytest.fail(
-            f"One or more CI dispatch tests failed for {hf_model_name}. Please check the log above for more info",
+            f"Pytest failed with exit code {exit_code} for {hf_model_name}. " "Check logs above for details.",
             pytrace=False,
         )

--- a/models/demos/gemma3/tests/test_ci_dispatch.py
+++ b/models/demos/gemma3/tests/test_ci_dispatch.py
@@ -43,8 +43,8 @@ def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_gene
         "models/tt_transformers/tests/test_embedding.py",
         "models/tt_transformers/tests/test_rms_norm.py",
         "models/tt_transformers/tests/test_mlp.py",
-        # "models/tt_transformers/tests/test_attention.py",
-        # "models/tt_transformers/tests/test_attention_prefill.py",
+        "models/tt_transformers/tests/test_attention.py",
+        "models/tt_transformers/tests/test_attention_prefill.py",
         "models/tt_transformers/tests/test_decoder.py",
         "models/tt_transformers/tests/test_decoder_prefill.py",
     ]

--- a/models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py
+++ b/models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py
@@ -55,16 +55,16 @@ def test_perf_gemma_vision(mesh_device, batch_size, nr_forward_iterations):
         measurements[k] = profiler.get_duration(k) if k != "model_forward_inference" else inference_mean
         logger.info(f"measurement {k}: {measurements[k]}")
 
-    targets = load_targets(
-        TARGETS_JSON_FILENAME,
-        device_type=determine_device_name(mesh_device),
-    )
+    model_name = get_model_name()
+
+    targets = load_targets(TARGETS_JSON_FILENAME, device_type=determine_device_name(mesh_device), model_name=model_name)
 
     if SAVE_NEW_PERF_TARGETS:
         helper_write_to_json(
             determine_device_name(mesh_device),
             measurements["model_forward_inference"],
             output_filename=TARGETS_JSON_FILENAME,
+            model_name=model_name,
         )
 
     upper_threshold = targets["model_forward_inference"] * (1 + THRESHOLD_PERCENT / 100)
@@ -72,7 +72,7 @@ def test_perf_gemma_vision(mesh_device, batch_size, nr_forward_iterations):
     assert lower_threshold < inference_mean < upper_threshold
 
 
-def helper_write_to_json(device_type, measurements, output_filename):
+def helper_write_to_json(device_type, measurements, output_filename, model_name):
     """
     This function reads the file /output_filename/ and updates it with the new measurements. For example if the file has measurements for N150 it will overwrite them with the new measurements.
     """
@@ -80,7 +80,7 @@ def helper_write_to_json(device_type, measurements, output_filename):
     with open(output_filename, "r") as f:
         file_dict = json.load(f)
 
-    file_dict[device_type] = {"model_forward_inference": measurements}
+    file_dict[model_name][device_type] = {"model_forward_inference": measurements}
 
     with open(output_filename, "w") as f:
         json.dump(file_dict, f, indent=4)
@@ -134,7 +134,7 @@ def run_model(mesh_device, batch_size, profiler, nr_forward_iterations):
     return tt_output_torch
 
 
-def load_targets(filename, device_type):
+def load_targets(filename, device_type, model_name):
     if not os.path.exists(filename):
         logger.warning(f"Expected outputs file {filename} does not exist. Skipping loading targets.")
         return []
@@ -146,6 +146,20 @@ def load_targets(filename, device_type):
             logger.error(f"Error decoding JSON from {filename}: {e}. Returning empty list.")
             return []
 
-    dict_targets = targets[device_type]
+    dict_targets = targets[model_name][device_type]
 
     return dict_targets
+
+
+def get_model_name():
+    full_name = os.getenv("HF_MODEL")
+
+    if "gemma" not in full_name:
+        raise ValueError(f"Unsupported model name: {full_name}")
+
+    if "4b" in full_name:
+        return "gemma-3-4b-it"
+    elif "27b" in full_name:
+        return "gemma-3-27b-it"
+    else:
+        raise ValueError(f"Unsupported model name: {full_name}")

--- a/models/demos/siglip/tests/test_attention.py
+++ b/models/demos/siglip/tests/test_attention.py
@@ -38,11 +38,8 @@ from models.demos.siglip.tt.attention import siglip_attention_ttnn
 )
 @pytest.mark.parametrize("attention_func", [siglip_attention, siglip_attention_ttnn])
 def test_attention(mesh_device, attention_func, model_location_generator, is_ci_env):
-    config = AutoConfig.from_pretrained(
-        model_location_generator(model_version=os.getenv("HF_MODEL"), download_if_ci_v2=True)
-        if is_ci_env
-        else os.getenv("HF_MODEL")
-    )
+    config = AutoConfig.from_pretrained(os.getenv("HF_MODEL"))
+
     assert hasattr(
         config, "vision_config"
     ), f"Unexpected model config provided. Expected a vision_config field to be present in: {config}"

--- a/models/demos/siglip/tests/test_attention.py
+++ b/models/demos/siglip/tests/test_attention.py
@@ -38,8 +38,11 @@ from models.demos.siglip.tt.attention import siglip_attention_ttnn
 )
 @pytest.mark.parametrize("attention_func", [siglip_attention, siglip_attention_ttnn])
 def test_attention(mesh_device, attention_func, model_location_generator, is_ci_env):
-    config = AutoConfig.from_pretrained(os.getenv("HF_MODEL"))
-
+    config = AutoConfig.from_pretrained(
+        model_location_generator(model_version=os.getenv("HF_MODEL"), download_if_ci_v2=True)
+        if is_ci_env
+        else os.getenv("HF_MODEL")
+    )
     assert hasattr(
         config, "vision_config"
     ), f"Unexpected model config provided. Expected a vision_config field to be present in: {config}"

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -178,7 +178,9 @@ def test_decoder_inference(
 
         # Reference model
         attn_mask = torch.triu(torch.full((max_seq_len, max_seq_len), torch.finfo(torch.float32).min), diagonal=1)
-        if model_args.sliding_window > 0:
+        if model_args.sliding_window > 0 and (
+            hasattr(reference_model, "attention_type") and reference_model.attention_type == "sliding_attention"
+        ):
             attn_mask += torch.tril(
                 torch.full((max_seq_len, max_seq_len), -float("inf")), diagonal=-model_args.sliding_window
             )

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -177,13 +177,16 @@ def test_decoder_inference(
         )[positions]
 
         # Reference model
-        attn_mask = torch.full((max_seq_len, max_seq_len), torch.finfo(torch.float32).min)
-        attn_mask_torch = torch.triu(attn_mask, diagonal=1)
+        attn_mask = torch.triu(torch.full((max_seq_len, max_seq_len), torch.finfo(torch.float32).min), diagonal=1)
+        if model_args.sliding_window > 0:
+            attn_mask += torch.tril(
+                torch.full((max_seq_len, max_seq_len), -float("inf")), diagonal=-model_args.sliding_window
+            )
         ref_output = reference_model(
             pt_decode_input,
             positions[0],
             freqs_cis_i,
-            mask=attn_mask_torch,
+            mask=attn_mask,
         )
         # Run TT model
         tt_out = tt_model(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1616,6 +1616,9 @@ class ModelArgs:
 
         self.query_pre_attn_scalar = text_config.get("query_pre_attn_scalar", None)
 
+        # Sliding window attention
+        self.sliding_window = text_config.get("sliding_window", None)
+
         # Configurable MLP activation type
         self.mlp_activation_type = self._get_hidden_activation_type(text_config)
 


### PR DESCRIPTION
### Problem description
- After https://github.com/tenstorrent/tt-metal/commit/4719befdfcbcdbb7681f502858c67240681338ed, some tests for Gemma3 stopped running but CI was still passing (practically speaking these tests were skipped). This gave us false positives for the tests (without running them at all)
- NOTE: **for 2 weeks the tests were giving false positives/passing**
- This PR made the CI run again, but some tests are now failing (because of the changes in the previous 2 weeks)
- Small note: even though the CI is reenabled it stops running after the first tests fails, so we still have poor visibility

### What's changed
This PR aims to fix the above mentioned problem:
1. From now on `tests/nightly/single_card/gemma3/test_ci_dispatch.py` and `models/demos/gemma3/tests/test_ci_dispatch.py` will fail if given wrong tests paths. (shown/proven in https://github.com/tenstorrent/tt-metal/actions/runs/18845223291/job/53769074852)
2. The actual incorrect file path introduced in https://github.com/tenstorrent/tt-metal/commit/4719befdfcbcdbb7681f502858c67240681338ed was corrected
3. Fixes the test `models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py` (which we thought was good because of the false positives in CI before)
4. Small fix for sliding window attention (which we thought was good because of the false positives in CI before)

### Tests that were temporarily passing without running
- Gemma3 tests for "(T3K) T3000 unit tests" (defined in `.github/workflows/t3000-unit-tests.yaml`)
-  Gemma3 tests for "(Single-card) Frequent model and ttnn tests" (defined in `.github/workflows/fast-dispatch-full-regressions-and-models.yaml`)

### Tests
