### PR TITLE
#31327: Allow T3K Performance Jobs to be run on a per-model basis

### DIFF
--- a/.github/matrices/all-models.json
+++ b/.github/matrices/all-models.json
@@ -1,8 +1,0 @@
-{
-  "include": [
-    {"model": "falcon7b", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/falcon7b_common/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "mamba", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/wormhole/mamba/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "yolov8s", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "yolov8s", "arch": "blackhole", "platform": "P150", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["P150", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""}
-  ]
-}

--- a/.github/matrices/all-models.json
+++ b/.github/matrices/all-models.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    {"model": "falcon7b", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/falcon7b_common/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "mamba", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/wormhole/mamba/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "yolov8s", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "yolov8s", "arch": "blackhole", "platform": "P150", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["P150", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""}
+  ]
+}

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -52,7 +52,6 @@ jobs:
           },
           {
             name: "Llama Galaxy Perf Unit Tests",
-            model-type: "Llama-Unit-Tests",
             model-name: "llama_unit_tests",
             arch: wormhole_b0,
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests',
@@ -63,7 +62,7 @@ jobs:
           },
           {
             name: "Galaxy Llama 70B prefill perf tests",
-            model-type: "Llama-70B-Prefill",
+            model-type: "Llama-70B",
             model-name: "llama70b_prefill",
             arch: wormhole_b0,
             save-perf-data: true,

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -12,6 +12,10 @@ on:
       docker-image:
         required: true
         type: string
+      model:
+        required: false
+        type: string
+        default: "all"
       extra-tag:
         required: false
         type: string
@@ -23,13 +27,13 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k LLM falcon7b model perf tests", model: "falcon7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: U05RWH3QUPM}, # Salar Hosseini
-          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "t3k CNN resnet50 model perf tests", model: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75, owner_id: U0837MYG788}, # Marko Radosavljevic
-          { name: "t3k CNN sentence_bert model perf tests", model: "sentence_bert", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          { name: "t3k DiT SD3.5 model perf tests", model: "stable_diffusion_35_large", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_stable_diffusion_35_large_tests, timeout: 75, owner_id: U03FJB5TM5Y}, # Colman Glagovich
-          { name: "t3k DiT Mochi model perf tests", model: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
-          { name: "t3k DiT Flux.1-dev model perf tests", model: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
+          { name: "t3k LLM falcon7b model perf tests", model-name: "falcon7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          { name: "t3k LLM falcon40b model perf tests", model-name: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: U053W15B6JF}, # Djordje Ivanovic
+          { name: "t3k CNN resnet50 model perf tests", model-name: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75, owner_id: U0837MYG788}, # Marko Radosavljevic
+          { name: "t3k CNN sentence_bert model perf tests", model-name: "sentence_bert", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          { name: "t3k DiT SD3.5 model perf tests", model-name: "stable_diffusion_35_large", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_stable_diffusion_35_large_tests, timeout: 75, owner_id: U03FJB5TM5Y}, # Colman Glagovich
+          { name: "t3k DiT Mochi model perf tests", model-name: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
+          { name: "t3k DiT Flux.1-dev model perf tests", model-name: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -70,6 +74,7 @@ jobs:
           governor: performance
       - name: Run model perf regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
+        if: ${{ inputs.model == 'all' || inputs.model == matrix.test-group.model-name }}
         shell: bash
         run: |
           source /work/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -91,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:
-          name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.model }}-bare-metal
+          name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.model-name }}-bare-metal
           path: "${{ steps.check-perf-report.outputs.perf_report_filename }}"
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -2,6 +2,19 @@ name: "(T3K) T3000 model perf tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      model:
+        description: 'Select model to test'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - falcon7b
+          - falcon40b
+          - resnet50
+          - sentence_bert
+          - stable_diffusion_35_large
   schedule:
     - cron: "0 */12 * * *" # This cron schedule runs the workflow every 12 hours
 
@@ -23,4 +36,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      model: ${{ inputs.model || 'all' }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}


### PR DESCRIPTION
### Ticket

#31327 

### Problem description
Free model developers to execute T3K performance workflows for a specific model therefore reducing the machine time.

### What's changed

Model input was added (as well as `all`option, default) on the workflow.
Create a filter on model step to only execute the test step if the model input matches the model name in the matrix

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes