### PR TITLE
Added RoPE delta based dynamic mROPE calculation during decode in Qwen2.5-VL models

### DIFF
--- a/models/demos/qwen25_vl/tt/common.py
+++ b/models/demos/qwen25_vl/tt/common.py
@@ -129,6 +129,8 @@ def multimodal_rope_from_hf(
         second_per_grid_ts=None,
         attention_mask=padded_attention_mask,
     )
+    logger.info(f"position_ids: {position_ids.shape}")
+    logger.info(f"rope_deltas: {rope_deltas.shape}")
     # Qwen2_5_VLModel.forward:
     cos, sin = reference_model.model.language_model.rotary_emb(input_embeds, position_ids)
     # apply_multimodal_rotary_pos_emb:
@@ -138,8 +140,9 @@ def multimodal_rope_from_hf(
     sin = torch.cat([m[i % 3] for i, m in enumerate(sin.split(mrope_section, dim=-1))], dim=-1).unsqueeze(unsqueeze_dim)
     # convert to meta-style interleaved format:
     cos, sin = convert_rope_style_hf_to_meta(cos, sin)
+    logger.info(f"rope_deltas: {rope_deltas}")
     # we have precomputed embeddings for the entire sequence length and converted to 1D so we no longer need to track rope_deltas
-    return cos, sin
+    return cos, sin, rope_deltas
 
 
 def check_tensor(ttnn_tensor, name, mesh_device):

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -86,6 +86,12 @@ class Generator:
             self.model.rope_setup.sin_matrix_pt[i] = sin[0]
         self.update_cos_sin()
 
+    def update_rope_deltas(self, rope_deltas_list: list):
+        # pad rope_deltas_list to the batch size
+        rope_deltas_list = rope_deltas_list + [0] * (self.model.rope_setup.batch_size - len(rope_deltas_list))
+        # convert to torch tensor
+        self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
+
     def decode_forward_text(
         self,
         tokens,

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -214,7 +214,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             pad_embedding=self.reference_model.model.language_model.embed_tokens(torch.tensor(pad_token_id)),
         )
         # Get user-specific rotary position embeddings
-        cos, sin = multimodal_rope_from_hf(
+        cos, sin, rope_deltas = multimodal_rope_from_hf(
             inputs, input_embeds, self.reference_model, self.model_args, pad_token_id=pad_token_id
         )
         rot_mats = (cos, sin)
@@ -226,13 +226,13 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             kv_cache=kv_cache,
             prompt_lens=decoding_pos,
         )
-        return logits, rot_mats
+        return logits, rope_deltas
 
     def decode_forward(self, *args, **kwargs):
-        rot_mats_list: list = kwargs.pop(
-            "rot_mats_all_users", None
+        rope_deltas_list: list = kwargs.pop(
+            "rope_deltas_all_users", None
         )  # [INFO] update the cos/sin matrices for the current users in the batch
-        if rot_mats_list is not None:
-            super().update_cos_sin_rows(rot_mats_list)
+        if rope_deltas_list is not None:
+            super().update_rope_deltas(rope_deltas_list)
 
         return super().decode_forward_text(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -31,6 +31,7 @@ class RotarySetup(LightweightModule):
         super().__init__()
 
         self.batch_size = batch_size
+        self.rope_deltas = torch.zeros(batch_size, dtype=torch.int32)
         self.head_dim = head_dim
         self.device = device
         self.is_mesh_device = isinstance(device, ttnn._ttnn.multi_device.MeshDevice)
@@ -51,9 +52,6 @@ class RotarySetup(LightweightModule):
             orig_context_len=rope_scaling.original_max_position_embeddings if rope_scaling is not None else None,
             position_ids=torch.arange(max_seq_len),
         )
-        # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]; clone to allocate memory for the expanded tensor
-        self.cos_matrix_pt = self.cos_matrix_pt.expand(self.batch_size, -1, -1, -1).clone()
-        self.sin_matrix_pt = self.sin_matrix_pt.expand(self.batch_size, -1, -1, -1).clone()
         self.setup_cos_sin()
 
         self.batch_grid = (
@@ -154,14 +152,14 @@ class RotarySetup(LightweightModule):
 
         if on_host:  # If tensor is on host, don't pass a mesh mapper if single-device
             rot_idxs = ttnn.as_tensor(
-                position_idxs,
+                position_idxs + self.rope_deltas,
                 dtype=ttnn.uint32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.device) if self.is_mesh_device else None,
             )
         else:  # On device
             rot_idxs = ttnn.as_tensor(
-                position_idxs,
+                position_idxs + self.rope_deltas,
                 dtype=ttnn.uint32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=self.device,
@@ -185,8 +183,8 @@ class RotarySetup(LightweightModule):
         cos, sin = None, None
         for i in range(batch_size):
             pos_i = position_idxs[i : i + 1]
-            cos_i = ttnn.embedding(pos_i, self.cos_matrix[i : i + 1, ...])  # [1, head_dim]
-            sin_i = ttnn.embedding(pos_i, self.sin_matrix[i : i + 1, ...])  # [1, head_dim]
+            cos_i = ttnn.embedding(pos_i, self.cos_matrix)  # [1, head_dim]
+            sin_i = ttnn.embedding(pos_i, self.sin_matrix)  # [1, head_dim]
             cos = cos_i if cos is None else ttnn.concat([cos, cos_i], dim=0)  # towards [batch_size, head_dim]
             sin = sin_i if sin is None else ttnn.concat([sin, sin_i], dim=0)  # towards [batch_size, head_dim]
 
@@ -224,3 +222,6 @@ class RotarySetup(LightweightModule):
         assert self.transformation_mat is not None, "Transformation matrix not initialized"
         assert self.transformation_mat_prefill is not None, "Prefill Transformation matrix not initialized"
         return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}
+
+    def rotary_embed(self, position_idxs):
+        pass

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -190,7 +190,6 @@ class RotarySetup(LightweightModule):
 
         cos = ttnn.to_layout(cos, ttnn.TILE_LAYOUT)
         sin = ttnn.to_layout(sin, ttnn.TILE_LAYOUT)
-        # } todo))
 
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch_size, head_dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch_size, head_dim]

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -222,6 +222,3 @@ class RotarySetup(LightweightModule):
         assert self.transformation_mat is not None, "Transformation matrix not initialized"
         assert self.transformation_mat_prefill is not None, "Prefill Transformation matrix not initialized"
         return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}
