### PR TITLE
#31304: SDXL img2img prep for refiner

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -13,16 +13,15 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
     SDXL_FABRIC_CONFIG,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
 )
 import os
 from models.common.utility_functions import profiler
 from conftest import is_galaxy
 
 from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
-
-MAX_SEQUENCE_LENGTH = 77
-TEXT_ENCODER_2_PROJECTION_DIM = 1280
-CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
 
 
 @torch.no_grad()

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
@@ -14,6 +14,9 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
     SDXL_FABRIC_CONFIG,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
 )
 import os
 from models.common.utility_functions import profiler
@@ -23,10 +26,6 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_img2img_pipeline im
     TtSDXLImg2ImgPipeline,
     TtSDXLImg2ImgPipelineConfig,
 )
-
-MAX_SEQUENCE_LENGTH = 77
-TEXT_ENCODER_2_PROJECTION_DIM = 1280
-CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
 
 
 @torch.no_grad()

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py
@@ -14,6 +14,9 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
     SDXL_FABRIC_CONFIG,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
 )
 import os
 from models.common.utility_functions import profiler
@@ -23,10 +26,6 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_inpainting_pipeline
     TtSDXLInpaintingPipeline,
     TtSDXLInpaintingPipelineConfig,
 )
-
-MAX_SEQUENCE_LENGTH = 77
-TEXT_ENCODER_2_PROJECTION_DIM = 1280
-CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
 
 
 @torch.no_grad()

