### PR TITLE
#29819: Add tools section to ttnndocs

### DIFF
--- a/docs/source/ttnn/index.rst
+++ b/docs/source/ttnn/index.rst
@@ -21,6 +21,7 @@ Welcome to TT-NN documentation!
    ttnn/adding_new_ttnn_operation
    ttnn/profiling_ttnn_operations
    ttnn/demos
+   tools/index
 
 .. toctree::
    :caption: Resources

--- a/docs/source/ttnn/tools/index.rst
+++ b/docs/source/ttnn/tools/index.rst
@@ -14,3 +14,9 @@ For more information, check out the `Getting Started <https://github.com/tenstor
 * `vllm <https://github.com/tenstorrent/vllm>`_
 
 A high-throughput and memory-efficient inference and serving engine for Large Language Models (LLMs) on Tenstorrent hardware.
+
+* `tracy profiler <https://github.com/tenstorrent/tracy>`_
+
+Tracy is a real-time, high-performance tracing tool designed for analyzing and visualizing the execution of deep learning models and operations on Tenstorrent hardware.
+
+For detailed instructions on profiling TT-NN operations, refer to the `Profiling TT-NN Operations <../ttnn/profiling_ttnn_operations>` guide.

--- a/docs/source/ttnn/tools/index.rst
+++ b/docs/source/ttnn/tools/index.rst
@@ -8,3 +8,7 @@ The Tenstorrent System Management Interface (TT-SMI) is a command-line tool that
 * `ttnn-visualizer <https://github.com/tenstorrent/ttnn-visualizer>`_
 
 TTNN-Visualizer is an interactive tool for visualizing and analyzing model execution on Tenstorrent hardware, providing detailed insights through graphs, memory plots, tensor and buffer views, operation flow diagrams, and multi-instance support via file or SSH report loading. Check out getting started guide: `Getting Started <https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md>`_ and our tutorial: :doc:`TTNN-Visualizer Tutorial <../ttnn/tutorials/2025_dx_rework/ttnn_visualizer>`.
+
+* `vllm <https://github.com/tenstorrent/vllm>`_
+
+A high-throughput and memory-efficient inference and serving engine for LLMs on Tenstorrent hardware.

--- a/docs/source/ttnn/tools/index.rst
+++ b/docs/source/ttnn/tools/index.rst
@@ -19,4 +19,4 @@ A high-throughput and memory-efficient inference and serving engine for Large La
 
 Tracy is a real-time, high-performance tracing tool designed for analyzing and visualizing the execution of deep learning models and operations on Tenstorrent hardware.
 
-For detailed instructions on profiling TT-NN operations, refer to the `Profiling TT-NN Operations <../ttnn/profiling_ttnn_operations>` guide.
+For detailed instructions on profiling TT-NN operations, refer to the :doc:`Profiling TT-NN Operations <../ttnn/profiling_ttnn_operations>` guide.

--- a/docs/source/ttnn/tools/index.rst
+++ b/docs/source/ttnn/tools/index.rst
@@ -7,8 +7,10 @@ The Tenstorrent System Management Interface (TT-SMI) is a command-line tool that
 
 * `ttnn-visualizer <https://github.com/tenstorrent/ttnn-visualizer>`_
 
-TTNN-Visualizer is an interactive tool for visualizing and analyzing model execution on Tenstorrent hardware, providing detailed insights through graphs, memory plots, tensor and buffer views, operation flow diagrams, and multi-instance support via file or SSH report loading. Check out getting started guide: `Getting Started <https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md>`_ and our tutorial: :doc:`TTNN-Visualizer Tutorial <../ttnn/tutorials/2025_dx_rework/ttnn_visualizer>`.
+TTNN-Visualizer is an interactive tool for visualizing and analyzing model execution on Tenstorrent hardware. It provides detailed insights through graphs, memory plots, tensor and buffer views, operation flow diagrams, and multi-instance support via file or SSH report loading.
+
+For more information, check out the `Getting Started <https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md>`_ guide and our tutorial: :doc:`TTNN-Visualizer Tutorial <../ttnn/tutorials/2025_dx_rework/ttnn_visualizer>`.
 
 * `vllm <https://github.com/tenstorrent/vllm>`_
 
-A high-throughput and memory-efficient inference and serving engine for LLMs on Tenstorrent hardware.
+A high-throughput and memory-efficient inference and serving engine for Large Language Models (LLMs) on Tenstorrent hardware.

--- a/docs/source/ttnn/tools/index.rst
+++ b/docs/source/ttnn/tools/index.rst
@@ -1,0 +1,10 @@
+Tools
+=====
+
+* `tt-smi <https://github.com/tenstorrent/tt-smi>`_
+
+The Tenstorrent System Management Interface (TT-SMI) is a command-line tool that provides a simple way to interact with Tenstorrent devices, collect telemetry, and display device and firmware information.
+
+* `ttnn-visualizer <https://github.com/tenstorrent/ttnn-visualizer>`_
+
+TTNN-Visualizer is an interactive tool for visualizing and analyzing model execution on Tenstorrent hardware, providing detailed insights through graphs, memory plots, tensor and buffer views, operation flow diagrams, and multi-instance support via file or SSH report loading. Check out getting started guide: `Getting Started <https://github.com/tenstorrent/ttnn-visualizer/blob/main/docs/getting-started.md>`_ and our tutorial: :doc:`TTNN-Visualizer Tutorial <../ttnn/tutorials/2025_dx_rework/ttnn_visualizer>`.


### PR DESCRIPTION
### Ticket

#29819 

### What's changed

Added a **Tools** section to TTNN, mirroring the structure of the TTNN Metalium documentation, to improve the visibility of tools specific to this layer of the software stack.

<img width="1649" height="784" alt="Screenshot 2025-11-03 at 09 25 06" src="https://github.com/user-attachments/assets/13d0db67-0547-45da-992c-6dccd9e19213" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19028360136

### Note

> [!NOTE]
> This PR is connected with https://github.com/tenstorrent/tenstorrent.github.io/pull/96.