### PR TITLE
Add fp32 input support and upper-dim broadcasting to minimal matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -154,15 +154,8 @@ tt::tt_metal::operation::ProgramWithCallbacks minimal_matmul_factory(
     auto in0_tensor_shape = input_tensor.padded_shape();
     auto in1_tensor_shape = weight_tensor.padded_shape();
     // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M
-    uint32_t M = in0_tensor_shape[-2];
     uint32_t K = in0_tensor_shape[-1];
-    if (in0_tensor_shape.rank() > 2) {
-        uint32_t folded = 1;
-        for (int i = 0; i < static_cast<int>(in0_tensor_shape.rank()) - 2; ++i) {
-            folded *= in0_tensor_shape[i];
-        }
-        M *= folded;
-    }
+    uint32_t M = input_tensor.physical_volume() / K;
     uint32_t N = in1_tensor_shape[-1];
 
     uint32_t M_tiles = M / tt::constants::TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -153,8 +153,16 @@ tt::tt_metal::operation::ProgramWithCallbacks minimal_matmul_factory(
 
     auto in0_tensor_shape = input_tensor.padded_shape();
     auto in1_tensor_shape = weight_tensor.padded_shape();
+    // Fold activation (LHS) upper dimensions into rows: M_total = prod(upper dims) * M
     uint32_t M = in0_tensor_shape[-2];
     uint32_t K = in0_tensor_shape[-1];
+    if (in0_tensor_shape.rank() > 2) {
+        uint32_t folded = 1;
+        for (int i = 0; i < static_cast<int>(in0_tensor_shape.rank()) - 2; ++i) {
+            folded *= in0_tensor_shape[i];
+        }
+        M *= folded;
+    }
     uint32_t N = in1_tensor_shape[-1];
 
     uint32_t M_tiles = M / tt::constants::TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_pybind.cpp
@@ -35,7 +35,7 @@ void py_bind_minimal_matmul(py::module& module) {
             - Layout: TILE (required).
             - Device: must be on device and allocated in a device buffer.
             - DType: one of {DataType::BFLOAT16, DataType::BFLOAT8_B, DataType::BFLOAT4_B}.
-            - Shape: [..., M, K] with no batching; all leading dimensions (dims < -2) must be 1.
+            - Shape: [..., M, K]. Upper (leading) dimensions are broadcast over rows (folded into M).
 
         weight_tensor : ttnn.Tensor
             Weight matrix B.
@@ -106,10 +106,11 @@ void py_bind_minimal_matmul(py::module& module) {
         --------------------------
         - All tensors must be on the same device and allocated in device buffers.
         - All tensors must be in TILE layout (sharded tensors must be tile-aligned at shard boundaries).
-        - Supported dtypes for inputs: BF16, BF8_B, BF4_B. Bias (if present)
+        - Supported dtypes for inputs: BF16, BF8_B, BF4_B, FLOAT32. Bias (if present)
           must be one of the supported dtypes. The dtype of the output is the same as the dtype of the inputs.
         - No implicit transpose flags are supported; provide `weight_tensor` with logical shape [..., K, N].
-        - No batching: all leading dimensions for inputs and bias must be 1.
+        - Weight and bias must have 1 in all leading dimensions (dims < -2). Activation may have arbitrary
+          upper dimensions; these are broadcast across rows (internally folded into M for execution).
         - Performance and memory footprint are sensitive to block sizes and subblock shapes. Providing non-sensible
           values in `config` may degrade performance. Defaults are generally a good starting point.
 


### PR DESCRIPTION
### Problem description
In integrating minimal MM into TT-DiT models, we found that there were a few features unsupported.

### What's changed
- Allow FP32 inputs
- Allow upper dim broadcasting on activations

### Checklist
- [x] L2 nightly https://github.com/tenstorrent/tt-metal/actions/runs/18874535566