### PR TITLE
[skip ci] #29578: Re-enable Galaxy CCL tests

### DIFF
--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          #{ name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: U05ACKAJTHS}, # Naif Tarafdar #See issue #29578
+          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29578)
[Link to Github Issue 2](https://github.com/tenstorrent/tt-metal/issues/29848)

### Problem description
Galaxy CCL tests were disabled due to fabric issues.

### What's changed
Fabric issues are resolved, so re-enabling tests.

### Checklist
- [x] [Galaxy nightly](https://github.com/tenstorrent/tt-metal/actions/runs/18919262778)