### PR TITLE
[skip ci] Fix the ccache command when PCH is enabled

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -17,11 +17,16 @@ function(useCcache)
     endif()
 
     if(CMAKE_GENERATOR MATCHES "Ninja")
-        set(CMAKE_CXX_COMPILER_LAUNCHER
-            ${CCACHE_ENV}
-            ${CCACHE_EXECUTABLE}
-            PARENT_SCOPE
-        )
+        foreach(lang IN ITEMS C CXX)
+            set(CMAKE_${lang}_COMPILER_LAUNCHER
+                ${CMAKE_COMMAND}
+                -E
+                env
+                ${CCACHE_ENV}
+                ${CCACHE_EXECUTABLE}
+                PARENT_SCOPE
+            )
+        endforeach()
         message(STATUS "ccache enabled")
     endif()
 endfunction()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The ccache command was malformed when PCH was enabled. The intent was:
> VAR=value ccache ...

However COMPILER_LAUNCHER is not a shell invocation.  That doesn't work.  The first argument is expected to be an executable.

Fortunately ccache accepts
> ccache VAR=value ...

### What's changed
Use the format that keeps the executable as the first argument but still allows us to force overrides on the CLI regardless of the config on the system.