-
-    def rotary_embed(self, position_idxs):
-        pass


### PR DESCRIPTION
### Ticket
Related to #30980 

### Problem description
We are facing OOMs on Qwen2.5-VL-72B-Instruct because for each user in the batch, we are allocating cos/sin matrices across the max-model length. This is giving us a tensor of size `(B, 1, max_model_len, head_dim)` which occupies too much DRAM and causes OOMs. It also decreases DRAM throughput during online inferencing because swapping these large cos and sin tensors from host to device is very slow.

### What's changed
Instead of caching the actual sin/cos values for the multimodal RoPE, we instead cache only the RoPE deltas. For text tokens generated during decode, the effective position embedding can be calculated as `actual_pos_idx=pos_idx+rope_delta` and we can simply index into the cos and sin matrices as we do in regular RoPE. So we only store one copy of cos & sin matrices for the entire batch and the rope_deltas which is essentially a list of B integers. Another advantage is that during prefill we must not pad the entire sequence of cos and sin matrices to the entire max_seq_len. Instead we pad it to the max prefill length.

Acompanied vLLM PR: https://github.com/tenstorrent/vllm/pull/228

### Checklist
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
  - https://github.com/tenstorrent/tt-metal/actions/runs/18944205923
- [ ] vLLM nightly
  - https://github.com/tenstorrent/tt-metal/actions/runs/18962415371 