### PR TITLE
SparseMatmul: Use mailboxes to send sparsity boolean from reader to compute kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -116,7 +116,6 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
 @pytest.mark.parametrize("tile_h", [16])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
-@skip_for_blackhole("Semaphores used to broadcast sparsity is not propagating on BH, Issue #27979")
 def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype):
     torch.manual_seed(0)
     m, k, n = mkn

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -34,7 +34,7 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
 
     # Mark some as 0 to test the sparsity
     sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
-    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    number_of_zeros = torch.randint(0, sparsity.numel(), ()).item()
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 
@@ -220,7 +220,7 @@ def test_batched_sparse_matmul_with_nnz(device, mkn, num_experts, tile_h, tile_w
 
     # Mark some as 0 to test the sparsity
     sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
-    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    number_of_zeros = torch.randint(0, sparsity.numel(), ()).item()
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 
@@ -315,7 +315,7 @@ def test_sparse_matmul_inputA_with_nnz(device, mkn, num_experts, num_batches, ti
 
     # Mark some as 0 to test the sparsity
     sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
-    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    number_of_zeros = torch.randint(0, sparsity.numel(), ()).item()
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -129,7 +129,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
 
     # Mark some as 0 to test the sparsity
     sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
-    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    number_of_zeros = torch.randint(0, sparsity.numel(), ()).item()
     zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
     sparsity.view(-1)[zero_indices] = 0.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -79,23 +79,6 @@ inline void reblock_and_untilize(
     cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
 }
 
-inline uint32_t get_nnz(uint32_t nnz_cb_id, uint32_t tile_index) {
-    uint32_t nnz;
-    UNPACK(uint32_t operand_id = get_operand_id(nnz_cb_id);
-           uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-           uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-           uint32_t byte_address = (base_address + offset_address) << 4;
-           auto nnz_addr_ptr = (volatile uint32_t*)byte_address;
-           // The first 4 entries have metadata, so we look at the 5th entry
-           // for our value pushed from the reader.
-           nnz = nnz_addr_ptr[4];
-           mailbox_write(ThreadId::MathThreadId, nnz);
-           mailbox_write(ThreadId::PackThreadId, nnz);)
-    MATH(nnz = mailbox_read(ThreadId::UnpackThreadId);)
-    PACK(nnz = mailbox_read(ThreadId::UnpackThreadId);)
-    return nnz;
-}
-
 void MAIN {
 // RUNTIME ARGS
 #ifdef MATMUL_DRAM_SHARDED
@@ -134,10 +117,6 @@ void MAIN {
     constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_4;
     constexpr uint32_t mm_partials_cb_id = tt::CBIndex::c_5;
-    // Reader will use this CB to pass the number of non-zero (nnz) entries in the sparsity tensor.
-    constexpr uint32_t nnz_cb_id = tt::CBIndex::c_25;
-    volatile uint32_t* nnz_addr_ptr;
-
     constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
 
 #ifdef FUSE_BIAS
@@ -164,11 +143,11 @@ void MAIN {
     for (uint32_t b = 0; b < batch; b++) {
         if constexpr (get_batch_from_reader) {
             // Check whether this batch is valid
-            cb_wait_front(nnz_cb_id, 1);
-            uint32_t nnz = get_nnz(nnz_cb_id, 0);
-            cb_pop_front(nnz_cb_id, 1);
-
-            if (nnz == 0) {
+            bool is_batch_valid;
+            UNPACK(is_batch_valid = (bool)mailbox_read_full(0);)  // 0 is BRISC ThreadID, no enum for that.
+            MATH(is_batch_valid = (bool)mailbox_read_full(0);)    // 0 is BRISC ThreadID, no enum for that.
+            PACK(is_batch_valid = (bool)mailbox_read_full(0);)    // 0 is BRISC ThreadID, no enum for that.
+            if (!is_batch_valid) {
                 continue;
             }
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -144,9 +144,10 @@ void MAIN {
         if constexpr (get_batch_from_reader) {
             // Check whether this batch is valid
             bool is_batch_valid;
-            UNPACK(is_batch_valid = (bool)mailbox_read_full(0);)  // 0 is BRISC ThreadID, no enum for that.
-            MATH(is_batch_valid = (bool)mailbox_read_full(0);)    // 0 is BRISC ThreadID, no enum for that.
-            PACK(is_batch_valid = (bool)mailbox_read_full(0);)    // 0 is BRISC ThreadID, no enum for that.
+            // 0 is BRISC ThreadID, no enum for that. Issue #27979 will address this.
+            UNPACK(is_batch_valid = (bool)mailbox_read_full(0);)
+            MATH(is_batch_valid = (bool)mailbox_read_full(0);)
+            PACK(is_batch_valid = (bool)mailbox_read_full(0);)
             if (!is_batch_valid) {
                 continue;
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -51,6 +51,7 @@ void kernel_main() {
 
             const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
             // We need to pass the value to compute cores regardless of the value of is_batch_valid
+            // TODO: Issue #27979 to move this to functions that encapsulate the mailbox addresses.
             (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC1000))[0] = (uint32_t)is_batch_valid;
             (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC2000))[0] = (uint32_t)is_batch_valid;
             (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC3000))[0] = (uint32_t)is_batch_valid;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -169,6 +169,7 @@ void kernel_main() {
                     noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
 #endif  // SKIP_MCAST
         // We need to pass the value to compute cores regardless of the value of is_batch_valid
+        // TODO: Issue #27979 to move this to functions that encapsulate the mailbox addresses.
                     (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC1000))[0] = (uint32_t)is_batch_valid;
                     (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC2000))[0] = (uint32_t)is_batch_valid;
                     (reinterpret_cast<volatile uint32_t tt_reg_ptr*>(0xFFEC3000))[0] = (uint32_t)is_batch_valid;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -165,7 +165,6 @@ void kernel_main() {
                     noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
                     noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
                     noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, is_batch_valid ? VALID : IGNORE_BATCH);
-                    ckernel::wait(500);
                     noc_semaphore_set_multicast(
                         in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
                     noc_async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -3417,7 +3417,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
         in0_mcast_sender_cores,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = in0_noc,
             .compile_args = in0_sender_compile_time_args,
             .defines = mm_kernel_in0_sender_writer_defines});
@@ -3429,7 +3429,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
             "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
             in0_mcast_receivers,
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = in0_noc,
                 .compile_args = in0_receiver_compile_time_args});
     }
@@ -3440,7 +3440,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
         "reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
         all_cores_with_work,
         tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = in1_noc,
             .compile_args = in1_sender_writer_compile_time_args,
             .defines = mm_kernel_in1_sender_writer_defines});
@@ -3676,8 +3676,7 @@ tt::tt_metal::operation::ProgramWithCallbacks sparse_matmul_multi_core_reuse_mca
                 (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
                 (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
             };
-            tt_metal::SetRuntimeArgs(
-                program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);  // RISCV_1_default
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);
         }
         if (i < num_cores_with_work) {
             std::vector<uint32_t> mm_in1_sender_writer_args = {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27979

### Problem description
Please see the issue above for complete details. 

### What's changed
This PR implements a fix for the hang by using mailboxes to move data between the cores.
Since the defines and functions required to write to the mailboxes are not available in BRISC headers, we resort to writing directly to the mailboxes with a TODO added in for future clean up.

This PR should downgrade the P0 to P1 while the follow up PRs that implement the cleaner solutions land (they need both LLK and metal changes)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes