### PR TITLE
Make build_key 64-bit.

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -144,9 +144,9 @@ int main(int argc, char** argv) {
         auto devices = tt::tt_metal::detail::CreateDevices(ids);
         std::vector<tt_metal::Program> programs;
         // kernel->binaries() returns 32B aligned binaries
-        std::map<uint32_t, std::vector<const ll_api::memory*>> compute_binaries;
-        std::map<uint32_t, std::vector<const ll_api::memory*>> brisc_binaries;
-        std::map<uint32_t, std::vector<const ll_api::memory*>> ncrisc_binaries;
+        std::map<uint64_t, std::vector<const ll_api::memory*>> compute_binaries;
+        std::map<uint64_t, std::vector<const ll_api::memory*>> brisc_binaries;
+        std::map<uint64_t, std::vector<const ll_api::memory*>> ncrisc_binaries;
 
         for (int i = 0; i < num_devices; i++) {
             auto device = devices[i];
@@ -188,8 +188,7 @@ int main(int argc, char** argv) {
             TT_FATAL(compute_kernel != nullptr && riscv0_kernel != nullptr && riscv1_kernel != nullptr, "Error");
 
             // Run iteration to get golden
-            uint32_t mask =
-                tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
+            auto mask = tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
             tt_metal::detail::CompileProgram(device, program);
             compute_binaries.insert({mask, tt_metal::KernelImpl::from(*compute_kernel).binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -229,9 +228,9 @@ int main(int argc, char** argv) {
                 auto& program = new_programs[i];
                 ths.emplace_back([&] {
                     for (int j = 0; j < num_compiles; j++) {
-                        uint32_t mask = tt_metal::BuildEnvManager::get_instance()
-                                            .get_device_build_env(device->build_id())
-                                            .build_key;
+                        auto mask = tt_metal::BuildEnvManager::get_instance()
+                                        .get_device_build_env(device->build_id())
+                                        .build_key;
                         tt_metal::detail::CompileProgram(device, program);
                         uint32_t programmable_core_index =
                             tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -161,8 +161,7 @@ void MetalContext::initialize(
         // Combine build_key and fw_compile_hash using XOR to create unique firmware build key
         // Uses full 64-bit fw_compile_hash for proper change detection
         uint64_t fw_build_key =
-            (static_cast<uint64_t>(BuildEnvManager::get_instance().get_device_build_env(device_id).build_key)) ^
-            fw_compile_hash;
+            BuildEnvManager::get_instance().get_device_build_env(device_id).build_key ^ fw_compile_hash;
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -91,7 +91,7 @@ void Inspector::program_destroyed(const detail::ProgramImpl* program) noexcept {
 }
 
 void Inspector::program_compile_started(
-    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -107,7 +107,7 @@ void Inspector::program_compile_started(
 }
 
 void Inspector::program_compile_already_exists(
-    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -147,7 +147,7 @@ void Inspector::program_kernel_compile_finished(
 }
 
 void Inspector::program_compile_finished(
-    const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept {
+    const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept {
     if (!is_enabled()) {
         return;
     }

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -32,16 +32,16 @@ public:
     static void program_set_binary_status(
         const detail::ProgramImpl* program, std::size_t device_id, ProgramBinaryStatus status) noexcept;
     static void program_compile_started(
-        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept;
     static void program_compile_already_exists(
-        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept;
     static void program_kernel_compile_finished(
         const detail::ProgramImpl* program,
         const IDevice* device,
         const std::shared_ptr<Kernel>& kernel,
         const tt::tt_metal::JitBuildOptions& build_options) noexcept;
     static void program_compile_finished(
-        const detail::ProgramImpl* program, const IDevice* device, uint32_t build_key) noexcept;
+        const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept;
 
     static void mesh_device_created(
         const distributed::MeshDevice* mesh_device, std::optional<int> parent_mesh_id) noexcept;

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -70,7 +70,7 @@ struct MeshWorkloadData {
 # enabling correct firmware path resolution without relying on relative
 # paths
 struct BuildEnvData {
-    buildKey @0 :UInt32; # Unique identifier for the build configuration
+    buildKey @0 :UInt64; # Unique identifier for the build configuration
     firmwarePath @1 :Text; # Absolute path to the firmware directory for this device
     fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
 }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -288,7 +288,7 @@ uint8_t ComputeKernel::expected_num_binaries() const {
     return 3;
 }
 
-const std::vector<const ll_api::memory*>& KernelImpl::binaries(uint32_t build_key) const {
+const std::vector<const ll_api::memory*>& KernelImpl::binaries(uint64_t build_key) const {
     auto iter = binaries_.find(build_key);
     TT_FATAL(iter != binaries_.end(), "binary not found");
     if (iter->second.size() != expected_num_binaries()) {
@@ -576,7 +576,7 @@ void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_
     jit_build_subset(build_states, this);
 }
 
-void KernelImpl::set_binaries(uint32_t build_key, std::vector<const ll_api::memory*>&& binaries) {
+void KernelImpl::set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>&& binaries) {
     // Try inserting an empty vector, as that is cheap to construct
     // and avoids an additional move.
     auto pair = binaries_.insert({build_key, {}});

--- a/tt_metal/impl/kernels/kernel_impl.hpp
+++ b/tt_metal/impl/kernels/kernel_impl.hpp
@@ -156,10 +156,10 @@ private:
 
 class KernelImpl : public Kernel, public JitBuildSettings {
 public:
-    const std::vector<const ll_api::memory*>& binaries(uint32_t build_key) const;
+    const std::vector<const ll_api::memory*>& binaries(uint64_t build_key) const;
     uint32_t get_binary_packed_size(IDevice* device, int index) const override;
     uint32_t get_binary_text_size(IDevice* device, int index) const;
-    void set_binaries(uint32_t build_key, std::vector<const ll_api::memory*>&& binaries);
+    void set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>&& binaries);
 
     const std::string& get_full_kernel_name() const override;
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
@@ -203,10 +203,8 @@ protected:
             compile_args,
             defines,
             named_compile_args) {}
-    // DataMovement kernels have one binary each and Compute kernels have three binaries
-    // Different set of binaries per device because kernel compilation is device dependent
-    // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
-    std::unordered_map<ChipId, std::vector<const ll_api::memory*>> binaries_;
+    // Build key -> binaries
+    std::unordered_map<uint64_t, std::vector<const ll_api::memory*>> binaries_;
 
     std::vector<std::string> file_paths(IDevice& device) const;
 };

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -76,6 +76,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "host_api.hpp"
 #include "kernels/kernel_impl.hpp"
+#include "tt_stl/reflection.hpp"
 
 namespace tt {
 class tt_hlk_desc;
@@ -176,7 +177,7 @@ void GenerateBinaries(IDevice* device, JitBuildOptions& build_options, const std
 #include <fstream>
 #endif
 
-size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions& build_options, uint32_t build_key) {
+size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions& build_options, uint64_t build_key) {
     // Store the build key into the KernelCompile hash. This will be unique per command queue
     // configuration (necessary for dispatch kernels).
     // Also account for watcher/dprint enabled in hash because they enable additional code to
@@ -1295,7 +1296,7 @@ void ProgramImpl::generate_dispatch_commands(IDevice* device, bool use_prefetche
     if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
-        device_hash = (device_hash << 32) | (device->id());
+        ttsl::hash::hash_combine(device_hash, device->id());
     }
     if (!is_cached()) {
         set_cached(device_hash);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -355,7 +355,7 @@ private:
 
     std::vector<Semaphore> semaphores_;
 
-    std::unordered_set<uint32_t> compiled_;
+    std::unordered_set<uint64_t> compiled_;
     bool local_circular_buffer_allocation_needed_;
 
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -92,7 +92,7 @@ std::string get_default_root_path() {
 JitBuildEnv::JitBuildEnv() = default;
 
 void JitBuildEnv::init(
-    uint32_t build_key,
+    uint64_t build_key,
     size_t fw_compile_hash,
     tt::ARCH arch,
     const std::map<std::string, std::string>& device_kernel_defines) {

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
 #include "jit_build_options.hpp"
 
 namespace tt::tt_metal {
@@ -48,7 +47,7 @@ class JitBuildEnv {
 public:
     JitBuildEnv();
     void init(
-        uint32_t build_key,
+        uint64_t build_key,
         size_t fw_compile_hash,
         tt::ARCH arch,
         const std::map<std::string, std::string>& device_kernel_defines);
@@ -123,9 +122,7 @@ protected:
         const std::string& obj) const;
     void link(const std::string& log_file, const std::string& out_path, const JitBuildSettings* settings) const;
     void weaken(const std::string& log_file, const std::string& out_path) const;
-    void copy_kernel(const std::string& kernel_in_path, const std::string& op_out_path) const;
     void extract_zone_src_locations(const std::string& log_file) const;
-    void finish_init(HalProgrammableCoreType core_type, HalProcessorClassType processor_class);
 
 public:
     JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& build_config);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -19,12 +19,10 @@
 #include "core_coord.hpp"
 #include "core_descriptor.hpp"
 #include "dispatch_core_common.hpp"
-#include "hal.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "jit_build/build.hpp"
 #include "metal_soc_descriptor.h"
-#include "dispatch/system_memory_manager.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 
 namespace tt::tt_metal {
@@ -102,7 +100,7 @@ std::map<std::string, std::string> initialize_device_kernel_defines(ChipId devic
     return device_kernel_defines;
 }
 
-uint32_t compute_build_key(ChipId device_id, uint8_t num_hw_cqs) {
+uint64_t compute_build_key(ChipId device_id, uint8_t num_hw_cqs) {
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
 
     // Collect all the parameters that affect the build configuration
@@ -130,8 +128,7 @@ uint32_t compute_build_key(ChipId device_id, uint8_t num_hw_cqs) {
         hash ^= uint32_hasher(harvested_core_count) << 4;
     }
 
-    // Convert the hash to a 32-bit value
-    return static_cast<uint32_t>(hash);
+    return static_cast<uint64_t>(hash);
 }
 
 std::vector<JitBuildState> create_build_state(
@@ -173,7 +170,7 @@ std::vector<JitBuildState> create_build_state(
 
 void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs) {
     const std::lock_guard<std::mutex> lock(this->lock);
-    uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
+    uint64_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
     const size_t fw_compile_hash =
         std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -22,7 +22,7 @@ using ProgCoreMapping =
 
 // A struct to hold device-specific build environment
 struct DeviceBuildEnv {
-    uint32_t build_key = 0;
+    uint64_t build_key = 0;
     JitBuildEnv build_env;
     std::vector<JitBuildState> firmware_build_states;
     std::vector<JitBuildState> kernel_build_states;
@@ -31,7 +31,7 @@ struct DeviceBuildEnv {
 // A struct to hold device-specific build environment info (lightweight version of DeviceBuildEnv)
 struct BuildEnvInfo {
     ChipId device_id;
-    uint32_t build_key;
+    uint64_t build_key;
     std::string firmware_root_path;
 };
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31362

### Problem description
We should capture all compilation flags into build key or compile hash.  Making build_key 64 bits makes it easier because a [similar attempt ran into entropy loss problem](https://github.com/tenstorrent/tt-metal/pull/29986#discussion_r2434300229) with 32-bit build_key.

### What's changed
Made build_key 64-bit.  There should be no functional changes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18890126263/job/53919825414) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18890127611) CI with demo tests passes (if applicable)