### PR TITLE
[skip ci] upload debians to release

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -240,7 +240,15 @@ jobs:
           echo "=== Verifying files that would be included in the release ==="
           echo ""
           echo "Checking for required files:"
-          for file in VERSION CHANGELOG.txt README.md INSTALLING.md models/docs/MODEL_UPDATES.md tt-metalium.tar.gz; do
+          required_files=(
+            "VERSION"
+            "CHANGELOG.txt"
+            "README.md"
+            "INSTALLING.md"
+            "models/docs/MODEL_UPDATES.md"
+            "tt-metalium.tar.gz"
+          )
+          for file in "${required_files[@]}"; do
             if [ -f "$file" ]; then
               echo "✓ $file ($(du -h "$file" | cut -f1))"
             else
@@ -252,13 +260,13 @@ jobs:
           if [ -d "debian-packages" ]; then
             deb_count=$(find debian-packages -name "*.deb" | wc -l)
             echo "Found $deb_count Debian package(s):"
-            find debian-packages -name "*.deb" -exec echo "  ✓ {} ($(du -h {} | cut -f1))" \;
+            find debian-packages -name "*.deb" -exec bash -c 'for f in "$@"; do size=$(du -h "$f" | cut -f1); echo "  ✓ $f ($size)"; done' _ {} +
           else
             echo "✗ debian-packages directory not found"
           fi
           echo ""
           echo "=== All files that would be uploaded to release ==="
-          ls -lh VERSION CHANGELOG.txt README.md INSTALLING.md models/docs/MODEL_UPDATES.md tt-metalium.tar.gz debian-packages/*.deb 2>/dev/null || echo "Some files are missing!"
+          ls -lh "${required_files[@]}" debian-packages/*.deb 2>/dev/null || echo "Some files are missing!"
       - name: Release (skipped for dry run)
         if: ${{ !inputs.dry-run }}
         uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -204,7 +204,7 @@ jobs:
 
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [create-tag, create-release-notes]
+    needs: [create-tag, create-release-notes, build-test-publish]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
@@ -228,6 +228,37 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
           name: changelog
+      - name: Download Debian packages (all Ubuntu versions)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          pattern: packages-*
+          path: debian-packages
+          merge-multiple: true
+      - name: Verify files for release (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "=== Verifying files that would be included in the release ==="
+          echo ""
+          echo "Checking for required files:"
+          for file in VERSION CHANGELOG.txt README.md INSTALLING.md models/docs/MODEL_UPDATES.md tt-metalium.tar.gz; do
+            if [ -f "$file" ]; then
+              echo "✓ $file ($(du -h "$file" | cut -f1))"
+            else
+              echo "✗ $file (MISSING)"
+            fi
+          done
+          echo ""
+          echo "Checking for Debian packages:"
+          if [ -d "debian-packages" ]; then
+            deb_count=$(find debian-packages -name "*.deb" | wc -l)
+            echo "Found $deb_count Debian package(s):"
+            find debian-packages -name "*.deb" -exec echo "  ✓ {} ($(du -h {} | cut -f1))" \;
+          else
+            echo "✗ debian-packages directory not found"
+          fi
+          echo ""
+          echo "=== All files that would be uploaded to release ==="
+          ls -lh VERSION CHANGELOG.txt README.md INSTALLING.md models/docs/MODEL_UPDATES.md tt-metalium.tar.gz debian-packages/*.deb 2>/dev/null || echo "Some files are missing!"
       - name: Release (skipped for dry run)
         if: ${{ !inputs.dry-run }}
         uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
@@ -244,6 +275,7 @@ jobs:
             INSTALLING.md
             models/docs/MODEL_UPDATES.md
             tt-metalium.tar.gz
+            debian-packages/*.deb
           fail_on_unmatched_files: true
 
   check-stable-for-new-commits:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31244)

### Problem description
Because we're still having issues with cloudsmith, users currently don't have an easy way to access the debians. 

### What's changed
This PR adds the debians to the release assets page.

### Checklist
- [x] [Package and Release](https://github.com/tenstorrent/tt-metal/actions/workflows/package-and-release.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18887738602