### PR TITLE
[skip ci] Set tracy to true in bisect workflow

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -6,7 +6,7 @@ on:
       tracy:
         required: true
         type: boolean
-        default: false
+        default: true
         description: "Build with tracy enabled"
       nd-mode:
         required: true


### PR DESCRIPTION
### Problem description
Bisect is looking only for non profiler builds so it is building on every commit

### What's changed
Set tracy to default to true as this is default in all our workflows. And that bisect first tries to download profiler build