### PR TITLE
[skip ci] Specify that vllm pipeline requires galaxy runner to be wormhole

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -128,6 +128,7 @@ jobs:
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}
+      - ${{ matrix.test-group.runner-label == 'topology-6u' && 'arch-wormhole_b0' || '' }}
       - in-service
       - pipeline-functional
     container:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -30,6 +30,7 @@ jobs:
             server-timeout: 5,
             benchmark-timeout: 5,
             runner-label: config-t3000,
+            arch: arch-wormhole_b0,
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\"}",
@@ -43,6 +44,7 @@ jobs:
             server-timeout: 10,
             benchmark-timeout: 5,
             runner-label: config-t3000,
+            arch: arch-wormhole_b0,
             mesh-device: T3K,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
@@ -56,6 +58,7 @@ jobs:
             server-timeout: 5,
             benchmark-timeout: 5,
             runner-label: BH-DeskBox,
+            arch: arch-blackhole,
             mesh-device: P150x2,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 2}",
@@ -68,6 +71,7 @@ jobs:
             server-timeout: 5,
             benchmark-timeout: 5,
             runner-label: bh-LLMBox,
+            arch: arch-blackhole,
             mesh-device: P150x4,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 4}",
@@ -80,6 +84,7 @@ jobs:
             server-timeout: 35,
             benchmark-timeout: 10,
             runner-label: bh-rackbox,
+            arch: arch-blackhole,
             mesh-device: P150x8,
             tt-llama-text-ver: tt_transformers,
             override-tt-config: "{\"data_parallel\": 8}",
@@ -92,6 +97,7 @@ jobs:
             server-timeout: 35,
             benchmark-timeout: 10,
             runner-label: topology-6u,
+            arch: arch-wormhole_b0,
             mesh-device: TG,
             tt-llama-text-ver: llama3_70b_galaxy,
             override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
@@ -105,6 +111,7 @@ jobs:
             server-timeout: 10,
             benchmark-timeout: 5,
             runner-label: topology-6u,
+            arch: arch-wormhole_b0,
             mesh-device: TG,
             override-tt-config: "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
             tt-llama-text-ver: tt_transformers,
@@ -118,6 +125,7 @@ jobs:
             server-timeout: 10,
             benchmark-timeout: 5,
             runner-label: config-t3000,
+            arch: arch-wormhole_b0,
             mesh-device: T3K,
             override-tt-config: "{\"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 768}",
             tt-llama-text-ver: tt_transformers,
@@ -128,7 +136,7 @@ jobs:
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}
-      - ${{ matrix.test-group.runner-label == 'topology-6u' && 'arch-wormhole_b0' || '' }}
+      - ${{ matrix.test-group.arch }}
       - in-service
       - pipeline-functional
     container:


### PR DESCRIPTION
### Problem description
A blackhole galaxy runner has been added to CI. vllm pipelines fail when they run on that one, as they are expecting a wormhole galaxy. Other galaxy pipelines reportedly already specify the architecture

### What's changed
Added a tag specifying wormhole arch for the galaxy tests in the vllm pipeline

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes