### PR TITLE
Make a CBWriter class for use in the prefetcher

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -257,10 +257,9 @@ FORCE_INLINE void cb_wait_all_pages(uint32_t n) {
     WAYPOINT("TAPD");
 }
 
-
 template <uint32_t my_sem_id, uint8_t noc_idx, uint32_t downstream_noc_xy, uint32_t downstream_sem_id>
 class CBWriter {
-  public:
+public:
     FORCE_INLINE void acquire_pages(uint32_t n) {
         volatile tt_l1_ptr uint32_t* sem_addr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_sem_id));
@@ -295,10 +294,11 @@ class CBWriter {
     }
 
     FORCE_INLINE void release_pages(uint32_t n) {
-        noc_semaphore_inc(get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_sem_id)), n, noc_idx);
+        noc_semaphore_inc(
+            get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_sem_id)), n, noc_idx);
     }
 
-  uint32_t additional_count{0};
+    uint32_t additional_count{0};
 };
 
 template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -257,61 +257,45 @@ FORCE_INLINE void cb_wait_all_pages(uint32_t n) {
     WAYPOINT("TAPD");
 }
 
+
 template <uint32_t sem_id>
-FORCE_INLINE void cb_wait_all_pages(uint32_t n, uint32_t& additional_count) {
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
+class CBWriter {
+  public:
+    void acquire_pages(uint32_t n) {
+        volatile tt_l1_ptr uint32_t* sem_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
 
-    // Downstream component sets the MSB as a terminate bit
-    // Mask that off to avoid a race between the sem count and terminate
-    n &= 0x7fffffff;
+        // Ensure last sem_inc has landed
+        noc_async_atomic_barrier();
 
-    WAYPOINT("TAPW");
-    do {
-        invalidate_l1_cache();
-    } while (((additional_count + *sem_addr) & 0x7fffffff) != n);  // mask off terminate bit
-    WAYPOINT("TAPD");
-}
+        WAYPOINT("DAPW");
+        // Use a wrapping compare here to compare distance
+        // Required for trace which steals downstream credits and may make the value negative
+        uint32_t heartbeat = 0;
+        do {
+            invalidate_l1_cache();
+            IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+        } while (wrap_gt(n, additional_count + *sem_addr));
+        WAYPOINT("DAPD");
+        additional_count -= n;
+    }
+    void wait_all_pages(uint32_t n) {
+        volatile tt_l1_ptr uint32_t* sem_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
 
-template <uint32_t noc_xy, uint32_t sem_id>
-void cb_acquire_pages(uint32_t n) {
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
+        // Downstream component sets the MSB as a terminate bit
+        // Mask that off to avoid a race between the sem count and terminate
+        n &= 0x7fffffff;
 
-    // Ensure last sem_inc has landed
-    noc_async_atomic_barrier();
+        WAYPOINT("TAPW");
+        do {
+            invalidate_l1_cache();
+        } while (((additional_count + *sem_addr) & 0x7fffffff) != n);  // mask off terminate bit
+        WAYPOINT("TAPD");
+    }
 
-    WAYPOINT("DAPW");
-    // Use a wrapping compare here to compare distance
-    // Required for trace which steals downstream credits and may make the value negative
-    uint32_t heartbeat = 0;
-    do {
-        invalidate_l1_cache();
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-    } while (wrap_gt(n, *sem_addr));
-    WAYPOINT("DAPD");
-    noc_semaphore_inc(get_noc_addr_helper(noc_xy, (uint32_t)sem_addr), -n);
-}
-
-template <uint32_t noc_xy, uint32_t sem_id>
-void cb_acquire_pages(uint32_t n, uint32_t& additional_count) {
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
-
-    // Ensure last sem_inc has landed
-    noc_async_atomic_barrier();
-
-    WAYPOINT("DAPW");
-    // Use a wrapping compare here to compare distance
-    // Required for trace which steals downstream credits and may make the value negative
-    uint32_t heartbeat = 0;
-    do {
-        invalidate_l1_cache();
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-    } while (wrap_gt(n, additional_count + *sem_addr));
-    WAYPOINT("DAPD");
-    additional_count -= n;
-}
+  uint32_t additional_count{0};
+};
 
 template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE void cb_release_pages(uint32_t n) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -353,7 +353,7 @@ void process_exec_buf_end_h() {
     cmd_ptr += sizeof(CQDispatchCmd);
 }
 
