### PR TITLE
[skip ci] Remove publishing of debian package

### DIFF
--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -161,6 +161,10 @@ jobs:
     name: Publish Debian packages
     runs-on: ubuntu-latest
     needs: build-artifact
+    permissions:
+      id-token: write  # Required for Cloudsmith OIDC
+      packages: write
+      contents: write
     if: ${{ github.ref == 'refs/heads/main' || inputs.dry-run }}
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -157,36 +157,6 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
-  publish-debs:
-    name: Publish Debian packages
-    runs-on: ubuntu-latest
-    needs: build-artifact
-    if: ${{ github.ref == 'refs/heads/main' || inputs.dry-run }}
-    steps:
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.packages-artifact-name || 'packages artifact unresolved!' }}
-          path: pkgs/
-      - name: Install CLI tool and deps
-        run: |
-          pip install --upgrade cloudsmith-cli
-          sudo apt update && sudo apt install -y distro-info
-      - name: Push packages
-        shell: bash
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          codename=$(ubuntu-distro-info -f --all \
-            | awk -v v="$VERSION" '$2==v' \
-            | cut -d'"' -f2 \
-            | awk '{print tolower($1)}')
-          echo "Publishing to $codename"
-          for deb in pkgs/*.deb; do
-            cloudsmith push deb tenstorrent/metalium/ubuntu/${codename} $deb -k ${{ secrets.CLOUDSMITH_API_KEY }} --component unstable
-          done
-
   publish-wheels:
     name: "Publish wheels to internal PyPI"
     needs: build-artifact

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -161,10 +161,6 @@ jobs:
     name: Publish Debian packages
     runs-on: ubuntu-latest
     needs: build-artifact
-    permissions:
-      id-token: write  # Required for Cloudsmith OIDC
-      packages: write
-      contents: write
     if: ${{ github.ref == 'refs/heads/main' || inputs.dry-run }}
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0


### PR DESCRIPTION
### Problem description
We have used this job as a proof of concept for publishing debs. It seem that our free trial run out and now we get 403 permission denied.

### What's changed
Removed publishing debs job