### PR TITLE
Add option for Quasar when setting asic_location

### DIFF
--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -123,6 +123,9 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         } else if (arch == tt::ARCH::BLACKHOLE) {
             // Query ASIC Location from the Cluster Descriptor for BH.
             asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
+        } else if (arch == tt::ARCH::QUASAR) {
+            // Query ASIC Location from the Cluster Descriptor for QUASAR.
+            asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
         } else {
             TT_THROW("Unrecognized Architecture. Cannot determine asic location.");
         }


### PR DESCRIPTION
### Problem description
Running Quasar simulation was facing a crash because the physical system didn't include an option to set ASIC location for Quasar

### What's changed
Added the option to set the value for Quasar, using the same value as BH

### Checklist
Didn't run any tests as this change won't affect any current tests