### PR TITLE
prototype for struct as runtime arguments

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -157,7 +157,41 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
 
 // clang-format off
 /**
- * Pushes a given number of tiles in the back of the specified CB’s queue.
+ * Returns a reference to unique runtime arguments as a POD struct. The runtime arguments are reinterpreted
+ * as the given struct type.
+ *
+ * Return value: Reference to the runtime arguments as type T
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|-------------|----------|
+ * | T (template argument) | POD struct type to interpret the arguments as  | Any POD struct        | N/A         | True     |
+ */
+// clang-format on
+template <typename T>
+FORCE_INLINE T& get_runtime_arguments() {
+    return *((tt_l1_ptr T*)(rta_l1_base));
+}
+
+// clang-format off
+/**
+ * Returns a reference to common runtime arguments as a POD struct. The runtime arguments are reinterpreted
+ * as the given struct type.
+ *
+ * Return value: Reference to the common runtime arguments as type T
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|-------------|----------|
+ * | T (template argument) | POD struct type to interpret the arguments as  | Any POD struct        | N/A         | True     |
+ */
+// clang-format on
+template <typename T>
+FORCE_INLINE T& get_common_runtime_arguments() {
+    return *((tt_l1_ptr T*)(crta_l1_base));
+}
+
+// clang-format off
+/**
+ * Pushes a given number of tiles in the back of the specified CB's queue.
  * Decreases the available space in the circular buffer by this number of
  * tiles. This call is used by the producer to make the tiles visible to the
  * consumer of the CB.

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -84,6 +84,40 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
 
 // clang-format off
 /**
+ * Returns a reference to unique runtime arguments as a POD struct. The runtime arguments are reinterpreted
+ * as the given struct type.
+ *
+ * Return value: Reference to the runtime arguments as type T
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|-------------|----------|
+ * | T (template argument) | POD struct type to interpret the arguments as  | Any POD struct        | N/A         | True     |
+ */
+// clang-format on
+template <typename T>
+FORCE_INLINE T& get_runtime_arguments() {
+    return *((tt_l1_ptr T*)(rta_l1_base));
+}
+
+// clang-format off
+/**
+ * Returns a reference to common runtime arguments as a POD struct. The runtime arguments are reinterpreted
+ * as the given struct type.
+ *
+ * Return value: Reference to the common runtime arguments as type T
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|-------------|----------|
+ * | T (template argument) | POD struct type to interpret the arguments as  | Any POD struct        | N/A         | True     |
+ */
+// clang-format on
+template <typename T>
+FORCE_INLINE T& get_common_runtime_arguments() {
+    return *((tt_l1_ptr T*)(crta_l1_base));
+}
+
+// clang-format off
+/**
  * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate
  * is the one relative to the origin of the physical grid.
  *

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/loopback)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/matmul)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/pad_multi_core)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/shard_data_rm)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/struct_runtime_args)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vecadd_sharding)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vecadd_multi_core)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NoC_tile_transfer)
@@ -46,6 +47,7 @@ install(
         loopback
         matmul
         shard_data_rm
+        struct_runtime_args
         NoC_tile_transfer
         sfpu_eltwise_chain
         custom_sfpi_add
@@ -74,6 +76,7 @@ install(
         loopback
         matmul
         shard_data_rm
+        struct_runtime_args
         NoC_tile_transfer
         sfpu_eltwise_chain
         custom_sfpi_add

--- a/tt_metal/programming_examples/struct_runtime_args/CMakeLists.txt
+++ b/tt_metal/programming_examples/struct_runtime_args/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.22...3.30)
+project(metal_example_struct_runtime_args)
+
+add_executable(metal_example_struct_runtime_args)
+target_sources(metal_example_struct_runtime_args PRIVATE struct_runtime_args.cpp)
+
+if(NOT TARGET TT::Metalium)
+    find_package(TT-Metalium REQUIRED)
+endif()
+target_link_libraries(metal_example_struct_runtime_args PUBLIC TT::Metalium)

--- a/tt_metal/programming_examples/struct_runtime_args/kernels/dataflow/struct_args_kernel.cpp
+++ b/tt_metal/programming_examples/struct_runtime_args/kernels/dataflow/struct_args_kernel.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "debug/dprint.h"  // required in all kernels using DPRINT
+#include "dataflow_api.h"
+#include <array>
+#include <utility>
+#include <tuple>
+
+// Define the same complex struct as on the host side
+enum class OperationType : uint32_t { ADD = 0, MULTIPLY = 1, SUBTRACT = 2, DIVIDE = 3 };
+
+struct NestedData {
+    uint32_t id;
+    uint32_t value;
+    uint32_t multiplier;
+};
+
+struct CommonRuntimeArgs {
+    uint32_t global_offset;
+    uint32_t global_scale;
+    std::array<uint32_t, 3> constants;
+    NestedData shared_data;
+    OperationType operation;
+};
+
+struct RuntimeArgs {
+    uint32_t core_id;
+    std::array<uint32_t, 4> vector_data;
+    std::pair<uint32_t, uint32_t> range;
+    std::tuple<uint32_t, uint32_t, uint32_t> triple;
+    NestedData nested;
+    OperationType op_mode;
+};
+
+void kernel_main() {
+    // Get runtime arguments using the new struct-based API
+    auto& rt_args = get_runtime_arguments<RuntimeArgs>();
+    auto& common_args = get_common_runtime_arguments<CommonRuntimeArgs>();
+
+    // Print core coordinates
+    DPRINT << "=== Core (" << (uint32_t)get_absolute_logical_x() << "," << (uint32_t)get_absolute_logical_y()
+           << ") ===" << ENDL();
+
+    // Print runtime args (unique per core)
+    DPRINT << "Runtime Args:" << ENDL();
+    DPRINT << "  core_id: " << rt_args.core_id << ENDL();
+
+    DPRINT << "  vector_data: [";
+    for (uint32_t i = 0; i < 4; i++) {
+        DPRINT << rt_args.vector_data[i];
+        if (i < 3) {
+            DPRINT << ", ";
+        }
+    }
+    DPRINT << "]" << ENDL();
+
+    DPRINT << "  range: (" << rt_args.range.first << ", " << rt_args.range.second << ")" << ENDL();
+
+    DPRINT << "  triple: (" << std::get<0>(rt_args.triple) << ", " << std::get<1>(rt_args.triple) << ", "
+           << std::get<2>(rt_args.triple) << ")" << ENDL();
+
+    DPRINT << "  nested.id: " << rt_args.nested.id << ENDL();
+    DPRINT << "  nested.value: " << rt_args.nested.value << ENDL();
+    DPRINT << "  nested.multiplier: " << rt_args.nested.multiplier << ENDL();
+
+    DPRINT << "  op_mode: " << static_cast<uint32_t>(rt_args.op_mode) << ENDL();
+
+    // Print common args (same for all cores)
+    DPRINT << "Common Runtime Args:" << ENDL();
+    DPRINT << "  global_offset: " << common_args.global_offset << ENDL();
+    DPRINT << "  global_scale: " << common_args.global_scale << ENDL();
+
+    DPRINT << "  constants: [";
+    for (uint32_t i = 0; i < 3; i++) {
+        DPRINT << common_args.constants[i];
+        if (i < 2) {
+            DPRINT << ", ";
+        }
+    }
+    DPRINT << "]" << ENDL();
+
+    DPRINT << "  shared_data.id: " << common_args.shared_data.id << ENDL();
+    DPRINT << "  shared_data.value: " << common_args.shared_data.value << ENDL();
+    DPRINT << "  shared_data.multiplier: " << common_args.shared_data.multiplier << ENDL();
+
+    DPRINT << "  operation: " << static_cast<uint32_t>(common_args.operation) << ENDL();
+
+    // Perform a simple computation using the arguments
+    uint32_t result = (rt_args.core_id * common_args.global_scale) + common_args.global_offset;
+    result += rt_args.vector_data[0] * rt_args.nested.multiplier;
+
+    // Use the enum to modify the result
+    switch (rt_args.op_mode) {
+        case OperationType::ADD: result += 100; break;
+        case OperationType::MULTIPLY: result *= 2; break;
+        case OperationType::SUBTRACT: result -= 50; break;
+        case OperationType::DIVIDE: result /= 2; break;
+    }
+
+    DPRINT << "Computed result (after op_mode): " << result << ENDL();
+    DPRINT << ENDL();
+}

--- a/tt_metal/programming_examples/struct_runtime_args/struct_runtime_args.cpp
+++ b/tt_metal/programming_examples/struct_runtime_args/struct_runtime_args.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <utility>
+#include <tuple>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+// Define complex POD structs for runtime arguments
+enum class OperationType : uint32_t { ADD = 0, MULTIPLY = 1, SUBTRACT = 2, DIVIDE = 3 };
+
+struct NestedData {
+    uint32_t id;
+    uint32_t value;
+    uint32_t multiplier;
+};
+
+struct CommonRuntimeArgs {
+    uint32_t global_offset;
+    uint32_t global_scale;
+    std::array<uint32_t, 3> constants;
+    NestedData shared_data;
+    OperationType operation;
+};
+
+struct RuntimeArgs {
+    uint32_t core_id;
+    std::array<uint32_t, 4> vector_data;
+    std::pair<uint32_t, uint32_t> range;
+    std::tuple<uint32_t, uint32_t, uint32_t> triple;
+    NestedData nested;
+    OperationType op_mode;
+};
+
+int main() {
+    // Check for DPRINT environment variable
+    char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
+    if (env_var == nullptr) {
+        fmt::print(
+            "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to (0,0),(1,0) to see the output of "
+            "the Data Movement kernels.\n");
+        fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)\n");
+    }
+
+    // Initialize mesh device (1x1) and command queue
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    // Create a program
+    Program program = CreateProgram();
+
+    // Define two cores to demonstrate different runtime args per core
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRangeSet cores({CoreRange(core0, core1)});
+
+    // Create a single kernel that will run on both cores
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "struct_runtime_args/kernels/dataflow/struct_args_kernel.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // Set common runtime arguments (shared by all cores) using struct API
+    CommonRuntimeArgs common_args = {
+        .global_offset = 1000,
+        .global_scale = 10,
+        .constants = {42, 314, 271},
+        .shared_data =
+            {
+                .id = 999,
+                .value = 5000,
+                .multiplier = 3,
+            },
+        .operation = OperationType::MULTIPLY,
+    };
+
+    SetCommonRuntimeArgs(program, kernel_id, common_args);
+
+    // Set unique runtime arguments for core0
+    RuntimeArgs args_core0 = {
+        .core_id = 0,
+        .vector_data = {10, 20, 30, 40},
+        .range = {0, 100},
+        .triple = std::make_tuple(111, 222, 333),
+        .nested =
+            {
+                .id = 1,
+                .value = 100,
+                .multiplier = 2,
+            },
+        .op_mode = OperationType::ADD,
+    };
+
+    // Set unique runtime arguments for core1
+    RuntimeArgs args_core1 = {
+        .core_id = 1,
+        .vector_data = {50, 60, 70, 80},
+        .range = {100, 200},
+        .triple = std::make_tuple(444, 555, 666),
+        .nested =
+            {
+                .id = 2,
+                .value = 200,
+                .multiplier = 4,
+            },
+        .op_mode = OperationType::MULTIPLY,
+    };
+
+    // Use the struct-based API to set runtime args
+    SetRuntimeArgs(program, kernel_id, core0, args_core0);
+    SetRuntimeArgs(program, kernel_id, core1, args_core1);
+
+    // Alternative: Set runtime args for multiple cores using vector API
+    // std::vector<CoreCoord> cores = {core0, core1};
+    // std::vector<RuntimeArgs> args_vec = {args_core0, args_core1};
+    // SetRuntimeArgs(program, kernel_id, cores, args_vec);
+
+    fmt::print("Launching program with struct-based runtime arguments on cores (0,0) and (1,0)...\n");
+    fmt::print("Common args: global_offset={}, global_scale={}\n", common_args.global_offset, common_args.global_scale);
+    fmt::print(
+        "Core (0,0): core_id={}, vector[0]={}, range=({},{}), op_mode=ADD\n",
+        args_core0.core_id,
+        args_core0.vector_data[0],
+        args_core0.range.first,
+        args_core0.range.second);
+    fmt::print(
+        "Core (1,0): core_id={}, vector[0]={}, range=({},{}), op_mode=MULTIPLY\n",
+        args_core1.core_id,
+        args_core1.vector_data[0],
+        args_core1.range.first,
+        args_core1.range.second);
+
+    // Execute the program
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    fmt::print("\nProgram execution completed. Check the output above for kernel DPRINT messages.\n");
+
+    mesh_device->close();
+    return 0;
+}

--- a/tt_metal/programming_examples/struct_runtime_args/struct_runtime_args.md
+++ b/tt_metal/programming_examples/struct_runtime_args/struct_runtime_args.md
@@ -1,0 +1,162 @@
+# Struct-Based Runtime Arguments Example
+
+This example demonstrates the new struct-based runtime arguments API for TT-Metalium kernels, which provides a type-safe and convenient way to pass complex structured data to device kernels.
+
+## Overview
+
+Instead of manually packing and unpacking runtime arguments as vectors of `uint32_t`, you can now define POD (Plain Old Data) structs containing:
+- Nested structs
+- `std::array`
+- `std::pair`
+- `std::tuple`
+- Enums (including `enum class`)
+- Basic types like `uint32_t`
+- Any combination of the above
+
+The API automatically handles the conversion between struct format and the underlying `uint32_t` vector representation.
+
+## Key Features Demonstrated
+
+### 1. Complex Struct Definition
+Both host and device code define matching struct types:
+
+```cpp
+enum class OperationType : uint32_t {
+    ADD = 0,
+    MULTIPLY = 1,
+    SUBTRACT = 2,
+    DIVIDE = 3
+};
+
+struct NestedData {
+    uint32_t id;
+    uint32_t value;
+    uint32_t multiplier;
+};
+
+struct RuntimeArgs {
+    uint32_t core_id;
+    std::array<uint32_t, 4> vector_data;
+    std::pair<uint32_t, uint32_t> range;
+    std::tuple<uint32_t, uint32_t, uint32_t> triple;
+    NestedData nested;
+    OperationType op_mode;
+};
+```
+
+### 2. Setting Runtime Arguments (Host Side)
+
+**Per-Core Arguments:**
+```cpp
+RuntimeArgs args = {};
+args.core_id = 0;
+args.vector_data = {10, 20, 30, 40};
+args.range = {0, 100};
+args.triple = std::make_tuple(111, 222, 333);
+// ... set other fields ...
+
+SetRuntimeArgs(program, kernel_id, core, args);
+```
+
+**Common Arguments (Shared by All Cores):**
+```cpp
+CommonRuntimeArgs common_args;
+common_args.global_offset = 1000;
+// ... set other fields ...
+
+SetCommonRuntimeArgs(program, kernel_id, common_args);
+```
+
+**Multiple Cores at Once:**
+```cpp
+std::vector<CoreCoord> cores = {core0, core1};
+std::vector<RuntimeArgs> args_vec = {args_core0, args_core1};
+SetRuntimeArgs(program, kernel_id, cores, args_vec);
+```
+
+### 3. Getting Runtime Arguments (Device Side)
+
+```cpp
+auto& rt_args = get_runtime_arguments<RuntimeArgs>();
+auto& common_args = get_common_runtime_arguments<CommonRuntimeArgs>();
+
+// Access fields directly
+uint32_t id = rt_args.core_id;
+uint32_t first_elem = rt_args.vector_data[0];
+uint32_t start = rt_args.range.first;
+uint32_t triple_elem = std::get<0>(rt_args.triple);
+OperationType mode = rt_args.op_mode;
+
+// Use enum in switch statement
+switch (rt_args.op_mode) {
+    case OperationType::ADD:
+        // Handle ADD
+        break;
+    case OperationType::MULTIPLY:
+        // Handle MULTIPLY
+        break;
+    // ...
+}
+```
+
+## Running the Example
+
+1. Set the DPRINT environment variable to see kernel output:
+   ```bash
+   export TT_METAL_DPRINT_CORES=(0,0),(1,0)
+   ```
+
+2. Build and run:
+   ```bash
+   ./build/tt_metal/programming_examples/struct_runtime_args
+   ```
+
+## Expected Output
+
+The program will:
+1. Launch kernels on two cores: (0,0) and (1,0)
+2. Each core receives unique runtime arguments via the struct API
+3. Both cores share common runtime arguments
+4. The kernels print all received arguments using DPRINT
+5. Each kernel performs a computation using the structured data
+
+Example output:
+```
+=== Core (0,0) ===
+Runtime Args:
+  core_id: 0
+  vector_data: [10, 20, 30, 40]
+  range: (0, 100)
+  triple: (111, 222, 333)
+  nested.id: 1
+  nested.value: 100
+  nested.multiplier: 2
+Common Runtime Args:
+  global_offset: 1000
+  global_scale: 10
+  constants: [42, 314, 271]
+  shared_data.id: 999
+  ...
+Computed result: 1020
+
+=== Core (1,0) ===
+Runtime Args:
+  core_id: 1
+  vector_data: [50, 60, 70, 80]
+  ...
+```
+
+## Benefits of Struct-Based API
+
+1. **Type Safety**: Compile-time checking of argument types
+2. **Readability**: Clear structure definition instead of magic indices
+3. **Maintainability**: Easy to add/remove fields without updating indices
+4. **Flexibility**: Supports complex nested data structures
+5. **Performance**: Zero overhead - uses `reinterpret_cast` internally
+
+## Implementation Details
+
+- Structs must be POD (Plain Old Data) types
+- Struct size is automatically padded to 4-byte alignment
+- The API uses `memcpy` and zero-initialization for safe memory handling
+- Both old (`get_arg_val`) and new (`get_runtime_arguments`) APIs can coexist


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18033)

### Problem description
Currently passing arguments to kernels is very ugly and error-prone, since user has to properly map indices of arguments to values passed on the host. If we allow passing trivially-copyable structs, that would simplify life a lot. 

### What's changed
Current application just converts struct to vector of uint32_t and reuses current runtime api. On the device-side we simply reinterpret cast rt buffer. This works, but it is very unsafe, since there are no guarantees that struct memory layout would be the same between compilers and platforms. TODO: Add proper (de)serialization

Now we can do something like that:

Host-side: 
```c++
enum class OperationType : uint32_t { ADD = 0, MULTIPLY = 1, SUBTRACT = 2, DIVIDE = 3 };

struct NestedData {
    uint32_t id;
    uint32_t value;
    uint32_t multiplier;
};

struct RuntimeArgs {
    uint32_t core_id;
    std::array<uint32_t, 4> arr_data;
    std::pair<uint32_t, uint32_t> range;
    std::tuple<uint32_t, uint32_t, uint32_t> triple;
    NestedData nested;
    OperationType op_mode;
    uint32_t result_buffer_addr;
};
// ...
RuntimeArgs args_core = {
    .core_id = 1,
    .arr_data = {50, 60, 70, 80},
    .range = {100, 200},
    .triple = std::make_tuple(444, 555, 666),
    .nested =
        {
            .id = 2,
            .value = 200,
            .multiplier = 4,
        },
    .op_mode = OperationType::MULTIPLY,
    .result_buffer_addr = result_buffer->address(),
};

SetRuntimeArgs(program, kernel_id, core0, args_core);
```

Device-side: 
```c++
auto& rt_args = get_runtime_arguments<RuntimeArgs>();
for (const auto& v: rt_args.arr_data) {
    // ...
}
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] New/Existing tests provide coverage for changes