--- a/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
@@ -1,0 +1,362 @@
+import pytest
+import ttnn
+import torch
+from diffusers import StableDiffusionXLImg2ImgPipeline, DiffusionPipeline
+from loguru import logger
+from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from models.experimental.stable_diffusion_xl_base.tests.test_common import (
+    SDXL_L1_SMALL_SIZE,
+    SDXL_TRACE_REGION_SIZE,
+    SDXL_FABRIC_CONFIG,
+)
+import os
+from models.common.utility_functions import profiler
+
+from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_img2img_pipeline import (
+    TtSDXLImg2ImgPipeline,
+    TtSDXLImg2ImgPipelineConfig,
+)
+
+MAX_SEQUENCE_LENGTH = 77
+TEXT_ENCODER_2_PROJECTION_DIM = 1280
+CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
+
+
+# NOTE: This serves as a temporary example of how to use img2img pipeline for additional denoising
+# TODO: remove this file once we have refiner img2img enabled
+@torch.no_grad()
+def run_demo_inference(
+    ttnn_device,
+    is_ci_env,
+    prompts,
+    negative_prompts,
+    num_inference_steps,
+    vae_on_device,
+    encoders_on_device,
+    evaluation_range,
+    capture_trace,
+    guidance_scale,
+    use_cfg_parallel,
+    fixed_seed_for_batch,
+    strength,
+    denoising_start,
+    prompt_2=None,
+    negative_prompt_2=None,
+    crop_coords_top_left=(0, 0),
+    guidance_rescale=0.0,
+    timesteps=None,
+    sigmas=None,
+):
+    batch_size = list(ttnn_device.shape)[1] if use_cfg_parallel else ttnn_device.get_num_devices()
+
+    start_from, _ = evaluation_range
+
+    assert 0.0 <= guidance_rescale <= 1.0, f"guidance_rescale must be in [0.0, 1.0], got {guidance_rescale}"
+
+    assert not (timesteps is not None and sigmas is not None), "Cannot pass both timesteps and sigmas. Choose one."
+
+    if isinstance(prompts, str):
+        prompts = [prompts]
+
+    if prompt_2 is not None and isinstance(prompt_2, str):
+        prompt_2 = [prompt_2]
+
+    needed_padding = (batch_size - len(prompts) % batch_size) % batch_size
+    if isinstance(negative_prompts, list):
+        assert len(negative_prompts) == len(prompts), "prompts and negative_prompt lists must be the same length"
+
+    prompts = prompts + [""] * needed_padding
+    if prompt_2 is not None:
+        prompt_2 = prompt_2 + [""] * needed_padding
+    if isinstance(negative_prompts, list):
+        negative_prompts = negative_prompts + [""] * needed_padding
+
+    # 1. Load components
+    profiler.start("diffusion_pipeline_from_pretrained")
+    base = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
+    )
+    pipeline = StableDiffusionXLImg2ImgPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+        local_files_only=is_ci_env,
+    ).to("cpu")
+    profiler.end("diffusion_pipeline_from_pretrained")
+
+    assert isinstance(pipeline.text_encoder, CLIPTextModel), "pipeline.text_encoder is not a CLIPTextModel"
+    assert isinstance(
+        pipeline.text_encoder_2, CLIPTextModelWithProjection
+    ), "pipeline.text_encoder_2 is not a CLIPTextModelWithProjection"
+
+    tt_sdxl = TtSDXLImg2ImgPipeline(
+        ttnn_device=ttnn_device,
+        torch_pipeline=pipeline,
+        pipeline_config=TtSDXLImg2ImgPipelineConfig(
+            capture_trace=capture_trace,
+            vae_on_device=vae_on_device,
+            encoders_on_device=encoders_on_device,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            strength=strength,
+            is_galaxy=True,
+            use_cfg_parallel=use_cfg_parallel,
+            crop_coords_top_left=crop_coords_top_left,
+            guidance_rescale=guidance_rescale,
+        ),
+    )
+
+    if encoders_on_device:
+        tt_sdxl.compile_text_encoding()
+
+    images = [
+        base(
+            prompt=prompts[0],
+            num_inference_steps=num_inference_steps,
+            denoising_end=denoising_start,
+            output_type="latent",
+        ).images
+    ]
+
+    images = images + [images[0]] * needed_padding
+
+    images = [tt_sdxl.torch_pipeline.image_processor.preprocess(image).to(dtype=torch.float32) for image in images]
+
+    images = torch.cat(images, dim=0)  # [batch_size, 3, 1024, 1024]
+
+    tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+        torch_image=torch.randn(batch_size, images.shape[1], images.shape[2], images.shape[3]),
+        all_prompt_embeds_torch=torch.randn(batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE),
+        torch_add_text_embeds=torch.randn(batch_size, 2, TEXT_ENCODER_2_PROJECTION_DIM),
+        timesteps=timesteps,
+        sigmas=sigmas,
+        denoising_start=denoising_start,
+    )
+
+    tt_sdxl.compile_image_processing()
+
+    logger.info("=" * 80)
+    for key, data in profiler.times.items():
+        logger.info(f"{key}: {data[-1]:.2f} seconds")
+    logger.info("=" * 80)
+
+    profiler.clear()
+
+    if not is_ci_env and not os.path.exists("output"):
+        os.mkdir("output")
+
+    out_images = []
+    logger.info("Starting ttnn inference...")
+    for iter in range(len(prompts) // batch_size):
+        profiler.start("end_to_end_generation")
+        logger.info(
+            f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
+        )
+
+        prompts_batch = prompts[iter * batch_size : (iter + 1) * batch_size]
+        negative_prompts_batch = (
+            negative_prompts[iter * batch_size : (iter + 1) * batch_size]
+            if isinstance(negative_prompts, list)
+            else negative_prompts
+        )
+
+        prompts_2_batch = (
+            prompt_2[iter * batch_size : (iter + 1) * batch_size] if isinstance(prompt_2, list) else prompt_2
+        )
+        negative_prompts_2_batch = (
+            negative_prompt_2[iter * batch_size : (iter + 1) * batch_size]
+            if isinstance(negative_prompt_2, list)
+            else negative_prompt_2
+        )
+
+        (
+            all_prompt_embeds_torch,
+            torch_add_text_embeds,
+        ) = tt_sdxl.encode_prompts(prompts_batch, negative_prompts_batch, prompts_2_batch, negative_prompts_2_batch)
+
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
+            torch_image=images[iter * batch_size : (iter + 1) * batch_size],
+            all_prompt_embeds_torch=all_prompt_embeds_torch,
+            torch_add_text_embeds=torch_add_text_embeds,
+            start_latent_seed=0,
+            fixed_seed_for_batch=fixed_seed_for_batch,
+            timesteps=timesteps,
+            sigmas=sigmas,
+            denoising_start=denoising_start,
+        )
+
+        tt_sdxl.prepare_input_tensors(
+            [
+                tt_latents,
+                tt_prompt_embeds[0],
+                tt_add_text_embeds[0],
+            ]
+        )
+
+        imgs = tt_sdxl.generate_images()
+
+        logger.info(
+            f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
+        )
+        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
+        logger.info(
+            f"Denoising loop for {batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
+        )
+        logger.info(
+            f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
+        )
+        logger.info(f"Output tensor read completed in {profiler.times['read_output_tensor'][-1]:.2f} seconds")
+
+        profiler.end("end_to_end_generation")
+
+        for idx, img in enumerate(imgs):
+            if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:
+                break
+            img = img.unsqueeze(0)
+            img = pipeline.image_processor.postprocess(img, output_type="pil")[0]
+            out_images.append(img)
+            if is_ci_env:
+                logger.info(f"Image {len(out_images)}/{len(prompts) // batch_size} generated successfully")
+            else:
+                img.save(f"output/output{len(out_images) + start_from}_tt_img2img.png")
+                logger.info(f"Image saved to output/output{len(out_images) + start_from}_tt_img2img.png")
+
+    return out_images
+
+
+def prepare_device(mesh_device, use_cfg_parallel):
+    if use_cfg_parallel:
+        assert mesh_device.get_num_devices() % 2 == 0, "Mesh device must have even number of devices"
+        mesh_device.reshape(ttnn.MeshShape(2, mesh_device.get_num_devices() // 2))
+
+
+# Note: The 'fabric_config' parameter is only required when running with cfg_parallel enabled,
+# as the all_gather_async operation used in this mode depends on fabric being set.
+@pytest.mark.parametrize(
+    "device_params, use_cfg_parallel",
+    [
+        (
+            {
+                "l1_small_size": SDXL_L1_SMALL_SIZE,
+                "trace_region_size": SDXL_TRACE_REGION_SIZE,
+                "fabric_config": SDXL_FABRIC_CONFIG,
+            },
+            True,
+        ),
+        (
+            {
+                "l1_small_size": SDXL_L1_SMALL_SIZE,
+                "trace_region_size": SDXL_TRACE_REGION_SIZE,
+            },
+            False,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["use_cfg_parallel", "no_cfg_parallel"],
+)
+@pytest.mark.parametrize(
+    "fixed_seed_for_batch",
+    (False,),
+)
+@pytest.mark.parametrize(
+    "prompt",
+    (("An astronaut riding a green horse"),),
+)
+@pytest.mark.parametrize(
+    "negative_prompt",
+    ((None),),
+)
+@pytest.mark.parametrize(
+    "num_inference_steps",
+    ((40),),
+)
+@pytest.mark.parametrize(
+    "guidance_scale",
+    ((5.0),),
+)
+@pytest.mark.parametrize(
+    "vae_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_vae", "host_vae"),
+)
+@pytest.mark.parametrize(
+    "encoders_on_device",
+    [
+        (True),
+        (False),
+    ],
+    ids=("device_encoders", "host_encoders"),
+)
+@pytest.mark.parametrize(
+    "capture_trace",
+    [
+        (True),
+        (False),
+    ],
+    ids=("with_trace", "no_trace"),
+)
+@pytest.mark.parametrize(
+    "strength",
+    ((0.3),),
+)
+@pytest.mark.parametrize(
+    "denoising_start",
+    ((0.8),),
+)
+@pytest.mark.parametrize(
+    "prompt_2, negative_prompt_2, crop_coords_top_left, guidance_rescale, timesteps, sigmas",
+    [
+        (None, None, (0, 0), 0.0, None, None),
+    ],
+    ids=["default_additional_parameters"],
+)
+def test_demo(
+    validate_fabric_compatibility,
+    device,
+    is_ci_env,
+    prompt,
+    negative_prompt,
+    num_inference_steps,
+    vae_on_device,
+    encoders_on_device,
+    capture_trace,
+    evaluation_range,
+    guidance_scale,
+    use_cfg_parallel,
+    fixed_seed_for_batch,
+    strength,
+    denoising_start,
+    prompt_2,
+    negative_prompt_2,
+    crop_coords_top_left,
+    guidance_rescale,
+    timesteps,
+    sigmas,
+):
+    mesh_device = device
+    prepare_device(mesh_device, use_cfg_parallel)
+    return run_demo_inference(
+        mesh_device,
+        is_ci_env,
+        prompt,
+        negative_prompt,
+        num_inference_steps,
+        vae_on_device,
+        encoders_on_device,
+        evaluation_range,
+        capture_trace,
+        guidance_scale,
+        use_cfg_parallel,
+        fixed_seed_for_batch,
+        strength,
+        denoising_start,
+        prompt_2,
+        negative_prompt_2,
+        crop_coords_top_left,
+        guidance_rescale,
+        timesteps,
+        sigmas,
+    )

--- a/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import ttnn
 import torch
@@ -8,6 +12,9 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
     SDXL_FABRIC_CONFIG,
+    MAX_SEQUENCE_LENGTH,
+    TEXT_ENCODER_2_PROJECTION_DIM,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE,
 )
 import os
 from models.common.utility_functions import profiler
@@ -16,10 +23,6 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_img2img_pipeline im
     TtSDXLImg2ImgPipeline,
     TtSDXLImg2ImgPipelineConfig,
 )
-
-MAX_SEQUENCE_LENGTH = 77
-TEXT_ENCODER_2_PROJECTION_DIM = 1280
-CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
 
 
 # NOTE: This serves as a temporary example of how to use img2img pipeline for additional denoising

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -27,6 +27,9 @@ SDXL_L1_SMALL_SIZE = 30000
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
 SDXL_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_1D
+MAX_SEQUENCE_LENGTH = 77
+TEXT_ENCODER_2_PROJECTION_DIM = 1280
+CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
 
 
 def create_tt_clip_text_encoders(pipeline, ttnn_device):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py
@@ -56,7 +56,6 @@ class TtSDXLImg2ImgPipeline(TtSDXLPipeline):
             self.num_inference_steps,
             self.pipeline_config.strength,
             denoising_start,
-            self.torch_pipeline,
         )
 
         if self.num_inference_steps < 1:


### PR DESCRIPTION
### Ticket
#31304

### What's changed
Img2img pipeline adapted to enable its use for additional denoising:

- `denoising_start`/ `add_noise` parameter enabled
- `get_timesteps` and `prepare_image_latents` modified

### Checklist
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/18876444205) CI passes