### PR TITLE
#27979: Use mailboxes to send sparsity value from brisc to trisc cores and fix core-grid for blackhole 

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -116,8 +116,8 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
-@skip_for_blackhole("Semaphores used to broadcast sparsity is not propagating on BH, Issue #27979")
-def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype):
+@pytest.mark.parametrize("core_grid", [(4, 4)])
+def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid):
     torch.manual_seed(0)
     m, k, n = mkn
     b, s = num_batches
@@ -129,7 +129,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
 
     # Mark some as 0 to test the sparsity
     sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
-    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    number_of_zeros = torch.randint(0, sparsity.numel(), ()).item()
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 
@@ -164,6 +164,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    core_x, core_y = core_grid
     output_tile = ttnn.Tile([tile_h, tile_w])
     output_t = ttnn.sparse_matmul(
         in0_t,
@@ -171,6 +172,19 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
         sparsity=sparsity_t,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         output_tile=output_tile,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // tile_h,
+            per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
     )
 
     output_tensor = ttnn.to_torch(output_t)

--- a/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
@@ -23,6 +23,21 @@
 #include "remote_circular_buffer_api.h"
 #endif
 
+namespace ckernel {
+volatile tt_reg_ptr uint* regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+volatile tt_reg_ptr uint* pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+
+// There are 16 mailboxes within each Tensix tile, one from each of RISCV (B, T0, T1, T2) to each of RISCV (B, T0, T1,
+// T2). Note that there are no mailboxes to or from RISCV NC. The 16 mailboxes are referenced using 4 particular address
+// ranges starting from bases listed below. Which particular mailbox is being referenced depends on the address, the
+// issuing RISCV, and whether the access is a read or a write.
+volatile tt_reg_ptr uint* mailbox_base[4] = {
+    reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
+    reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),
+    reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX2_BASE),
+    reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX3_BASE)};
+}  // namespace ckernel
+
 extern "C" [[gnu::section(".start")]]
 uint32_t _start() {
     // Enable GPREL optimizations.

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -117,10 +117,6 @@ void MAIN {
     constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_4;
     constexpr uint32_t mm_partials_cb_id = tt::CBIndex::c_5;
-    // Reader will use this CB to pass the number of non-zero (nnz) entries in the sparsity tensor.
-    constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
-    volatile uint32_t* nnz_addr_ptr;
-
     constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
 
 #ifdef FUSE_BIAS
@@ -147,16 +143,11 @@ void MAIN {
     for (uint32_t b = 0; b < batch; b++) {
         if constexpr (get_batch_from_reader) {
             // Check whether this batch is valid
-            cb_wait_front(nnz_cb_id, 1);
-            tensix_sync();
-            cb_get_tile(nnz_cb_id, 0, &nnz_addr_ptr);
-            // The first 4 entries have metadata, so we look at the 5th entry
-            // for our value pushed from the reader.
-            uint32_t nnz = nnz_addr_ptr[4];
-            cb_release_tile(nnz_cb_id);
-            cb_pop_front(nnz_cb_id, 1);
-
-            if (nnz == 0) {
+            bool is_batch_valid = false;
+            UNPACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            MATH(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            PACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            if (!is_batch_valid) {
                 continue;
             }
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -6,6 +6,8 @@
 
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "ckernel.h"
+#include "ckernel_defs.h"
 
 void kernel_main() {
     // in0 mcast args
@@ -27,9 +29,6 @@ void kernel_main() {
     // sparsity args
     // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
     constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(7);
-    // Reader will use this CB to pass the number of non-zero (nnz) entries in the sparsity tensor.
-    constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
-    constexpr uint32_t IGNORE_BATCH = 0x2;
 
     constexpr uint32_t cb_id_in0 = 0;
 
@@ -43,7 +42,7 @@ void kernel_main() {
         if constexpr (get_batch_from_reader) {
             // This means we have unstructured sparsity.
             // The compute kernel needs to be made aware whether this batch is valid or not.
-            // We do this by passing the value to the compute kernel via nnz_cb_id.
+            // We do this by passing the value to the compute kernel via mailbox.
             // But first, lets wait for the sparsity data to be multicast to us.
             // Set in0 semaphore value to INVALID
             noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
@@ -53,12 +52,11 @@ void kernel_main() {
             noc_semaphore_wait_min(in0_mcast_receiver_semaphore_addr_ptr, VALID);
 
             const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
-            // We need to pass the value to compute UNPACK regardless of the value of is_batch_valid
-            cb_reserve_back(nnz_cb_id, 1);
-            auto nnz_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(nnz_cb_id));
-            // Pass chunk_count to compute UNPACK
-            nnz_ptr[0] = is_batch_valid;
-            cb_push_back(nnz_cb_id, 1);
+
+            // We need to pass the value to compute cores regardless of the value of is_batch_valid
+            ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+            ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
 
             // Skip sending the input tensor for this batch as it is not valid.
             if (!is_batch_valid) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "pad_tile.hpp"
 #include "ckernel.h"
+#include "ckernel_defs.h"
 
 void kernel_main() {
     uint32_t rt_args_idx = 0;
@@ -68,9 +69,6 @@ void kernel_main() {
 
     constexpr auto in0_args = TensorAccessorArgs<25>();
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-
-    // Reader will use this CB to pass the number of non-zero (nnz) entries in the sparsity tensor.
-    constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
 
     // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
     // 0x1 is used to specify "VALID" state, i.e. when the batch is valid.
@@ -165,18 +163,17 @@ void kernel_main() {
                     noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
                     noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
                     noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, is_batch_valid ? VALID : IGNORE_BATCH);
-                    ckernel::wait(500);
                     noc_semaphore_set_multicast(
                         in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
                     noc_async_writes_flushed();
                     // Reset the semaphore value to VALID
                     noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
 #endif  // SKIP_MCAST
-        // We need to pass the value to compute UNPACK regardless of the value of is_batch_valid
-                    cb_reserve_back(nnz_cb_id, 1);
-                    auto nnz_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(nnz_cb_id));
-                    nnz_ptr[0] = is_batch_valid;
-                    cb_push_back(nnz_cb_id, 1);
+
+                    // We need to pass the value to compute cores regardless of the value of is_batch_valid
+                    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_batch_valid);
+                    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_batch_valid);
                 }
 
                 if (!is_batch_valid) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -3417,7 +3417,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
         in0_mcast_sender_cores,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = in0_noc,
             .compile_args = in0_sender_compile_time_args,
             .defines = mm_kernel_in0_sender_writer_defines});
@@ -3429,7 +3429,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
             "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
             in0_mcast_receivers,
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = in0_noc,
                 .compile_args = in0_receiver_compile_time_args});
     }
@@ -3440,7 +3440,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
         all_cores_with_work,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = in1_noc,
             .compile_args = in1_sender_writer_compile_time_args,
             .defines = mm_kernel_in1_sender_writer_defines});
@@ -3547,17 +3547,6 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
 
     tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config0);
     tt_metal::CreateCircularBuffer(program, all_cores, sparsity_cb_config1);
-
-    if (!nnz.has_value()) {
-        // When nnz is not provided, we need to infer this at runtime based on the sparsity tensor.
-        // We create a circular buffer to pass this value to the compute kernel from the reader.
-        uint32_t nnz_cb_index = tt::CBIndex::c_25;
-        const auto nnz_data_format = tt::DataFormat::UInt32;
-        const auto nnz_cb_size = sparsity.logical_volume() * tt::datum_size(nnz_data_format);
-        const auto nnz_cb_config = tt_metal::CircularBufferConfig(nnz_cb_size, {{nnz_cb_index, nnz_data_format}})
-                                       .set_page_size(nnz_cb_index, nnz_cb_size);
-        tt_metal::CreateCircularBuffer(program, all_cores, nnz_cb_config);
-    }
 
     if (interm0_data_format != output_data_format) {
         // output
@@ -3676,8 +3665,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
                 (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
                 (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
             };
-            tt_metal::SetRuntimeArgs(
-                program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);  // RISCV_1_default
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
         }
         if (i < num_cores_with_work) {
             std::vector<uint32_t> mm_in1_sender_writer_args = {


### PR DESCRIPTION
Use mailboxes to send sparsity value from brisc to trisc cores
Fix core-grid value to make test case test_sparse_matmul_without_nnz work on blackhole

### Ticket
#27979 

### Problem description
There were hangs due to unexpected use of semaphores while passing sparsity values and core-gird was not compatible with blackhole.

### What's changed
Sparsity values are passued only through using mailboxes. Core grid values are made compatible with blackhole. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18864219649) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18864227103/job/53829017556) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes