### PR TITLE
Add Sfpu Reduce LLK to Compute Kernel API

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -32,3 +32,4 @@
 #include "llk_math_eltwise_unary_sfpu_prelu.h"
 #include "llk_math_eltwise_unary_sfpu_i1.h"
 #include "llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h"
+#include "llk_math_eltwise_unary_sfpu_reduce.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -10,10 +10,7 @@
 #include "sfpu/ckernel_sfpu_reduce.h"
 #include "ckernel_instr_params.h"
 
-using namespace sfpi;
-
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void calculate_reduce() {
@@ -27,5 +24,4 @@ inline void init_reduce() {
     _init_reduce_<format>();
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -6,7 +6,6 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpu/ckernel_sfpu_reduce.h"
 #include "ckernel_instr_params.h"
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "sfpu/ckernel_sfpu_reduce.h"
+#include "ckernel_instr_params.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void calculate_reduce() {
+    // Use the specified parameters for the reduction operation
+    _calculate_reduce_<pool_type, reduce_dim, format>();
+}
+
+template <DataFormat format>
+inline void init_reduce() {
+    // Use the specified format for initialization
+    _init_reduce_<format>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -8,7 +8,7 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_abs.h"
 
-namespace ckernel::sfpu {
+namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
@@ -17,12 +17,14 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel::sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -8,7 +8,7 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_abs.h"
 
-namespace ckernel {
+namespace ckernel::sfpu {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
@@ -17,14 +17,12 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -8,17 +8,17 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_reduce.h"
 
-namespace ckernel::sfpu {
+namespace ckernel {
 
 template <bool APPROXIMATE, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(init_reduce<format>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(sfpu::init_reduce<format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel::sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -8,19 +8,17 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_reduce.h"
 
-namespace ckernel {
+namespace ckernel::sfpu {
 
 template <bool APPROXIMATE, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce_sum_avg, APPROXIMATE>(ckernel::sfpu::init_reduce<format>);
+inline void llk_math_eltwise_unary_sfpu_reduce_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(init_reduce<format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+inline void llk_math_eltwise_unary_sfpu_reduce(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_reduce<pool_type, reduce_dim, format>,
-        dst_index,
-        vector_mode);
+        calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_reduce.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce_sum_avg, APPROXIMATE>(ckernel::sfpu::init_reduce<format>);
+}
+
+template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_reduce<pool_type, reduce_dim, format>,
+        dst_index,
+        vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -131,5 +131,5 @@ enum SfpuType {
     rpow,
     cbrt,  // cube root
     hardmish,
-    reduce_sum_avg,
+    reduce,
 };

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -131,4 +131,5 @@ enum SfpuType {
     rpow,
     cbrt,  // cube root
     hardmish,
+    reduce_sum_avg,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -41,3 +41,4 @@
 #include "llk_math_eltwise_unary_sfpu_prelu.h"
 #include "llk_math_eltwise_unary_sfpu_i1.h"
 #include "llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h"
+#include "llk_math_eltwise_unary_sfpu_reduce.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -10,10 +10,7 @@
 #include "sfpu/ckernel_sfpu_reduce.h"
 #include "ckernel_instr_params.h"
 
-using namespace sfpi;
-
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void calculate_reduce() {
@@ -27,5 +24,4 @@ inline void init_reduce() {
     _init_reduce_<format>();
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -6,7 +6,6 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "sfpu/ckernel_sfpu_reduce.h"
 #include "ckernel_instr_params.h"
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "sfpu/ckernel_sfpu_reduce.h"
+#include "ckernel_instr_params.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void calculate_reduce() {
+    // Use the specified parameters for the reduction operation
+    _calculate_reduce_<pool_type, reduce_dim, format>();
+}
+
+template <DataFormat format>
+inline void init_reduce() {
+    // Use the specified format for initialization
+    _init_reduce_<format>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -8,17 +8,17 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_reduce.h"
 
-namespace ckernel::sfpu {
+namespace ckernel {
 
 template <bool APPROXIMATE, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(init_reduce<format>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(sfpu::init_reduce<format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
 inline void llk_math_eltwise_unary_sfpu_reduce(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel::sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -8,17 +8,17 @@
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_reduce.h"
 
-namespace ckernel {
+namespace ckernel::sfpu {
 
 template <bool APPROXIMATE, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce_sum_avg, APPROXIMATE>(ckernel::sfpu::init_reduce<format>);
+inline void llk_math_eltwise_unary_sfpu_reduce_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce, APPROXIMATE>(init_reduce<format>);
 }
 
 template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+inline void llk_math_eltwise_unary_sfpu_reduce(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
+        calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
 }
 
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_reduce.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reduce_sum_avg, APPROXIMATE>(ckernel::sfpu::init_reduce<format>);
+}
+
+template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
+inline void llk_math_eltwise_unary_sfpu_reduce_sum_avg(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -131,4 +131,5 @@ enum class SfpuType {
     rpow,
     cbrt,  // cube root
     hardmish,
+    reduce_sum_avg,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -131,5 +131,5 @@ enum class SfpuType {
     rpow,
     cbrt,  // cube root
     hardmish,
-    reduce_sum_avg,
+    reduce,
 };

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -601,7 +601,7 @@ ALWI void max_reduce_with_indices_init() {
  * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
  * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register containing the data to be reduced  | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | pool_type       | The type of reduction operation (SUM or AVG)                             | PoolType  | SUM, AVG                                              | True     |
+ * | pool_type       | The type of reduction operation, SUM or AVG (MAX not supported)          | PoolType  | SUM, AVG                                              | True     |
  * | format          | The data format for the reduction operation                              | DataFormat| Float32, Int32, UInt16, UInt32                        | True     |
  * | reduce_dim      | The reduction dimension, set to column for column reduce                 | ReduceDim | REDUCE_COL                                            | False    |
  * | is_32x32_tile   | The tile dimensions to perform the reduction on                          | bool      | true                                                  | False    |
@@ -612,9 +612,10 @@ template <
     DataFormat format = DataFormat::Int32,
     ReduceDim reduce_dim = ReduceDim::REDUCE_COL,
     bool is_32x32_tile = true>
-ALWI void sfpu_reduce_sum_avg(uint32_t idst) {
+ALWI void sfpu_reduce(uint32_t idst) {
     static_assert(is_32x32_tile, "Only 32x32 tile dimensions are supported for reduce operations");
     static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+    static_assert(pool_type != PoolType::MAX, "MAX pool type is not supported for reduce operations");
 
     MATH((llk_math_eltwise_unary_sfpu_reduce<true, pool_type, reduce_dim, format>(idst)));
 }
@@ -622,9 +623,9 @@ ALWI void sfpu_reduce_sum_avg(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-template <DataFormat format>
-ALWI void sfpu_reduce_sum_avg_init() {
-    MATH((llk_math_eltwise_unary_sfpu_reduce_sum_avg_init<true, format>()));
+template <DataFormat format = DataFormat::Int32>
+ALWI void sfpu_reduce_init() {
+    MATH((llk_math_eltwise_unary_sfpu_reduce_init<true, format>()));
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -602,16 +602,16 @@ ALWI void max_reduce_with_indices_init() {
  * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register containing the data to be reduced  | uint32_t  | Must be less than the size of the DST register buffer | True     |
  * | pool_type       | The type of reduction operation (SUM or AVG)                             | PoolType  | SUM, AVG                                              | True     |
- * | reduce_dim      | The reduction dimension, set to column for column reduce                 | ReduceDim | REDUCE_COL                                            | True     |
- * | is_32x32_tile   | The tile dimensions to perform the reduction on                          | bool      | true                                                  | True     |
  * | format          | The data format for the reduction operation                              | DataFormat| Float32, Int32, UInt16, UInt32                        | True     |
+ * | reduce_dim      | The reduction dimension, set to column for column reduce                 | ReduceDim | REDUCE_COL                                            | False    |
+ * | is_32x32_tile   | The tile dimensions to perform the reduction on                          | bool      | true                                                  | False    |
  */
 // clang-format on
 template <
     PoolType pool_type,
+    DataFormat format = DataFormat::Int32,
     ReduceDim reduce_dim = ReduceDim::REDUCE_COL,
-    bool is_32x32_tile = true,
-    DataFormat format = DataFormat::Int32>
+    bool is_32x32_tile = true>
 ALWI void sfpu_reduce_sum_avg(uint32_t idst) {
     static_assert(is_32x32_tile, "Only 32x32 tile dimensions are supported for reduce operations");
     static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -589,6 +589,44 @@ ALWI void max_reduce_with_indices_init() {
     MATH((llk_math_eltwise_binary_sfpu_max_pool_with_indices_init<true, layout>()));
 }
 
+// clang-format off
+/**
+ * Performs reduce operation (sum or average) on a 32x32 tile, placing output values into the first row.
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Only column-wise reduction is supported at this time.
+ * Only 32x32 tile dimensions are supported.
+ *
+ * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
+ * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register containing the data to be reduced  | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | pool_type       | The type of reduction operation (SUM or AVG)                             | PoolType  | SUM, AVG                                              | True     |
+ * | reduce_dim      | The reduction dimension, set to column for column reduce                 | ReduceDim | REDUCE_COL                                            | True     |
+ * | is_32x32_tile   | The tile dimensions to perform the reduction on                          | bool      | true                                                  | True     |
+ * | format          | The data format for the reduction operation                              | DataFormat| Float32, Int32, UInt16, UInt32                        | True     |
+ */
+// clang-format on
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim = ReduceDim::REDUCE_COL,
+    bool is_32x32_tile = true,
+    DataFormat format = DataFormat::Int32>
+ALWI void sfpu_reduce_sum_avg(uint32_t idst) {
+    static_assert(is_32x32_tile, "Only 32x32 tile dimensions are supported for reduce operations");
+    static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+
+    MATH((llk_math_eltwise_unary_sfpu_reduce_sum_avg<true, pool_type, reduce_dim, format>(idst)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+template <DataFormat format>
+ALWI void sfpu_reduce_sum_avg_init() {
+    MATH((llk_math_eltwise_unary_sfpu_reduce_sum_avg_init<true, format>()));
+}
+
 /**
  * Pauses the cores so that the debug interface can be used to inspect the value of the registers.
  *

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -616,7 +616,7 @@ ALWI void sfpu_reduce_sum_avg(uint32_t idst) {
     static_assert(is_32x32_tile, "Only 32x32 tile dimensions are supported for reduce operations");
     static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
 
-    MATH((llk_math_eltwise_unary_sfpu_reduce_sum_avg<true, pool_type, reduce_dim, format>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_reduce<true, pool_type, reduce_dim, format>(idst)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
#29535
https://github.com/tenstorrent/tt-metal/issues/21071
### Problem description
Implemented Sfpu Reduce LLK for Sum/Avg op (https://github.com/tenstorrent/tt-llk/pull/722). Ops team needs this exposed in tt-metal for further use, the following are metal-side changed to merge sum/avg LLK into Compute Kernel API.
### What's changed
Sum/Avg kernel exposed in compute kernel API. Performs column reduction on a 32x32 tile, returning 32 reduction results for each column in the top row of the tile (face 0 and face 1). It requires a flag to indicate whether the operation is a sum or average, and a format parameter to indicate the data format of datums in the destination register that Sfpu operates on.

LLK Implementation details can be found here:
`tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_reduce.h`
`tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_reduce.h`
https://github.com/tenstorrent/tt-metal/issues/29535 and https://github.com/tenstorrent/tt-llk/pull/722

Note: I did thorough testing on the LLK side, but I have not tested my changes on the Metal side for the Compute Kernel API. Everything compiles, but it would be good for the Metal team to first create a simple test to confirm the sum/avg compute kernels before further use.
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes