### PR TITLE
Add a quick SDPA health check to galaxy CI

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -36,7 +36,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-        TT_METAL_ENABLE_ERISC_IRAM: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -68,6 +67,7 @@ jobs:
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py::test_sdpa_tt_glx_health -k "bf16 and large";
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
@@ -94,7 +94,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-        TT_METAL_ENABLE_ERISC_IRAM: 1
         GTEST_OUTPUT: xml:/work/generated/test_reports/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -292,11 +292,9 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
     ids=["small", "large"],
 )
 @pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
-@pytest.mark.parametrize("device_id", range(32), ids=[f"device_{i}" for i in range(32)])
-def test_sdpa_tt_glx_health(mesh_device, device_id, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, reset_seeds):
+def test_sdpa_tt_glx_health(mesh_device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, reset_seeds):
     # Tests every device in the galaxy mesh to ensure they are working correctly
-    device = mesh_device.create_submeshes(ttnn.MeshShape(1, 1))[device_id]
-    logger.info(f"Running on grid {device.compute_with_storage_grid_size()}")
+    devices = mesh_device.create_submeshes(ttnn.MeshShape(1, 1))
 
     if dtype == ttnn.bfloat4_b and (
         q_chunk_size > 128 or k_chunk_size > 128 or [b, nh, nkv, s, d] != [1, 8, 1, 2048, 128]
@@ -306,7 +304,11 @@ def test_sdpa_tt_glx_health(mesh_device, device_id, b, nh, nkv, s, d, q_chunk_si
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     rmse_threshold = 0.0092 if (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b) else 0.0093
     ttnn.device.DisablePersistentKernelCache()
-    run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
+
+    for device_id in range(32):
+        device = devices[device_id]
+        logger.info(f"Running on device {device_id} with grid {device.compute_with_storage_grid_size()}")
+        run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -13,6 +13,7 @@ import ttnn
 from loguru import logger
 import pytest
 from models.common.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
+from conftest import is_galaxy
 
 
 def fa_rand(*shape):
@@ -279,6 +280,7 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
     run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
 
 
+@pytest.mark.skipif(not is_galaxy(), reason="Test requires galaxy machine")
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp4", "bfp8", "bf16"])
 @pytest.mark.parametrize("q_chunk_size", [32], ids=["q32"])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -80,23 +80,12 @@ def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window, is_causal
 
 
 def run_test_sdpa_tt(
-    device,
-    b,
-    nh,
-    nkv,
-    s,
-    d,
-    q_chunk_size,
-    k_chunk_size,
-    dtype,
-    use_high_precision_compute=False,
-    rmse_threshold=None,
-    core_grid=None,
+    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_high_precision_compute=False, rmse_threshold=None
 ):
     torch.manual_seed(1234)
 
     program_config = ttnn.SDPAProgramConfig(
-        compute_with_storage_grid_size=core_grid or device.compute_with_storage_grid_size(),
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=True,
@@ -135,14 +124,14 @@ def run_test_sdpa_tt(
     V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)  # b, nh, d, S
     gt = torch.nn.functional.scaled_dot_product_attention(Q, K_repeated, V_repeated, is_causal=True)
 
-    all_pass = True
-    for n in range(nh):
-        out_pass, out_pcc = comp_pcc(gt[:, n : n + 1, :, :], tt_back[:, n : n + 1, :, :], 0.994)
-        logger.debug(f"python vs pytorch head {n}: {out_pcc}")
-        rmse = torch.sqrt(((gt[:, n : n + 1, :, :] - tt_back[:, n : n + 1, :, :]) ** 2).mean()).item()
-        logger.debug(f"rmse head {n}: {rmse}")
-        all_pass = all_pass and out_pass and rmse < rmse_threshold
-    assert all_pass
+    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.994)
+    logger.debug(f"python vs pytorch: {out_pcc}")
+    rmse = torch.sqrt(((gt - tt_back) ** 2).mean()).item()
+    logger.debug(f"rmse: {rmse}")
+    if rmse_threshold is not None:
+        assert rmse < rmse_threshold
+    else:
+        assert out_pass
 
 
 def run_sdpa_noncausal(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31121

This health check will help us detect future issues on specific galaxy chips, like the one detailed in the issue above.

Removed `TT_METAL_ENABLE_ERISC_IRAM=1` from the CI script since this flag is not used anymore.

### Checks
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/18885616269)
  - [ ] [Galaxy quick (updated)](https://github.com/tenstorrent/tt-metal/actions/runs/18885981666)
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/18885695207)