### PR TITLE
[skip ci] Enable volatile compiler warning in GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overflow>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-stringop-overread>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-unused-local-typedefs>"
-    "$<$<CXX_COMPILER_ID:GNU>:-Wno-volatile>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-pessimizing-move>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-dangling-reference>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-overloaded-virtual>"


### PR DESCRIPTION
### Ticket
#23444 

### Problem description
We have this compiler warning disabled in GCC seemingly for no reason, as it doesn't currently trigger any warning in GCC12.

### What's changed
- rm -rf