### PR TITLE
Revert "#31137: [skip ci] TTNN stress test: bump timeout and skip ccl test"

### DIFF
--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 70
+        default: 45
       docker-image:
         required: true
         type: string
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Stress Tests
         timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/stress_tests/ --ignore=tests/ttnn/stress_tests/test_ccl.py
+        run: pytest tests/ttnn/stress_tests/
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#31138
PR bumped timeout which is not needed after fix merged into main.

TTNN stress tests: https://github.com/tenstorrent/tt-metal/actions/runs/18844261122