### PR TITLE
Revert Embedding Change due to Galaxy Model CI Fails

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -42,6 +42,7 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
         if (is_sharded(this->output_mem_config.memory_layout())) {
             TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Embedding only supports height sharded Row Major outputs");
         }
+        TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     if(a.layout() == Layout::ROW_MAJOR) {
         TT_FATAL(a.padded_shape()[1] == 1 && a.padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
@@ -62,7 +63,7 @@ std::vector<TensorSpec> Embeddings::compute_output_specs(const std::vector<Tenso
 
     ttnn::Shape output_shape({batch_num, 1, num_output_embeddings, num_embedding_dims});
     auto output_layout = (tilized && input_tensors.at(0).layout() != Layout::TILE)? Layout::TILE : Layout::ROW_MAJOR;
-    return {TensorSpec(output_shape, TensorLayout(weight_tensor.dtype(), PageConfig(output_layout), output_mem_config))};
+    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(output_layout), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks Embeddings::create_program(

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
@@ -19,6 +19,7 @@ struct Embeddings {
     const bool tilized;
     const EmbeddingsType embeddings_type;
     const std::optional<uint32_t> pad_token;
+    const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
@@ -32,7 +32,6 @@ void kernel_main() {
 
     constexpr uint32_t face_size = 16;
     constexpr uint32_t tile_height = 32;
-    constexpr uint32_t face_hw = face_size * face_size;
 
     prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
 
@@ -107,39 +106,17 @@ void kernel_main() {
                     offset = 0;
                 } else {
                     curr_tile -= (tiles_per_row - 1);
-                    if (face % 2 == 0) {
-#if defined ONLY_ONE_FACE_COLUMN
-                        // In this case, we need to ignore face 1 and face 3.
-                        // If we are in the last row of face 0, we need to jump to the start of face 2
-                        // If we are in the last row of face 2, we need to jump to the start of next tile (face 0 of
-                        // next tile)
-                        if (face == 0) {
-                            uint32_t last_column_face_0 = (offset - (face_hw - face_size));
-                            if (last_column_face_0 < (face_size)) {
-                                offset += face_hw;
-                            }
-                            offset += face_size;
-                        } else {
-                            uint32_t last_column_face_2 = (offset - (face_hw * 3 - face_size));
-                            if (last_column_face_2 < (face_size)) {
-                                offset = 0;
-                                curr_tile++;
-                            } else {
-                                offset += face_size;
-                            }
-                        }
-#else
+                    if (offset < 256) {
                         offset += face_size;
-#endif
                     } else {
                         offset -= face_size * (face_size - 1);
                     }
                 }
             } else if (face % 2 == 0) {
-                offset += face_hw;
+                offset += face_size * face_size;
             } else {
                 curr_tile++;
-                offset -= face_hw;
+                offset -= face_size * face_size;
                 read_indices = true;
             }
         }


### PR DESCRIPTION
This reverts commit 5e986ea827ba824e6841ac6f8ad201d2d9bdd778.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31219)

### Problem description
This embedding change appears to be changing L1 space used in models on Galaxy.

### What's changed
The only CB change should be due to the alignment for BH, but the error is occurring on WH. Need to debug further

### Checklist. For the future PR, the below needs to pass
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/18884937689) CI passes (if applicable)
- [ ] [Galaxy quick - WAS FAILING](https://github.com/tenstorrent/tt-metal/actions/runs/18884910938) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama - WAS FAILING](https://github.com/tenstorrent/tt-metal/actions/runs/18884917104) CI passes, if applicable, because of current Llama work