### PR TITLE
#31344: Set CMAKE_CHANGED to true when submodules are changed

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -88,8 +88,8 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
     # Something to make more efficient in future.
     TOOLS_CHANGED=true
     ANY_CODE_CHANGED=true
-	# Issue: https://github.com/tenstorrent/tt-metal/issues/31344
-	CMAKE_CHANGED=true
+    # Issue: https://github.com/tenstorrent/tt-metal/issues/31344
+    CMAKE_CHANGED=true
 fi
 
 declare -A changes=(

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -88,6 +88,8 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
     # Something to make more efficient in future.
     TOOLS_CHANGED=true
     ANY_CODE_CHANGED=true
+	# Issue: https://github.com/tenstorrent/tt-metal/issues/31344
+	CMAKE_CHANGED=true
 fi
 
 declare -A changes=(


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/31344

### Problem description
cmake-version check is skipped when submodules are updated 

### What's changed
For now assume we have cmake changes when submodules change 


### Checklist
- [x] cmake version check runs and successfully catches the version mismatch (cherry-picked umd bump as a test): https://github.com/tenstorrent/tt-metal/actions/runs/18886008672/job/53901379698?pr=31350