### PR TITLE
[skip ci] #28487: remove todos after investigation completed

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -18,7 +18,6 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize(
     "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
-        # TODO: restore pcc thresholds after #28487 is resolved
         ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.996),
         ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.994),
     ],

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
@@ -20,7 +20,6 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
         ((1, 4096, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
         ((1, 4096, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
         ((1, 1024, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.998),
-        # TODO: restore pcc threshold after #28487 is resolved
         ((1, 1024, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.997),
     ],
 )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -18,7 +18,6 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
     [
         ((1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.998),
-        # TODO: restore pcc threshold after #28487 is resolved
         ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.995),
     ],
 )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -24,7 +24,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
 import matplotlib.pyplot as plt
 from models.common.utility_functions import is_wormhole_b0
 
-# TODO: restore pcc thesholds after #28487 is resolved
 UNET_LOOP_PCC = {"10": 0.862, "50": 0.894}
 
 

--- a/models/experimental/stable_diffusion_xl_refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -17,7 +17,6 @@ from models.experimental.stable_diffusion_xl_refiner.tests.test_common import SD
 @pytest.mark.parametrize(
     "input_shape, temb_shape, encoder_shape, down_block_id, pcc",
     [
-        # TODO: restore pcc thresholds after #28487 is resolved
         ((1, 384, 64, 64), (1, 1536), (1, 77, 1280), 1, 0.997),
         ((1, 768, 32, 32), (1, 1536), (1, 77, 1280), 2, 0.997),
     ],

--- a/models/experimental/stable_diffusion_xl_refiner/tests/pcc/test_module_tt_transformer2dmodel.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/pcc/test_module_tt_transformer2dmodel.py
@@ -16,7 +16,6 @@ from models.experimental.stable_diffusion_xl_refiner.tests.test_common import SD
 @pytest.mark.parametrize(
     "input_shape, encoder_shape, down_block_id, pcc",
     [
-        # TODO: restore pcc thresholds after #28487 is resolved
         ((1, 768, 64, 64), (1, 77, 1280), 1, 0.998),
         ((1, 1536, 32, 32), (1, 77, 1280), 2, 0.997),
     ],


### PR DESCRIPTION
### Ticket
Link to Github Issue #28487

### Problem description
A fix to reconfig to make layernorm work correctly caused PCC to be slightly lower for SDXL. An investigation found that this is not related to the layernorm op. Given that the PCC changes are small and seeds have a larger impact, it should be ok to adjust the PCCs.

### What's changed
Remove the TODOs and leave the slightly lower PCCs.