### PR TITLE
[skip ci] Bump resnet50 perf on BH

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10003.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13500.0],
+        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10300.0],
+        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 13900.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):


### PR DESCRIPTION
### Problem description
Device Perf regressions CI is red because of resnet50
https://github.com/tenstorrent/tt-metal/actions/runs/18866899570/job/53836901460#step:36:43

### What's changed
- bumped expected perf