### PR TITLE
[skip ci] add time since last success to pipeline status tracker

### DIFF
--- a/.github/actions/analyze-workflow-data/action.yml
+++ b/.github/actions/analyze-workflow-data/action.yml
@@ -44,6 +44,9 @@ inputs:
   other-logs-index-path:
     description: 'Path to JSON mapping run_id -> extracted other logs dir (optional)'
     required: false
+  last-success-timestamps-path:
+    description: 'Path to JSON mapping workflow_name -> last success timestamp info (optional)'
+    required: false
 
 outputs:
   failed_workflows:

--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -1285,7 +1285,7 @@ async function run() {
       __lastSuccessTimestamps = loadLastSuccessTimestamps(lastSuccessTimestampsPath);
       if (__lastSuccessTimestamps && __lastSuccessTimestamps.size) {
         core.info(`Loaded last success timestamps with ${__lastSuccessTimestamps.size} entries from ${lastSuccessTimestampsPath}`);
-      } else if (lastSuccessTimestampsPath) {
+      } else {
         core.info(`No valid entries found in last success timestamps file at ${lastSuccessTimestampsPath}`);
       }
     }

--- a/.github/actions/fetch-workflow-data/action.yml
+++ b/.github/actions/fetch-workflow-data/action.yml
@@ -49,6 +49,8 @@ outputs:
     description: 'Absolute path to directory containing downloaded other logs per run (failures without annotations)'
   other-logs-index-path:
     description: 'Absolute path to JSON mapping of run_id -> other logs dir'
