### PR TITLE
#0: have better TT_FATAL messages

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/api/test_banked.cpp
@@ -111,7 +111,12 @@ bool reader_cb_writer(
     log_debug(
         tt::LogTest, "Output buffer: [address: {} B, size: {} B]", output_buffer->address(), output_buffer->size());
 
-    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes, "Error");
+    TT_FATAL(
+        cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes,
+        "Configuration validation failed: num_tiles ({}) * page_size_bytes ({}) must equal size_bytes ({})",
+        cfg.num_tiles,
+        cfg.page_size_bytes,
+        cfg.size_bytes);
     CircularBufferConfig input_buffer_cb_config =
         CircularBufferConfig(cfg.page_size_bytes, {{cb_id, cfg.l1_data_format}})
             .set_page_size(cb_id, cfg.page_size_bytes);
@@ -217,7 +222,12 @@ bool reader_datacopy_writer(const std::shared_ptr<distributed::MeshDevice>& mesh
     auto input_buffer = distributed::MeshBuffer::create(in_buffer_config, in_config, mesh_device.get());
     auto output_buffer = distributed::MeshBuffer::create(out_buffer_config, out_config, mesh_device.get());
 
-    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes, "Error");
+    TT_FATAL(
+        cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes,
+        "Configuration validation failed: num_tiles ({}) * page_size_bytes ({}) must equal size_bytes ({})",
+        cfg.num_tiles,
+        cfg.page_size_bytes,
+        cfg.size_bytes);
     CircularBufferConfig l1_input_cb_config =
         CircularBufferConfig(cfg.page_size_bytes, {{input0_cb_index, cfg.l1_data_format}})
             .set_page_size(input0_cb_index, cfg.page_size_bytes);
@@ -308,7 +318,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_banks % 2 == 0, "Error");
+        TT_FATAL(num_banks % 2 == 0, "Number of banks ({}) must be even for this test", num_banks);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 3;
@@ -363,7 +373,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1WriterOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_banks % 2 == 0, "Error");
+        TT_FATAL(num_banks % 2 == 0, "Number of banks ({}) must be even for this test", num_banks);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 3;
@@ -444,7 +454,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndWriter
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -474,7 +484,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndL1Writ
         test_config.input_buffer_type = BufferType::DRAM;
 
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -502,7 +512,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderAndDramWrit
         test_config.output_buffer_type = BufferType::DRAM;
 
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -520,7 +530,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyL1W
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -558,7 +568,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyDra
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -579,7 +589,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyL
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0, "Error");
+        TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -153,6 +153,6 @@ int main(int argc, char** argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
+    TT_FATAL(pass, "PCIe buffer read/write test failed");
     return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -127,6 +127,6 @@ int main(int argc, char** argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
+    TT_FATAL(pass, "PCIe DRAM read/write test failed");
     return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -101,6 +101,6 @@ int main(int argc, char** argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
+    TT_FATAL(pass, "PCIe L1 read/write test failed");
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -465,13 +465,21 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
     std::shared_ptr<tt_metal::Buffer> src, dst;
     if constexpr (src_is_in_l1) {
-        TT_FATAL((buffer_size % num_l1_banks) == 0, "Error");
+        TT_FATAL(
+            (buffer_size % num_l1_banks) == 0,
+            "Buffer size ({}) must be divisible by number of L1 banks ({})",
+            buffer_size,
+            num_l1_banks);
 
         src = CreateBuffer(l1_config);
         tt_metal::detail::WriteToBuffer(src, host_buffer);
 
     } else {
-        TT_FATAL((buffer_size % num_dram_banks) == 0, "Error");
+        TT_FATAL(
+            (buffer_size % num_dram_banks) == 0,
+            "Buffer size ({}) must be divisible by number of DRAM banks ({})",
+            buffer_size,
+            num_dram_banks);
 
         src = CreateBuffer(dram_config);
         tt_metal::detail::WriteToBuffer(src, host_buffer);
@@ -521,7 +529,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
     pass &= tt_metal::CloseDevice(device);
 
-    TT_FATAL(pass, "Error");
+    TT_FATAL(pass, "Test failed - buffer comparison did not match");
 
     return pass;
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -619,9 +619,19 @@ void write_tensor(const Tensor& src, Tensor& dst, bool blocking, std::optional<t
         return;
     }
 
-    TT_FATAL(src.logical_shape() == dst.logical_shape(), "Error");
-    TT_FATAL(src.dtype() == dst.dtype(), "Error");
-    TT_FATAL(src.tensor_spec().page_config() == dst.tensor_spec().page_config(), "Error");
+    TT_FATAL(
+        src.logical_shape() == dst.logical_shape(),
+        "Source and destination tensors must have the same logical shape. Source: {}, Destination: {}",
+        src.logical_shape(),
+        dst.logical_shape());
+    TT_FATAL(
+        src.dtype() == dst.dtype(),
+        "Source and destination tensors must have the same data type. Source: {}, Destination: {}",
+        src.dtype(),
+        dst.dtype());
+    TT_FATAL(
+        src.tensor_spec().page_config() == dst.tensor_spec().page_config(),
+        "Source and destination tensors must have the same page configuration");
 
     auto mesh_buffer = dst.device_storage().mesh_buffer;
     TT_FATAL(!blocking, "Blocking is not supported for host to device copy");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -96,14 +96,22 @@ void Conv2d::validate(
     TT_FATAL(input_tensor_a.memory_config().is_sharded(), "Activation tensor should be sharded.");
     TT_FATAL(!input_tensor_b.memory_config().is_sharded(), "Weights tensor should not be sharded.");
     if (this->untilize_out) {
-        TT_FATAL((this->dtype == DataType::BFLOAT16) || (this->dtype == DataType::FLOAT32), "Error");
+        TT_FATAL(
+            (this->dtype == DataType::BFLOAT16) || (this->dtype == DataType::FLOAT32),
+            "Untilize output requires BFLOAT16 or FLOAT32 data type but got {}",
+            this->dtype);
     }
     if (this->memory_config.is_sharded()) {
         uint32_t per_core_out_matrix_width_ntiles = parallelization_config.per_core_out_matrix_width_ntile;
         uint32_t out_width_ntiles =
             this->compute_output_specs(input_tensors).at(0).padded_shape()[-1] / tt::constants::TILE_WIDTH;
         if (this->memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            TT_FATAL(per_core_out_matrix_width_ntiles == out_width_ntiles, "Error");
+            TT_FATAL(
+                per_core_out_matrix_width_ntiles == out_width_ntiles,
+                "Per-core output matrix width in tiles ({}) must equal output width in tiles ({}) for height sharded "
+                "layout",
+                per_core_out_matrix_width_ntiles,
+                out_width_ntiles);
             TT_FATAL(
                 this->block_config.out_subblock_w_ntiles == out_width_ntiles ||
                     this->block_config.out_subblock_h_ntiles == 1,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -137,8 +137,11 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] = compute_opt_conv_activation_as_mm_shape(
         ashape_with_channels_padded, sliding_window_config, parallelization_config.num_cores_nhw, out_block_h_ntiles);
-    TT_FATAL(act_matrix_shape.size() == 3, "Error");
-    TT_FATAL(act_matrix_shape[0] == 1, "Error");
+    TT_FATAL(
+        act_matrix_shape.size() == 3,
+        "Activation matrix shape must have 3 dimensions but got {}",
+        act_matrix_shape.size());
+    TT_FATAL(act_matrix_shape[0] == 1, "Activation matrix first dimension must be 1 but got {}", act_matrix_shape[0]);
     uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
     uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
 
@@ -146,8 +149,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
 
     if (has_bias) {
         // Tensor bias is of shape {output_channels}
-        TT_FATAL(bias.has_value(), "Error");
-        TT_FATAL(bias.value().buffer() != nullptr, "Error");
+        TT_FATAL(bias.has_value(), "Bias tensor must be provided when has_bias is true");
+        TT_FATAL(bias.value().buffer() != nullptr, "Bias tensor buffer must not be null");
         auto bias_shape_without_padding = bias.value().logical_shape();
         TT_FATAL(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
     }

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -68,7 +68,7 @@ struct ToMemoryConfig {
                 } else {
                     // for row-major tensors where shard-spec[1] is different for input shard and output shard
 
-                    TT_FATAL(memory_config.is_sharded(), "Error");
+                    TT_FATAL(memory_config.is_sharded(), "Memory config must be sharded for this operation");
                     Tensor temp = tt::tt_metal::operation::run(
                                       data_movement::ShardedToInterleavedDeviceOperation{
                                           .output_mem_config = ttnn::DRAM_MEMORY_CONFIG,

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -285,7 +285,11 @@ struct FullRep {
         rep{n_rows / tile_height, n_rows % tile_height, n_pads / tile_height, times},
         pad{0, 0, (n_rows + n_pads) * pads_mul / tile_height, 1},
         times_total(times_total) {
-        TT_FATAL((n_rows + n_pads) % tile_height == 0 && "total rows must be divisible by {}", "Error", tile_height);
+        TT_FATAL(
+            (n_rows + n_pads) % tile_height == 0,
+            "Total rows ({}) must be divisible by tile height ({})",
+            n_rows + n_pads,
+            tile_height);
     }
 
     std::vector<BlockRep> to_block_reps() const {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -24,22 +24,44 @@ Tensor BcastOperation::invoke(
     auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
 
     if (bcast_dim == BcastOpDim::W) {
-        TT_FATAL(input_tensor_a.padded_shape()[-2] == input_tensor_b.padded_shape()[-2], "Error");
+        TT_FATAL(
+            input_tensor_a.padded_shape()[-2] == input_tensor_b.padded_shape()[-2],
+            "Input tensor A height ({}) must equal input tensor B height ({}) for width broadcast",
+            input_tensor_a.padded_shape()[-2],
+            input_tensor_b.padded_shape()[-2]);
         if (input_tensor_b.layout() == Layout::TILE) {
-            TT_FATAL(input_tensor_b.padded_shape()[-1] == TILE_WIDTH, "Error");
+            TT_FATAL(
+                input_tensor_b.padded_shape()[-1] == TILE_WIDTH,
+                "Input tensor B width ({}) must equal TILE_WIDTH ({}) for tile layout",
+                input_tensor_b.padded_shape()[-1],
+                TILE_WIDTH);
         } else if (input_tensor_b.layout() == Layout::ROW_MAJOR) {
             TT_FATAL(
-                input_tensor_b.padded_shape()[-1] == 1 || input_tensor_b.padded_shape()[-1] == TILE_WIDTH, "Error");
+                input_tensor_b.padded_shape()[-1] == 1 || input_tensor_b.padded_shape()[-1] == TILE_WIDTH,
+                "Input tensor B width ({}) must be 1 or TILE_WIDTH ({}) for row major layout",
+                input_tensor_b.padded_shape()[-1],
+                TILE_WIDTH);
         } else {
             TT_THROW("Unsupported layout");
         }
     } else if (bcast_dim == BcastOpDim::H) {
-        TT_FATAL(input_tensor_a.padded_shape()[-1] == input_tensor_b.padded_shape()[-1], "Error");
+        TT_FATAL(
+            input_tensor_a.padded_shape()[-1] == input_tensor_b.padded_shape()[-1],
+            "Input tensor A width ({}) must equal input tensor B width ({}) for height broadcast",
+            input_tensor_a.padded_shape()[-1],
+            input_tensor_b.padded_shape()[-1]);
         if (input_tensor_b.layout() == Layout::TILE) {
-            TT_FATAL(input_tensor_b.padded_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(
+                input_tensor_b.padded_shape()[-2] == TILE_HEIGHT,
+                "Input tensor B height ({}) must equal TILE_HEIGHT ({}) for tile layout",
+                input_tensor_b.padded_shape()[-2],
+                TILE_HEIGHT);
         } else if (input_tensor_b.layout() == Layout::ROW_MAJOR) {
             TT_FATAL(
-                input_tensor_b.padded_shape()[-2] == 1 || input_tensor_b.padded_shape()[-2] == TILE_HEIGHT, "Error");
+                input_tensor_b.padded_shape()[-2] == 1 || input_tensor_b.padded_shape()[-2] == TILE_HEIGHT,
+                "Input tensor B height ({}) must be 1 or TILE_HEIGHT ({}) for row major layout",
+                input_tensor_b.padded_shape()[-2],
+                TILE_HEIGHT);
         } else {
             TT_THROW("Unsupported layout");
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -66,8 +66,14 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(
     const auto& input_shape_a = input_tensor_a.padded_shape();
     const auto& input_shape_b = input_tensor_b.padded_shape();
 
-    TT_FATAL(input_tensor_a.layout() == Layout::TILE, "Error");
-    TT_FATAL(input_tensor_b.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor_a.layout() == Layout::TILE,
+        "Input tensor A layout must be TILE but got {}",
+        input_tensor_a.layout());
+    TT_FATAL(
+        input_tensor_b.layout() == Layout::TILE,
+        "Input tensor B layout must be TILE but got {}",
+        input_tensor_b.layout());
     TT_FATAL(is_floating_point(input_tensor_a.dtype()), "Unsupported data format");
     if (!output_tensors.empty() && output_tensors.at(0).has_value()) {
         TT_FATAL(is_floating_point(output_tensors.at(0).value().dtype()), "Unsupported data format");
@@ -80,8 +86,16 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(
             out_tensor.padded_shape());
     }
     if (this->in_place) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == this->output_mem_config.memory_layout(), "Error");
-        TT_FATAL(input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(), "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == this->output_mem_config.memory_layout(),
+            "Input tensor A memory layout ({}) must match output memory config layout ({})",
+            input_tensor_a.memory_config().memory_layout(),
+            this->output_mem_config.memory_layout());
+        TT_FATAL(
+            input_tensor_a.memory_config().buffer_type() == this->output_mem_config.buffer_type(),
+            "Input tensor A buffer type ({}) must match output memory config buffer type ({})",
+            input_tensor_a.memory_config().buffer_type(),
+            this->output_mem_config.buffer_type());
     }
     auto out_mem_config = (!output_tensors.empty() && output_tensors.at(0).has_value())
                               ? output_tensors.at(0).value().memory_config()
@@ -133,13 +147,31 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(
 
     // validate input dimensions
     if (this->dim == BcastOpDim::W) {
-        TT_FATAL(height_a == height_b && width_b == TILE_WIDTH, "Error");
+        TT_FATAL(
+            height_a == height_b && width_b == TILE_WIDTH,
+            "For width broadcast: height_a ({}) must equal height_b ({}) and width_b ({}) must equal TILE_WIDTH ({})",
+            height_a,
+            height_b,
+            width_b,
+            TILE_WIDTH);
     }
     if (this->dim == BcastOpDim::H) {
-        TT_FATAL(width_a == width_b && height_b == TILE_HEIGHT, "Error");
+        TT_FATAL(
+            width_a == width_b && height_b == TILE_HEIGHT,
+            "For height broadcast: width_a ({}) must equal width_b ({}) and height_b ({}) must equal TILE_HEIGHT ({})",
+            width_a,
+            width_b,
+            height_b,
+            TILE_HEIGHT);
     }
     if (this->dim == BcastOpDim::HW) {
-        TT_FATAL(width_b == TILE_WIDTH && height_b == TILE_HEIGHT, "Error");
+        TT_FATAL(
+            width_b == TILE_WIDTH && height_b == TILE_HEIGHT,
+            "For HW broadcast: width_b ({}) must equal TILE_WIDTH ({}) and height_b ({}) must equal TILE_HEIGHT ({})",
+            width_b,
+            TILE_WIDTH,
+            height_b,
+            TILE_HEIGHT);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -31,9 +31,21 @@ void CopyDeviceOperation::validate_with_output_tensors(
 
     if (input_tensors.size() == 2) {
         const auto& dst_tensor = input_tensors[1];
-        TT_FATAL(input_tensor_a.padded_shape() == dst_tensor.padded_shape(), "Error");
-        TT_FATAL(input_tensor_a.layout() == dst_tensor.layout(), "Error");
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == dst_tensor.memory_config().memory_layout(), "Error");
+        TT_FATAL(
+            input_tensor_a.padded_shape() == dst_tensor.padded_shape(),
+            "Input tensor padded shape ({}) must equal destination tensor padded shape ({})",
+            input_tensor_a.padded_shape(),
+            dst_tensor.padded_shape());
+        TT_FATAL(
+            input_tensor_a.layout() == dst_tensor.layout(),
+            "Input tensor layout ({}) must equal destination tensor layout ({})",
+            input_tensor_a.layout(),
+            dst_tensor.layout());
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == dst_tensor.memory_config().memory_layout(),
+            "Input tensor memory layout ({}) must equal destination tensor memory layout ({})",
+            input_tensor_a.memory_config().memory_layout(),
+            dst_tensor.memory_config().memory_layout());
     }
     DataType output_dtype = this->output_dtype;
     if (!output_tensors.empty() && output_tensors.at(0).has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -91,9 +91,24 @@ operation::ProgramWithCallbacks fill_rm_single_core(
 
 void FillRM::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
-    TT_FATAL((this->N > 0 && this->C > 0 && this->H > 0 && this->W > 0), "Error");
-    TT_FATAL((this->hFill <= this->H && this->wFill <= this->W), "Error");
-    TT_FATAL(input_tensor_a.dtype() == DataType::BFLOAT16, "Error");
+    TT_FATAL(
+        (this->N > 0 && this->C > 0 && this->H > 0 && this->W > 0),
+        "All dimensions must be positive: N={}, C={}, H={}, W={}",
+        this->N,
+        this->C,
+        this->H,
+        this->W);
+    TT_FATAL(
+        (this->hFill <= this->H && this->wFill <= this->W),
+        "Fill dimensions must be <= tensor dimensions: hFill={} <= H={}, wFill={} <= W={}",
+        this->hFill,
+        this->H,
+        this->wFill,
+        this->W);
+    TT_FATAL(
+        input_tensor_a.dtype() == DataType::BFLOAT16,
+        "Input tensor dtype must be BFLOAT16 but got {}",
+        input_tensor_a.dtype());
     TT_FATAL(
         input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "FillRM does not currently support sharding");

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
@@ -27,7 +27,10 @@ void IndexedFill::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(this->dim == 0, "Currently only supporting batch dimension");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to Index Fill need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to Index Fill need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Input tensor memory layout must be INTERLEAVED but got {}",
+        input_tensor_a.memory_config().memory_layout());
     TT_FATAL(
         input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Index Fill does not currently support sharding");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -18,7 +18,10 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to reshape need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::FLOAT32, "Error");
+    TT_FATAL(
+        input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::FLOAT32,
+        "Input tensor dtype must be BFLOAT16 or FLOAT32 but got {}",
+        input_tensor_a.dtype());
 
     TT_FATAL(
         input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR,
@@ -32,7 +35,11 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
         "Reshape does not currently support sharding. Use ttnn::reshape for reshaping sharded inputs");
 
     if (input_tensor_a.layout() == Layout::TILE) {
-        TT_FATAL(input_tensor_a.physical_volume() % TILE_HW == 0, "Error");
+        TT_FATAL(
+            input_tensor_a.physical_volume() % TILE_HW == 0,
+            "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+            input_tensor_a.physical_volume(),
+            TILE_HW);
     } else if (input_tensor_a.layout() == Layout::ROW_MAJOR) {
         uint32_t ROW_MAJOR_WIDTH = 8;
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
@@ -209,7 +209,11 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 }
 
 operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor& a, Tensor& output) {
-    TT_FATAL(a.dtype() == output.dtype(), "Error");
+    TT_FATAL(
+        a.dtype() == output.dtype(),
+        "Input tensor dtype ({}) must match output tensor dtype ({})",
+        a.dtype(),
+        output.dtype());
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -71,7 +71,10 @@ ttnn::Tensor ReshapeOperation::invoke(
         ((padded_output_shape.volume() / padded_output_shape[-1]) % TILE_HEIGHT != 0 ||
          padded_output_shape[-1] % TILE_WIDTH != 0 || input_tensor.padded_shape()[-1] % TILE_WIDTH != 0 ||
          (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % TILE_HEIGHT != 0)) {
-        TT_FATAL(input_tensor.dtype() == DataType::BFLOAT16, "Error");
+        TT_FATAL(
+            input_tensor.dtype() == DataType::BFLOAT16,
+            "Input tensor dtype must be BFLOAT16 for this reshape operation but got {}",
+            input_tensor.dtype());
 
         return detail::manual_insertion(
             (tt::tt_metal::Tensor)input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -27,8 +27,8 @@ void InterleavedToShardedDeviceOperation::validate_with_output_tensors(const std
         TT_FATAL(output_tensor.device() == input_tensor.device(), "Operands to shard need to be on the same device!");
     }
 
-    TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-    TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+    TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Input tensor memory layout must be INTERLEAVED but got {}", input_tensor.memory_config().memory_layout());
+    TT_FATAL(this->output_mem_config.is_sharded(), "Output memory config must be sharded");
     if (this->output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_FATAL(this->output_mem_config.buffer_type() == BufferType::L1, "We don't support DRAM block sharding");
     }
@@ -36,7 +36,7 @@ void InterleavedToShardedDeviceOperation::validate_with_output_tensors(const std
         TT_FATAL((*this->output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() % hal::get_l1_alignment() == 0, "Shard page size must currently have L1 aligned page size");
     }
     if (input_tensor.dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+        TT_FATAL(input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE when dtype conversion is needed but got {}", input_tensor.layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
@@ -65,9 +65,21 @@ void ReshardDeviceOperation::validate_with_output_tensors(
     bool has_output_tensor = output_tensors.size() == 1 && output_tensors[0].has_value();
     if (has_output_tensor) {
         const auto& output_tensor = output_tensors[0].value();
-        TT_FATAL(input_tensor.logical_shape() == output_tensor.logical_shape(), "Error");
-        TT_FATAL(input_tensor.dtype() == output_tensor.dtype(), "Error");
-        TT_FATAL(input_tensor.layout() == output_tensor.layout(), "Error");
+        TT_FATAL(
+            input_tensor.logical_shape() == output_tensor.logical_shape(),
+            "Input tensor logical shape ({}) must equal output tensor logical shape ({})",
+            input_tensor.logical_shape(),
+            output_tensor.logical_shape());
+        TT_FATAL(
+            input_tensor.dtype() == output_tensor.dtype(),
+            "Input tensor dtype ({}) must equal output tensor dtype ({})",
+            input_tensor.dtype(),
+            output_tensor.dtype());
+        TT_FATAL(
+            input_tensor.layout() == output_tensor.layout(),
+            "Input tensor layout ({}) must equal output tensor layout ({})",
+            input_tensor.layout(),
+            output_tensor.layout());
     }
     const auto& out_mem_config =
         has_output_tensor ? output_tensors[0].value().memory_config() : this->output_mem_config;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -32,7 +32,10 @@ void InterleavedToShardedPartialDeviceOperation::validate(const std::vector<Tens
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Input tensor must be Interleaved");
     if (input_tensor.dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+        TT_FATAL(
+            input_tensor.layout() == Layout::TILE,
+            "Input tensor layout must be TILE but got {}",
+            input_tensor.layout());
     }
     auto device_grid = input_tensor.device()->compute_with_storage_grid_size();
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
@@ -30,15 +30,21 @@ void ShardedToInterleavedPartialDeviceOperation::validate(const std::vector<Tens
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
 
-    TT_FATAL(input_tensor.memory_config().is_sharded(), "Error");
+    TT_FATAL(input_tensor.memory_config().is_sharded(), "Input tensor must be sharded");
     if (input_tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
         if (input_tensor.padded_shape()[-1] % shard_spec.shape[1] != 0 ||
             ((input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % shard_spec.shape[0]) != 0) {
-            TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1, "Error");
+            TT_FATAL(
+                input_tensor.shard_spec().value().grid.ranges().size() == 1,
+                "Input tensor shard spec must have exactly 1 grid range but got {}",
+                input_tensor.shard_spec().value().grid.ranges().size());
         }
     }
     if (input_tensor.dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+        TT_FATAL(
+            input_tensor.layout() == Layout::TILE,
+            "Input tensor layout must be TILE but got {}",
+            input_tensor.layout());
     }
     // Divisibility of num_cores and shard size with tensor shape is done in tensor creation, so no need to assert here
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
@@ -19,7 +19,7 @@ ttnn::Tensor ShardedToInterleavedPartialOperation::invoke(
     const std::optional<DataType>& data_type_arg) {
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Input tensor must have a shard spec");
     operation::run(
         ShardedToInterleavedPartialDeviceOperation{
             .num_slices = num_slices,

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -101,7 +101,11 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     tt::tt_metal::Buffer* in0_buffer = input_tensor.buffer();
 
     // Output buffers
-    TT_FATAL(output_tensors.size() == num_chunks, "Error");
+    TT_FATAL(
+        output_tensors.size() == num_chunks,
+        "Number of output tensors ({}) must equal number of chunks ({})",
+        output_tensors.size(),
+        num_chunks);
     tt::tt_metal::Tensor& out0 = output_tensors[0];
     tt::tt_metal::Tensor& out1 = output_tensors[1];
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -17,7 +17,11 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
 
-    TT_FATAL(input_tensor_a.physical_volume() % tt::constants::TILE_HW == 0, "Error");
+    TT_FATAL(
+        input_tensor_a.physical_volume() % tt::constants::TILE_HW == 0,
+        "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+        input_tensor_a.physical_volume(),
+        tt::constants::TILE_HW);
 
     auto width = input_tensor_a.padded_shape()[-1];
     uint32_t stick_s = width;
@@ -31,13 +35,29 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL((stick_size % 2) == 0, "Stick size must be divisible by 2");
 
     if (input_tensor_a.memory_config().is_sharded()) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
-        TT_FATAL(this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(), "Error");
-        TT_FATAL(this->use_multicore == true, "Error");
-        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+            "Input tensor memory layout must be HEIGHT_SHARDED but got {}",
+            input_tensor_a.memory_config().memory_layout());
+        TT_FATAL(
+            this->output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),
+            "Output memory config layout ({}) must match input tensor memory layout ({})",
+            this->output_mem_config.memory_layout(),
+            input_tensor_a.memory_config().memory_layout());
+        TT_FATAL(this->use_multicore == true, "Multicore must be enabled for sharded input");
+        TT_FATAL(
+            input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+            "Input tensor shard orientation must be ROW_MAJOR but got {}",
+            input_tensor_a.shard_spec().value().orientation);
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-        TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor memory layout must be INTERLEAVED but got {}",
+            input_tensor_a.memory_config().memory_layout());
+        TT_FATAL(
+            this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            this->output_mem_config.memory_layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -55,7 +55,13 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
             "Output tensor must have the same memory layout as input tensor");
         for (uint32_t i = 0; i < input_tensor_a.padded_shape().rank(); i++) {
             if (i != input_shape.rank() - 2) {
-                TT_FATAL(input_shape[i] == this->output_padded_shape[i], "Error");
+                TT_FATAL(
+                    input_shape[i] == this->output_padded_shape[i],
+                    "Input shape[{}] ({}) must equal output padded shape[{}] ({})",
+                    i,
+                    input_shape[i],
+                    i,
+                    this->output_padded_shape[i]);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -101,7 +101,10 @@ template <typename T>
 std::pair<std::string, std::string> get_op_init_and_func_parameterized(
     UnaryOpType op_type, std::span<const T> params, const std::string& idst, std::optional<DataType> input_dtype) {
     std::pair<std::string, std::string> op_init_and_name;
-    TT_FATAL(is_parametrized_type(op_type), "operator should support at least one parameter", "Error");
+    TT_FATAL(
+        is_parametrized_type(op_type),
+        "operator should support at least one parameter but op_type {} does not",
+        op_type);
     // TODO don't cast T to float when precision needs to be preserved
     const T param0_raw = params[0];
     float param0 = static_cast<float>(params[0]);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1635,7 +1635,7 @@ std::vector<Tensor> ExecuteUnaryBackwardRepeat::invoke(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
 
     auto shape_wh = input.padded_shape();
-    TT_FATAL(shape_wh[0] == 1 && "input shape[0] should be 1", "Error");
+    TT_FATAL(shape_wh[0] == 1, "Input shape[0] must be 1 but got {}", shape_wh[0]);
     auto ttnn_device = input.device();
     // input.padded_shape()[0]
     // If repeat shape has 0's, it returns zeros of given input

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -20,7 +20,7 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
     auto &a = input_tensors.at(0);
     const auto &weights = input_tensors.at(1);
-    TT_FATAL(weights.layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(weights.layout() == Layout::ROW_MAJOR, "Weights tensor layout must be ROW_MAJOR but got {}", weights.layout());
     TT_FATAL(a.dtype() == DataType::UINT32 or a.dtype() == DataType::BFLOAT16, "Input must be UINT32 or BFLOAT16");
     TT_FATAL(weights.dtype() == DataType::BFLOAT16, "Weights tensor must have BFLOAT16 dtype");
     TT_FATAL(a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharded inputs");

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -21,7 +21,7 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
     const auto &index_tensor_shape = index_tensor.padded_shape();
     const auto &grad_tensor_shape = grad_tensor.padded_shape();
 
-    TT_FATAL(index_tensor.layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(index_tensor.layout() == Layout::ROW_MAJOR, "Index tensor layout must be ROW_MAJOR but got {}", index_tensor.layout());
     TT_FATAL(
         index_tensor.dtype() == DataType::UINT32 or index_tensor.dtype() == DataType::BFLOAT16,
         "Index tensor must be UINT32 or BFLOAT16");
@@ -36,7 +36,7 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
         index_tensor_shape[-1] % TILE_WIDTH == 0,
         "Number of columns in the index tensor must be divisible by tile width");
 
-    TT_FATAL(grad_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(grad_tensor.layout() == Layout::TILE, "Gradient tensor layout must be TILE but got {}", grad_tensor.layout());
     TT_FATAL(
         grad_tensor.dtype() == DataType::BFLOAT16 or grad_tensor.dtype() == DataType::BFLOAT8_B,
         "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion_program_factory.cpp
@@ -779,7 +779,10 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor storage type must be DEVICE but got {}",
+            c.storage_type());
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -794,16 +797,40 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input buffer 0 size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input buffer 1 size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
 
     TT_FATAL(
         ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % in0_tile_shape[0] == 0, "Error");
-    TT_FATAL(ashape[-1] % in0_tile_shape[1] == 0, "Error");
-    TT_FATAL(bshape[-2] % in1_tile_shape[0] == 0, "Error");
-    TT_FATAL(bshape[-1] % in1_tile_shape[1] == 0, "Error");
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "Input A height ({}) must be divisible by tile height ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "Input A width ({}) must be divisible by tile width ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "Input B height ({}) must be divisible by tile height ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "Input B width ({}) must be divisible by tile width ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -822,7 +849,11 @@ ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t matmul_mul
         Mt = B * Mt;
         B = 1;
     }
-    TT_FATAL(Kt % in0_block_w == 0, "Error");
+    TT_FATAL(
+        Kt % in0_block_w == 0,
+        "K dimension in tiles ({}) must be divisible by input block width ({})",
+        Kt,
+        in0_block_w);
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -15,7 +15,7 @@ void AttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_tensor
     // intermediate: [q_heads, batch, batch, kv_len]
     // output: [q_len, q_heads, batch, kv_len]
 
-    TT_FATAL(input_tensors.size() == 2, "Error");
+    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors but got {}", input_tensors.size());
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -18,7 +18,10 @@ Tensor _fast_reduce_nc(
     const std::optional<const ttnn::Tensor>& output,
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Error");
+    TT_FATAL(
+        input.storage_type() == StorageType::DEVICE,
+        "Input tensor storage type must be DEVICE but got {}",
+        input.storage_type());
     auto kernel_config_val =
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
@@ -20,7 +20,10 @@ void SliceWriteDeviceOperation::validate_with_output_tensors(
     const auto output_padded_shape = output_tensor.padded_shape();
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(
+        input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR,
+        "Input tensor layout must be TILE or ROW_MAJOR but got {}",
+        input_tensor_a.layout());
     TT_FATAL(
         input_tensor_a.padded_shape().rank() == this->slice_start.rank() &&
             output_padded_shape.rank() == this->slice_start.rank() &&

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
@@ -12,7 +12,7 @@ namespace ttnn::operations::experimental::ssm {
 
 void HCSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
-    TT_FATAL(input_tensors.size() == 1, "Error");
+    TT_FATAL(input_tensors.size() == 1, "Expected 1 input tensor but got {}", input_tensors.size());
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL((input_tensor_a.layout() == Layout::TILE), "Inputs to ssm_1d_sum_reduce must be tilized");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::ssm {
 
 void RepeatAndInterleaveEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
-    TT_FATAL(input_tensors.size() == 2, "Error");
+    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors but got {}", input_tensors.size());
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -16,7 +16,8 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
     TT_FATAL(input_tensor.is_sharded(), "Operands to TM must be sharded");
     const auto& input_shape = input_tensor.padded_shape();
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
@@ -26,7 +27,10 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
         (bbox.end_coord.x < input_tensor.device()->compute_with_storage_grid_size().x &&
          bbox.end_coord.y < input_tensor.device()->compute_with_storage_grid_size().y),
         "Error");
-    TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED, "Error");
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+        "Input tensor memory layout must be BLOCK_SHARDED but got {}",
+        input_tensor.memory_config().memory_layout());
     ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
     uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
@@ -45,7 +49,10 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
         num_w_cores,
         tt::constants::TILE_WIDTH);
 
-    TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+    TT_FATAL(
+        this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Output memory config layout must be HEIGHT_SHARDED but got {}",
+        this->output_mem_config.memory_layout());
     TT_FATAL(input_shape[0] == num_h_cores, "Batch size {} must be equal to num cores {}", input_shape[0], num_h_cores);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -23,7 +23,11 @@ static inline tt::tt_metal::operation::ProgramWithCallbacks create_heads_combine
     // groups = kv_heads usually
     // heads_per_group = [x 1 1] if qkv since q_heads >= kv_heads and k=v heads but this should be generic
     TT_FATAL(head_dim % TILE_WIDTH == 0, "head dim {} needs to be a multiple of tile width {}", head_dim, TILE_WIDTH);
-    TT_FATAL(heads_per_group.size() == output.size() && output.size() == 3, "Error");
+    TT_FATAL(
+        heads_per_group.size() == output.size() && output.size() == 3,
+        "heads_per_group size ({}) and output size ({}) must both equal 3",
+        heads_per_group.size(),
+        output.size());
 
     const uint32_t total_heads_per_group =
         std::accumulate(heads_per_group.begin(), heads_per_group.end(), 0u);  // num q heads + 2 * num_kv_heads

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -17,19 +17,42 @@ void NLPConcatHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == tt::tt_metal::Layout::TILE,
+        "Input tensor layout must be TILE but got {}",
+        input_tensor.layout());
 
     if (input_tensor.is_sharded()) {
         TT_FATAL(
-            input_tensor.memory_config().memory_layout() != tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            input_tensor.memory_config().memory_layout() != tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
+            "Input tensor memory layout must not be WIDTH_SHARDED but got {}",
+            input_tensor.memory_config().memory_layout());
         auto shard_spec = input_tensor.shard_spec().value();
-        TT_FATAL(shard_spec.shape[1] == input_tensor.padded_shape()[-1], "Error");
-        TT_FATAL(shard_spec.shape[0] % input_tensor.padded_shape()[-2] == 0, "Error");
         TT_FATAL(
-            input_tensor.padded_shape()[1] % (shard_spec.shape[0] / input_tensor.padded_shape()[-2]) == 0, "Error");
-        TT_FATAL(this->output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+            shard_spec.shape[1] == input_tensor.padded_shape()[-1],
+            "Input tensor shard width ({}) must equal padded width ({})",
+            shard_spec.shape[1],
+            input_tensor.padded_shape()[-1]);
+        TT_FATAL(
+            shard_spec.shape[0] % input_tensor.padded_shape()[-2] == 0,
+            "Input tensor shard height ({}) must be divisible by padded height ({})",
+            shard_spec.shape[0],
+            input_tensor.padded_shape()[-2]);
+        TT_FATAL(
+            input_tensor.padded_shape()[1] % (shard_spec.shape[0] / input_tensor.padded_shape()[-2]) == 0,
+            "Input tensor padded height ({}) must be divisible by shard height / padded height ({} / {})",
+            input_tensor.padded_shape()[1],
+            shard_spec.shape[0],
+            input_tensor.padded_shape()[-2]);
+        TT_FATAL(
+            this->output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+            "Output memory config layout must not be HEIGHT_SHARDED but got {}",
+            this->output_mem_config.memory_layout());
     } else {
-        TT_FATAL(this->output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            this->output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            this->output_mem_config.memory_layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
@@ -17,18 +17,41 @@ void NLPConcatHeadsBoltzDeviceOperation::validate(const std::vector<Tensor>& inp
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == tt::tt_metal::Layout::TILE,
+        "Input tensor layout must be TILE but got {}",
+        input_tensor.layout());
     if (input_tensor.is_sharded()) {
         TT_FATAL(
-            input_tensor.memory_config().memory_layout() != tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            input_tensor.memory_config().memory_layout() != tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
+            "Input tensor memory layout must not be WIDTH_SHARDED but got {}",
+            input_tensor.memory_config().memory_layout());
         auto shard_spec = input_tensor.shard_spec().value();
-        TT_FATAL(shard_spec.shape[1] == input_tensor.padded_shape()[-1], "Error");
-        TT_FATAL(shard_spec.shape[0] % input_tensor.padded_shape()[-2] == 0, "Error");
         TT_FATAL(
-            input_tensor.padded_shape()[1] % (shard_spec.shape[0] / input_tensor.padded_shape()[-2]) == 0, "Error");
-        TT_FATAL(this->output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+            shard_spec.shape[1] == input_tensor.padded_shape()[-1],
+            "Input tensor shard width ({}) must equal padded width ({})",
+            shard_spec.shape[1],
+            input_tensor.padded_shape()[-1]);
+        TT_FATAL(
+            shard_spec.shape[0] % input_tensor.padded_shape()[-2] == 0,
+            "Input tensor shard height ({}) must be divisible by padded height ({})",
+            shard_spec.shape[0],
+            input_tensor.padded_shape()[-2]);
+        TT_FATAL(
+            input_tensor.padded_shape()[1] % (shard_spec.shape[0] / input_tensor.padded_shape()[-2]) == 0,
+            "Input tensor padded height ({}) must be divisible by shard height / padded height ({} / {})",
+            input_tensor.padded_shape()[1],
+            shard_spec.shape[0],
+            input_tensor.padded_shape()[-2]);
+        TT_FATAL(
+            this->output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+            "Output memory config layout must not be HEIGHT_SHARDED but got {}",
+            this->output_mem_config.memory_layout());
     } else {
-        TT_FATAL(this->output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            this->output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            this->output_mem_config.memory_layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -26,7 +26,8 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
 
     TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, "Unsupported input height {} is not tile aligned", input_shape[2]);
     TT_FATAL(input_shape[1] == 1, "Unsupported input sequence length {} is not equal to 1", input_shape[1]);
@@ -34,44 +35,78 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             input_tensor.shard_spec().value().shape[0] ==
                 input_tensor.physical_volume() / input_tensor.padded_shape()[-1],
-            "Error");
+            "Shard spec shape[0] ({}) must equal physical volume / padded shape[-1] ({})",
+            input_tensor.shard_spec().value().shape[0],
+            input_tensor.physical_volume() / input_tensor.padded_shape()[-1]);
         TT_FATAL(
             operation_attributes.output_mem_config.is_sharded() &&
                 operation_attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-            "Error");
-        TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+            "Output memory config must be sharded and not WIDTH_SHARDED but got memory_layout: {}",
+            operation_attributes.output_mem_config.memory_layout());
+        TT_FATAL(
+            input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+            "Input tensor shard orientation must be ROW_MAJOR but got {}",
+            input_tensor.shard_spec().value().orientation);
         auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
         uint32_t num_cores = core_grid.x * core_grid.y;
         // 1 Head Per Core Max for now
-        TT_FATAL(operation_attributes.num_q_heads <= num_cores, "Error");
-        TT_FATAL(operation_attributes.num_kv_heads <= num_cores, "Error");
-        TT_FATAL(operation_attributes.num_q_heads >= operation_attributes.num_kv_heads, "Error");
-        TT_FATAL(operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
+        TT_FATAL(
+            operation_attributes.num_q_heads <= num_cores,
+            "Number of Q heads ({}) must be <= number of cores ({})",
+            operation_attributes.num_q_heads,
+            num_cores);
+        TT_FATAL(
+            operation_attributes.num_kv_heads <= num_cores,
+            "Number of KV heads ({}) must be <= number of cores ({})",
+            operation_attributes.num_kv_heads,
+            num_cores);
+        TT_FATAL(
+            operation_attributes.num_q_heads >= operation_attributes.num_kv_heads,
+            "Number of Q heads ({}) must be >= number of KV heads ({})",
+            operation_attributes.num_q_heads,
+            operation_attributes.num_kv_heads);
+        TT_FATAL(
+            operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0,
+            "Number of Q heads ({}) must be divisible by number of cores ({})",
+            operation_attributes.num_q_heads,
+            input_tensor.shard_spec().value().num_cores());
         if (tensor_args.input_tensor_kv.has_value()) {
-            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded(), "Error");
+            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded(), "Input tensor KV must be sharded");
             TT_FATAL(
                 input_tensor.shard_spec().value().grid == tensor_args.input_tensor_kv.value().shard_spec().value().grid,
-                "Error");
+                "Input tensor and KV tensor must have the same shard grid");
             TT_FATAL(
                 input_tensor.shard_spec().value().orientation ==
                     tensor_args.input_tensor_kv.value().shard_spec().value().orientation,
-                "Error");
+                "Input tensor and KV tensor must have the same shard orientation");
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] ==
                     (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) *
                         operation_attributes.head_dim,
-                "Error");
+                "Shard spec shape[1] ({}) must equal (num_q_heads / num_kv_heads) * head_dim ({})",
+                input_tensor.shard_spec().value().shape[1],
+                (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) * operation_attributes.head_dim);
         } else {
-            TT_FATAL(operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
+            TT_FATAL(
+                operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0,
+                "Number of KV heads ({}) must be divisible by number of cores ({})",
+                operation_attributes.num_kv_heads,
+                input_tensor.shard_spec().value().num_cores());
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] ==
                     (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) *
                         operation_attributes.head_dim,
-                "Error");
+                "Shard spec shape[1] ({}) must equal (num_q_heads / num_kv_heads + 2) * head_dim ({})",
+                input_tensor.shard_spec().value().shape[1],
+                (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) *
+                    operation_attributes.head_dim);
         }
-        TT_FATAL(!operation_attributes.transpose_k_heads, "Error");
+        TT_FATAL(!operation_attributes.transpose_k_heads, "Transpose K heads must be false");
     } else {
-        TT_FATAL(operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            operation_attributes.output_mem_config.memory_layout());
     }
 
     if (tensor_args.input_tensor_kv.has_value()) {
@@ -81,21 +116,36 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(input_tensor_kv.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
         TT_FATAL(input_tensor_kv.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
         TT_FATAL(input_tensor_kv.dtype() == input_tensor.dtype(), "KV tensor dtype must be same as Q tensor dtype!");
-        TT_FATAL(input_tensor_kv.layout() == Layout::TILE, "Error");
+        TT_FATAL(
+            input_tensor_kv.layout() == Layout::TILE,
+            "Input tensor KV layout must be TILE but got {}",
+            input_tensor_kv.layout());
 
         TT_FATAL(input_shape_kv[0] == input_shape[0], "KV tensor batch dim must be same as Q tensor batch!");
         TT_FATAL(input_shape_kv[1] == 1, "Unsupported input shape {} is not equal to 1", input_shape_kv[1]);
         TT_FATAL(input_shape_kv[2] == input_shape[2], "KV tensor seq_len dim must be same as Q tensor seq_len!");
         if (input_tensor_kv.is_sharded()) {
-            TT_FATAL(input_tensor.is_sharded(), "Error");
+            TT_FATAL(input_tensor.is_sharded(), "Input tensor must be sharded when KV tensor is sharded");
             TT_FATAL(
                 input_tensor_kv.shard_spec().value().shape[0] ==
                     input_tensor_kv.physical_volume() / input_tensor_kv.padded_shape()[-1],
-                "Error");
-            TT_FATAL(input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
-            TT_FATAL(input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim, "Error");
+                "KV tensor shard spec shape[0] ({}) must equal physical volume / padded shape[-1] ({})",
+                input_tensor_kv.shard_spec().value().shape[0],
+                input_tensor_kv.physical_volume() / input_tensor_kv.padded_shape()[-1]);
             TT_FATAL(
-                operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0, "Error");
+                input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "KV tensor shard orientation must be ROW_MAJOR but got {}",
+                input_tensor_kv.shard_spec().value().orientation);
+            TT_FATAL(
+                input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim,
+                "KV tensor shard spec shape[1] ({}) must equal 2 * head_dim ({})",
+                input_tensor_kv.shard_spec().value().shape[1],
+                2 * operation_attributes.head_dim);
+            TT_FATAL(
+                operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0,
+                "Number of KV heads ({}) must be divisible by KV tensor number of cores ({})",
+                operation_attributes.num_kv_heads,
+                input_tensor_kv.shard_spec().value().num_cores());
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
@@ -25,28 +25,51 @@ void NlpCreateHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data type");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
 
     TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, "Unsupported input height {} is not tile aligned", input_shape[2]);
     if (input_tensor.is_sharded()) {
         TT_FATAL(
             input_tensor.shard_spec().value().shape[0] ==
                 input_tensor.logical_shape().volume() / input_tensor.padded_shape()[-1],
-            "Error");
+            "Shard spec shape[0] ({}) must equal logical volume / padded shape[-1] ({})",
+            input_tensor.shard_spec().value().shape[0],
+            input_tensor.logical_shape().volume() / input_tensor.padded_shape()[-1]);
         TT_FATAL(
             operation_attributes.output_mem_config.is_sharded() &&
                 operation_attributes.output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-            "Error");
-        TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+            "Output memory config must be sharded and not WIDTH_SHARDED but got memory_layout: {}",
+            operation_attributes.output_mem_config.memory_layout());
+        TT_FATAL(
+            input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+            "Input tensor shard orientation must be ROW_MAJOR but got {}",
+            input_tensor.shard_spec().value().orientation);
         auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
         uint32_t num_cores = core_grid.x * core_grid.y;
         // 1 Head Per Core Max for now
-        TT_FATAL(operation_attributes.num_q_heads <= num_cores, "Error");
-        TT_FATAL(operation_attributes.num_kv_heads <= num_cores, "Error");
-        TT_FATAL(operation_attributes.num_q_heads >= operation_attributes.num_kv_heads, "Error");
-        TT_FATAL(operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
+        TT_FATAL(
+            operation_attributes.num_q_heads <= num_cores,
+            "Number of Q heads ({}) must be <= number of cores ({})",
+            operation_attributes.num_q_heads,
+            num_cores);
+        TT_FATAL(
+            operation_attributes.num_kv_heads <= num_cores,
+            "Number of KV heads ({}) must be <= number of cores ({})",
+            operation_attributes.num_kv_heads,
+            num_cores);
+        TT_FATAL(
+            operation_attributes.num_q_heads >= operation_attributes.num_kv_heads,
+            "Number of Q heads ({}) must be >= number of KV heads ({})",
+            operation_attributes.num_q_heads,
+            operation_attributes.num_kv_heads);
+        TT_FATAL(
+            operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0,
+            "Number of Q heads ({}) must be divisible by number of cores ({})",
+            operation_attributes.num_q_heads,
+            input_tensor.shard_spec().value().num_cores());
         if (tensor_args.input_tensor_kv.has_value()) {
-            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded(), "Error");
+            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded(), "Input tensor KV must be sharded");
             TT_FATAL(
                 input_tensor.shard_spec().value().grid == tensor_args.input_tensor_kv.value().shard_spec().value().grid,
                 "Error");
@@ -58,18 +81,30 @@ void NlpCreateHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
                 input_tensor.shard_spec().value().shape[1] ==
                     (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) *
                         operation_attributes.head_dim,
-                "Error");
+                "Shard spec shape[1] ({}) must equal (num_q_heads / num_kv_heads) * head_dim ({})",
+                input_tensor.shard_spec().value().shape[1],
+                (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) * operation_attributes.head_dim);
         } else {
-            TT_FATAL(operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
+            TT_FATAL(
+                operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0,
+                "Number of KV heads ({}) must be divisible by number of cores ({})",
+                operation_attributes.num_kv_heads,
+                input_tensor.shard_spec().value().num_cores());
             TT_FATAL(
                 input_tensor.shard_spec().value().shape[1] ==
                     (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) *
                         operation_attributes.head_dim,
-                "Error");
+                "Shard spec shape[1] ({}) must equal (num_q_heads / num_kv_heads + 2) * head_dim ({})",
+                input_tensor.shard_spec().value().shape[1],
+                (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) *
+                    operation_attributes.head_dim);
         }
-        TT_FATAL(!operation_attributes.transpose_k_heads, "Error");
+        TT_FATAL(!operation_attributes.transpose_k_heads, "Transpose K heads must be false");
     } else {
-        TT_FATAL(operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            operation_attributes.output_mem_config.memory_layout());
     }
 
     if (tensor_args.input_tensor_kv.has_value()) {
@@ -79,20 +114,35 @@ void NlpCreateHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(input_tensor_kv.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
         TT_FATAL(input_tensor_kv.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
         TT_FATAL(input_tensor_kv.dtype() == input_tensor.dtype(), "KV tensor dtype must be same as Q tensor dtype!");
-        TT_FATAL(input_tensor_kv.layout() == Layout::TILE, "Error");
+        TT_FATAL(
+            input_tensor_kv.layout() == Layout::TILE,
+            "Input tensor KV layout must be TILE but got {}",
+            input_tensor_kv.layout());
 
         TT_FATAL(input_shape_kv[0] == input_shape[0], "KV tensor batch dim must be same as Q tensor batch!");
         TT_FATAL(input_shape_kv[2] == input_shape[2], "KV tensor seq_len dim must be same as Q tensor seq_len!");
         if (input_tensor_kv.is_sharded()) {
-            TT_FATAL(input_tensor.is_sharded(), "Error");
+            TT_FATAL(input_tensor.is_sharded(), "Input tensor must be sharded when KV tensor is sharded");
             TT_FATAL(
                 input_tensor_kv.shard_spec().value().shape[0] ==
                     input_tensor_kv.logical_shape().volume() / input_tensor_kv.padded_shape()[-1],
-                "Error");
-            TT_FATAL(input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
-            TT_FATAL(input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim, "Error");
+                "KV tensor shard spec shape[0] ({}) must equal logical volume / padded shape[-1] ({})",
+                input_tensor_kv.shard_spec().value().shape[0],
+                input_tensor_kv.logical_shape().volume() / input_tensor_kv.padded_shape()[-1]);
             TT_FATAL(
-                operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0, "Error");
+                input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+                "KV tensor shard orientation must be ROW_MAJOR but got {}",
+                input_tensor_kv.shard_spec().value().orientation);
+            TT_FATAL(
+                input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim,
+                "KV tensor shard spec shape[1] ({}) must equal 2 * head_dim ({})",
+                input_tensor_kv.shard_spec().value().shape[1],
+                2 * operation_attributes.head_dim);
+            TT_FATAL(
+                operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0,
+                "Number of KV heads ({}) must be divisible by KV tensor number of cores ({})",
+                operation_attributes.num_kv_heads,
+                input_tensor_kv.shard_spec().value().num_cores());
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -20,11 +20,19 @@ void NlpCreateHeadsFalcon7BDeviceOperation::validate(const std::vector<Tensor>& 
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
 
-    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
+    TT_FATAL(
+        input_shape[2] % tt::constants::TILE_HEIGHT == 0,
+        "Input shape[2] ({}) must be divisible by TILE_HEIGHT ({})",
+        input_shape[2],
+        tt::constants::TILE_HEIGHT);
     TT_FATAL((input_shape == ttnn::Shape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
-    TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Output memory config layout must be INTERLEAVED but got {}",
+        this->output_mem_config.memory_layout());
 }
 
 std::vector<ttnn::TensorSpec> NlpCreateHeadsFalcon7BDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
@@ -20,13 +20,25 @@ void NlpCreateHeadsSegformerDeviceOperation::validate(const std::vector<Tensor>&
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
 
-    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
-    TT_FATAL(input_shape[3] % tt::constants::TILE_HEIGHT == 0, "Error");
+    TT_FATAL(
+        input_shape[2] % tt::constants::TILE_HEIGHT == 0,
+        "Input shape[2] ({}) must be divisible by TILE_HEIGHT ({})",
+        input_shape[2],
+        tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        input_shape[3] % tt::constants::TILE_HEIGHT == 0,
+        "Input shape[3] ({}) must be divisible by TILE_HEIGHT ({})",
+        input_shape[3],
+        tt::constants::TILE_HEIGHT);
     // TT_FATAL((input_shape == tt::tt_metal::LegacyShape({input_shape[0], 1, input_shape[2], 2304})), "Unsupported
     // input shape");
-    TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Output memory config layout must be INTERLEAVED but got {}",
+        this->output_mem_config.memory_layout());
 }
 
 std::vector<ttnn::TensorSpec> NlpCreateHeadsSegformerDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
@@ -20,11 +20,19 @@ void NlpCreateHeadsVitDeviceOperation::validate(const std::vector<Tensor>& input
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
             input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format");
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Error");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
 
-    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
+    TT_FATAL(
+        input_shape[2] % tt::constants::TILE_HEIGHT == 0,
+        "Input shape[2] ({}) must be divisible by TILE_HEIGHT ({})",
+        input_shape[2],
+        tt::constants::TILE_HEIGHT);
     TT_FATAL((input_shape == ttnn::Shape({input_shape[0], 1, input_shape[2], 2304})), "Unsupported input shape");
-    TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Output memory config layout must be INTERLEAVED but got {}",
+        this->output_mem_config.memory_layout());
 }
 
 std::vector<ttnn::TensorSpec> NlpCreateHeadsVitDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -18,7 +18,7 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto& cos = input_tensors.at(1);
     const auto& sin = input_tensors.at(2);
-    TT_FATAL(input_tensors.size() == 3, "Error");
+    TT_FATAL(input_tensors.size() == 3, "Expected 3 input tensors but got {}", input_tensors.size());
     auto ref_device = input_tensor.device();
     for (const auto& input : input_tensors) {
         TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to rotary embedding need to be on device!");
@@ -41,8 +41,15 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
         TT_FATAL(cos.padded_shape()[-2] >= seq_len, "Cos dims must match input dims");
     }
     if (input_tensor.is_sharded()) {
-        TT_FATAL(input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-        TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1], "Error");
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "Input tensor memory layout must not be WIDTH_SHARDED but got {}",
+            input_tensor.memory_config().memory_layout());
+        TT_FATAL(
+            input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
+            "Input tensor shard width ({}) must equal padded width ({})",
+            input_tensor.shard_spec().value().shape[1],
+            input_tensor.padded_shape()[-1]);
         // Require even work division for now
         TT_FATAL(
             (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
@@ -50,13 +57,25 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
                 0,
             "Error");
         if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            TT_FATAL(
+                this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+                "Output memory config layout must not be WIDTH_SHARDED but got {}",
+                this->output_mem_config.memory_layout());
         }
     } else if (this->output_mem_config.is_sharded()) {
-        TT_FATAL(this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+        TT_FATAL(
+            this->output_mem_config.memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            "Output memory config layout must not be WIDTH_SHARDED but got {}",
+            this->output_mem_config.memory_layout());
     } else {
-        TT_FATAL(input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
-        TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Input tensor memory layout must be INTERLEAVED but got {}",
+            input_tensor.memory_config().memory_layout());
+        TT_FATAL(
+            this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "Output memory config layout must be INTERLEAVED but got {}",
+            this->output_mem_config.memory_layout());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -17,7 +17,7 @@ void RotaryEmbeddingLlama::validate(const std::vector<Tensor>& input_tensors) co
     const auto& cos = input_tensors.at(1);
     const auto& sin = input_tensors.at(2);
     const auto& trans_mat = input_tensors.at(3);
-    TT_FATAL(input_tensors.size() == 4, "Error");
+    TT_FATAL(input_tensors.size() == 4, "Expected 4 input tensors but got {}", input_tensors.size());
 
     auto ref_device = input_tensor.device();
     for (const auto& input : input_tensors) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.cpp
@@ -13,7 +13,7 @@ namespace tt_metal {
 
 void RotaryEmbeddingLlamaFusedQK::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
-    TT_FATAL(input_tensors.size() == 5, "Error");
+    TT_FATAL(input_tensors.size() == 5, "Expected 5 input tensors but got {}", input_tensors.size());
     const auto& q_input_tensor = input_tensors.at(0);
     const auto& k_input_tensor = input_tensors.at(1);
     const auto& cos = input_tensors.at(2);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -27,10 +27,19 @@ void SplitFusedQKVAndSplitHeadsDeviceOperation::validate_with_output_tensors(
         TT_FATAL(
             (bbox.end_coord.x < this->compute_with_storage_grid_size.x &&
              bbox.end_coord.y < this->compute_with_storage_grid_size.y),
-            "Error");
-        TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1, "Error");
+            "Bounding box end coordinates ({}, {}) must be less than grid size ({}, {})",
+            bbox.end_coord.x,
+            bbox.end_coord.y,
+            this->compute_with_storage_grid_size.x,
+            this->compute_with_storage_grid_size.y);
         TT_FATAL(
-            input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED, "Error");
+            input_tensor.shard_spec().value().grid.ranges().size() == 1,
+            "Input tensor shard spec must have exactly 1 grid range but got {}",
+            input_tensor.shard_spec().value().grid.ranges().size());
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+            "Input tensor memory layout must be BLOCK_SHARDED but got {}",
+            input_tensor.memory_config().memory_layout());
     }
 
     if (!output_tensors.empty()) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
@@ -28,7 +28,10 @@ void MorehArangeOperation::validate_inputs(
     }
     TT_FATAL(output->buffer() != nullptr, "Must have 1 output tensor.");
     TT_FATAL(dtype == output->dtype(), "If output is provided as input, its dtype should match the dtype parameter.");
-    TT_FATAL(output->memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(
+        output->memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Output memory config layout must be INTERLEAVED but got {}",
+        output->memory_config().memory_layout());
 
     auto output_layout = output->layout();
     if (operation_attributes.untilize_out) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -388,10 +388,22 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
         expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
 
         for (int i = 0; i < input_shape.rank(); ++i) {
-            TT_FATAL(input_dim[i] == output_dim[i], "Error");
+            TT_FATAL(
+                input_dim[i] == output_dim[i],
+                "Input dimension[{}] ({}) must equal output dimension[{}] ({})",
+                i,
+                input_dim[i],
+                i,
+                output_dim[i]);
         }
         for (int i = 0; i < input_shape_wo_padding.rank(); ++i) {
-            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i], "Error");
+            TT_FATAL(
+                input_dim_wo_padding[i] == output_dim_wo_padding[i],
+                "Input dimension without padding[{}] ({}) must equal output dimension without padding[{}] ({})",
+                i,
+                input_dim_wo_padding[i],
+                i,
+                output_dim_wo_padding[i]);
         }
     } else {
         ttnn::SmallVector<uint32_t> expected_output_shape;
@@ -413,10 +425,23 @@ void validate_output_with_keepdim(const Tensor& input, const Tensor& output, con
         log_debug(
             LogOp, "{}:{} expected_output_shape_wo_padding {}", __func__, __LINE__, expected_output_shape_wo_padding);
         for (int i = 0; i < expected_output_shape.size(); ++i) {
-            TT_FATAL(i == padded_dim || input_shape[i] == expected_output_shape[i], "Error");
+            TT_FATAL(
+                i == padded_dim || input_shape[i] == expected_output_shape[i],
+                "Input shape[{}] ({}) must equal expected output shape[{}] ({}) when not padded dimension",
+                i,
+                input_shape[i],
+                i,
+                expected_output_shape[i]);
         }
         for (int i = 0; i < expected_output_shape_wo_padding.size(); ++i) {
-            TT_FATAL(i == dim || input_shape_wo_padding[i] == expected_output_shape_wo_padding[i], "Error");
+            TT_FATAL(
+                i == dim || input_shape_wo_padding[i] == expected_output_shape_wo_padding[i],
+                "Input shape without padding[{}] ({}) must equal expected output shape without padding[{}] ({}) when "
+                "not target dimension",
+                i,
+                input_shape_wo_padding[i],
+                i,
+                expected_output_shape_wo_padding[i]);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -121,7 +121,10 @@ std::vector<std::optional<Tensor>> MorehLinearBackward::invoke(
             weight.storage_type() == StorageType::DEVICE,
         "input and weight tensors need to be on device");
 
-    TT_FATAL(output_grad.storage_type() == StorageType::DEVICE, "Error");
+    TT_FATAL(
+        output_grad.storage_type() == StorageType::DEVICE,
+        "Output grad storage type must be DEVICE but got {}",
+        output_grad.storage_type());
     moreh_linear_backward_validate(output_grad, input, weight, input_grad, weight_grad, bias_grad);
 
     if (input_required_grad) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -34,7 +34,13 @@ void MorehSumBackwardOperation::validate_inputs(
     // validate output_grad shape
     if (keepdim) {
         for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_shape_wo_padding[i] >= output_grad_shape_wo_padding[i], "Error");
+            TT_FATAL(
+                input_shape_wo_padding[i] >= output_grad_shape_wo_padding[i],
+                "Input shape without padding[{}] ({}) must be >= output grad shape without padding[{}] ({})",
+                i,
+                input_shape_wo_padding[i],
+                i,
+                output_grad_shape_wo_padding[i]);
         }
     } else {
         std::vector<uint32_t> expected_output_grad_shape;
@@ -64,7 +70,13 @@ void MorehSumBackwardOperation::validate_inputs(
         uint32_t rank = output_grad_shape_wo_padding.rank();
         TT_FATAL(expected_rank == rank, "expected_rank {} == rank {}", expected_rank, rank);
         for (int i = 0; i < rank; ++i) {
-            TT_FATAL(expected_output_grad_shape[i] >= output_grad_shape_wo_padding[i], "Error");
+            TT_FATAL(
+                expected_output_grad_shape[i] >= output_grad_shape_wo_padding[i],
+                "Expected output grad shape[{}] ({}) must be >= output grad shape without padding[{}] ({})",
+                i,
+                expected_output_grad_shape[i],
+                i,
+                output_grad_shape_wo_padding[i]);
             log_debug(
                 tt::LogOp,
                 "rank {} expected_output_grad_shape {}, output_grad_shape_wo_padding {}",

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -135,7 +135,11 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         "Output sticks per shard {} should be same as output sticks per core {}",
         out_nsticks_per_core,
         output_nsticks_per_core);
-    TT_FATAL(input_nsticks_per_core % in_w == 0, "Error");
+    TT_FATAL(
+        input_nsticks_per_core % in_w == 0,
+        "Input sticks per core ({}) must be divisible by input width ({})",
+        input_nsticks_per_core,
+        in_w);
 
     // creating halo input tensor
     auto halo_in = HaloTensorCreation(input);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -25,7 +25,11 @@ void HaloDeviceOperation::validate(const std::vector<Tensor>& input_tensors) con
         // skip the untilize, only do halo
         log_debug(tt::LogOp, "Input is ROW_MAJOR, no need to untilize.");
     } else {
-        TT_FATAL(input_tensor.physical_volume() % tt::constants::TILE_HW == 0, "Error");
+        TT_FATAL(
+            input_tensor.physical_volume() % tt::constants::TILE_HW == 0,
+            "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",
+            input_tensor.physical_volume(),
+            tt::constants::TILE_HW);
     }
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -835,11 +835,19 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     if (Sk_chunk_t > 0) {
         const uint32_t sub_exp_granularity = std::min(Sk_chunk_t, dst_size);
         const uint32_t log2_sub_exp_granularity = std::log2(sub_exp_granularity);
-        TT_FATAL(sub_exp_granularity == (1 << log2_sub_exp_granularity), "Error");
+        TT_FATAL(
+            sub_exp_granularity == (1 << log2_sub_exp_granularity),
+            "Sub-exp granularity ({}) must be a power of 2 (2^{})",
+            sub_exp_granularity,
+            log2_sub_exp_granularity);
 
         const uint32_t mul_bcast_granularity = std::min(PNHt * Sk_chunk_t, dst_size);
         const uint32_t log2_mul_bcast_granularity = std::log2(mul_bcast_granularity);
-        TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity), "Error");
+        TT_FATAL(
+            mul_bcast_granularity == (1 << log2_mul_bcast_granularity),
+            "Mul-bcast granularity ({}) must be a power of 2 (2^{})",
+            mul_bcast_granularity,
+            log2_mul_bcast_granularity);
 
         compute_defines["SUB_EXP_GRANULARITY"] = std::to_string(sub_exp_granularity);
         compute_defines["LOG2_SUB_EXP_GRANULARITY"] = std::to_string(log2_sub_exp_granularity);


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
We have too many TT_FATALs with "Error" as the error message.

### What's changed
Updated the messages to be better. I tried to update all of the ones I could find with just "Error", except for a bunch in some tests.

### Checklist

- PR Gate passes https://github.com/tenstorrent/tt-metal/actions/runs/18856197770
- Merge Gate passes https://github.com/tenstorrent/tt-metal/actions/runs/18856167988


- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18853283658 (waiting on galaxy)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes