### PR TITLE
Fix row-major layernorm/rmsnorm kernel paths (fix CI issues)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
@@ -1,0 +1,443 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.common.utility_functions import is_blackhole
+from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH
+
+
+def generate_input_tensor(h, w, type, dtype):
+    """
+    Generate various torch tensors
+    Returns:
+        A torch tensor of shape (h, w) of the given type and dtype.
+    """
+    if type == "random":
+        return torch.rand((h, w), dtype=dtype)
+    elif type == "random_normal":
+        return torch.randn((h, w), dtype=dtype)
+    elif type == "ascending_values_repeated_rows":
+        return torch.arange(w).repeat(h, 1).to(dtype)
+    elif type == "monotonically_ascending_values":
+        return torch.arange(h * w).reshape(h, w).to(dtype)
+    else:
+        raise ValueError(f"Invalid tensor type: {type}")
+
+
+def create_shard_spec(shard_height, shard_width, num_cores_h, num_cores_w):
+    """
+    Create a shard spec for a given height, width, number of cores, and number of cores per row.
+    Args:
+        shard_height: The height of the shard.
+        shard_width: The width of the shard.
+        num_cores_h: The number of cores in y
+        num_cores_w: The number of cores in x.
+    Returns:
+        Shard spec corresponding to given input shapes
+    """
+    return ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(num_cores_w - 1, num_cores_h - 1),
+                )
+            }
+        ),
+        [shard_height, shard_width],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+
+def create_single_stage_shard_spec(h, w, num_cores_h, num_cores_w):
+    """
+    Create a shard spec that will trigger the single-stage reduction
+    algorithm
+    Args:
+        h: The height of the input tensor.
+        w: The width of the input tensor.
+        num_cores_h: The number of cores in y.
+        num_cores_w: The number of cores in x.
+    Returns:
+        Shard spec corresponding to given input shapes
+    """
+    shard_height = h // num_cores_h
+    shard_width = w // num_cores_w
+    return create_shard_spec(shard_height, shard_width, num_cores_h, num_cores_w)
+
+
+def create_two_stage_shard_spec(h, w, num_cores_h, num_cores_w):
+    """
+    Create a shard spec that will trigger the two-stage reduction
+    algorithm
+    Args:
+        h: The height of the input tensor.
+        w: The width of the input tensor.
+        num_cores_h: The number of cores in y.
+        num_cores_w: The number of cores in x.
+    Returns:
+        Shard spec corresponding to given input shapes
+    """
+    shard_height = h
+    shard_width = w // (num_cores_w * num_cores_h)
+    return create_shard_spec(shard_height, shard_width, num_cores_h, num_cores_w)
+
+
+def create_sharded_mem_config(h, w, num_cores_h, num_cores_w, two_stage):
+    """
+    Create a sharded memory config for a given height, width, number of cores, and number of cores per row..
+    Sets up the config to trigger the single-stage or two-stage reduction algorithm based
+    on the input flag
+    Args:
+        h: The height of the input tensor.
+        w: The width of the input tensor.
+        num_cores_h: The number of cores in y.
+        num_cores_w: The number of cores in x.
+        two_stage: Whether to use the two-stage reduction algorithm.
+    Returns:
+        Sharded memory config corresponding to given input shapes
+    """
+    mem_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED if two_stage else ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    if two_stage:
+        shard_spec = create_two_stage_shard_spec(h, w, num_cores_h, num_cores_w)
+    else:
+        shard_spec = create_single_stage_shard_spec(h, w, num_cores_h, num_cores_w)
+    return ttnn.MemoryConfig(memory_layout=mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec)
+
+
+def ttnn_layer_norm_sharded(
+    device, tt_input_tensor, use_welford, block_ht, block_wt, subblock_w=1, residual=None, weight=None, bias=None
+):
+    """
+    Run layer norm sharded on a TTNN tensor.
+    Args:
+        device: The device to run the layer norm on.
+        tt_input_tensor: The TTNN tensor to run the layer norm on.
+        use_welford: Whether to use Welford's algorithm.
+        block_ht: The height of the block in tiles.
+        block_wt: The width of the block in tiles.
+        subblock_w: The width of the subblock in tiles.
+        residual: The residual tensor to add to the input tensor.
+        weight: The weight tensor to use for the layer norm.
+        bias: The bias tensor to use for the layer norm.
+    Returns:
+        The output tensor as a torch tensor.
+    """
+    # Create output memory config (same sharding as input)
+    output_memory_config = ttnn.get_memory_config(tt_input_tensor)
+
+    # Run layernorm
+    output_ttnn = ttnn.layer_norm(
+        tt_input_tensor,
+        residual_input_tensor=residual,
+        weight=weight,
+        bias=bias,
+        memory_config=output_memory_config,
+        program_config=ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            block_h=block_ht,
+            block_w=block_wt,
+            subblock_w=subblock_w,
+            use_welford=use_welford,
+            inplace=False,
+        ),
+    )
+
+    output_ttnn = ttnn.to_layout(output_ttnn, ttnn.ROW_MAJOR_LAYOUT)
+    output_ttnn = ttnn.from_device(output_ttnn)
+    return ttnn.to_torch(output_ttnn)
+
+
+def ttnn_rms_norm_sharded(device, tt_input_tensor, block_ht, block_wt, subblock_w=1, residual=None, weight=None):
+    """
+    Run rms norm sharded on a TTNN tensor.
+    Args:
+        device: The device to run the rms norm on.
+        tt_input_tensor: The TTNN tensor to run the rms norm on.
+        block_ht: The height of the block in tiles.
+        block_wt: The width of the block in tiles.
+        subblock_w: The width of the subblock in tiles.
+        residual: The residual tensor to add to the input tensor.
+        weight: The weight tensor to use for the rms norm.
+    Returns:
+        The output tensor as a torch tensor.
+    """
+    # Create output memory config (same sharding as input)
+    output_memory_config = ttnn.get_memory_config(tt_input_tensor)
+
+    # Run rms norm
+    output_ttnn = ttnn.rms_norm(
+        tt_input_tensor,
+        residual_input_tensor=residual,
+        weight=weight,
+        memory_config=output_memory_config,
+        program_config=ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            block_h=block_ht,
+            block_w=block_wt,
+            subblock_w=subblock_w,
+            use_welford=False,
+            inplace=False,
+        ),
+    )
+
+    output_ttnn = ttnn.to_layout(output_ttnn, ttnn.ROW_MAJOR_LAYOUT)
+    output_ttnn = ttnn.from_device(output_ttnn)
+    return ttnn.to_torch(output_ttnn)
+
+
+def torch_layer_norm(torch_input_tensor, residual=None, weight=None, bias=None):
+    """
+    Run layer norm in torch
+    Args:
+        torch_input_tensor: The input tensor to run the layer norm on.
+        residual: The residual tensor to add to the input tensor.
+        weight: The weight tensor to use for the layer norm.
+        bias: The bias tensor to use for the layer norm.
+    Returns:
+        The output tensor as a torch tensor.
+    """
+    if residual is not None:
+        torch_input_tensor += residual
+    return torch.nn.functional.layer_norm(
+        torch_input_tensor, normalized_shape=[torch_input_tensor.shape[1]], weight=weight, bias=bias
+    )
+
+
+def rms_norm_golden(input_tensor, weight):
+    """
+    Compute golden RMS output for an input tensor and weight tensor.
+    Args:
+        input_tensor: The input tensor to run the rms norm on.
+        weight: The weight tensor to use for the rms norm.
+    Returns:
+        The output tensor as a torch tensor.
+    """
+    golden_function = ttnn.get_golden_function(ttnn.rms_norm)
+    return golden_function(input_tensor, weight)
+
+
+def simple_size_params(two_stage):
+    """
+    Generate a valid single set of shape inputs for either
+    the single-stage or two-stage reduction algorithm
+    """
+    h = 32 * 8
+    w = 32 * 10
+    num_cores_h = 2
+    num_cores_w = 5
+    if two_stage:
+        block_ht = 8
+        block_wt = 1
+        subblock_wt = 1
+    else:
+        block_ht = 4
+        block_wt = 2
+        subblock_wt = 1
+
+    return h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt
+
+
+def single_stage_param_sets():
+    """
+    Generate valid single-stage reduction tensor,block and shard shapes
+    for input h,w
+    Returns:
+        List[Tuple] of (h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt) sets
+    """
+    hs = [32 * 2, 32 * 8]
+    ws = [32 * 2, 32 * 16]
+    num_cores_hs = [4, 8]
+    num_cores_ws = [4, 8]
+    block_ht_mults = [1, 2, 4, 8]
+    block_wt_mults = [1, 2, 4, 8]
+    possible_subblock_wts = [1, 2]
+    param_sets = []
+    for h in hs:
+        for w in ws:
+            for num_cores_h in num_cores_hs:
+                for num_cores_w in num_cores_ws:
+                    h_per_core = h // num_cores_h
+                    w_per_core = w // num_cores_w
+                    ht_per_core = h_per_core // TILE_HEIGHT
+                    wt_per_core = w_per_core // TILE_WIDTH
+                    possible_block_hts = [
+                        v for v in [h_per_core // (TILE_HEIGHT * m) for m in block_ht_mults] if v >= 1
+                    ]
+                    possible_block_wts = [v for v in [w_per_core // (TILE_WIDTH * m) for m in block_wt_mults] if v >= 1]
+                    for block_ht in possible_block_hts:
+                        for block_wt in possible_block_wts:
+                            for subblock_wt in possible_subblock_wts:
+                                block_ht_valid = block_ht >= 1 and block_ht == ht_per_core
+                                block_wt_valid = block_wt >= 1 and block_wt == wt_per_core
+                                subblock_wt_valid = subblock_wt >= 1 and subblock_wt <= block_wt
+                                if block_ht_valid and block_wt_valid and subblock_wt_valid:
+                                    param_sets.append((h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt))
+    return param_sets
+
+
+def do_test_main(
+    device,
+    h,
+    w,
+    num_cores_h,
+    num_cores_w,
+    block_ht,
+    block_wt,
+    subblock_wt,
+    use_welford,
+    two_stage,
+    tensor_type,
+    dtype,
+    residual=None,
+    weight=None,
+    bias=None,
+    weight_bias_layout=ttnn.TILE_LAYOUT,
+    op_name="layer_norm",
+):
+    """
+    Helper function to run the layer norm or rms norm tests.
+    Runs the ttnn op and compares to a reference tensor (torch or golden).
+    Asserts PCC agreement
+    """
+
+    if op_name not in ["layer_norm", "rms_norm"]:
+        raise ValueError(f"Invalid operation name: {op_name}")
+
+    torch.manual_seed(12345)
+
+    # Run torch layernorm to get the reference tensor
+    torch_input_tensor = generate_input_tensor(h, w, tensor_type, dtype)
+    if op_name == "layer_norm":
+        ref_output_tensor = torch_layer_norm(torch_input_tensor, residual=residual, weight=weight, bias=bias)
+    elif op_name == "rms_norm":
+        ref_output_tensor = rms_norm_golden(torch_input_tensor, weight)
+
+    # Generate the tt tensor based on the inputs
+    sharded_mem_config = create_sharded_mem_config(h, w, num_cores_h, num_cores_w, two_stage)
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.Layout.TILE,
+        device=device,
+        memory_config=sharded_mem_config,
+    )
+
+    if residual is not None:
+        residual = ttnn.from_torch(residual, layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded_mem_config)
+    if weight is not None:
+        weight = ttnn.from_torch(weight, layout=weight_bias_layout, device=device)
+    if bias is not None:
+        bias = ttnn.from_torch(bias, layout=weight_bias_layout, device=device)
+
+    # Run the ttnn op
+    if op_name == "layer_norm":
+        output_ttnn = ttnn_layer_norm_sharded(
+            device,
+            tt_input_tensor,
+            use_welford,
+            block_ht,
+            block_wt,
+            subblock_wt,
+            residual=residual,
+            weight=weight,
+            bias=bias,
+        )
+    elif op_name == "rms_norm":
+        output_ttnn = ttnn_rms_norm_sharded(
+            device,
+            tt_input_tensor,
+            block_ht,
+            block_wt,
+            subblock_wt,
+            residual=residual,
+            weight=weight,
+        )
+
+    # Check PCC
+    assert_with_pcc(ref_output_tensor, output_ttnn, 0.9998)
+
+
+def layernorm_test_main(
+    device,
+    h,
+    w,
+    num_cores_h,
+    num_cores_w,
+    block_ht,
+    block_wt,
+    subblock_wt,
+    use_welford,
+    two_stage,
+    tensor_type,
+    dtype,
+    residual=None,
+    weight=None,
+    bias=None,
+    weight_bias_layout=ttnn.TILE_LAYOUT,
+):
+    """
+    Run the layer norm test for inputs
+    """
+    do_test_main(
+        device,
+        h,
+        w,
+        num_cores_h,
+        num_cores_w,
+        block_ht,
+        block_wt,
+        subblock_wt,
+        use_welford,
+        two_stage,
+        tensor_type,
+        dtype,
+        residual=residual,
+        weight=weight,
+        bias=bias,
+        weight_bias_layout=weight_bias_layout,
+        op_name="layer_norm",
+    )
+
+
+def rms_norm_test_main(
+    device,
+    h,
+    w,
+    num_cores_h,
+    num_cores_w,
+    block_ht,
+    block_wt,
+    subblock_wt,
+    two_stage,
+    tensor_type,
+    dtype,
+    residual=None,
+    weight=None,
+    weight_layout=ttnn.TILE_LAYOUT,
+):
+    """
+    Run the rms norm test for inputs
+    """
+    do_test_main(
+        device,
+        h,
+        w,
+        num_cores_h,
+        num_cores_w,
+        block_ht,
+        block_wt,
+        subblock_wt,
+        False,  # use_welford
+        two_stage,
+        tensor_type,
+        dtype,
+        residual=residual,
+        weight=weight,
+        bias=None,
+        weight_bias_layout=weight_layout,
+        op_name="rms_norm",
+    )

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -67,6 +67,34 @@ def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
 
 
 @pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [32])
+@pytest.mark.parametrize("use_welford", [True, False])
+@skip_welford_blackhole("'use_welford'")
+def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_weight = torch.rand((w,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((w,), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.nn.functional.layer_norm(
+        torch_input_tensor, normalized_shape=[w], weight=torch_weight, bias=torch_bias
+    )
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    weight = ttnn.from_torch(torch_weight, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch_bias, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
+    output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9998)
+
+
+@pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("use_welford", [True, False])
 @skip_welford_blackhole("'use_welford'")

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -12,9 +12,10 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
-@pytest.mark.parametrize("h", [32, 224, 384, 2048])
-@pytest.mark.parametrize("w", [64, 160, 1024, 2048])
-def test_rms_norm(device, batch_size, h, w):
+@pytest.mark.parametrize("h", [32, 384])
+@pytest.mark.parametrize("w", [64, 1024])
+@pytest.mark.parametrize("weight_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_rms_norm(device, batch_size, h, w, weight_layout):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((batch_size, h, w), dtype=torch.bfloat16)
@@ -23,7 +24,27 @@ def test_rms_norm(device, batch_size, h, w):
     torch_output_tensor = golden_function(torch_input_tensor, torch_weight)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
-    weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.TILE_LAYOUT)
+    weight = ttnn.from_torch(torch_weight, device=device, layout=weight_layout)
+    output_tensor = ttnn.rms_norm(input_tensor, weight=weight)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9998)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("h", [32, 384])
+@pytest.mark.parametrize("w", [32])
+def test_rms_norm_row_major(device, batch_size, h, w):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((batch_size, h, w), dtype=torch.bfloat16)
+    torch_weight = torch.rand((w,), dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.rms_norm)
+    torch_output_tensor = golden_function(torch_input_tensor, torch_weight)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
+    weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.rms_norm(input_tensor, weight=weight)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("h", [32, 384])
 @pytest.mark.parametrize("w", [64, 1024])
-@pytest.mark.parametrize("weight_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_rms_norm(device, batch_size, h, w, weight_layout):
+def test_rms_norm(device, batch_size, h, w):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((batch_size, h, w), dtype=torch.bfloat16)
@@ -24,7 +23,7 @@ def test_rms_norm(device, batch_size, h, w, weight_layout):
     torch_output_tensor = golden_function(torch_input_tensor, torch_weight)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
-    weight = ttnn.from_torch(torch_weight, device=device, layout=weight_layout)
+    weight = ttnn.from_torch(torch_weight, device=device, layout=ttnn.TILE_LAYOUT)
     output_tensor = ttnn.rms_norm(input_tensor, weight=weight)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
@@ -33,7 +32,7 @@ def test_rms_norm(device, batch_size, h, w, weight_layout):
 
 
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("h", [32, 384])
+@pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [32])
 def test_rms_norm_row_major(device, batch_size, h, w):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
@@ -10,24 +10,16 @@ import tests.ttnn.unit_tests.operations.fused.sharded_test_utils as stu
 from models.common.utility_functions import is_blackhole
 
 
-def skip_welford_blackhole(use_welford):
-    return pytest.mark.skipif(
-        use_welford and is_blackhole(), reason="Welford's algorithm is not supported on Blackhole"
-    )
-
-
 @pytest.mark.parametrize(
     "h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt", stu.single_stage_param_sets()
 )
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_single_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, use_welford, two_stage, tensor_type, dtype
+def test_rms_norm_sharded_single_stage(
+    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
 ):
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -36,7 +28,6 @@ def test_layer_norm_sharded_single_stage(
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
@@ -47,15 +38,13 @@ def test_layer_norm_sharded_single_stage(
     "h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt",
     [(32 * 2, 32 * 4, 2, 2, 2, 1, 1), (32 * 4, 32 * 8, 4, 2, 4, 1, 1), (32 * 8, 32 * 16, 2, 4, 8, 2, 1)],
 )
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [True])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_two_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, use_welford, two_stage, tensor_type, dtype
+def test_rms_norm_sharded_two_stage(
+    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
 ):
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -64,26 +53,23 @@ def test_layer_norm_sharded_two_stage(
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
     )
 
 
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_residual(device, two_stage, tensor_type, dtype):
     if tensor_type == "random" or tensor_type == "random_normal":
         pytest.skip("Low PCC, see #30455")
 
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = stu.simple_size_params(two_stage)
 
     residual = stu.generate_input_tensor(h, w, "random_normal", dtype)
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -92,27 +78,22 @@ def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
         residual=residual,
         weight=None,
-        bias=None,
     )
 
 
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias(device, two_stage, tensor_type, dtype):
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = stu.simple_size_params(two_stage)
 
     weight = stu.generate_input_tensor(1, w, "random", dtype)
-    bias = stu.generate_input_tensor(1, w, "random_normal", dtype)
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -121,28 +102,23 @@ def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage,
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
         residual=None,
         weight=weight[0],
-        bias=bias[0],
     )
 
 
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias_row_major(device, two_stage, tensor_type, dtype):
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = 64, 32, 2, 1, 1, 1, 1
     # h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = stu.simple_size_params(two_stage)
 
     weight = stu.generate_input_tensor(1, w, "random", dtype)
-    bias = stu.generate_input_tensor(1, w, "random_normal", dtype)
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -151,23 +127,19 @@ def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, 
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
         residual=None,
         weight=weight[0],
-        bias=bias[0],
-        weight_bias_layout=ttnn.ROW_MAJOR_LAYOUT,
+        weight_layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
 
-@pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welford, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias_and_residual(device, two_stage, tensor_type, dtype):
     if tensor_type == "random" or tensor_type == "random_normal":
         pytest.skip("Low PCC, see #30455")
 
@@ -175,8 +147,7 @@ def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welfor
 
     residual = stu.generate_input_tensor(h, w, "random_normal", dtype)
     weight = stu.generate_input_tensor(1, w, "random", dtype)
-    bias = stu.generate_input_tensor(1, w, "random_normal", dtype)
-    stu.layernorm_test_main(
+    stu.rms_norm_test_main(
         device,
         h,
         w,
@@ -185,19 +156,16 @@ def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welfor
         block_ht,
         block_wt,
         subblock_wt,
-        use_welford,
         two_stage,
         tensor_type,
         dtype,
         residual=residual,
         weight=weight[0],
-        bias=bias[0],
     )
 
 
-@pytest.mark.parametrize("use_welford", [True])
-@skip_welford_blackhole("'use_welford'")
-def test_layer_norm_sharded_padded(device, use_welford):
+@pytest.mark.parametrize("h,w", [(32, 256)])
+def test_rms_norm_sharded_padded(device, h, w):
     """
     Test layer norm on a sharded tensor that is padded with zeros
     in the width dimension.
@@ -207,10 +175,11 @@ def test_layer_norm_sharded_padded(device, use_welford):
     """
     torch.manual_seed(0)
 
-    h, w = 32, 256
+    dtype = torch.bfloat16
+
     num_cores_h, num_cores_w = 1, 8
     non_zero_columns = 3
-    torch_input_tensor = torch.zeros((h, w), dtype=torch.bfloat16)
+    torch_input_tensor = torch.zeros((h, w), dtype=dtype)
     torch_input_tensor[:, :non_zero_columns] = 1.0
 
     # Create sharded memory config for 2x8 core grid
@@ -243,20 +212,18 @@ def test_layer_norm_sharded_padded(device, use_welford):
     )
 
     # Run sharded layer norm
-    output_ttnn = stu.ttnn_layer_norm_sharded(
+    output_ttnn = stu.ttnn_rms_norm_sharded(
         device,
         tt_input_tensor,
-        use_welford,
         block_ht=1,
         block_wt=1,
         subblock_w=1,
         residual=None,
         weight=None,
-        bias=None,
     )
+    output_ttnn = output_ttnn.to(dtype)
 
-    golden = ttnn.get_golden_function(ttnn.layer_norm)
-    golden_output = golden(torch_input_tensor, weight=None, bias=None, eps=1e-12)
+    golden_output = stu.rms_norm_golden(torch_input_tensor, weight=None).to(dtype)
 
     # Assert that the output is close to the golden output
     rtol = 1.6e-2

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -130,7 +130,6 @@ void MAIN {
     // ---------------------------------------------------------------------------
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
     constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
     constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_beta = tt::CBIndex::c_6;
     constexpr uint32_t cb_x = tt::CBIndex::c_24;          // x minus mean

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -26,7 +26,8 @@ void kernel_main() {
     const DataFormat src0_data_format = get_dataformat(cb_id_in0);
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);  // needed for correctness of softmax/LN kernels
-    constexpr auto src0_args = TensorAccessorArgs<1>();
+    constexpr bool use_welford = get_compile_time_arg_val(1) == 1;
+    constexpr auto src0_args = TensorAccessorArgs<2>();
     constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
     constexpr auto gamma_args = TensorAccessorArgs<src1_args.next_compile_time_args_offset()>();
     constexpr auto beta_args = TensorAccessorArgs<gamma_args.next_compile_time_args_offset()>();
@@ -48,7 +49,7 @@ void kernel_main() {
 #endif
 
     // Generate constant tiles for layernorm compute
-    {
+    if constexpr (!use_welford) {
         constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         uint32_t scaler = get_arg_val<uint32_t>(4);
         generate_reduce_scaler(cb_in_2, scaler);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -43,20 +43,20 @@ void kernel_main() {
 
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
 
-    if (!use_welford) {
+    if constexpr (!use_welford) {
         constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         const uint32_t scalar_w = get_arg_val<uint32_t>(1);
         generate_reduce_scaler(cb_in_2, scalar_w);
-    }
-    if constexpr (is_all_to_all_worker && !use_welford) {
-        constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
-        const uint32_t scalar_c = get_arg_val<uint32_t>(0);
-        generate_reduce_scaler(cb_in_4, scalar_c);
-    }
-    constexpr uint32_t eps_cb_id = 3;
-    const uint32_t eps = get_arg_val<uint32_t>(2);
-    if (!use_welford) {
+
+        constexpr uint32_t eps_cb_id = 3;
+        const uint32_t eps = get_arg_val<uint32_t>(2);
         generate_bcast_col_scalar(eps_cb_id, eps);
+
+        if constexpr (is_all_to_all_worker) {
+            constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
+            const uint32_t scalar_c = get_arg_val<uint32_t>(0);
+            generate_reduce_scaler(cb_in_4, scalar_c);
+        }
     }
 
     if constexpr (fuse_gamma) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -46,19 +46,21 @@ void kernel_main() {
 
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
 
-    {
+    if constexpr (!use_welford) {
         constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         const uint32_t scalar_w = get_arg_val<uint32_t>(1);
         generate_reduce_scaler(cb_in_2, scalar_w);
+
+        constexpr uint32_t eps_cb_id = 3;
+        const uint32_t eps = get_arg_val<uint32_t>(2);
+        generate_bcast_col_scalar(eps_cb_id, eps);
+
+        if constexpr (is_all_to_all_worker) {
+            constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
+            const uint32_t scalar_c = get_arg_val<uint32_t>(0);
+            generate_reduce_scaler(cb_in_4, scalar_c);
+        }
     }
-    if constexpr (is_all_to_all_worker && !use_welford) {
-        constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
-        const uint32_t scalar_c = get_arg_val<uint32_t>(0);
-        generate_reduce_scaler(cb_in_4, scalar_c);
-    }
-    constexpr uint32_t eps_cb_id = 3;
-    const uint32_t eps = get_arg_val<uint32_t>(2);
-    generate_bcast_col_scalar(eps_cb_id, eps);
 
     if constexpr (fuse_gamma) {
         const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1280,6 +1280,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         block_wt_resharded * out_single_tile_size);  // out_reshard_tensor_stride_w_bytes: how many bytes to skip to get
                                                      // to the next data chunk
     writer_mcast_receiver_compile_time_args.push_back(block_ht);  // height in tiles
+    writer_mcast_receiver_compile_time_args.push_back(use_welford);
 
     // writer kernel
     bool use_row_major_kernel = (gamma.has_value() and gamma.value().layout() == Layout::ROW_MAJOR) or

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -108,10 +108,10 @@ def _golden_function(input_tensor: ttnn.Tensor, weight=None, *, epsilon=1e-12, *
     variance = input_tensor.to(torch.float32).pow(2).mean(-1, keepdim=True)
     input_tensor = input_tensor * torch.rsqrt(variance + epsilon)
 
-    if weight.dtype in [torch.float16, torch.bfloat16]:
+    if weight is not None and weight.dtype in [torch.float16, torch.bfloat16]:
         input_tensor = input_tensor.to(weight.dtype)
 
-    return weight * input_tensor
+    return weight * input_tensor if weight is not None else input_tensor
 
 
 ttnn.attach_golden_function(ttnn.rms_norm, golden_function=_golden_function)


### PR DESCRIPTION
### Problem description
Row-major gamma/beta tensors in layernorm/rmsnorm have their own reader kernels. They were broken with #31133 when the use_welford flag was introduced to the non-large reader kernels.

### What's changed
Added the use_welford flag to the row-major reader kernels and greatly expanded test suite to cover more cases (row-major, sharded RMS).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes