### PR TITLE
[skip ci] Enable unknown-pragmas compiler warning in Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-logical-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas>"
     "$<$<CXX_COMPILER_ID:Clang>:SHELL:-Xclang -fno-pch-timestamp>" # ccache-friendly PCH flag
     "$<$<CXX_COMPILER_ID:GNU>:-fpch-preprocess>" # ccache-friendly PCH flag
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-array-bounds>"


### PR DESCRIPTION
### Ticket
#23444 

### Problem description
We have this compiler warning disabled, apparently for no reason.

### What's changed
- Enable warning