### PR TITLE
assert that input is tile aligned in RMS norm and layer norm

### DIFF
--- a/models/experimental/tt_dit/layers/normalization.py
+++ b/models/experimental/tt_dit/layers/normalization.py
@@ -15,6 +15,9 @@ class RMSNorm(Module):
     def __init__(self, embedding_dim, norm_eps=1e-5, norm_elementwise_affine=True, bias=True, mesh_device=None):
         super().__init__()
 
+        # https://github.com/tenstorrent/tt-metal/issues/31216
+        assert embedding_dim % 32 == 0, "embedding_dim must be divisible by tile size"
+
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
         self.norm_elementwise_affine = norm_elementwise_affine
@@ -56,6 +59,8 @@ class LayerNorm(Module):
         use_row_major_workaround=False,  # Issue #20789
     ):
         super().__init__()
+
+        assert embedding_dim % 32 == 0, "embedding_dim must be divisible by tile size"
 
         self.embedding_dim = embedding_dim
         self.norm_eps = norm_eps
@@ -149,6 +154,9 @@ class DistributedRMSNorm(Module):
 
         n = self.TILE_SIZE * self.mesh_width
 
+        # https://github.com/tenstorrent/tt-metal/issues/31216
+        assert embedding_dim % n == 0, "embedding_dim must be divisible by tile size times mesh width"
+
         self.weight = (
             Parameter(
                 total_shape=[embedding_dim // n, n],
@@ -236,6 +244,8 @@ class DistributedLayerNorm(Module):
 
         n = self.TILE_SIZE * self.mesh_width
         shape = [embedding_dim // n, n]
+
+        assert embedding_dim % n == 0, "embedding_dim must be divisible by tile size times mesh width"
 
         self.weight = (
             Parameter(total_shape=shape, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_axes=[None, mesh_axis], device=mesh_device)


### PR DESCRIPTION
Adds a check in `RMSNorm`, `LayerNorm`, `DistributedRMSNorm`, and `DistributedLayerNorm` to make sure that the input tensor is tile aligned. Related issue: https://github.com/tenstorrent/tt-metal/issues/31216