### PR TITLE
Improve accuracy of accurate sigmoid_tile

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -18,15 +18,13 @@ template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
-    sfpi::vFloat value = -x;
-    value = ckernel::sfpu::_sfpu_exp_21f_<true>(value);
-    value = sfpi::vConst1 + value;
 
-    sfpi::vFloat result;
+    sfpi::vFloat denominator = sfpi::vConst1 + ckernel::sfpu::_sfpu_exp_21f_<true>(-x);
+
+    constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
+    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<recip_mode>(denominator);
+
     if constexpr (!is_fp32_acc_to_dest_mode) {
-        result = ckernel::sfpu::_sfpu_reciprocal_<2>(value);
-    } else {
-        result = ckernel::sfpu::_sfpu_reciprocal_<1>(value);
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -7,29 +7,54 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
+#include "ckernel_sfpu_recip.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
+    // Compute sigmoid as:
+    // sigmoid(x) = 1 / (1 + exp(-x))
+    sfpi::vFloat value = -x;
+    value = ckernel::sfpu::_sfpu_exp_21f_<true>(value);
+    value = sfpi::vConst1 + value;
+
+    sfpi::vFloat result;
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = ckernel::sfpu::_sfpu_reciprocal_<2>(value);
+    } else {
+        result = ckernel::sfpu::_sfpu_reciprocal_<1>(value);
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
+    vFloat result = 0.0f;
+
+    v_if(val < 0.0f) { val = -val; }
+    v_endif;
+
+    result = _sigmoid_piecewise_linear_positive_(val);
+
+    val = dst_reg[0];
+    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_endif;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_sigmoid() {
-    if constexpr (APPROXIMATION_MODE == false) {
+    static_assert(ITERATIONS == 8, "ITERATIONS must be 8");
+    if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
             vFloat val = dst_reg[0];
-            vFloat result = 0.0f;
-
-            v_if(val < 0.0f) { val = -val; }
-            v_endif;
-
-            result = _sigmoid_piecewise_linear_positive_(val);
-
-            val = dst_reg[0];
-            v_if(val < 0.0f) { result = 1.0f - result; }
-            v_endif;
+            vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
             dst_reg[0] = result;
             dst_reg++;
@@ -39,37 +64,41 @@ inline void calculate_sigmoid() {
     }
 }
 
+sfpi_inline void _sfpu_sigmoid_legacy_init() {
+    // imm0 = 0x3DFF;
+    // imm1 = 0x21D8;
+    // imm2 = 0xFF10;
+    // TTI_SFPLOADI(0, 2, imm0);
+    // TTI_SFPLOADI(1, 2, imm1);
+    // TTI_SFPLOADI(2, 2, imm2);
+    // Using a 6 piece LUT to calculate and model sigmoid  directly
+    // x <= 0.5 --> 0.2452x + (-0.0004997)
+    // x <= 1.0 --> 0.2173x + 0.0152
+    // x <= 1.5 --> 0.1731x + 0.05988
+    // x <= 2.0 --> 0.1262x + 0.1298
+    // x <= 4.0 --> 0.0485x + 0.2998
+    // x >  4.0 --> 0.4998
+
+    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
+    _sfpu_load_imm32_(0, 0x32F433D9);
+    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
+    _sfpu_load_imm32_(4, 0x23C89018);
+
+    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
+    _sfpu_load_imm32_(1, 0x300A318A);
+    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
+    _sfpu_load_imm32_(5, 0x30272BAA);
+
+    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
+    _sfpu_load_imm32_(2, 0x7C002A35);
+    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
+    _sfpu_load_imm32_(6, 0x37ff34CC);
+}
+
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
     if constexpr (APPROXIMATION_MODE == false) {
-        // imm0 = 0x3DFF;
-        // imm1 = 0x21D8;
-        // imm2 = 0xFF10;
-        // TTI_SFPLOADI(0, 2, imm0);
-        // TTI_SFPLOADI(1, 2, imm1);
-        // TTI_SFPLOADI(2, 2, imm2);
-        // Using a 6 piece LUT to calculate and model sigmoid  directly
-        // x <= 0.5 --> 0.2452x + (-0.0004997)
-        // x <= 1.0 --> 0.2173x + 0.0152
-        // x <= 1.5 --> 0.1731x + 0.05988
-        // x <= 2.0 --> 0.1262x + 0.1298
-        // x <= 4.0 --> 0.0485x + 0.2998
-        // x >  4.0 --> 0.4998
-
-        // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-        _sfpu_load_imm32_(0, 0x32F433D9);
-        // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-        _sfpu_load_imm32_(4, 0x23C89018);
-
-        // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-        _sfpu_load_imm32_(1, 0x300A318A);
-        // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-        _sfpu_load_imm32_(5, 0x30272BAA);
-
-        // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-        _sfpu_load_imm32_(2, 0x7C002A35);
-        // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-        _sfpu_load_imm32_(6, 0x37ff34CC);
+        ckernel::sfpu::_init_reciprocal_<false, false>();
     } else {
         sigmoid_appx_init();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -34,16 +34,16 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
-    vFloat result = 0.0f;
+    vFloat result = sfpi::vConst0;
 
-    vFloat x = sfpi::setsgn(val, 0);  // x = abs(val)
+    vFloat x = sfpi::abs(val);
 
-    // Polynomial approximation of sigmoid on [0; +inf[
+    // Polynomial approximation of sigmoid on [0; +inf]
     result = _sigmoid_piecewise_linear_positive_(x);
 
     // Sigmoid is anti-symmetric and offset by 1.
     // If input was negative then subtract result from 1.0f to get the correct result
-    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_if(val < sfpi::vConst0) { result = sfpi::vConst1 - result; }
     v_endif;
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -36,12 +36,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
-    v_if(val < 0.0f) { val = -val; }
-    v_endif;
+    vFloat x = sfpi::setsgn(val, 0);
+    result = _sigmoid_piecewise_linear_positive_(x);
 
-    result = _sigmoid_piecewise_linear_positive_(val);
-
-    val = dst_reg[0];
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -35,7 +35,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
-sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
     v_if(val < 0.0f) { val = -val; }
@@ -46,11 +46,12 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
     val = dst_reg[0];
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
+
+    return result;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_sigmoid() {
-    static_assert(ITERATIONS == 8, "ITERATIONS must be 8");
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
             vFloat val = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -60,37 +60,6 @@ inline void calculate_sigmoid() {
     }
 }
 
-sfpi_inline void _sfpu_sigmoid_legacy_init() {
-    // imm0 = 0x3DFF;
-    // imm1 = 0x21D8;
-    // imm2 = 0xFF10;
-    // TTI_SFPLOADI(0, 2, imm0);
-    // TTI_SFPLOADI(1, 2, imm1);
-    // TTI_SFPLOADI(2, 2, imm2);
-    // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
-
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    _sfpu_load_imm32_(0, 0x32F433D9);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    _sfpu_load_imm32_(4, 0x23C89018);
-
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    _sfpu_load_imm32_(1, 0x300A318A);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    _sfpu_load_imm32_(5, 0x30272BAA);
-
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    _sfpu_load_imm32_(2, 0x7C002A35);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    _sfpu_load_imm32_(6, 0x37ff34CC);
-}
-
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
     if constexpr (APPROXIMATION_MODE == false) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -36,9 +36,13 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
-    vFloat x = sfpi::setsgn(val, 0);
+    vFloat x = sfpi::setsgn(val, 0);  // x = abs(val)
+
+    // Polynomial approximation of sigmoid on [0; +inf[
     result = _sigmoid_piecewise_linear_positive_(x);
 
+    // Sigmoid is anti-symmetric and offset by 1.
+    // If input was negative then subtract result from 1.0f to get the correct result
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -30,10 +30,10 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {
-        return _sfpu_reciprocal_<2>(denominator);
+        result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        return sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;
@@ -74,8 +74,8 @@ inline void calculate_sigmoid() {
 
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
-    if constexpr (APPROXIMATION_MODE == false) {
-        _init_reciprocal_<false, false>();
+    if constexpr (!APPROXIMATION_MODE) {
+        _init_sfpu_reciprocal_<false>();
     } else {
         sigmoid_appx_init();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -17,7 +17,16 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
 
-    sfpi::vFloat denominator = sfpi::vConst1 + _sfpu_exp_21f_<true>(-x);
+    sfpi::vFloat exp_neg_x;
+    // If fp32 then use higher accuracy exp function
+    // Otherwise, use exp_21f (~1 ULP on bfloat16)
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        exp_neg_x = _sfpu_exp_21f_<true>(-x);
+    } else {
+        exp_neg_x = _sfpu_exp_improved_<true>(-x);
+    }
+
+    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
 
     constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
     sfpi::vFloat result = _sfpu_reciprocal_<recip_mode>(denominator);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -19,10 +19,10 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
 
-    sfpi::vFloat denominator = sfpi::vConst1 + ckernel::sfpu::_sfpu_exp_21f_<true>(-x);
+    sfpi::vFloat denominator = sfpi::vConst1 + _sfpu_exp_21f_<true>(-x);
 
     constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
-    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<recip_mode>(denominator);
+    sfpi::vFloat result = _sfpu_reciprocal_<recip_mode>(denominator);
 
     if constexpr (!is_fp32_acc_to_dest_mode) {
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
@@ -34,9 +34,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
-    vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = sfpi::vConst0;
 
-    vFloat x = sfpi::abs(val);
+    sfpi::vFloat x = sfpi::abs(val);
 
     // Polynomial approximation of sigmoid on [0; +inf]
     result = _sigmoid_piecewise_linear_positive_(x);
@@ -53,11 +53,11 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en 
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
-            vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+            sfpi::vFloat val = sfpi::dst_reg[0];
+            sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
-            dst_reg[0] = result;
-            dst_reg++;
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
     } else {
         calculate_sigmoid_appx<ITERATIONS>();
@@ -67,7 +67,7 @@ inline void calculate_sigmoid() {
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
     if constexpr (APPROXIMATION_MODE == false) {
-        ckernel::sfpu::_init_reciprocal_<false, false>();
+        _init_reciprocal_<false, false>();
     } else {
         sigmoid_appx_init();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -57,7 +57,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     return result;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -9,8 +9,6 @@
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_recip.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -20,19 +20,20 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     sfpi::vFloat exp_neg_x;
     // If fp32 then use higher accuracy exp function
     // Otherwise, use exp_21f (~1 ULP on bfloat16)
-    if constexpr (!is_fp32_acc_to_dest_mode) {
-        exp_neg_x = _sfpu_exp_21f_<true>(-x);
-    } else {
+    if constexpr (is_fp32_acc_to_dest_mode) {
         exp_neg_x = _sfpu_exp_improved_<true>(-x);
+    } else {
+        exp_neg_x = _sfpu_exp_21f_<true>(-x);
     }
 
     sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
 
-    constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
-    sfpi::vFloat result = _sfpu_reciprocal_<recip_mode>(denominator);
-
-    if constexpr (!is_fp32_acc_to_dest_mode) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    sfpi::vFloat result;
+    if constexpr (is_fp32_acc_to_dest_mode) {
+        return _sfpu_reciprocal_<2>(denominator);
+    } else {
+        result = _sfpu_reciprocal_<1>(denominator);
+        return sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -35,16 +35,16 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
-    vFloat result = 0.0f;
+    vFloat result = sfpi::vConst0;
 
-    vFloat x = sfpi::setsgn(val, 0);  // x = abs(val)
+    vFloat x = sfpi::abs(val);
 
-    // Polynomial approximation of sigmoid on [0; +inf[
+    // Polynomial approximation of sigmoid on [0; +inf]
     result = _sigmoid_piecewise_linear_positive_(x);
 
     // Sigmoid is anti-symmetric and offset by 1.
     // If input was negative then subtract result from 1.0f to get the correct result
-    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_if(val < sfpi::vConst0) { result = sfpi::vConst1 - result; }
     v_endif;
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -36,7 +36,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
-sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
     v_if(val < 0.0f) { val = -val; }
@@ -47,14 +47,16 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
     val = dst_reg[0];
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
+
+    return result;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_sigmoid() {
-    static_assert(ITERATIONS == 8, "ITERATIONS must be 8");
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
             vFloat val = dst_reg[0];
+
             vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
             dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -62,37 +62,6 @@ inline void calculate_sigmoid() {
     }
 }
 
-sfpi_inline void _sfpu_sigmoid_legacy_init() {
-    // imm0 = 0x3DFF;
-    // imm1 = 0x21D8;
-    // imm2 = 0xFF10;
-    // TTI_SFPLOADI(0, 2, imm0);
-    // TTI_SFPLOADI(1, 2, imm1);
-    // TTI_SFPLOADI(2, 2, imm2);
-    // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
-
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    _sfpu_load_imm32_(0, 0x32F433D9);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    _sfpu_load_imm32_(4, 0x23C89018);
-
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    _sfpu_load_imm32_(1, 0x300A318A);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    _sfpu_load_imm32_(5, 0x30272BAA);
-
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    _sfpu_load_imm32_(2, 0x7C002A35);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    _sfpu_load_imm32_(6, 0x37ff34CC);
-}
-
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
     if constexpr (!APPROXIMATION_MODE) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -19,15 +19,13 @@ template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
-    sfpi::vFloat value = -x;
-    value = ckernel::sfpu::_sfpu_exp_21f_<true>(value);
-    value = sfpi::vConst1 + value;
 
-    sfpi::vFloat result;
+    sfpi::vFloat denominator = sfpi::vConst1 + ckernel::sfpu::_sfpu_exp_21f_<true>(-x);
+
+    constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
+    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<recip_mode>(denominator);
+
     if constexpr (!is_fp32_acc_to_dest_mode) {
-        result = ckernel::sfpu::_sfpu_reciprocal_<2>(value);
-    } else {
-        result = ckernel::sfpu::_sfpu_reciprocal_<1>(value);
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -8,29 +8,54 @@
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
+#include "ckernel_sfpu_recip.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
+    // Compute sigmoid as:
+    // sigmoid(x) = 1 / (1 + exp(-x))
+    sfpi::vFloat value = -x;
+    value = ckernel::sfpu::_sfpu_exp_21f_<true>(value);
+    value = sfpi::vConst1 + value;
+
+    sfpi::vFloat result;
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = ckernel::sfpu::_sfpu_reciprocal_<2>(value);
+    } else {
+        result = ckernel::sfpu::_sfpu_reciprocal_<1>(value);
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat x) {
+    vFloat result = 0.0f;
+
+    v_if(val < 0.0f) { val = -val; }
+    v_endif;
+
+    result = _sigmoid_piecewise_linear_positive_(val);
+
+    val = dst_reg[0];
+    v_if(val < 0.0f) { result = 1.0f - result; }
+    v_endif;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_sigmoid() {
-    if constexpr (APPROXIMATION_MODE == false) {
+    static_assert(ITERATIONS == 8, "ITERATIONS must be 8");
+    if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
             vFloat val = dst_reg[0];
-            vFloat result = 0.0f;
-
-            v_if(val < 0.0f) { val = -val; }
-            v_endif;
-
-            result = _sigmoid_piecewise_linear_positive_(val);
-
-            val = dst_reg[0];
-            v_if(val < 0.0f) { result = 1.0f - result; }
-            v_endif;
+            vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
             dst_reg[0] = result;
             dst_reg++;
@@ -40,37 +65,41 @@ inline void calculate_sigmoid() {
     }
 }
 
+sfpi_inline void _sfpu_sigmoid_legacy_init() {
+    // imm0 = 0x3DFF;
+    // imm1 = 0x21D8;
+    // imm2 = 0xFF10;
+    // TTI_SFPLOADI(0, 2, imm0);
+    // TTI_SFPLOADI(1, 2, imm1);
+    // TTI_SFPLOADI(2, 2, imm2);
+    // Using a 6 piece LUT to calculate and model sigmoid  directly
+    // x <= 0.5 --> 0.2452x + (-0.0004997)
+    // x <= 1.0 --> 0.2173x + 0.0152
+    // x <= 1.5 --> 0.1731x + 0.05988
+    // x <= 2.0 --> 0.1262x + 0.1298
+    // x <= 4.0 --> 0.0485x + 0.2998
+    // x >  4.0 --> 0.4998
+
+    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
+    _sfpu_load_imm32_(0, 0x32F433D9);
+    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
+    _sfpu_load_imm32_(4, 0x23C89018);
+
+    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
+    _sfpu_load_imm32_(1, 0x300A318A);
+    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
+    _sfpu_load_imm32_(5, 0x30272BAA);
+
+    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
+    _sfpu_load_imm32_(2, 0x7C002A35);
+    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
+    _sfpu_load_imm32_(6, 0x37ff34CC);
+}
+
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
-    if constexpr (APPROXIMATION_MODE == false) {
-        // imm0 = 0x3DFF;
-        // imm1 = 0x21D8;
-        // imm2 = 0xFF10;
-        // TTI_SFPLOADI(0, 2, imm0);
-        // TTI_SFPLOADI(1, 2, imm1);
-        // TTI_SFPLOADI(2, 2, imm2);
-        // Using a 6 piece LUT to calculate and model sigmoid  directly
-        // x <= 0.5 --> 0.2452x + (-0.0004997)
-        // x <= 1.0 --> 0.2173x + 0.0152
-        // x <= 1.5 --> 0.1731x + 0.05988
-        // x <= 2.0 --> 0.1262x + 0.1298
-        // x <= 4.0 --> 0.0485x + 0.2998
-        // x >  4.0 --> 0.4998
-
-        // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-        _sfpu_load_imm32_(0, 0x32F433D9);
-        // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-        _sfpu_load_imm32_(4, 0x23C89018);
-
-        // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-        _sfpu_load_imm32_(1, 0x300A318A);
-        // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-        _sfpu_load_imm32_(5, 0x30272BAA);
-
-        // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-        _sfpu_load_imm32_(2, 0x7C002A35);
-        // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-        _sfpu_load_imm32_(6, 0x37ff34CC);
+    if constexpr (!APPROXIMATION_MODE) {
+        ckernel::sfpu::_init_reciprocal_<false, false>();
     } else {
         sigmoid_appx_init();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -37,12 +37,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
-    v_if(val < 0.0f) { val = -val; }
-    v_endif;
+    vFloat x = sfpi::setsgn(val, 0);
+    result = _sigmoid_piecewise_linear_positive_(x);
 
-    result = _sigmoid_piecewise_linear_positive_(val);
-
-    val = dst_reg[0];
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -37,9 +37,13 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     vFloat result = 0.0f;
 
-    vFloat x = sfpi::setsgn(val, 0);
+    vFloat x = sfpi::setsgn(val, 0);  // x = abs(val)
+
+    // Polynomial approximation of sigmoid on [0; +inf[
     result = _sigmoid_piecewise_linear_positive_(x);
 
+    // Sigmoid is anti-symmetric and offset by 1.
+    // If input was negative then subtract result from 1.0f to get the correct result
     v_if(val < 0.0f) { result = 1.0f - result; }
     v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -18,7 +18,16 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
 
-    sfpi::vFloat denominator = sfpi::vConst1 + _sfpu_exp_21f_<true>(-x);
+    sfpi::vFloat exp_neg_x;
+    // If fp32 then use higher accuracy exp function
+    // Otherwise, use exp_21f (~1 ULP on bfloat16)
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        exp_neg_x = _sfpu_exp_21f_<true>(-x);
+    } else {
+        exp_neg_x = _sfpu_exp_improved_<true>(-x);
+    }
+
+    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
 
     constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
     sfpi::vFloat result = _sfpu_reciprocal_<recip_mode>(denominator);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -34,7 +34,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        result sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -20,10 +20,10 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
 
-    sfpi::vFloat denominator = sfpi::vConst1 + ckernel::sfpu::_sfpu_exp_21f_<true>(-x);
+    sfpi::vFloat denominator = sfpi::vConst1 + _sfpu_exp_21f_<true>(-x);
 
     constexpr int recip_mode = is_fp32_acc_to_dest_mode ? 2 : 1;
-    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<recip_mode>(denominator);
+    sfpi::vFloat result = _sfpu_reciprocal_<recip_mode>(denominator);
 
     if constexpr (!is_fp32_acc_to_dest_mode) {
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
@@ -35,9 +35,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 // sigmoid is anti-symmetric and offset by 1
 // sigmoid[-x] = 1 - sigmoid[x]
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
-    vFloat result = sfpi::vConst0;
+    sfpi::vFloat result = sfpi::vConst0;
 
-    vFloat x = sfpi::abs(val);
+    sfpi::vFloat x = sfpi::abs(val);
 
     // Polynomial approximation of sigmoid on [0; +inf]
     result = _sigmoid_piecewise_linear_positive_(x);
@@ -54,12 +54,12 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en 
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
 
-            vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+            sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
 
-            dst_reg[0] = result;
-            dst_reg++;
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
     } else {
         calculate_sigmoid_appx<ITERATIONS>();
@@ -69,7 +69,7 @@ inline void calculate_sigmoid() {
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
     if constexpr (!APPROXIMATION_MODE) {
-        ckernel::sfpu::_init_reciprocal_<false, false>();
+        _init_reciprocal_<false, false>();
     } else {
         sigmoid_appx_init();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -58,7 +58,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
     return result;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
         for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -31,10 +31,10 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {
-        return _sfpu_reciprocal_<2>(denominator);
+        result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        return sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        result sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -10,8 +10,6 @@
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_recip.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid, APPROXIMATE>(sfpu::sigmoid_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sigmoid<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -79,7 +79,7 @@ ALWI void sigmoid_tile_init() {
 // clang-format on
 template <int vec_mode = VectorMode::RC, bool fast_and_approx = false>
 ALWI void sigmoid_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx>(idst, vec_mode)));
+    MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx, DST_ACCUM_MODE>(idst, vec_mode)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
#26946

### Problem description

There are 4 versions of sigmoid in ttnn:
- `ttnn.sigmoid()`
- `ttnn.sigmoid(fast_and_approximate_mode=True)`
- `ttnn.sigmoid_accurate()`
- `ttnn.sigmoid_accurate(fast_and_approximate_mode=True)`

`ttnn.sigmoid()` implementations have their own kernel and call `sigmoid_tile`. However, neither are accurate enough for model team. 
On the other hand, `ttnn.sigmoid_accurate()` is more accurate but is slower due to being a Metal Kernel implementation (it's a fused kernel calls SFPU kernels + their respective inits).  
This kernel uses the `sigmoid(x) = 1 / (1 + exp(-x))` formula. 

### What's changed

This PR improves the accuracy of `sigmoid_tile` when `fast_and_approximate_mode = False`.

This is done by redefining the accurate implementation of `calculate_sigmoid` as `1 / (1 + exp(-x))`, where `exp` is the `exp_21f` implementation. 

The accuracy improvements of sigmoid are as shown on the graphs:


#### bfloat16 

Error of new `ttnn.sigmoid` (`sigmoid-21f`, in purple) is always < 1ULP and it is the most accurate. 
 
<img width="700" height="350" alt="sigmoid-bfloat16" src="https://github.com/user-attachments/assets/094d690f-978b-40b1-ac9e-926b18b53536" />

#### float32

On float32, the new sigmoid function (`sigmoid-21f`, in green) gives identical results to `ttnn.sigmoid_accurate` (same formula, no truncation due to DST register format). 

<img width="700" height="350" alt="sigmoid-float32" src="https://github.com/user-attachments/assets/e0c466cd-21ba-41d2-b813-33d80ef8793b" />

### Execution time overhead


#### Wormhole 

Compared to the current accurate `ttnn.sigmoid`, this new approximation is ~35% slower. 
Compared to ttnn.sigmoid_accurate, it is ~15% faster.

OP | Cycles/Point | Cycles/Tile | time / main (lower is better)
-- | -- | -- | --
sigmoid (main) | 1.55 | 1588 | 1.00
sigmoid (approx=True) | 0.28 | 289 | 0.18
sigmoid_accurate | 2.36 | 2413 | 1.52
sigmoid (new) | 2.03 | 2074 | 1.31


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK, pending galaxy-app](https://github.com/tenstorrent/tt-metal/actions/runs/18845621769)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/18845566060)
- [x] L2 Nightly test : https://github.com/tenstorrent/tt-metal/actions/runs/18854809531
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18854833316
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18854833316
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). https://github.com/tenstorrent/tt-metal/actions/runs/18908250901
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) [OK, failed tests on main](https://github.com/tenstorrent/tt-metal/actions/runs/18871471999)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) 
- [ ] New/Existing tests provide coverage for changes