-CBWriter<my_downstream_cb_sem_id> dispatch_h_cb_writer{};
+CBWriter<my_downstream_cb_sem_id, 0, 0, 0> dispatch_h_cb_writer{};
 
 // Relay, potentially through the mux/dmux/tunneller path
 // Code below sends 1 page worth of data except at the end of a cmd

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -353,6 +353,8 @@ void process_exec_buf_end_h() {
     cmd_ptr += sizeof(CQDispatchCmd);
 }
 
+CBWriter<my_downstream_cb_sem_id> dispatch_h_cb_writer{};
+
 // Relay, potentially through the mux/dmux/tunneller path
 // Code below sends 1 page worth of data except at the end of a cmd
 // This means the downstream buffers are always page aligned, simplifies wrap handling
@@ -380,7 +382,7 @@ void relay_to_next_cb(
         while (length > 0) {
             ASSERT(downstream_cb_end > downstream_cb_data_ptr);
 
-            cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(1);
+            dispatch_h_cb_writer.acquire_pages(1);
 
             uint32_t xfer_size;
             bool not_end_of_cmd;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -200,7 +200,8 @@ struct DispatchSRelayInlineState {
     static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
     static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_REG_CMD_BUF;
     static constexpr uint32_t downstream_noc_index = my_noc_index;
-    static inline CBWriter<my_dispatch_s_cb_sem_id, my_noc_index, dispatch_s_noc_xy, downstream_dispatch_s_cb_sem_id> cb_writer{};
+    static inline CBWriter<my_dispatch_s_cb_sem_id, my_noc_index, dispatch_s_noc_xy, downstream_dispatch_s_cb_sem_id>
+        cb_writer{};
 };
 
 struct PrefetchExecBufState {
@@ -1084,7 +1085,9 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     // DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
     uint32_t npages =
         (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
-    static_assert(&RelayInlineState::cb_writer.additional_count ==  &DispatchRelayInlineState::cb_writer.additional_count || &RelayInlineState::cb_writer.additional_count ==  &DispatchSRelayInlineState::cb_writer.additional_count); 
+    static_assert(
+        &RelayInlineState::cb_writer.additional_count == &DispatchRelayInlineState::cb_writer.additional_count ||
+        &RelayInlineState::cb_writer.additional_count == &DispatchSRelayInlineState::cb_writer.additional_count);
 
     // Assume the downstream buffer is big relative to cmddat command size that we can
     // grab what we need in one chunk

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1085,6 +1085,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     // DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
     uint32_t npages =
         (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
+    static_assert(&RelayInlineState::cb_writer.additional_count ==  &DispatchRelayInlineState::cb_writer.additional_count || &RelayInlineState::cb_writer.additional_count ==  &DispatchSRelayInlineState::cb_writer.additional_count); 
 
     // Assume the downstream buffer is big relative to cmddat command size that we can
     // grab what we need in one chunk


### PR DESCRIPTION
### Ticket
#31354

### Problem description
Currently we have  multiple variants of cb_acquire_pages, and it's confusing to know which to use at any specific point. Every use also has to pass in the exact same set of arguments, which is easy to mess up.

### What's changed
Add A CBWriter class. The variants of cb_wait_all_pages, cb_acquire_pages, and cb_release_pages used from the prefetcher when writing to the dispatcher are added to this class, and additional_count is added so we don't need to have separate my_downstream_cb_sem_additional_count and my_dispatch_s_cb_sem_additional_count variables that are always passed in.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes