### PR TITLE
#31382: Add nan and inf handling in log accurate version

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -236,6 +236,18 @@ def test_log(device, h, w):
     run_unary_test(device, h, w, ttnn.log)
 
 
+def test_log_edge_cases(device):
+    in_data = torch.tensor(
+        [-10.0, 0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch.float32
+    )
+    input_tensor = ttnn.from_torch(in_data, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.log(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.log)
+    golden_tensor = golden_function(in_data, device=device)
+    assert torch.allclose(ttnn.to_torch(output_tensor), golden_tensor, equal_nan=True)
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -249,8 +261,8 @@ def test_log(device, h, w):
     [
         # for negative input values torch output is nan
         # for ttnn bfloat8_b due to shared exponent inf/nan values will result in incorrect results due to flushing
-        # Hence ignoring the negative input for bfloat8_b
         (ttnn.log, torch.bfloat16, ttnn.bfloat8_b, 1, 100),
+        # Hence ignoring the negative input for bfloat8_b
         (ttnn.log2, torch.bfloat16, ttnn.bfloat8_b, 1, 100),
         (ttnn.log10, torch.bfloat16, ttnn.bfloat8_b, 1, 100),
         # for ttnn bfloat16 nan is packed as inf (doesn't match with torch behavior).

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -62,9 +62,13 @@ sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
     v_endif;
 
     if constexpr (!FAST_APPROX) {
-        v_if(in < 0.0F) {
+        sfpi::vInt exp = sfpi::exexp(in);
+        sfpi::vInt man = sfpi::exman9(in);
+        sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000;  // returns 0 for +ve value
+        v_if((exp == 128 && man != 0) || in < 0.0F) {
             result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
+        v_elseif(signbit == 0 && exp == 128 && man == 0) { result = std::numeric_limits<float>::infinity(); }
         v_endif;
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -62,9 +62,13 @@ sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
     v_endif;
 
     if constexpr (!FAST_APPROX) {
-        v_if(in < 0.0F) {
+        sfpi::vInt exp = sfpi::exexp(in);
+        sfpi::vInt man = sfpi::exman9(in);
+        sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000;  // returns 0 for +ve value
+        v_if((exp == 128 && man != 0) || in < 0.0F) {
             result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
+        v_elseif(signbit == 0 && exp == 128 && man == 0) { result = std::numeric_limits<float>::infinity(); }
         v_endif;
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -33,6 +33,15 @@ Tensor MorehClipGradNorm::invoke(
     const std::optional<const Tensor>& total_norm,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    // Early validation: if error_if_nonfinite is true, check if norm_type itself is NaN
+    if (error_if_nonfinite && std::isnan(norm_type)) {
+        TT_FATAL(
+            false,
+            "The total norm of order {} for gradients from `parameters` is non-finite, so it cannot be "
+            "clipped. To disable this error and scale the gradients by the non-finite norm anyway, set "
+            "`error_if_nonfinite=False`",
+            norm_type);
+    }
     auto device = inputs.at(0).device();
     const auto compute_kernel_config_val =
         init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);


### PR DESCRIPTION
### Ticket
Link to Github Issue #31382

### Problem description
log return numerical values when input is inf or nan
<img width="304" height="196" alt="image" src="https://github.com/user-attachments/assets/f3c95b93-3810-4cde-b184-47442bbe94d4" />

### What's changed
Added nan and inf handling in log accurate version

**Clip_grad_norm:**
Added an early fatal check for cases where the norm type is NaN and error_if_nonfinite is set to true, since Torch shows the same behavior. Torch reference attached below.
<img width="1566" height="388" alt="Screenshot 2025-11-06 at 2 52 15 PM" src="https://github.com/user-attachments/assets/0613def7-f495-4c13-a015-4ba04324c561" />


### Checklist
- [x] [All post commit]
- [x] [Blackhole Post commit]