+  last-success-timestamps-path:
+    description: 'Absolute path to JSON mapping of workflow_name -> last success timestamp info'
 
 runs:
   using: 'node20'

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -439,6 +439,8 @@ async function run() {
     // For each workflow, find the last successful run (even if outside the window)
     // This is used to calculate "days since last success" for failing workflows
     const lastSuccessTimestamps = new Map();
+    const owner = github.context.repo.owner;
+    const repo = github.context.repo.repo;
 
     for (const [name, runs] of grouped.entries()) {
       try {
@@ -544,8 +546,6 @@ async function run() {
     // The logs will be extracted under a dedicated directory so downstream steps
     // can parse them without performing network calls again.
     // Separate gtest logs from other logs (non-gtest failures with no annotations)
-    const owner = github.context.repo.owner;
-    const repo = github.context.repo.repo;
     const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
     const gtestLogsRoot = path.join(workspace, 'logs', 'gtest');
     const otherLogsRoot = path.join(workspace, 'logs', 'other');

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -484,7 +484,7 @@ async function run() {
 
         // Search through workflow history to find the last successful run
         let foundSuccess = false;
-        const maxPagesToSearch = 10; // Limit search to ~1000 most recent runs to avoid excessive API calls
+        const maxPagesToSearch = 10; // Limit search to up to 1000 most recent runs to avoid excessive API calls
 
         for (let page = 1; page <= maxPagesToSearch; page++) {
           const { data } = await octokit.rest.actions.listWorkflowRuns({

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -345,6 +345,48 @@ async function run() {
         core.warning(`[TEST MODE] Failed to restore logs artifact: ${e.message}`);
       }
 
+      // Additionally fetch the last success timestamps artifact from the same run, if present
+      try {
+        const owner = github.context.repo.owner;
+        const repo = github.context.repo.repo;
+        const lastSuccessArtifact = artifacts.find(a => a && a.name === 'last-success-timestamps');
+        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+        let lastSuccessPath = path.join(workspace, 'last-success-timestamps.json');
+        if (lastSuccessArtifact) {
+          const timestampsZipPath = path.join(tmpDir, `${lastSuccessArtifact.name}.zip`);
+          const respTimestamps = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: lastSuccessArtifact.id, archive_format: 'zip' });
+          fs.writeFileSync(timestampsZipPath, Buffer.from(respTimestamps.data));
+          const extractTimestampsDir = path.join(tmpDir, `${lastSuccessArtifact.name}-extract`);
+          if (!fs.existsSync(extractTimestampsDir)) fs.mkdirSync(extractTimestampsDir, { recursive: true });
+          execFileSync('unzip', ['-o', timestampsZipPath, '-d', extractTimestampsDir], { stdio: 'ignore' });
+          // Find last-success-timestamps.json
+          const stack3 = [extractTimestampsDir];
+          let foundTimestampsPath;
+          while (stack3.length && !foundTimestampsPath) {
+            const dir = stack3.pop();
+            const entries = fs.readdirSync(dir, { withFileTypes: true });
+            for (const ent of entries) {
+              const p = path.join(dir, ent.name);
+              if (ent.isDirectory()) stack3.push(p);
+              else if (ent.isFile() && ent.name === 'last-success-timestamps.json') { foundTimestampsPath = p; break; }
+            }
+          }
+          if (foundTimestampsPath) {
+            fs.cpSync(foundTimestampsPath, lastSuccessPath, { recursive: false });
+            core.info(`[TEST MODE] Restored last success timestamps to ${lastSuccessPath}`);
+          } else {
+            core.info('[TEST MODE] No last-success-timestamps.json found; creating empty object');
+            if (!fs.existsSync(lastSuccessPath)) fs.writeFileSync(lastSuccessPath, JSON.stringify({}));
+          }
+        } else {
+          core.info('[TEST MODE] No last-success-timestamps artifact found in selected run; creating empty object');
+          if (!fs.existsSync(lastSuccessPath)) fs.writeFileSync(lastSuccessPath, JSON.stringify({}));
+        }
+        core.setOutput('last-success-timestamps-path', lastSuccessPath);
+      } catch (e) {
+        core.warning(`[TEST MODE] Failed to restore last success timestamps artifact: ${e.message}`);
+      }
+
       // Exit early
       return;
     }
@@ -393,6 +435,108 @@ async function run() {
     }
     // Save grouped runs to artifact file
     fs.writeFileSync(outputPath, JSON.stringify(Array.from(grouped.entries())));
+
+    // For each workflow, find the last successful run (even if outside the window)
+    // This is used to calculate "days since last success" for failing workflows
+    const lastSuccessTimestamps = new Map();
+
+    for (const [name, runs] of grouped.entries()) {
+      try {
+        // Check if latest run on main is failing
+        const mainRuns = runs
+          .filter(r => r.head_branch === branch)
+          .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+        const latestRun = mainRuns[0];
+        if (!latestRun || latestRun.conclusion === 'success') {
+          // Workflow is passing, store the success timestamp
+          if (latestRun && latestRun.conclusion === 'success') {
+            lastSuccessTimestamps.set(name, {
+              timestamp: latestRun.created_at,
+              sha: latestRun.head_sha,
+              run_id: latestRun.id,
+              in_window: true
+            });
+          }
+          continue;
+        }
+
+        // Workflow is currently failing - check if we already have a success in our window
+        const successInWindow = mainRuns.find(r => r.conclusion === 'success');
+        if (successInWindow) {
+          // We already have the info, no API call needed
+          lastSuccessTimestamps.set(name, {
+            timestamp: successInWindow.created_at,
+            sha: successInWindow.head_sha,
+            run_id: successInWindow.id,
+            in_window: true
+          });
+          continue;
+        }
+
+        // Workflow is failing and no success in window - make targeted API call to search all history
+        const workflowPath = runs[0]?.path;
+        if (!workflowPath) continue;
+
+        core.info(`Searching for last success in full history for failing workflow: ${name}`);
+
+        // Search through workflow history to find the last successful run
+        let foundSuccess = false;
+        const maxPagesToSearch = 10; // Limit search to ~1000 most recent runs to avoid excessive API calls
+
+        for (let page = 1; page <= maxPagesToSearch; page++) {
+          const { data } = await octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id: workflowPath,
+            branch,
+            status: 'completed',
+            per_page: 100,
+            page
+          });
+
+          if (!data.workflow_runs || data.workflow_runs.length === 0) {
+            break; // No more runs to check
+          }
+
+          // Find first successful run on this page
+          const successRun = data.workflow_runs.find(r => r.conclusion === 'success');
+          if (successRun) {
+            lastSuccessTimestamps.set(name, {
+              timestamp: successRun.created_at,
+              sha: successRun.head_sha,
+              run_id: successRun.id,
+              in_window: false
+            });
+            core.info(`Found last success for ${name}: ${successRun.created_at}`);
+            foundSuccess = true;
+            break;
+          }
+
+          // If we got fewer runs than requested, we've reached the end
+          if (data.workflow_runs.length < 100) {
+            break;
+          }
+        }
+
+        if (!foundSuccess) {
+          // Never succeeded in searchable history
+          core.info(`No successful run found in history for ${name} (never succeeded or very old)`);
+          lastSuccessTimestamps.set(name, { never_succeeded: true });
+        }
+
+        // Small delay to avoid rate limiting
+        await delay(500);
+      } catch (e) {
+        core.warning(`Failed to fetch last success timestamp for ${name}: ${e.message}`);
+      }
+    }
+
+    // Save the last success timestamps index
+    const lastSuccessPath = path.join(outputDir, 'last-success-timestamps.json');
+    fs.writeFileSync(lastSuccessPath, JSON.stringify(Object.fromEntries(lastSuccessTimestamps)));
+    core.setOutput('last-success-timestamps-path', lastSuccessPath);
+    core.info(`Saved last success timestamps for ${lastSuccessTimestamps.size} workflows to ${lastSuccessPath}`);
 
     // Download logs for the latest failing run per workflow and build an index
     // Constraint: Only fetch logs when the latest run for that workflow (on target branch)

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -24,6 +24,7 @@ jobs:
       gtest-logs-index-path: ${{ steps.fetch.outputs.gtest-logs-index-path }}
       other-logs-root: ${{ steps.fetch.outputs.other-logs-root }}
       other-logs-index-path: ${{ steps.fetch.outputs.other-logs-index-path }}
+      last-success-timestamps-path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
 
@@ -76,6 +77,13 @@ jobs:
           path: |
             ${{ steps.fetch.outputs.other-logs-root }}/
             ${{ steps.fetch.outputs.other-logs-index-path }}
+          retention-days: 1
+
+      - name: Upload last success timestamps artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: last-success-timestamps
+          path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
           retention-days: 1
 
       - name: Debug cache file
@@ -165,6 +173,11 @@ jobs:
         with:
           name: commits-main
           path: ${{ github.workspace }}
+      - name: Download last success timestamps
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: last-success-timestamps
+          path: ${{ github.workspace }}
       - name: Analyze workflow data
         id: analyze
         uses: ./.github/actions/analyze-workflow-data
@@ -177,6 +190,7 @@ jobs:
           commits-path: ${{ github.workspace }}/commits-main.json
           gtest-logs-index-path: ${{ github.workspace }}/logs/gtest/gtest-logs-index.json
           other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
+          last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
           alert-all: 'false'
           workflow_configs: |
             [
@@ -216,6 +230,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -230,6 +230,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31226)

### Problem description
Information on how long pipelines have been failing for is not readily available in the aggregate workflow data report.

### What's changed
Added a stat on how long it's been since a pipeline succeeded to the drop down menu in the report.

old:

<img width="380" height="730" alt="image" src="https://github.com/user-attachments/assets/bb388df9-3bcb-4ab8-b40f-0f09f11e76a6" />

new:

<img width="380" height="512" alt="image" src="https://github.com/user-attachments/assets/ff269fb3-7c31-419d-914d-72b0dc6ee651" />


### Checklist
- [ ] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18846605247