### PR TITLE
Allow Galaxy Performance Jobs to be run on a per-model basis

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -12,6 +12,10 @@ on:
       docker-image:
         required: true
         type: string
+      model:
+        required: false
+        type: string
+        default: "all"
       extra-tag:
         required: false
         type: string
@@ -30,6 +34,7 @@ jobs:
           {
             name: "Galaxy CNN model perf tests",
             model-type: "CNN",
+            model-name: "cnn",
             arch: wormhole_b0,
             save-perf-data: false,
             timeout: 60,
@@ -38,6 +43,7 @@ jobs:
           {
             name: "Galaxy Llama 70B model perf tests", #see GH issue #26295
             model-type: "Llama-70B",
+            model-name: "llama70b",
             arch: wormhole_b0,
             save-perf-data: true,
             timeout: 60,
@@ -46,6 +52,8 @@ jobs:
           },
           {
             name: "Llama Galaxy Perf Unit Tests",
+            model-type: "Llama-Unit-Tests",
+            model-name: "llama_unit_tests",
             arch: wormhole_b0,
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests',
             timeout: 100,
@@ -55,7 +63,8 @@ jobs:
           },
           {
             name: "Galaxy Llama 70B prefill perf tests",
-            model-type: "Llama-70B",
+            model-type: "Llama-70B-Prefill",
+            model-name: "llama70b_prefill",
             arch: wormhole_b0,
             save-perf-data: true,
             timeout: 60,
@@ -65,6 +74,7 @@ jobs:
           {
             name: "Galaxy DiT SD3.5 model perf tests",
             model-type: "SD3.5",
+            model-name: "sd35",
             arch: wormhole_b0,
             save-perf-data: true,
             timeout: 60,
@@ -84,6 +94,7 @@ jobs:
             name: "Galaxy Sentence Bert tests",
             arch: wormhole_b0,
             model-type: "sentence_bert",
+            model-name: "sentence_bert",
             save-perf-data: false,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_sentence_bert_model_perf_tg_device --dispatch-mode ""',
             timeout: 30,
@@ -133,6 +144,7 @@ jobs:
           name: ${{ inputs.wheel-artifact-name || 'wheel artifact not specified' }}
       - name: Run model perf regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
+        if: ${{ inputs.model == 'all' || inputs.model == matrix.test-group.model-name }}
         uses: ./.github/actions/docker-run
         env:
           LOGURU_LEVEL: INFO

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -2,6 +2,20 @@ name: "(Galaxy) model perf tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      model:
+        description: 'Select model to test'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - cnn
+          - llama70b
+          - llama_unit_tests
+          - llama70b_prefill
+          - sd35
+          - sentence_bert
   schedule:
     - cron: "0 10 * * *"  # Every day at 10:00 UTC
 
@@ -24,4 +38,5 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      model: ${{ inputs.model || 'all' }}
       topology: topology-6u


### PR DESCRIPTION
### Ticket
#31326 

### Problem description

Free model developers to execute performance workflows for a specific model therefore reducing the machine time.

### What's changed

- Model input was added (as well as `all` option) on the workflow.
- Create a filter on model step to only execute the test step if the model input matches the model name in the matrix

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes