### PR TITLE
Changing control plane initialization to happen during fabrc init

### DIFF
--- a/tests/scripts/multihost/run_dual_t3k_tests.sh
+++ b/tests/scripts/multihost/run_dual_t3k_tests.sh
@@ -21,8 +21,8 @@ run_dual_t3k_unit_tests() {
   local rank_binding="tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml"
   local strict_rank_binding="tests/tt_metal/distributed/config/dual_t3k_strict_connection_rank_bindings.yaml"
 
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/tools/scaleout/run_cluster_validation  --print-connectivity --send-traffic --hard-fail ; fail+=$?
+  mpirun $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
+  mpirun $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation  --print-connectivity --send-traffic --hard-fail ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/perf_microbenchmark/routing/test_dual_t3k.yaml ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/multi_host_fabric_tests ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml ; fail+=$?

--- a/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
@@ -21,6 +21,7 @@ constexpr auto k_ReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
+    control_plane->initialize();
     control_plane->initialize_fabric_context(k_FabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_FabricConfig, k_ReliabilityMode);
     return control_plane;

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -70,6 +70,7 @@ TEST(MultiHost, TestDualGalaxyControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(dual_galaxy_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -138,6 +139,7 @@ TEST(MultiHost, TestDual2x4ControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(dual_galaxy_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -204,6 +206,7 @@ TEST(MultiHost, TestSplit2x2ControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(split_2x2_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -267,6 +270,7 @@ TEST(MultiHost, TestBigMesh2x4ControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(big_mesh_2x4_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -287,6 +291,7 @@ TEST(MultiHost, TestBigMesh2x4Fabric2DSanity) {
 
     // Validate control plane apis
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
     const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     EXPECT_EQ(
         intramesh_connections.size(),
@@ -339,6 +344,7 @@ TEST(MultiHost, TestQuadGalaxyControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(quad_galaxy_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC,
@@ -450,6 +456,7 @@ TEST(MultiHost, TestBHQB4x4ControlPlaneInit) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/bh_qb_4x4_mesh_graph_descriptor.textproto";
     auto control_plane = std::make_unique<ControlPlane>(bhqb_mesh_graph_desc_path.string());
+    control_plane->initialize();
 
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(
         tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_XY,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -25,6 +25,7 @@ constexpr auto kReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_S
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
+    control_plane->initialize();
     control_plane->initialize_fabric_context(kFabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig, kReliabilityMode);
 
@@ -36,6 +37,7 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(
     const std::map<tt::tt_fabric::FabricNodeId, tt::ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(
         graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
+    control_plane->initialize();
     control_plane->initialize_fabric_context(kFabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig, kReliabilityMode);
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables_mgd2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables_mgd2.cpp
@@ -25,6 +25,7 @@ constexpr auto kReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_S
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
+    control_plane->initialize();
     control_plane->initialize_fabric_context(kFabricConfig);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig, kReliabilityMode);
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -76,7 +76,7 @@ public:
     ~ControlPlane();
 
     // Generate routing tables and validate connectivity in control plane
-    void initialize_control_plane();
+    void initialize();
 
     // Printing functions
     void print_routing_tables() const;
@@ -204,11 +204,14 @@ public:
     const std::unordered_map<tt_metal::distributed::multihost::Rank, std::pair<MeshId, MeshHostRankId>>&
     get_global_logical_bindings() const;
 
+    bool is_initialized() const { return is_initialized_; }
+
 private:
     // Check if the provided mesh is local to this host
     bool is_local_mesh(MeshId mesh_id) const;
 
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED
+    bool is_initialized_ = false;
     // TODO: remove this from local node control plane. Can get it from the global control plane
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -75,6 +75,9 @@ public:
 
     ~ControlPlane();
 
+    // Generate routing tables and validate connectivity in control plane
+    void initialize_control_plane();
+
     // Printing functions
     void print_routing_tables() const;
     void print_ethernet_channels() const;
@@ -205,14 +208,11 @@ private:
     // Check if the provided mesh is local to this host
     bool is_local_mesh(MeshId mesh_id) const;
 
-    void init_control_plane(
-        const std::string& mesh_graph_desc_file,
-        std::optional<std::reference_wrapper<const std::map<FabricNodeId, ChipId>>>
-            logical_mesh_chip_id_to_physical_chip_id_mapping = std::nullopt);
-
     uint16_t routing_mode_ = 0;  // ROUTING_MODE_UNDEFINED
     // TODO: remove this from local node control plane. Can get it from the global control plane
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
+
+    std::string mesh_graph_desc_file_;
 
     std::map<FabricNodeId, ChipId> logical_mesh_chip_id_to_physical_chip_id_mapping_;
 
@@ -253,8 +253,6 @@ private:
 
     ChipId get_physical_chip_id_from_eth_coord(const EthCoord& eth_coord) const;
 
-    void load_physical_chip_mapping(
-        const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
     size_t get_num_live_routing_planes(FabricNodeId fabric_node_id, RoutingDirection routing_direction) const;
     void initialize_dynamic_routing_plane_counts(
         const IntraMeshConnectivity& intra_mesh_connectivity,

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1973,7 +1973,6 @@ bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) con
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
-    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
     std::unordered_set<CoreCoord> active_ethernet_cores;
@@ -2035,7 +2034,6 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chi
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId chip_id) const {
-    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -435,29 +435,40 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_asic_id(uint64_t asic_id) con
     return FabricNodeId(MeshId{0}, 0);
 }
 
-void ControlPlane::initialize_control_plane() {
-    const auto& driver = tt::tt_metal::MetalContext::instance().get_cluster().get_driver();
-    const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(this->mesh_graph_desc_file_);
-    this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
-        driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
-    this->local_mesh_binding_ = this->initialize_local_mesh_binding();
+void ControlPlane::initialize() {
+    try {
+        this->is_initialized_ = true;
 
-    this->initialize_distributed_contexts();
+        const auto& driver = tt::tt_metal::MetalContext::instance().get_cluster().get_driver();
+        const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(this->mesh_graph_desc_file_);
+        this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
+            driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
+        this->local_mesh_binding_ = this->initialize_local_mesh_binding();
 
-    if (this->logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
-        this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
-            *this->routing_table_generator_->mesh_graph, *this->physical_system_descriptor_, this->local_mesh_binding_);
-        this->logical_mesh_chip_id_to_physical_chip_id_mapping_ =
-            this->topology_mapper_->get_local_logical_mesh_chip_id_to_physical_chip_id_mapping();
+        this->initialize_distributed_contexts();
+
+        if (this->logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
+            this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
+                *this->routing_table_generator_->mesh_graph,
+                *this->physical_system_descriptor_,
+                this->local_mesh_binding_);
+            this->logical_mesh_chip_id_to_physical_chip_id_mapping_ =
+                this->topology_mapper_->get_local_logical_mesh_chip_id_to_physical_chip_id_mapping();
+        }
+
+        this->validate_mesh_connections();
+
+        this->generate_intermesh_connectivity();
+
+        // Printing, only enabled with log_debug
+        this->routing_table_generator_->mesh_graph->print_connectivity();
+    } catch (const std::exception& e) {
+        this->is_initialized_ = false;
+        log_critical(tt::LogFabric, "Failed to initialize control plane: {}", e.what());
+        throw;
     }
-    this->validate_mesh_connections();
-
-    this->generate_intermesh_connectivity();
-
-    // Printing, only enabled with log_debug
-    this->routing_table_generator_->mesh_graph->print_connectivity();
 }
 
 ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) : mesh_graph_desc_file_(mesh_graph_desc_file) {}
@@ -469,6 +480,7 @@ ControlPlane::ControlPlane(
     logical_mesh_chip_id_to_physical_chip_id_mapping_(logical_mesh_chip_id_to_physical_chip_id_mapping) {}
 
 void ControlPlane::validate_mesh_connections(MeshId mesh_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     MeshShape mesh_shape = routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id);
     auto get_physical_chip_id = [&](const MeshCoordinate& mesh_coord) {
         auto fabric_chip_id = this->routing_table_generator_->mesh_graph->coordinate_to_chip(mesh_id, mesh_coord);
@@ -502,6 +514,7 @@ void ControlPlane::validate_mesh_connections(MeshId mesh_id) const {
 }
 
 void ControlPlane::validate_mesh_connections() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     for (const auto& mesh_id : this->routing_table_generator_->mesh_graph->get_mesh_ids()) {
         if (this->is_local_mesh(mesh_id)) {
             this->validate_mesh_connections(mesh_id);
@@ -511,11 +524,13 @@ void ControlPlane::validate_mesh_connections() const {
 
 routing_plane_id_t ControlPlane::get_routing_plane_id(
     chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto it = std::find(eth_chans_in_direction.begin(), eth_chans_in_direction.end(), eth_chan_id);
     return std::distance(eth_chans_in_direction.begin(), it);
 }
 
 routing_plane_id_t ControlPlane::get_routing_plane_id(FabricNodeId fabric_node_id, chan_id_t eth_chan_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     TT_FATAL(
         this->router_port_directions_to_physical_eth_chan_map_.contains(fabric_node_id),
         "Mesh {} Chip {} out of bounds",
@@ -542,6 +557,7 @@ routing_plane_id_t ControlPlane::get_routing_plane_id(FabricNodeId fabric_node_i
 
 chan_id_t ControlPlane::get_downstream_eth_chan_id(
     routing_plane_id_t src_routing_plane_id, const std::vector<chan_id_t>& candidate_target_chans) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     if (candidate_target_chans.empty()) {
         return eth_chan_magic_values::INVALID_DIRECTION;
     }
@@ -568,6 +584,7 @@ chan_id_t ControlPlane::get_downstream_eth_chan_id(
 };
 
 void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     // Routing tables contain direction from chip to chip
     // Convert it to be unique per ethernet channel
 
@@ -790,6 +807,7 @@ size_t ControlPlane::get_num_live_routing_planes(
 // fabric routers on device
 void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
     tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
@@ -940,6 +958,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
 }
 
 void ControlPlane::write_routing_tables_to_eth_cores(MeshId mesh_id, ChipId chip_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     FabricNodeId fabric_node_id{mesh_id, chip_id};
     const auto& chip_intra_mesh_routing_tables = this->intra_mesh_routing_tables_.at(fabric_node_id);
     const auto& chip_inter_mesh_routing_tables = this->inter_mesh_routing_tables_.at(fabric_node_id);
@@ -1032,6 +1051,7 @@ void ControlPlane::write_routing_tables_to_eth_cores(MeshId mesh_id, ChipId chip
 }
 
 FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physical_chip_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     for (const auto& [fabric_node_id, mapped_physical_chip_id] :
          this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
         if (mapped_physical_chip_id == physical_chip_id) {
@@ -1047,6 +1067,7 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physi
 }
 
 ChipId ControlPlane::get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     TT_ASSERT(logical_mesh_chip_id_to_physical_chip_id_mapping_.contains(fabric_node_id));
     return logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
 }
@@ -1132,6 +1153,7 @@ std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_id
 
 std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
     FabricNodeId fabric_node_id, routing_plane_id_t routing_plane_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::vector<chan_id_t> valid_eth_chans;
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
@@ -1145,6 +1167,7 @@ std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
 }
 
 eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDirection direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     eth_chan_directions dir;
     switch (direction) {
         case RoutingDirection::N: dir = eth_chan_directions::NORTH; break;
@@ -1158,6 +1181,7 @@ eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDire
 
 std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fabric_eth_channels(
     FabricNodeId fabric_node_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::set<std::pair<chan_id_t, eth_chan_directions>> active_fabric_eth_channels;
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
@@ -1169,6 +1193,7 @@ std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fab
 }
 
 eth_chan_directions ControlPlane::get_eth_chan_direction(FabricNodeId fabric_node_id, int chan) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         for (const auto& eth_chan : eth_chans) {
@@ -1182,6 +1207,7 @@ eth_chan_directions ControlPlane::get_eth_chan_direction(FabricNodeId fabric_nod
 
 std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, chan_id_t src_chan_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     // Query the mesh coord range owned by the current host
     auto host_local_coord_range = this->get_coord_range(this->get_local_mesh_id_bindings()[0], MeshScope::LOCAL);
     auto src_mesh_coord = this->routing_table_generator_->mesh_graph->chip_to_coordinate(
@@ -1229,6 +1255,7 @@ std::vector<std::pair<FabricNodeId, chan_id_t>> ControlPlane::get_fabric_route(
 
 std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto src_mesh_id = src_fabric_node_id.mesh_id;
     auto src_chip_id = src_fabric_node_id.chip_id;
     auto dst_mesh_id = dst_fabric_node_id.mesh_id;
@@ -1251,6 +1278,7 @@ std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
 
 std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& forwarding_direction = get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
     if (!forwarding_direction.has_value()) {
         return {};
@@ -1261,6 +1289,7 @@ std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
 
 std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
     FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, RoutingDirection forwarding_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::vector<chan_id_t> forwarding_channels;
     const auto& active_channels =
         this->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction);
@@ -1277,6 +1306,7 @@ std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
 
 stl::Span<const ChipId> ControlPlane::get_intra_chip_neighbors(
     FabricNodeId src_fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     for (const auto& [_, routing_edge] :
          this->routing_table_generator_->mesh_graph
              ->get_intra_mesh_connectivity()[*src_fabric_node_id.mesh_id][src_fabric_node_id.chip_id]) {
@@ -1289,6 +1319,7 @@ stl::Span<const ChipId> ControlPlane::get_intra_chip_neighbors(
 
 std::unordered_map<MeshId, std::vector<ChipId>> ControlPlane::get_chip_neighbors(
     FabricNodeId src_fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::unordered_map<MeshId, std::vector<ChipId>> neighbors;
     auto intra_neighbors = this->get_intra_chip_neighbors(src_fabric_node_id, routing_direction);
     auto src_mesh_id = src_fabric_node_id.mesh_id;
@@ -1306,6 +1337,7 @@ std::unordered_map<MeshId, std::vector<ChipId>> ControlPlane::get_chip_neighbors
 }
 
 size_t ControlPlane::get_num_active_fabric_routers(FabricNodeId fabric_node_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     // Return the number of active fabric routers on the chip
     // Not always all the available FABRIC_ROUTER cores given by Cluster, since some may be disabled
     size_t num_routers = 0;
@@ -1318,6 +1350,7 @@ size_t ControlPlane::get_num_active_fabric_routers(FabricNodeId fabric_node_id) 
 
 std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
     FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         if (routing_direction == direction) {
@@ -1600,6 +1633,7 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, Chip
 
 std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_direction(
     FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto eth_chans = get_active_fabric_eth_channels_in_direction(fabric_node_id, routing_direction);
     size_t num_routing_planes = 0;
     if (this->router_port_directions_to_num_routing_planes_map_.contains(fabric_node_id) &&
@@ -1621,6 +1655,7 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_dir
 
 size_t ControlPlane::get_num_available_routing_planes_in_direction(
     FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     if (this->router_port_directions_to_num_routing_planes_map_.contains(fabric_node_id) &&
         this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).contains(routing_direction)) {
         return this->router_port_directions_to_num_routing_planes_map_.at(fabric_node_id).at(routing_direction);
@@ -1630,6 +1665,7 @@ size_t ControlPlane::get_num_available_routing_planes_in_direction(
 
 template <>
 void ControlPlane::write_all_to_all_routing_fields<1, false>(MeshId mesh_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto host_rank_id = this->get_local_host_rank_id_binding();
     // TODO: Remove mesh graph chip ids once Topology mapper works for multi-mesh systems
     const auto& local_mesh_chip_id_container =
@@ -1694,6 +1730,7 @@ void ControlPlane::write_all_to_all_routing_fields<1, false>(MeshId mesh_id) con
 
 template <>
 void ControlPlane::write_all_to_all_routing_fields<2, true>(MeshId mesh_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto host_rank_id = this->get_local_host_rank_id_binding();
     // TODO: Remove mesh graph chip ids once Topology mapper works for multi-mesh systems
     const auto& local_mesh_chip_id_container =
@@ -1784,6 +1821,7 @@ void ControlPlane::write_all_to_all_routing_fields<2, true>(MeshId mesh_id) cons
 }
 
 void ControlPlane::write_routing_tables_to_all_chips() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     // Configure the routing tables on the chips
     TT_ASSERT(
         this->intra_mesh_routing_tables_.size() == this->inter_mesh_routing_tables_.size(),
@@ -1811,6 +1849,7 @@ void ControlPlane::write_routing_tables_to_all_chips() const {
 
 // TODO: remove this after TG is deprecated
 std::vector<MeshId> ControlPlane::get_user_physical_mesh_ids() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::vector<MeshId> physical_mesh_ids;
     const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     for (const auto& [fabric_node_id, physical_chip_id] : this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
@@ -1824,6 +1863,7 @@ std::vector<MeshId> ControlPlane::get_user_physical_mesh_ids() const {
 }
 
 MeshShape ControlPlane::get_physical_mesh_shape(MeshId mesh_id, MeshScope scope) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
 
@@ -1836,6 +1876,7 @@ MeshShape ControlPlane::get_physical_mesh_shape(MeshId mesh_id, MeshScope scope)
 }
 
 void ControlPlane::print_routing_tables() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     this->print_ethernet_channels();
 
     std::stringstream ss;
@@ -1869,6 +1910,7 @@ void ControlPlane::print_routing_tables() const {
 }
 
 void ControlPlane::print_ethernet_channels() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::stringstream ss;
     ss << "Control Plane: Physical eth channels in each direction" << std::endl;
     for (const auto& [fabric_node_id, fabric_eth_channels] : this->router_port_directions_to_physical_eth_chan_map_) {
@@ -1885,6 +1927,7 @@ void ControlPlane::print_ethernet_channels() const {
 }
 
 void ControlPlane::set_routing_mode(uint16_t mode) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     if (!(this->routing_mode_ == 0 || this->routing_mode_ == mode)) {
         log_warning(
             tt::LogFabric,
@@ -1895,31 +1938,42 @@ void ControlPlane::set_routing_mode(uint16_t mode) {
     this->routing_mode_ = mode;
 }
 
-uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
+uint16_t ControlPlane::get_routing_mode() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
+    return this->routing_mode_;
+}
 
 void ControlPlane::initialize_fabric_context(tt_fabric::FabricConfig fabric_config) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
     this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
 }
 
 FabricContext& ControlPlane::get_fabric_context() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     TT_FATAL(this->fabric_context_ != nullptr, "Trying to get un-initialized fabric context");
     return *this->fabric_context_;
 }
 
-void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }
+void ControlPlane::clear_fabric_context() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
+    this->fabric_context_.reset(nullptr);
+}
 
 void ControlPlane::initialize_fabric_tensix_datamover_config() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     TT_FATAL(this->fabric_context_ != nullptr, "Fabric context must be initialized first");
     this->fabric_context_->initialize_tensix_config();
 }
 
 bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto asic_id = tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(chip_id);
     return this->physical_system_descriptor_->is_cross_host_eth_link(tt::tt_metal::AsicID{asic_id}, chan_id);
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
     std::unordered_set<CoreCoord> active_ethernet_cores;
@@ -1981,6 +2035,7 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chi
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId chip_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
@@ -1995,6 +2050,7 @@ std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId c
 
 void ControlPlane::assign_direction_to_fabric_eth_chan(
     const FabricNodeId& fabric_node_id, chan_id_t chan_id, RoutingDirection direction) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     // TODO: get_fabric_ethernet_channels accounts for down links, but we should manage down links in control plane
     auto fabric_router_channels_on_chip =
@@ -2015,6 +2071,7 @@ void ControlPlane::assign_direction_to_fabric_eth_chan(
 
 void ControlPlane::assign_direction_to_fabric_eth_core(
     const FabricNodeId& fabric_node_id, const CoreCoord& eth_core, RoutingDirection direction) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     auto chan_id = tt::tt_metal::MetalContext::instance()
                        .get_cluster()
@@ -2023,9 +2080,13 @@ void ControlPlane::assign_direction_to_fabric_eth_core(
     this->assign_direction_to_fabric_eth_chan(fabric_node_id, chan_id, direction);
 }
 
-const MeshGraph& ControlPlane::get_mesh_graph() const { return *routing_table_generator_->mesh_graph; }
+const MeshGraph& ControlPlane::get_mesh_graph() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
+    return *routing_table_generator_->mesh_graph;
+}
 
 std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& mesh_id_bindings = this->local_mesh_binding_.mesh_ids;
     const auto& user_mesh_ids = this->get_user_physical_mesh_ids();
     std::vector<MeshId> local_mesh_ids;
@@ -2038,14 +2099,19 @@ std::vector<MeshId> ControlPlane::get_local_mesh_id_bindings() const {
     return local_mesh_ids;
 }
 
-MeshHostRankId ControlPlane::get_local_host_rank_id_binding() const { return this->local_mesh_binding_.host_rank; }
+MeshHostRankId ControlPlane::get_local_host_rank_id_binding() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
+    return this->local_mesh_binding_.host_rank;
+}
 
 MeshCoordinate ControlPlane::get_local_mesh_offset() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto coord_range = this->get_coord_range(this->get_local_mesh_id_bindings()[0], MeshScope::LOCAL);
     return coord_range.start_coord();
 }
 
 MeshCoordinateRange ControlPlane::get_coord_range(MeshId mesh_id, MeshScope scope) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
 
@@ -2058,12 +2124,14 @@ MeshCoordinateRange ControlPlane::get_coord_range(MeshId mesh_id, MeshScope scop
 }
 
 bool ControlPlane::is_local_mesh(MeshId mesh_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& local_mesh_ids = local_mesh_binding_.mesh_ids;
     return std::find(local_mesh_ids.begin(), local_mesh_ids.end(), mesh_id) != local_mesh_ids.end();
 }
 
 const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>& ControlPlane::get_distributed_context(
     MeshId mesh_id) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     auto distributed_context = distributed_contexts_.find(mesh_id);
     TT_FATAL(distributed_context != distributed_contexts_.end(), "Unknown mesh id: {}", mesh_id);
     return distributed_context->second;
@@ -2071,11 +2139,13 @@ const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>&
 
 const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>& ControlPlane::get_host_local_context()
     const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     return host_local_context_;
 }
 
 const std::unordered_map<tt_metal::distributed::multihost::Rank, std::pair<MeshId, MeshHostRankId>>&
 ControlPlane::get_global_logical_bindings() const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     return global_logical_bindings_;
 }
 
@@ -2136,6 +2206,7 @@ void ControlPlane::populate_fabric_connection_info(
     ChipId physical_chip_id,
     chan_id_t eth_channel_id,
     eth_chan_directions router_direction) const {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     constexpr uint16_t WORKER_FREE_SLOTS_STREAM_ID = 17;
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& fabric_context = this->get_fabric_context();
@@ -2186,6 +2257,7 @@ void ControlPlane::populate_fabric_connection_info(
 }
 
 void ControlPlane::collect_and_merge_router_port_directions_from_all_hosts() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
     if (*distributed_context.size() == 1) {
         // No need to collect from other hosts when running a single process
@@ -2267,6 +2339,7 @@ void ControlPlane::collect_and_merge_router_port_directions_from_all_hosts() {
 // Intermesh Connectivity Generation Functions
 
 void ControlPlane::generate_intermesh_connectivity() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     AnnotatedIntermeshConnections intermesh_connections;
     if (*(tt_metal::MetalContext::instance().global_distributed_context().size()) > 1) {
         // Intermesh Connectivity generation for the multi-host case
@@ -2285,6 +2358,7 @@ std::vector<PortDescriptor> ControlPlane::assign_logical_ports_to_exit_nodes(
     bool strict_binding,
     const std::unordered_set<FabricNodeId>& requested_exit_nodes,
     std::unordered_set<port_id_t>& assigned_port_ids) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& exit_nodes = physical_system_descriptor_->get_connecting_exit_nodes(my_host, neighbor_host);
     const auto& my_mesh_id = this->local_mesh_binding_.mesh_ids[0];
     const auto& mesh_edge_ports_to_chip_id =
@@ -2330,6 +2404,7 @@ std::vector<PortDescriptor> ControlPlane::assign_logical_ports_to_exit_nodes(
 }
 
 PortDescriptorTable ControlPlane::generate_port_descriptors_for_exit_nodes() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& mesh_graph = this->routing_table_generator_->mesh_graph;
     const auto& requested_intermesh_connections = mesh_graph->get_requested_intermesh_connections();
     const auto& requested_intermesh_ports = mesh_graph->get_requested_intermesh_ports();
@@ -2382,6 +2457,7 @@ std::unordered_set<FabricNodeId> ControlPlane::get_requested_exit_nodes(
     const RequestedIntermeshConnections& requested_intermesh_connections,
     const RequestedIntermeshPorts& requested_intermesh_ports,
     const std::vector<uint64_t>& src_exit_node_chips) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     std::unordered_set<FabricNodeId> requested_exit_nodes;
     if (!requested_intermesh_ports.empty()) {
         for (const auto& port : requested_intermesh_ports.at(*my_mesh_id).at(*neighbor_mesh_id)) {
@@ -2420,6 +2496,7 @@ std::unordered_set<FabricNodeId> ControlPlane::get_requested_exit_nodes(
 
 void ControlPlane::forward_descriptors_to_controller(
     PortDescriptorTable& port_descriptors, uint32_t my_rank, const std::string& my_host) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     using namespace tt::tt_metal::distributed::multihost;
     constexpr uint32_t CONTROLLER_RANK = 0;
     auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
@@ -2463,6 +2540,7 @@ void ControlPlane::forward_descriptors_to_controller(
 }
 
 void ControlPlane::forward_intermesh_connections_from_controller(AnnotatedIntermeshConnections& intermesh_connections) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     using namespace tt::tt_metal::distributed::multihost;
     auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
     constexpr uint32_t CONTROLLER_RANK = 0;
@@ -2507,6 +2585,7 @@ void ControlPlane::forward_intermesh_connections_from_controller(AnnotatedInterm
 }
 
 AnnotatedIntermeshConnections ControlPlane::pair_logical_intermesh_ports(const PortDescriptorTable& port_descriptors) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     AnnotatedIntermeshConnections intermesh_connections;
 
     const auto& mesh_graph = this->routing_table_generator_->mesh_graph;
@@ -2580,6 +2659,7 @@ AnnotatedIntermeshConnections ControlPlane::pair_logical_intermesh_ports(const P
 
 AnnotatedIntermeshConnections ControlPlane::convert_port_desciptors_to_intermesh_connections(
     PortDescriptorTable& port_descriptors) {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& my_host = physical_system_descriptor_->my_host_name();
     auto my_rank = physical_system_descriptor_->get_rank_for_hostname(my_host);
 
@@ -2611,6 +2691,7 @@ AnnotatedIntermeshConnections ControlPlane::convert_port_desciptors_to_intermesh
 }
 
 AnnotatedIntermeshConnections ControlPlane::generate_intermesh_connections_on_local_host() {
+    TT_FATAL(this->is_initialized_, "Control plane has not been initialized");
     const auto& mesh_graph = this->routing_table_generator_->mesh_graph;
     const auto& physical_system_descriptor = this->physical_system_descriptor_;
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -534,6 +534,9 @@ void MetalContext::initialize_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
+
+    control_plane.initialize_control_plane();
+
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         control_plane.initialize_fabric_context(this->fabric_config_);
     }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -421,6 +421,9 @@ tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
     if (!control_plane_) {
         this->initialize_control_plane();
     }
+    if (!control_plane_->is_initialized()) {
+        control_plane_->initialize();
+    }
     return *control_plane_;
 }
 
@@ -534,8 +537,6 @@ void MetalContext::initialize_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
-
-    control_plane.initialize_control_plane();
 
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         control_plane.initialize_fabric_context(this->fabric_config_);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -421,9 +421,6 @@ tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
     if (!control_plane_) {
         this->initialize_control_plane();
     }
-    if (!control_plane_->is_initialized()) {
-        control_plane_->initialize();
-    }
     return *control_plane_;
 }
 
@@ -537,6 +534,10 @@ void MetalContext::initialize_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
+
+    if (!control_plane_->is_initialized()) {
+        control_plane_->initialize();
+    }
 
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         control_plane.initialize_fabric_context(this->fabric_config_);


### PR DESCRIPTION
### Problem description
Currently whenever control plane is used by metal context, all of routing tables and physical system needs to be initialized. Which means, to do a simple call to metal context, the rank bindings file and MGD must be initialized and parsed. 

As we are moving towards Control plane 2.0, control plane initialization should be independent and only initialized when fabric is needed.

### What's changed
- [x] Changed tests to only init control plane when needed
- [x] Moved control plane initialization to fabric init in metal context instead of at construction time

### Checklist
- [ ] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/18855982961)
- [ ] [T3K](https://github.com/tenstorrent/tt-metal/actions/runs/18856022556)
- [ ] [Galaxy](https://github.com/tenstorrent/tt-metal/actions/runs/18856043956)
- [ ] [BH](https://github.com/tenstorrent/tt-metal/actions/runs/18856005424)
- [ ] [Multi-host tests](https://github.com/tenstorrent/tt-metal/actions/runs/18855992530)