### PR TITLE
Fix for Phi4 and ds_r1_qwen on CI v2 in tt_transformers

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -9,11 +9,11 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 import requests
 import torch
 from loguru import logger
 
-import pytest
 import ttnn
 from models.common.utility_functions import is_wormhole_b0
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -9,11 +9,11 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-import pytest
 import requests
 import torch
 from loguru import logger
 
+import pytest
 import ttnn
 from models.common.utility_functions import is_wormhole_b0
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
@@ -673,11 +673,6 @@ def test_demo_text(
     Simple demo with limited dependence on reference code.
     """
     test_id = request.node.callspec.id
-    HF_MODEL = os.getenv("HF_MODEL")
-    if HF_MODEL:
-        os.environ["HF_MODEL"] = str(
-            model_location_generator(os.getenv("HF_MODEL"), download_if_ci_v2=True, ci_v2_timeout_in_s=1800)
-        )
     if is_ci_env:
         if not ci_only:
             pytest.skip("CI only runs the CI-only tests")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/30511 and https://github.com/tenstorrent/tt-metal/pull/29320 made double call for model_location_generator that caused problem on single-card-demo-tests for CI v2 models.

### What's changed
Single-card-demo-tests for phi4 and ds_r1_qwen failed multiple times since the latest changes.
Double calling for model_location_generator has been removed so there are no more Weka issues.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18892021861) CI passes
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18884233569/job/53921455831) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/18766118373/job/53603904950 CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18766120251/job/53592058983)
- [x] (Single-card) [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/18766115657)