### PR TITLE
[skip ci] optimizing pipeline status tracker

### DIFF
--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -131,7 +131,7 @@ function getTimeSinceLastSuccess(workflowName) {
 
     const lastSuccessDate = new Date(info.timestamp);
     const now = new Date();
-    const daysSince = Math.round((now - lastSuccessDate) / (1000 * 60 * 60 * 24));
+    const daysSince = Math.floor((now - lastSuccessDate) / (1000 * 60 * 60 * 24));
 
     if (daysSince === 0) return 'Today';
     if (daysSince === 1) return '1 day ago';

--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -131,7 +131,7 @@ function getTimeSinceLastSuccess(workflowName) {
 
     const lastSuccessDate = new Date(info.timestamp);
     const now = new Date();
-    const daysSince = Math.floor((now - lastSuccessDate) / (1000 * 60 * 60 * 24));
+    const daysSince = Math.round((now - lastSuccessDate) / (1000 * 60 * 60 * 24));
 
     if (daysSince === 0) return 'Today';
     if (daysSince === 1) return '1 day ago';

--- a/.github/actions/fetch-workflow-data/action.yml
+++ b/.github/actions/fetch-workflow-data/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: 'Run ID to use for testing (optional)'
     required: false
     default: ''
+  workflow_configs:
+    description: 'JSON array of workflow configurations to filter by (array of objects with wkflw_name or wkflw_prefix)'
+    required: false
 
 outputs:
   total-runs:

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -188,9 +188,9 @@ function pruneOldRuns(grouped, cutoffDate) {
     const removed = beforeCount - filtered.length;
     if (removed > 0) {
       totalRemoved += removed;
-      const oldestRemoved = runs.find(r => new Date(r.created_at) < cutoffDate);
-      if (oldestRemoved) {
-        core.info(`[PRUNE] Workflow '${name}': removed ${removed} runs (oldest removed: ${oldestRemoved.created_at})`);
+      const newestRemoved = runs.find(r => new Date(r.created_at) < cutoffDate);
+      if (newestRemoved) {
+        core.info(`[PRUNE] Workflow '${name}': removed ${removed} runs (newest removed: ${newestRemoved.created_at})`);
       }
     }
     if (filtered.length > 0) {

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -13,7 +13,6 @@ const { execFileSync } = require('child_process');
 const MAX_PAGES = 100; // Maximum number of pages to fetch from GitHub API (tune for rate limits/performance)
 const RUNS_PER_PAGE = 100; // GitHub API max per page
 const DEFAULT_DAYS = 15; // Default rolling window in days
-
 /**
  * Get the cutoff date for filtering runs.
  * @param {number} days - Number of days to look back
@@ -75,7 +74,7 @@ async function fetchAllWorkflowRuns(github, context, days, cachedRunIds = null, 
       // Skip runs older than cutoff date
       if (runDate < cutoffDate) {
         skippedOldRuns++;
-        if (skippedOldRuns <= 5) {
+        if (skippedOldRuns <= MAX_CONSECUTIVE_CACHED) {
           core.info(`[FETCH] Skipping run ${runIdStr} (older than cutoff: ${runDate.toISOString()} < ${cutoffDate.toISOString()})`);
         }
         continue;
@@ -85,7 +84,7 @@ async function fetchAllWorkflowRuns(github, context, days, cachedRunIds = null, 
       if (cachedIds.size > 0 && cachedIds.has(runIdStr)) {
         consecutiveCachedRuns++;
         skippedCachedRuns++;
-        if (consecutiveCachedRuns <= 5) {
+        if (consecutiveCachedRuns <= MAX_CONSECUTIVE_CACHED) {
           core.info(`[FETCH] Skipping cached run ${runIdStr} (consecutive cached: ${consecutiveCachedRuns})`);
         }
         // If we've seen many consecutive cached runs, we've likely reached the boundary

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -26,21 +26,32 @@ function getCutoffDate(days) {
 }
 
 /**
- * Fetch all workflow runs for the repository, paginated, stopping at sinceDate if provided.
+ * Fetch all workflow runs for the repository, paginated, stopping early when cached runs are encountered.
  * @param {object} github - Octokit client
  * @param {object} context - GitHub Actions context
  * @param {number} days - Number of days to look back
  * @param {Date} sinceDate - Only fetch runs after this date
- * @returns {Promise<Array>} Array of workflow run objects
+ * @param {Set<string>} cachedRunIds - Set of run IDs that are already cached (skip these)
+ * @param {string} eventType - Optional event type filter
+ * @returns {Promise<Array>} Array of workflow run objects (only new, non-cached runs)
  */
-async function fetchAllWorkflowRuns(github, context, days, sinceDate, eventType='') {
+async function fetchAllWorkflowRuns(github, context, days, sinceDate, cachedRunIds = null, eventType='') {
   const allRuns = [];
   const cutoffDate = getCutoffDate(days);
   const createdDateFilter = `>=${cutoffDate.toISOString()}`;
+  const cachedIds = cachedRunIds || new Set();
 
-  core.info(`createdDateFilter: ${createdDateFilter}`);
-  core.info(`days ${days}, sinceDate: ${sinceDate}`);
+  core.info(`[FETCH] createdDateFilter: ${createdDateFilter}`);
+  core.info(`[FETCH] days: ${days}, sinceDate: ${sinceDate ? sinceDate.toISOString() : 'none'}, cachedRunIds: ${cachedIds.size}, eventType: ${eventType || 'all'}`);
+
+  let consecutiveCachedRuns = 0;
+  const MAX_CONSECUTIVE_CACHED = 10; // If we see 10 consecutive cached runs, assume we've caught up
+  let skippedOldRuns = 0;
+  let skippedCachedRuns = 0;
+  let addedNewRuns = 0;
+
   for (let page = 1; page <= MAX_PAGES; page++) { // download pages of runs from the GitHub API
+    core.info(`[FETCH] Fetching page ${page}...`);
     const params = {
       owner: context.repo.owner,
       repo: context.repo.repo,
@@ -52,22 +63,68 @@ async function fetchAllWorkflowRuns(github, context, days, sinceDate, eventType=
     }
     const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo(params); // listWorkflowRunsForRepo is a GitHub API call to list the workflow runs for the repository
     if (!runs.workflow_runs.length) {
+      core.info(`[FETCH] No runs on page ${page}, stopping`);
       break;
     }
 
+    core.info(`[FETCH] Page ${page}: processing ${runs.workflow_runs.length} runs`);
+
     for (const run of runs.workflow_runs) {
       const runDate = new Date(run.created_at);
+      const runIdStr = String(run.id);
+
+      // Skip runs older than cutoff date
+      if (runDate < cutoffDate) {
+        skippedOldRuns++;
+        if (skippedOldRuns <= 5) {
+          core.info(`[FETCH] Skipping run ${runIdStr} (older than cutoff: ${runDate.toISOString()} < ${cutoffDate.toISOString()})`);
+        }
+        continue;
+      }
+
+      // If we have cached run IDs, check if this run is already cached
+      if (cachedIds.size > 0 && cachedIds.has(runIdStr)) {
+        consecutiveCachedRuns++;
+        skippedCachedRuns++;
+        if (consecutiveCachedRuns <= 5) {
+          core.info(`[FETCH] Skipping cached run ${runIdStr} (consecutive cached: ${consecutiveCachedRuns})`);
+        }
+        // If we've seen many consecutive cached runs, we've likely reached the boundary
+        // Stop fetching since all remaining runs will be older and likely cached
+        if (consecutiveCachedRuns >= MAX_CONSECUTIVE_CACHED) {
+          core.info(`[FETCH] Early exit: found ${consecutiveCachedRuns} consecutive cached runs, stopping fetch`);
+          core.info(`[FETCH] Summary: added ${addedNewRuns} new runs, skipped ${skippedCachedRuns} cached, ${skippedOldRuns} old`);
+          return allRuns;
+        }
+        continue;
+      }
+
+      // Reset consecutive cached counter when we find a new run
+      if (consecutiveCachedRuns > 0) {
+        core.info(`[FETCH] Found new run after ${consecutiveCachedRuns} cached runs, resetting counter`);
+      }
+      consecutiveCachedRuns = 0;
+
+      // If sinceDate is provided and run is older/equal, stop (all future runs will be older)
       if (sinceDate && runDate <= sinceDate) {
-        core.info(`Early exit: found run at ${runDate} <= latest cached date ${sinceDate}`);
+        core.info(`[FETCH] Early exit: found run at ${runDate.toISOString()} <= latest cached date ${sinceDate.toISOString()}`);
+        core.info(`[FETCH] Summary: added ${addedNewRuns} new runs, skipped ${skippedCachedRuns} cached, ${skippedOldRuns} old`);
         return allRuns;
-      } // if a run is found that's too old, we can early exit cuz all future runs will be even older
-      if (runDate >= cutoffDate) {
-        allRuns.push(run);
+      }
+
+      // This is a new run, add it
+      addedNewRuns++;
+      allRuns.push(run);
+      if (addedNewRuns <= 10) {
+        core.info(`[FETCH] Added new run ${runIdStr} (${run.name}, ${runDate.toISOString()})`);
       }
     }
+
     // If the api call returned no runs, assume we've reached the end and break
     if (!runs.workflow_runs.length) break;
   }
+
+  core.info(`[FETCH] Completed all pages. Summary: added ${addedNewRuns} new runs, skipped ${skippedCachedRuns} cached, ${skippedOldRuns} old`);
   return allRuns;
 }
 
@@ -88,6 +145,120 @@ function groupRunsByName(runs) {
 }
 
 /**
+ * Find the most recent successful run of aggregate-workflow-data workflow on main branch.
+ * @param {object} octokit - Octokit client
+ * @param {object} context - GitHub Actions context
+ * @returns {Promise<number|null>} Run ID or null if not found
+ */
+async function findPreviousAggregateRun(octokit, context) {
+  try {
+    core.info('[CACHE] Searching for previous successful aggregate-workflow-data run...');
+    const workflowId = '.github/workflows/aggregate-workflow-data.yaml';
+    const resp = await octokit.rest.actions.listWorkflowRuns({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      workflow_id: workflowId,
+      branch: 'main',
+      status: 'completed',
+      per_page: 10
+    });
+    const allRuns = resp.data.workflow_runs || [];
+    core.info(`[CACHE] Found ${allRuns.length} completed runs for aggregate-workflow-data`);
+    const runs = allRuns.filter(r => r.conclusion === 'success');
+    core.info(`[CACHE] Found ${runs.length} successful runs`);
+    if (runs.length > 0) {
+      core.info(`[CACHE] Selected previous run ID: ${runs[0].id} (created: ${runs[0].created_at})`);
+      return runs[0].id;
+    }
+    core.info('[CACHE] No previous successful run found');
+    return null;
+  } catch (e) {
+    core.warning(`[CACHE] Failed to find previous aggregate run: ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Prune data older than cutoff date from grouped runs.
+ * @param {Map} grouped - Map of workflow name to array of runs
+ * @param {Date} cutoffDate - Cutoff date
+ * @returns {Map} Pruned grouped runs
+ */
+function pruneOldRuns(grouped, cutoffDate) {
+  const pruned = new Map();
+  for (const [name, runs] of grouped.entries()) {
+    const filtered = runs.filter(run => new Date(run.created_at) >= cutoffDate);
+    if (filtered.length > 0) {
+      pruned.set(name, filtered);
+    }
+  }
+  return pruned;
+}
+
+/**
+ * Prune annotations index to remove entries for runs older than cutoff date.
+ * @param {object} annotationsIndex - Index mapping runId -> directory
+ * @param {Map} grouped - Map of workflow name to array of runs (for date lookup)
+ * @param {Date} cutoffDate - Cutoff date
+ * @returns {object} Pruned annotations index
+ */
+function pruneAnnotationsIndex(annotationsIndex, grouped, cutoffDate) {
+  const pruned = {};
+  const runDates = new Map();
+  // Build map of run IDs to dates
+  for (const runs of grouped.values()) {
+    for (const run of runs) {
+      runDates.set(String(run.id), new Date(run.created_at));
+    }
+  }
+  for (const [runId, dir] of Object.entries(annotationsIndex || {})) {
+    const runDate = runDates.get(runId);
+    if (runDate && runDate >= cutoffDate) {
+      pruned[runId] = dir;
+    }
+  }
+  return pruned;
+}
+
+/**
+ * Prune logs index to remove entries for runs older than cutoff date.
+ * @param {object} logsIndex - Index mapping runId -> directory
+ * @param {Map} grouped - Map of workflow name to array of runs (for date lookup)
+ * @param {Date} cutoffDate - Cutoff date
+ * @returns {object} Pruned logs index
+ */
+function pruneLogsIndex(logsIndex, grouped, cutoffDate) {
+  const pruned = {};
+  const runDates = new Map();
+  // Build map of run IDs to dates
+  for (const runs of grouped.values()) {
+    for (const run of runs) {
+      runDates.set(String(run.id), new Date(run.created_at));
+    }
+  }
+  for (const [runId, dir] of Object.entries(logsIndex || {})) {
+    const runDate = runDates.get(runId);
+    if (runDate && runDate >= cutoffDate) {
+      pruned[runId] = dir;
+    }
+  }
+  return pruned;
+}
+
+/**
+ * Prune commits older than cutoff date.
+ * @param {Array} commits - Array of commit objects
+ * @param {Date} cutoffDate - Cutoff date
+ * @returns {Array} Pruned commits
+ */
+function pruneCommits(commits, cutoffDate) {
+  return (commits || []).filter(c => {
+    const commitDate = c.date ? new Date(c.date) : null;
+    return commitDate && commitDate >= cutoffDate;
+  });
+}
+
+/**
  * Main entrypoint for the action.
  * Loads previous cache, fetches new runs, merges/deduplicates, and saves updated cache.
  */
@@ -99,191 +270,167 @@ async function run() {
     const rawCachePath = core.getInput('cache-path', { required: false });
     const defaultOutputPath = path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'workflow-data.json');
     const outputPath = rawCachePath && rawCachePath.trim() ? rawCachePath : defaultOutputPath;
-    const testRunIdInput = core.getInput('test_run_id') || process.env.TEST_RUN_ID || '';
     // Create authenticated Octokit client
     const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', { required: true }));
-    // Load previous cache if it exists
+    const owner = github.context.repo.owner;
+    const repo = github.context.repo.repo;
+    const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+    const cutoffDate = getCutoffDate(days);
+
+    // Load cached data from previous aggregate run
     let previousRuns = [];
+    let cachedGrouped = new Map();
+    let cachedAnnotationsIndex = {};
+    let cachedGtestLogsIndex = {};
+    let cachedOtherLogsIndex = {};
+    let cachedCommits = [];
+    let cachedLastSuccessTimestamps = {};
     let latestCachedDate = null;
 
-    core.info(`Restored previousRuns count: ${previousRuns.length}`);
-    core.info(`Latest cached run date: ${latestCachedDate}`);
-    // Test mode: download workflow-data.json artifact from a specific run and exit early
-    if (testRunIdInput) {
-      const runId = parseInt(testRunIdInput, 10);
-      if (Number.isNaN(runId)) {
-        throw new Error(`Invalid test_run_id: ${testRunIdInput}`);
-      }
-      core.info(`[TEST MODE] Using workflow-data.json from run_id=${runId}`);
-      const owner = github.context.repo.owner;
-      const repo = github.context.repo.repo;
-      const { data: artifactsResp } = await octokit.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id: runId, per_page: 100 });
-      const artifacts = artifactsResp.artifacts || [];
-      if (artifacts.length === 0) {
-        throw new Error(`No artifacts found for run_id=${runId}`);
-      }
-      // Find an artifact zip that contains workflow-data.json
-      let found = false;
-      const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'wfzip-'));
-      for (const art of artifacts) {
-        try {
-          const resp = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: art.id, archive_format: 'zip' });
-          const zipPath = path.join(tmpDir, `${art.name}.zip`);
-          fs.writeFileSync(zipPath, Buffer.from(resp.data));
-          // Extract artifact to a temp dir and search for workflow JSON file
-          const extractDir = path.join(tmpDir, art.name);
-          if (!fs.existsSync(extractDir)) fs.mkdirSync(extractDir, { recursive: true });
-          // Avoid buffering large stdout/stderr to prevent ENOBUFS
-          execFileSync('unzip', ['-o', zipPath, '-d', extractDir], { stdio: 'ignore' });
-          // Search recursively for workflow JSON
-          const targetNames = new Set(['workflow-data.json', 'workflow.json']);
-          const stack = [extractDir];
-          let foundPath;
-          while (stack.length && !foundPath) {
-            const dir = stack.pop();
-            const entries = fs.readdirSync(dir, { withFileTypes: true });
-            for (const ent of entries) {
-              const p = path.join(dir, ent.name);
-              if (ent.isDirectory()) {
-                stack.push(p);
-              } else if (ent.isFile() && targetNames.has(ent.name)) {
-                foundPath = p;
-                break;
+    // Find and restore artifacts from previous successful run
+    const previousRunId = await findPreviousAggregateRun(octokit, github.context);
+    if (previousRunId) {
+      core.info(`[CACHE] Starting artifact restoration from run ${previousRunId}`);
+      try {
+        const { data: artifactsResp } = await octokit.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id: previousRunId, per_page: 100 });
+        const artifacts = artifactsResp.artifacts || [];
+        core.info(`[CACHE] Found ${artifacts.length} artifacts in previous run`);
+        for (const art of artifacts) {
+          core.info(`[CACHE]   - ${art.name} (${art.size_in_bytes} bytes, expired: ${art.expired})`);
+        }
+        const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'wfzip-'));
+        core.info(`[CACHE] Created temp directory: ${tmpDir}`);
+
+        // Restore workflow-data.json
+        const workflowDataArtifact = artifacts.find(a => a && a.name === 'workflow-data');
+        if (workflowDataArtifact) {
+          try {
+            const resp = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: workflowDataArtifact.id, archive_format: 'zip' });
+            const zipPath = path.join(tmpDir, `${workflowDataArtifact.name}.zip`);
+            fs.writeFileSync(zipPath, Buffer.from(resp.data));
+            const extractDir = path.join(tmpDir, workflowDataArtifact.name);
+            if (!fs.existsSync(extractDir)) fs.mkdirSync(extractDir, { recursive: true });
+            execFileSync('unzip', ['-o', zipPath, '-d', extractDir], { stdio: 'ignore' });
+            const targetNames = new Set(['workflow-data.json', 'workflow.json']);
+            const stack = [extractDir];
+            let foundPath;
+            while (stack.length && !foundPath) {
+              const dir = stack.pop();
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              for (const ent of entries) {
+                const p = path.join(dir, ent.name);
+                if (ent.isDirectory()) stack.push(p);
+                else if (ent.isFile() && targetNames.has(ent.name)) { foundPath = p; break; }
               }
             }
-          }
-          if (foundPath) {
-            const jsonBuf = fs.readFileSync(foundPath);
-            // Ensure output directory exists
-            const outputDir = path.dirname(outputPath);
-            if (!fs.existsSync(outputDir)) {
-              fs.mkdirSync(outputDir, { recursive: true });
-            }
-            fs.writeFileSync(outputPath, jsonBuf);
-            core.info(`[TEST MODE] Wrote ${outputPath} from ${path.basename(foundPath)} in artifact ${art.name}`);
-            // Compute outputs from content
-            let grouped;
-            try {
-              grouped = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-            } catch (e) {
-              throw new Error(`Parsed JSON invalid at ${outputPath}: ${e.message}`);
-            }
-            const workflowCount = Array.isArray(grouped) ? grouped.length : 0;
-            let totalRuns = 0;
-            if (Array.isArray(grouped)) {
-              for (const entry of grouped) {
-                if (Array.isArray(entry) && Array.isArray(entry[1])) {
-                  totalRuns += entry[1].length;
+            if (foundPath) {
+              core.info(`[CACHE] Found workflow-data.json at ${foundPath}`);
+              const groupedArray = JSON.parse(fs.readFileSync(foundPath, 'utf8'));
+              const beforePrune = Array.isArray(groupedArray) ? groupedArray.length : 0;
+              cachedGrouped = new Map(Array.isArray(groupedArray) ? groupedArray : []);
+              core.info(`[CACHE] Loaded ${cachedGrouped.size} workflows from cache (before pruning)`);
+
+              // Count runs before pruning
+              let totalRunsBeforePrune = 0;
+              for (const runs of cachedGrouped.values()) {
+                totalRunsBeforePrune += runs.length;
+              }
+
+              // Prune old runs
+              cachedGrouped = pruneOldRuns(cachedGrouped, cutoffDate);
+
+              // Count runs after pruning
+              let totalRunsAfterPrune = 0;
+              for (const runs of cachedGrouped.values()) {
+                totalRunsAfterPrune += runs.length;
+              }
+
+              core.info(`[CACHE] Pruned ${totalRunsBeforePrune - totalRunsAfterPrune} runs older than ${cutoffDate.toISOString()}`);
+              core.info(`[CACHE] Retained ${totalRunsAfterPrune} runs across ${cachedGrouped.size} workflows`);
+
+              // Extract all run dates to find latest
+              for (const runs of cachedGrouped.values()) {
+                for (const run of runs) {
+                  const runDate = new Date(run.created_at);
+                  if (!latestCachedDate || runDate > latestCachedDate) {
+                    latestCachedDate = runDate;
+                  }
                 }
               }
+              core.info(`[CACHE] Latest cached run date: ${latestCachedDate}`);
+            } else {
+              core.warning(`[CACHE] workflow-data.json not found in artifacts`);
             }
-            core.setOutput('total-runs', totalRuns);
-            core.setOutput('workflow-count', workflowCount);
-            core.setOutput('cache-path', outputPath);
-            found = true;
-            break;
+          } catch (e) {
+            core.warning(`Failed to restore workflow-data: ${e.message}`);
           }
-        } catch (e) {
-          core.warning(`[TEST MODE] Failed processing artifact ${art.name}: ${e.message}`);
         }
-      }
-      if (!found) {
-        throw new Error(`[TEST MODE] Could not find workflow-data.json in any artifacts for run_id=${runId}`);
-      }
-      // Additionally fetch the annotations artifact from the same run, if present
-      try {
-        const owner = github.context.repo.owner;
-        const repo = github.context.repo.repo;
+
+        // Restore annotations
         const annotationsArtifact = artifacts.find(a => a && a.name === 'workflow-annotations');
-        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
         const annotationsRoot = path.join(workspace, 'annotations');
         if (!fs.existsSync(annotationsRoot)) fs.mkdirSync(annotationsRoot, { recursive: true });
         let annotationsIndexPath = path.join(annotationsRoot, 'annotations-index.json');
         if (annotationsArtifact) {
-          const annZipPath = path.join(tmpDir, `${annotationsArtifact.name}.zip`);
-          const respAnn = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: annotationsArtifact.id, archive_format: 'zip' });
-          fs.writeFileSync(annZipPath, Buffer.from(respAnn.data));
-          const extractAnnDir = path.join(tmpDir, `${annotationsArtifact.name}-extract`);
-          if (!fs.existsSync(extractAnnDir)) fs.mkdirSync(extractAnnDir, { recursive: true });
-          execFileSync('unzip', ['-o', annZipPath, '-d', extractAnnDir], { stdio: 'ignore' });
-          // Find the annotations-index.json inside the extracted tree
-          const stack = [extractAnnDir];
-          let foundIndex;
-          while (stack.length && !foundIndex) {
-            const dir = stack.pop();
-            const entries = fs.readdirSync(dir, { withFileTypes: true });
-            for (const ent of entries) {
-              const p = path.join(dir, ent.name);
-              if (ent.isDirectory()) stack.push(p);
-              else if (ent.isFile() && ent.name === 'annotations-index.json') { foundIndex = p; break; }
+          try {
+            const annZipPath = path.join(tmpDir, `${annotationsArtifact.name}.zip`);
+            const respAnn = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: annotationsArtifact.id, archive_format: 'zip' });
+            fs.writeFileSync(annZipPath, Buffer.from(respAnn.data));
+            const extractAnnDir = path.join(tmpDir, `${annotationsArtifact.name}-extract`);
+            if (!fs.existsSync(extractAnnDir)) fs.mkdirSync(extractAnnDir, { recursive: true });
+            execFileSync('unzip', ['-o', annZipPath, '-d', extractAnnDir], { stdio: 'ignore' });
+            const stack = [extractAnnDir];
+            let foundIndex;
+            while (stack.length && !foundIndex) {
+              const dir = stack.pop();
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              for (const ent of entries) {
+                const p = path.join(dir, ent.name);
+                if (ent.isDirectory()) stack.push(p);
+                else if (ent.isFile() && ent.name === 'annotations-index.json') { foundIndex = p; break; }
+              }
             }
-          }
-          if (foundIndex) {
-            const artifactAnnRoot = path.dirname(foundIndex);
-            fs.cpSync(artifactAnnRoot, annotationsRoot, { recursive: true });
-            annotationsIndexPath = path.join(annotationsRoot, 'annotations-index.json');
-            core.info(`[TEST MODE] Restored annotations to ${annotationsRoot}`);
-          } else {
-            core.info('[TEST MODE] No annotations-index.json found; creating empty index');
-            if (!fs.existsSync(annotationsIndexPath)) fs.writeFileSync(annotationsIndexPath, JSON.stringify({}));
-          }
-        } else {
-          core.info('[TEST MODE] No workflow-annotations artifact found in selected run; creating empty index');
-          if (!fs.existsSync(annotationsIndexPath)) fs.writeFileSync(annotationsIndexPath, JSON.stringify({}));
-        }
-        core.setOutput('annotations-root', annotationsRoot);
-        core.setOutput('annotations-index-path', annotationsIndexPath);
-      } catch (e) {
-        core.warning(`[TEST MODE] Failed to restore annotations artifact: ${e.message}`);
-      }
+            if (foundIndex) {
+              core.info(`[CACHE] Found annotations-index.json at ${foundIndex}`);
+              const artifactAnnRoot = path.dirname(foundIndex);
+              fs.cpSync(artifactAnnRoot, annotationsRoot, { recursive: true });
+              annotationsIndexPath = path.join(annotationsRoot, 'annotations-index.json');
+              const beforePrune = JSON.parse(fs.readFileSync(annotationsIndexPath, 'utf8'));
+              const beforePruneCount = Object.keys(beforePrune).length;
+              cachedAnnotationsIndex = beforePrune;
+              core.info(`[CACHE] Loaded ${beforePruneCount} annotation entries (before pruning)`);
 
-      // Additionally fetch the commits artifact from the same run, if present
-      try {
-        const owner = github.context.repo.owner;
-        const repo = github.context.repo.repo;
-        const commitsArtifact = artifacts.find(a => a && a.name === 'commits-main');
-        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
-        let commitsPath = path.join(workspace, 'commits-main.json');
-        if (commitsArtifact) {
-          const commitsZipPath = path.join(tmpDir, `${commitsArtifact.name}.zip`);
-          const respCommits = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: commitsArtifact.id, archive_format: 'zip' });
-          fs.writeFileSync(commitsZipPath, Buffer.from(respCommits.data));
-          const extractCommitsDir = path.join(tmpDir, `${commitsArtifact.name}-extract`);
-          if (!fs.existsSync(extractCommitsDir)) fs.mkdirSync(extractCommitsDir, { recursive: true });
-          execFileSync('unzip', ['-o', commitsZipPath, '-d', extractCommitsDir], { stdio: 'ignore' });
-          // Find commits-main.json
-          const stack2 = [extractCommitsDir];
-          let foundCommitsPath;
-          while (stack2.length && !foundCommitsPath) {
-            const dir = stack2.pop();
-            const entries = fs.readdirSync(dir, { withFileTypes: true });
-            for (const ent of entries) {
-              const p = path.join(dir, ent.name);
-              if (ent.isDirectory()) stack2.push(p);
-              else if (ent.isFile() && ent.name === 'commits-main.json') { foundCommitsPath = p; break; }
+              // Prune old annotations (removes entries from index)
+              cachedAnnotationsIndex = pruneAnnotationsIndex(cachedAnnotationsIndex, cachedGrouped, cutoffDate);
+              const afterPruneCount = Object.keys(cachedAnnotationsIndex).length;
+              core.info(`[CACHE] Pruned ${beforePruneCount - afterPruneCount} annotation entries`);
+
+              // Also remove annotation directories for runs not in pruned index
+              const keptRunIds = new Set(Object.keys(cachedAnnotationsIndex));
+              let removedDirs = 0;
+              if (fs.existsSync(annotationsRoot)) {
+                const annDirs = fs.readdirSync(annotationsRoot, { withFileTypes: true });
+                for (const ent of annDirs) {
+                  if (ent.isDirectory() && ent.name !== 'annotations-index.json') {
+                    if (!keptRunIds.has(ent.name)) {
+                      fs.rmSync(path.join(annotationsRoot, ent.name), { recursive: true, force: true });
+                      removedDirs++;
+                    }
+                  }
+                }
+              }
+              if (removedDirs > 0) {
+                core.info(`[CACHE] Removed ${removedDirs} annotation directories for pruned runs`);
+              }
+              fs.writeFileSync(annotationsIndexPath, JSON.stringify(cachedAnnotationsIndex));
+              core.info(`[CACHE] Restored annotations index with ${afterPruneCount} entries`);
+            } else {
+              core.info(`[CACHE] annotations-index.json not found in artifacts, starting fresh`);
             }
+          } catch (e) {
+            core.warning(`Failed to restore annotations: ${e.message}`);
           }
-          if (foundCommitsPath) {
-            fs.cpSync(foundCommitsPath, commitsPath, { recursive: false });
-            core.info(`[TEST MODE] Restored commits index to ${commitsPath}`);
-          } else {
-            core.info('[TEST MODE] No commits-main.json found; creating empty list');
-            if (!fs.existsSync(commitsPath)) fs.writeFileSync(commitsPath, JSON.stringify([]));
-          }
-        } else {
-          core.info('[TEST MODE] No commits-main artifact found in selected run; creating empty list');
-          if (!fs.existsSync(commitsPath)) fs.writeFileSync(commitsPath, JSON.stringify([]));
         }
-        core.setOutput('commits-path', commitsPath);
-      } catch (e) {
-        core.warning(`[TEST MODE] Failed to restore commits artifact: ${e.message}`);
-      }
-
-      // Additionally download and index logs for failing workflow runs referenced by this prior aggregate run (test mode)
-      try {
-        const owner = github.context.repo.owner;
-        const repo = github.context.repo.repo;
-        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
 
         // Restore gtest logs
         const gtestLogsRoot = path.join(workspace, 'logs', 'gtest');
@@ -291,24 +438,49 @@ async function run() {
         let gtestLogsIndexPath = path.join(gtestLogsRoot, 'gtest-logs-index.json');
         const gtestLogsArtifact = artifacts.find(a => a && a.name === 'workflow-gtest-logs');
         if (gtestLogsArtifact) {
-          const logsZipPath = path.join(tmpDir, `${gtestLogsArtifact.name}.zip`);
-          const respLogs = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: gtestLogsArtifact.id, archive_format: 'zip' });
-          fs.writeFileSync(logsZipPath, Buffer.from(respLogs.data));
-          const extractLogsDir = path.join(tmpDir, `${gtestLogsArtifact.name}-extract`);
-          if (!fs.existsSync(extractLogsDir)) fs.mkdirSync(extractLogsDir, { recursive: true });
-          execFileSync('unzip', ['-o', logsZipPath, '-d', extractLogsDir], { stdio: 'ignore' });
-          // Copy the extracted logs tree into workspace logs/gtest/
-          fs.cpSync(extractLogsDir, gtestLogsRoot, { recursive: true });
-          const candidateIdx = path.join(gtestLogsRoot, 'gtest-logs-index.json');
-          if (fs.existsSync(candidateIdx)) {
-            gtestLogsIndexPath = candidateIdx;
-          } else if (!fs.existsSync(gtestLogsIndexPath)) {
-            fs.writeFileSync(gtestLogsIndexPath, JSON.stringify({}));
+          try {
+            const logsZipPath = path.join(tmpDir, `${gtestLogsArtifact.name}.zip`);
+            const respLogs = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: gtestLogsArtifact.id, archive_format: 'zip' });
+            fs.writeFileSync(logsZipPath, Buffer.from(respLogs.data));
+            const extractLogsDir = path.join(tmpDir, `${gtestLogsArtifact.name}-extract`);
+            if (!fs.existsSync(extractLogsDir)) fs.mkdirSync(extractLogsDir, { recursive: true });
+            execFileSync('unzip', ['-o', logsZipPath, '-d', extractLogsDir], { stdio: 'ignore' });
+            fs.cpSync(extractLogsDir, gtestLogsRoot, { recursive: true });
+            const candidateIdx = path.join(gtestLogsRoot, 'gtest-logs-index.json');
+            if (fs.existsSync(candidateIdx)) {
+              gtestLogsIndexPath = candidateIdx;
+              cachedGtestLogsIndex = JSON.parse(fs.readFileSync(gtestLogsIndexPath, 'utf8'));
+              const beforePruneCount = Object.keys(cachedGtestLogsIndex).length;
+              core.info(`[CACHE] Loaded ${beforePruneCount} gtest log entries (before pruning)`);
+
+              // Prune old logs (removes entries from index)
+              cachedGtestLogsIndex = pruneLogsIndex(cachedGtestLogsIndex, cachedGrouped, cutoffDate);
+              const afterPruneCount = Object.keys(cachedGtestLogsIndex).length;
+              core.info(`[CACHE] Pruned ${beforePruneCount - afterPruneCount} gtest log entries`);
+
+              // Also remove log directories for runs not in pruned index
+              const keptGtestRunIds = new Set(Object.keys(cachedGtestLogsIndex));
+              let removedDirs = 0;
+              if (fs.existsSync(gtestLogsRoot)) {
+                const logDirs = fs.readdirSync(gtestLogsRoot, { withFileTypes: true });
+                for (const ent of logDirs) {
+                  if (ent.isDirectory() && ent.name !== 'gtest-logs-index.json') {
+                    if (!keptGtestRunIds.has(ent.name)) {
+                      fs.rmSync(path.join(gtestLogsRoot, ent.name), { recursive: true, force: true });
+                      removedDirs++;
+                    }
+                  }
+                }
+              }
+              if (removedDirs > 0) {
+                core.info(`[CACHE] Removed ${removedDirs} gtest log directories for pruned runs`);
+              }
+              fs.writeFileSync(gtestLogsIndexPath, JSON.stringify(cachedGtestLogsIndex));
+              core.info(`[CACHE] Restored gtest logs index with ${afterPruneCount} entries`);
+            }
+          } catch (e) {
+            core.warning(`Failed to restore gtest logs: ${e.message}`);
           }
-          core.info(`[TEST MODE] Restored gtest logs to ${gtestLogsRoot}`);
-        } else {
-          core.info('[TEST MODE] No workflow-gtest-logs artifact found in selected run; creating empty index');
-          if (!fs.existsSync(gtestLogsIndexPath)) fs.writeFileSync(gtestLogsIndexPath, JSON.stringify({}));
         }
 
         // Restore other logs
@@ -317,79 +489,160 @@ async function run() {
         let otherLogsIndexPath = path.join(otherLogsRoot, 'other-logs-index.json');
         const otherLogsArtifact = artifacts.find(a => a && a.name === 'workflow-other-logs');
         if (otherLogsArtifact) {
-          const logsZipPath = path.join(tmpDir, `${otherLogsArtifact.name}.zip`);
-          const respLogs = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: otherLogsArtifact.id, archive_format: 'zip' });
-          fs.writeFileSync(logsZipPath, Buffer.from(respLogs.data));
-          const extractLogsDir = path.join(tmpDir, `${otherLogsArtifact.name}-extract`);
-          if (!fs.existsSync(extractLogsDir)) fs.mkdirSync(extractLogsDir, { recursive: true });
-          execFileSync('unzip', ['-o', logsZipPath, '-d', extractLogsDir], { stdio: 'ignore' });
-          // Copy the extracted logs tree into workspace logs/other/
-          fs.cpSync(extractLogsDir, otherLogsRoot, { recursive: true });
-          const candidateIdx = path.join(otherLogsRoot, 'other-logs-index.json');
-          if (fs.existsSync(candidateIdx)) {
-            otherLogsIndexPath = candidateIdx;
-          } else if (!fs.existsSync(otherLogsIndexPath)) {
-            fs.writeFileSync(otherLogsIndexPath, JSON.stringify({}));
+          try {
+            const logsZipPath = path.join(tmpDir, `${otherLogsArtifact.name}.zip`);
+            const respLogs = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: otherLogsArtifact.id, archive_format: 'zip' });
+            fs.writeFileSync(logsZipPath, Buffer.from(respLogs.data));
+            const extractLogsDir = path.join(tmpDir, `${otherLogsArtifact.name}-extract`);
+            if (!fs.existsSync(extractLogsDir)) fs.mkdirSync(extractLogsDir, { recursive: true });
+            execFileSync('unzip', ['-o', logsZipPath, '-d', extractLogsDir], { stdio: 'ignore' });
+            fs.cpSync(extractLogsDir, otherLogsRoot, { recursive: true });
+            const candidateIdx = path.join(otherLogsRoot, 'other-logs-index.json');
+            if (fs.existsSync(candidateIdx)) {
+              otherLogsIndexPath = candidateIdx;
+              cachedOtherLogsIndex = JSON.parse(fs.readFileSync(otherLogsIndexPath, 'utf8'));
+              const beforePruneCount = Object.keys(cachedOtherLogsIndex).length;
+              core.info(`[CACHE] Loaded ${beforePruneCount} other log entries (before pruning)`);
+
+              // Prune old logs (removes entries from index)
+              cachedOtherLogsIndex = pruneLogsIndex(cachedOtherLogsIndex, cachedGrouped, cutoffDate);
+              const afterPruneCount = Object.keys(cachedOtherLogsIndex).length;
+              core.info(`[CACHE] Pruned ${beforePruneCount - afterPruneCount} other log entries`);
+
+              // Also remove log directories for runs not in pruned index
+              const keptOtherRunIds = new Set(Object.keys(cachedOtherLogsIndex));
+              let removedDirs = 0;
+              if (fs.existsSync(otherLogsRoot)) {
+                const logDirs = fs.readdirSync(otherLogsRoot, { withFileTypes: true });
+                for (const ent of logDirs) {
+                  if (ent.isDirectory() && ent.name !== 'other-logs-index.json') {
+                    if (!keptOtherRunIds.has(ent.name)) {
+                      fs.rmSync(path.join(otherLogsRoot, ent.name), { recursive: true, force: true });
+                      removedDirs++;
+                    }
+                  }
+                }
+              }
+              if (removedDirs > 0) {
+                core.info(`[CACHE] Removed ${removedDirs} other log directories for pruned runs`);
+              }
+              fs.writeFileSync(otherLogsIndexPath, JSON.stringify(cachedOtherLogsIndex));
+              core.info(`[CACHE] Restored other logs index with ${afterPruneCount} entries`);
+            }
+          } catch (e) {
+            core.warning(`Failed to restore other logs: ${e.message}`);
           }
-          core.info(`[TEST MODE] Restored other logs to ${otherLogsRoot}`);
-        } else {
-          core.info('[TEST MODE] No workflow-other-logs artifact found in selected run; creating empty index');
-          if (!fs.existsSync(otherLogsIndexPath)) fs.writeFileSync(otherLogsIndexPath, JSON.stringify({}));
         }
 
-        core.setOutput('gtest-logs-root', gtestLogsRoot);
-        core.setOutput('gtest-logs-index-path', gtestLogsIndexPath);
-        core.setOutput('other-logs-root', otherLogsRoot);
-        core.setOutput('other-logs-index-path', otherLogsIndexPath);
-      } catch (e) {
-        core.warning(`[TEST MODE] Failed to restore logs artifact: ${e.message}`);
-      }
+        // Restore commits
+        const commitsArtifact = artifacts.find(a => a && a.name === 'commits-main');
+        let commitsPath = path.join(workspace, 'commits-main.json');
+        if (commitsArtifact) {
+          try {
+            const commitsZipPath = path.join(tmpDir, `${commitsArtifact.name}.zip`);
+            const respCommits = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: commitsArtifact.id, archive_format: 'zip' });
+            fs.writeFileSync(commitsZipPath, Buffer.from(respCommits.data));
+            const extractCommitsDir = path.join(tmpDir, `${commitsArtifact.name}-extract`);
+            if (!fs.existsSync(extractCommitsDir)) fs.mkdirSync(extractCommitsDir, { recursive: true });
+            execFileSync('unzip', ['-o', commitsZipPath, '-d', extractCommitsDir], { stdio: 'ignore' });
+            const stack2 = [extractCommitsDir];
+            let foundCommitsPath;
+            while (stack2.length && !foundCommitsPath) {
+              const dir = stack2.pop();
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              for (const ent of entries) {
+                const p = path.join(dir, ent.name);
+                if (ent.isDirectory()) stack2.push(p);
+                else if (ent.isFile() && ent.name === 'commits-main.json') { foundCommitsPath = p; break; }
+              }
+            }
+            if (foundCommitsPath) {
+              core.info(`[CACHE] Found commits-main.json at ${foundCommitsPath}`);
+              const beforePrune = JSON.parse(fs.readFileSync(foundCommitsPath, 'utf8'));
+              const beforePruneCount = beforePrune.length;
+              cachedCommits = beforePrune;
+              core.info(`[CACHE] Loaded ${beforePruneCount} commits (before pruning)`);
 
-      // Additionally fetch the last success timestamps artifact from the same run, if present
-      try {
-        const owner = github.context.repo.owner;
-        const repo = github.context.repo.repo;
+              cachedCommits = pruneCommits(cachedCommits, cutoffDate);
+              const afterPruneCount = cachedCommits.length;
+              core.info(`[CACHE] Pruned ${beforePruneCount - afterPruneCount} commits older than ${cutoffDate.toISOString()}`);
+
+              fs.writeFileSync(commitsPath, JSON.stringify(cachedCommits));
+              core.info(`[CACHE] Restored ${afterPruneCount} commits from cache`);
+            } else {
+              core.info(`[CACHE] commits-main.json not found in artifacts, starting fresh`);
+            }
+          } catch (e) {
+            core.warning(`Failed to restore commits: ${e.message}`);
+          }
+        }
+
+        // Restore last success timestamps
         const lastSuccessArtifact = artifacts.find(a => a && a.name === 'last-success-timestamps');
-        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
         let lastSuccessPath = path.join(workspace, 'last-success-timestamps.json');
         if (lastSuccessArtifact) {
-          const timestampsZipPath = path.join(tmpDir, `${lastSuccessArtifact.name}.zip`);
-          const respTimestamps = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: lastSuccessArtifact.id, archive_format: 'zip' });
-          fs.writeFileSync(timestampsZipPath, Buffer.from(respTimestamps.data));
-          const extractTimestampsDir = path.join(tmpDir, `${lastSuccessArtifact.name}-extract`);
-          if (!fs.existsSync(extractTimestampsDir)) fs.mkdirSync(extractTimestampsDir, { recursive: true });
-          execFileSync('unzip', ['-o', timestampsZipPath, '-d', extractTimestampsDir], { stdio: 'ignore' });
-          // Find last-success-timestamps.json
-          const stack3 = [extractTimestampsDir];
-          let foundTimestampsPath;
-          while (stack3.length && !foundTimestampsPath) {
-            const dir = stack3.pop();
-            const entries = fs.readdirSync(dir, { withFileTypes: true });
-            for (const ent of entries) {
-              const p = path.join(dir, ent.name);
-              if (ent.isDirectory()) stack3.push(p);
-              else if (ent.isFile() && ent.name === 'last-success-timestamps.json') { foundTimestampsPath = p; break; }
+          try {
+            const timestampsZipPath = path.join(tmpDir, `${lastSuccessArtifact.name}.zip`);
+            const respTimestamps = await octokit.rest.actions.downloadArtifact({ owner, repo, artifact_id: lastSuccessArtifact.id, archive_format: 'zip' });
+            fs.writeFileSync(timestampsZipPath, Buffer.from(respTimestamps.data));
+            const extractTimestampsDir = path.join(tmpDir, `${lastSuccessArtifact.name}-extract`);
+            if (!fs.existsSync(extractTimestampsDir)) fs.mkdirSync(extractTimestampsDir, { recursive: true });
+            execFileSync('unzip', ['-o', timestampsZipPath, '-d', extractTimestampsDir], { stdio: 'ignore' });
+            const stack3 = [extractTimestampsDir];
+            let foundTimestampsPath;
+            while (stack3.length && !foundTimestampsPath) {
+              const dir = stack3.pop();
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              for (const ent of entries) {
+                const p = path.join(dir, ent.name);
+                if (ent.isDirectory()) stack3.push(p);
+                else if (ent.isFile() && ent.name === 'last-success-timestamps.json') { foundTimestampsPath = p; break; }
+              }
             }
+            if (foundTimestampsPath) {
+              core.info(`[CACHE] Found last-success-timestamps.json at ${foundTimestampsPath}`);
+              cachedLastSuccessTimestamps = JSON.parse(fs.readFileSync(foundTimestampsPath, 'utf8'));
+              fs.writeFileSync(lastSuccessPath, JSON.stringify(cachedLastSuccessTimestamps));
+              core.info(`[CACHE] Restored last success timestamps for ${Object.keys(cachedLastSuccessTimestamps).length} workflows`);
+            } else {
+              core.info(`[CACHE] last-success-timestamps.json not found in artifacts, starting fresh`);
+            }
+          } catch (e) {
+            core.warning(`Failed to restore last success timestamps: ${e.message}`);
           }
-          if (foundTimestampsPath) {
-            fs.cpSync(foundTimestampsPath, lastSuccessPath, { recursive: false });
-            core.info(`[TEST MODE] Restored last success timestamps to ${lastSuccessPath}`);
-          } else {
-            core.info('[TEST MODE] No last-success-timestamps.json found; creating empty object');
-            if (!fs.existsSync(lastSuccessPath)) fs.writeFileSync(lastSuccessPath, JSON.stringify({}));
-          }
-        } else {
-          core.info('[TEST MODE] No last-success-timestamps artifact found in selected run; creating empty object');
-          if (!fs.existsSync(lastSuccessPath)) fs.writeFileSync(lastSuccessPath, JSON.stringify({}));
         }
-        core.setOutput('last-success-timestamps-path', lastSuccessPath);
-      } catch (e) {
-        core.warning(`[TEST MODE] Failed to restore last success timestamps artifact: ${e.message}`);
-      }
 
-      // Exit early
-      return;
+        // Clean up temp directory
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          core.info(`[CACHE] Cleaned up temp directory`);
+        } catch (_) { /* ignore */ }
+
+        core.info(`[CACHE] Artifact restoration completed successfully`);
+      } catch (e) {
+        core.warning(`[CACHE] Failed to restore artifacts from previous run: ${e.message}`);
+        core.warning(`[CACHE] Stack trace: ${e.stack}`);
+      }
+    } else {
+      core.info('[CACHE] No previous aggregate run found, starting fresh');
     }
+
+    // Convert cached grouped map to array of runs for merging
+    for (const runs of cachedGrouped.values()) {
+      previousRuns.push(...runs);
+    }
+
+    // Build set of cached run IDs to avoid re-downloading logs/annotations
+    const cachedRunIds = new Set();
+    for (const runs of cachedGrouped.values()) {
+      for (const run of runs) {
+        cachedRunIds.add(String(run.id));
+      }
+    }
+
+    core.info(`[CACHE] Summary: ${previousRuns.length} runs restored, ${cachedGrouped.size} workflows, latest date: ${latestCachedDate}`);
+    core.info(`[CACHE] Cached run IDs: ${cachedRunIds.size} unique run IDs`);
+
     // Fetch new runs from GitHub (for the last N days, only after latest cached run)
 
     // 1. Fetch runs for each event type separately
@@ -398,36 +651,41 @@ async function run() {
 
 
     core.info('Fetching all runs...');
-    const allRuns = await fetchAllWorkflowRuns(octokit, github.context, days, latestCachedDate);
-    core.info(`Fetched allRuns count: ${allRuns.length}`);
+    const allRuns = await fetchAllWorkflowRuns(octokit, github.context, days, latestCachedDate, cachedRunIds);
+    core.info(`[FETCH] Fetched ${allRuns.length} new runs (skipped cached runs during fetch)`);
 
     // Wait for 1 second to avoid rate limiting
     await delay(1000);
 
-    core.info('Fetching scheduled runs...');
-    const scheduledRuns = await fetchAllWorkflowRuns(octokit, github.context, days, latestCachedDate, 'schedule');
-    core.info(`Fetched scheduledRuns count: ${scheduledRuns.length}`);
+    core.info('[FETCH] Fetching scheduled runs...');
+    const scheduledRuns = await fetchAllWorkflowRuns(octokit, github.context, days, latestCachedDate, cachedRunIds, 'schedule');
+    core.info(`[FETCH] Fetched ${scheduledRuns.length} new scheduled runs (skipped cached runs during fetch)`);
 
-    // 2. Combine all the results into a single array
+    // 2. Combine all the results into a single array (already filtered for new runs only)
     const newRuns = [...scheduledRuns, ...allRuns];
+    core.info(`[FETCH] Total new runs fetched: ${newRuns.length} (${allRuns.length} all events + ${scheduledRuns.length} scheduled)`);
 
-    core.info(`Fetched a total of ${newRuns.length} new runs across all event types.`);
-
-    core.info(`Fetched newRuns count: ${newRuns.length}`);
-    // Merge and deduplicate by run id
+    // Merge and deduplicate by run id (though newRuns should already be deduplicated from cache)
     // This ensures we keep the most recent data for each run and avoid duplicates
+    core.info(`[MERGE] Merging ${previousRuns.length} cached runs + ${newRuns.length} new runs`);
     const seen = new Map();
     [...previousRuns, ...newRuns].forEach(run => seen.set(run.id, run));
     let mergedRuns = Array.from(seen.values());
+    core.info(`[MERGE] After deduplication: ${mergedRuns.length} unique runs`);
+
     // Only keep runs on main branch, completed, and within the last N days
     const cutoff = getCutoffDate(days);
+    const beforeFilter = mergedRuns.length;
     mergedRuns = mergedRuns.filter(run =>
       run.head_branch === branch &&
       run.status === 'completed' &&
       new Date(run.created_at) >= cutoff
     );
+    core.info(`[MERGE] After filtering (branch=${branch}, status=completed, date>=${cutoff.toISOString()}): ${mergedRuns.length} runs (removed ${beforeFilter - mergedRuns.length})`);
+
     // Group runs by workflow name
     const grouped = groupRunsByName(mergedRuns);
+    core.info(`[MERGE] Grouped into ${grouped.size} workflows`);
     // Ensure output directory exists
     const outputDir = path.dirname(outputPath);
     if (!fs.existsSync(outputDir)) {
@@ -436,11 +694,9 @@ async function run() {
     // Save grouped runs to artifact file
     fs.writeFileSync(outputPath, JSON.stringify(Array.from(grouped.entries())));
 
-    // For each workflow, find the last successful run (even if outside the window)
-    // This is used to calculate "days since last success" for failing workflows
-    const lastSuccessTimestamps = new Map();
-    const owner = github.context.repo.owner;
-    const repo = github.context.repo.repo;
+    // Merge cached last success timestamps with new ones (cached takes precedence for existing workflows)
+    const lastSuccessTimestamps = new Map(Object.entries(cachedLastSuccessTimestamps || {}));
+    core.info(`[LAST_SUCCESS] Starting last success search (cached: ${lastSuccessTimestamps.size} workflows)`);
 
     for (const [name, runs] of grouped.entries()) {
       try {
@@ -459,6 +715,7 @@ async function run() {
               run_id: latestRun.id,
               in_window: true
             });
+            core.info(`[LAST_SUCCESS] Workflow '${name}' is passing (run ${latestRun.id})`);
           }
           continue;
         }
@@ -473,14 +730,18 @@ async function run() {
             run_id: successInWindow.id,
             in_window: true
           });
+          core.info(`[LAST_SUCCESS] Workflow '${name}' failing, found success in window (run ${successInWindow.id})`);
           continue;
         }
 
         // Workflow is failing and no success in window - make targeted API call to search all history
         const workflowPath = runs[0]?.path;
-        if (!workflowPath) continue;
+        if (!workflowPath) {
+          core.info(`[LAST_SUCCESS] Workflow '${name}' has no path, skipping`);
+          continue;
+        }
 
-        core.info(`Searching for last success in full history for failing workflow: ${name}`);
+        core.info(`[LAST_SUCCESS] Searching for last success in full history for failing workflow: ${name}`);
 
         // Search through workflow history to find the last successful run
         let foundSuccess = false;
@@ -510,7 +771,7 @@ async function run() {
               run_id: successRun.id,
               in_window: false
             });
-            core.info(`Found last success for ${name}: ${successRun.created_at}`);
+            core.info(`[LAST_SUCCESS] Found last success for '${name}': run ${successRun.id} at ${successRun.created_at}`);
             foundSuccess = true;
             break;
           }
@@ -523,7 +784,7 @@ async function run() {
 
         if (!foundSuccess) {
           // Never succeeded in searchable history
-          core.info(`No successful run found in history for ${name} (never succeeded or very old)`);
+          core.info(`[LAST_SUCCESS] No successful run found in history for '${name}' (never succeeded or very old)`);
           lastSuccessTimestamps.set(name, { never_succeeded: true });
         }
 
@@ -534,11 +795,13 @@ async function run() {
       }
     }
 
-    // Save the last success timestamps index
+    // Save the last success timestamps index (merge cached + new)
     const lastSuccessPath = path.join(outputDir, 'last-success-timestamps.json');
-    fs.writeFileSync(lastSuccessPath, JSON.stringify(Object.fromEntries(lastSuccessTimestamps)));
+    // Update cached timestamps with any new ones found
+    const finalLastSuccessTimestamps = Object.fromEntries(lastSuccessTimestamps);
+    fs.writeFileSync(lastSuccessPath, JSON.stringify(finalLastSuccessTimestamps));
     core.setOutput('last-success-timestamps-path', lastSuccessPath);
-    core.info(`Saved last success timestamps for ${lastSuccessTimestamps.size} workflows to ${lastSuccessPath}`);
+    core.info(`[LAST_SUCCESS] Saved last success timestamps for ${lastSuccessTimestamps.size} workflows to ${lastSuccessPath}`);
 
     // Download logs for the latest failing run per workflow and build an index
     // Constraint: Only fetch logs when the latest run for that workflow (on target branch)
@@ -546,18 +809,22 @@ async function run() {
     // The logs will be extracted under a dedicated directory so downstream steps
     // can parse them without performing network calls again.
     // Separate gtest logs from other logs (non-gtest failures with no annotations)
-    const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+    const annotationsRoot = path.join(workspace, 'annotations');
     const gtestLogsRoot = path.join(workspace, 'logs', 'gtest');
     const otherLogsRoot = path.join(workspace, 'logs', 'other');
+    if (!fs.existsSync(annotationsRoot)) {
+      fs.mkdirSync(annotationsRoot, { recursive: true });
+    }
     if (!fs.existsSync(gtestLogsRoot)) {
       fs.mkdirSync(gtestLogsRoot, { recursive: true });
     }
     if (!fs.existsSync(otherLogsRoot)) {
       fs.mkdirSync(otherLogsRoot, { recursive: true });
     }
-    const annotationsIndex = {};
-    const gtestLogsIndex = {};
-    const otherLogsIndex = {};
+    // Initialize indices from cache
+    const annotationsIndex = { ...cachedAnnotationsIndex };
+    const gtestLogsIndex = { ...cachedGtestLogsIndex };
+    const otherLogsIndex = { ...cachedOtherLogsIndex };
     for (const [name, runs] of grouped.entries()) {
       try {
         // Consider only the target branch and sort newest first
@@ -583,6 +850,14 @@ async function run() {
           break;
         }
         if (!targetRun) continue;
+
+        // Skip if this run is already cached
+        if (cachedRunIds.has(String(targetRun.id))) {
+          core.info(`[LOGS] Skipping download for run ${targetRun.id} (workflow: ${name}) - already in cache`);
+          continue;
+        }
+
+        core.info(`[LOGS] Processing failing run ${targetRun.id} for workflow '${name}' (conclusion: ${targetRun.conclusion})`);
 
         // Fetch check-run annotations for this failing run
         let sawGtestFailure = false;
@@ -653,7 +928,7 @@ async function run() {
           fs.writeFileSync(annPath, JSON.stringify(allAnnotations));
           const relativeAnn = path.relative(workspace, annRoot) || annRoot;
           annotationsIndex[String(targetRun.id)] = relativeAnn;
-          core.info(`Fetched annotations for failing run ${targetRun.id} → ${allAnnotations.length} items`);
+          core.info(`[LOGS] Fetched annotations for run ${targetRun.id} → ${allAnnotations.length} items`);
         } catch (e) {
           core.warning(`Failed to fetch annotations for run ${targetRun.id}: ${e.message}`);
           annotationsFetchFailed = true;
@@ -711,7 +986,7 @@ async function run() {
             fs.writeFileSync(jobsIndexPath, JSON.stringify(jobsIndex));
             const relativeRunDir = path.relative(workspace, runDir) || runDir;
             gtestLogsIndex[String(targetRun.id)] = relativeRunDir;
-            core.info(`Downloaded and indexed gtest logs for failing run ${targetRun.id} → ${jobsIndex.jobs.length} job(s)`);
+            core.info(`[LOGS] Downloaded and indexed gtest logs for run ${targetRun.id} → ${jobsIndex.jobs.length} job(s), ${jobsIndex.jobs.reduce((sum, j) => sum + (j.files || []).length, 0)} files`);
           } else if (!sawAnyFailureAnnotations || annotationsFetchFailed) {
             // Download other logs (non-gtest failures with no annotations, or if annotation fetch failed entirely)
             // Just download and list files, no detailed indexing
@@ -745,7 +1020,7 @@ async function run() {
             fs.writeFileSync(logsListPath, JSON.stringify({ files: logFiles }));
             const relativeRunDir = path.relative(workspace, runDir) || runDir;
             otherLogsIndex[String(targetRun.id)] = relativeRunDir;
-            core.info(`Downloaded other logs for failing run ${targetRun.id} → ${logFiles.length} file(s)`);
+            core.info(`[LOGS] Downloaded other logs for run ${targetRun.id} → ${logFiles.length} file(s)`);
           }
         } catch (e) {
           core.warning(`Failed to download/index logs for run ${targetRun.id}: ${e.message}`);
@@ -755,8 +1030,6 @@ async function run() {
       }
     }
     // Persist annotations index alongside annotations directory
-    const annotationsRoot = path.join(workspace, 'annotations');
-    if (!fs.existsSync(annotationsRoot)) fs.mkdirSync(annotationsRoot, { recursive: true });
     const annotationsIndexPath = path.join(annotationsRoot, 'annotations-index.json');
     fs.writeFileSync(annotationsIndexPath, JSON.stringify(annotationsIndex));
 
@@ -779,9 +1052,14 @@ async function run() {
     // Build a commits index for the main branch within the last N days
     // The index is an array of commits sorted by commit author/commit date ascending.
     // Each entry: { sha, short, url, author_login, author_name, author_url, date }
-    const commits = [];
+    // Start with cached commits and merge with new ones
+    core.info(`[COMMITS] Starting commits fetch (cached: ${cachedCommits.length})`);
+    const cachedCommitsSet = new Map((cachedCommits || []).map(c => [c.sha, c]));
+    const commits = [...cachedCommits];
+    let newCommitsCount = 0;
     try {
       const sinceIso = getCutoffDate(days).toISOString();
+      core.info(`[COMMITS] Fetching commits since ${sinceIso}`);
       const perPage = 100;
       let page = 1;
       while (true) {
@@ -794,9 +1072,19 @@ async function run() {
           page,
         });
         const arr = resp.data || [];
-        if (!arr.length) break;
+        if (!arr.length) {
+          core.info(`[COMMITS] No more commits (page ${page})`);
+          break;
+        }
+        core.info(`[COMMITS] Fetched page ${page}: ${arr.length} commits`);
         for (const c of arr) {
           const sha = c.sha;
+          // Skip if already in cache
+          if (cachedCommitsSet.has(sha)) {
+            core.info(`[COMMITS] Skipping cached commit ${sha.substring(0, 7)}`);
+            continue;
+          }
+          newCommitsCount++;
           const short = sha ? sha.substring(0, 7) : '';
           const url = `https://github.com/${owner}/${repo}/commit/${sha}`;
           const author_login = c.author?.login;
@@ -805,19 +1093,25 @@ async function run() {
           const date = c.commit?.author?.date || c.commit?.committer?.date || null;
           const message = c.commit?.message || '';
           const description = typeof message === 'string' ? (message.split(/\r?\n/)[0] || '') : '';
-          commits.push({ sha, short, url, author_login, author_name, author_url, date, message, description });
+          const commitObj = { sha, short, url, author_login, author_name, author_url, date, message, description };
+          commits.push(commitObj);
+          cachedCommitsSet.set(sha, commitObj);
         }
         if (arr.length < perPage) break;
         page++;
       }
       // Sort oldest -> newest by date for deterministic slicing
       commits.sort((a, b) => new Date(a.date || 0) - new Date(b.date || 0));
+      core.info(`[COMMITS] Total commits: ${commits.length} (${cachedCommits.length} cached + ${newCommitsCount} new)`);
     } catch (e) {
-      core.warning(`Failed to build commits index: ${e.message}`);
+      core.warning(`[COMMITS] Failed to build commits index: ${e.message}`);
     }
     const commitsPath = path.join(workspace, 'commits-main.json');
     fs.writeFileSync(commitsPath, JSON.stringify(commits));
+    core.info(`[COMMITS] Saved commits index to ${commitsPath}`);
+
     // Set output
+    core.info(`[OUTPUT] Setting action outputs...`);
     core.setOutput('total-runs', mergedRuns.length);
     core.setOutput('workflow-count', grouped.size);
     core.setOutput('cache-path', outputPath);
@@ -828,11 +1122,16 @@ async function run() {
     core.setOutput('annotations-root', annotationsRoot);
     core.setOutput('annotations-index-path', annotationsIndexPath);
     core.setOutput('commits-path', commitsPath);
+    core.info(`[OUTPUT] total-runs: ${mergedRuns.length}, workflow-count: ${grouped.size}`);
+    core.info(`[OUTPUT] annotations: ${Object.keys(annotationsIndex).length} entries`);
+    core.info(`[OUTPUT] gtest-logs: ${Object.keys(gtestLogsIndex).length} entries`);
+    core.info(`[OUTPUT] other-logs: ${Object.keys(otherLogsIndex).length} entries`);
+
     // Log remaining GitHub API rate limit
     const rateLimit = await octokit.rest.rateLimit.get();
     const remaining = rateLimit.data.resources.core.remaining;
     const limit = rateLimit.data.resources.core.limit;
-    core.info(`GitHub API rate limit remaining: ${remaining} / ${limit}`);
+    core.info(`[RATE_LIMIT] GitHub API rate limit remaining: ${remaining} / ${limit} (${((remaining/limit)*100).toFixed(1)}%)`);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -230,6 +230,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - mchiou/0-aggregate-workflow-report
   schedule:
-    - cron: '*/15 * * * *' # every 15 minutes
+    - cron: '*/5 * * * *' # every 5 minutes
   workflow_dispatch:
     inputs:
       days:
@@ -13,35 +13,7 @@ on:
         default: '15'
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      workflow_configs: ${{ steps.config.outputs.workflow_configs }}
-    steps:
-      - name: Set workflow configs
-        id: config
-        run: |
-          echo 'workflow_configs<<EOF' >> $GITHUB_OUTPUT
-          cat >> $GITHUB_OUTPUT <<'CONFIG'
-          [
-            {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
-            {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
-            {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
-            {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
-            {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
-            {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
-            {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
-            {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},
-            {"display": "ttnn - Run sweeps", "wkflw_name": "ttnn - Run sweeps"},
-            {"display": "vLLM nightly tests", "wkflw_name": "vLLM nightly tests"},
-            {"display": "Metal microbenchmarks", "wkflw_name": "metal - Run microbenchmarks"},
-            {"display": "APC nightly debug run", "wkflw_name": "apc nightly debug run"}
-          ]
-          CONFIG
-          echo 'EOF' >> $GITHUB_OUTPUT
-
   fetch-data:
-    needs: setup
     runs-on: ubuntu-latest
     outputs:
       cache-path: ${{ steps.fetch.outputs.cache-path }}
@@ -66,7 +38,21 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           days: ${{ github.event.inputs.days || 15 }}
-          workflow_configs: ${{ needs.setup.outputs.workflow_configs }}
+          workflow_configs: |
+            [
+              {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
+              {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
+              {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
+              {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
+              {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
+              {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
+              {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
+              {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},
+              {"display": "ttnn - Run sweeps", "wkflw_name": "ttnn - Run sweeps"},
+              {"display": "vLLM nightly tests", "wkflw_name": "vLLM nightly tests"},
+              {"display": "Metal microbenchmarks", "wkflw_name": "metal - Run microbenchmarks"},
+              {"display": "APC nightly debug run", "wkflw_name": "apc nightly debug run"}
+            ]
       - name: Upload workflow data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
         with:
@@ -119,7 +105,7 @@ jobs:
         run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
 
   analyze-data:
-    needs: [setup, fetch-data]
+    needs: fetch-data
     runs-on: ubuntu-latest
     outputs:
       failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
@@ -221,7 +207,21 @@ jobs:
           other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
           last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
           alert-all: 'false'
-          workflow_configs: ${{ needs.setup.outputs.workflow_configs }}
+          workflow_configs: |
+            [
+              {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
+              {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
+              {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
+              {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
+              {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
+              {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
+              {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
+              {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},
+              {"display": "ttnn - Run sweeps", "wkflw_name": "ttnn - Run sweeps"},
+              {"display": "vLLM nightly tests", "wkflw_name": "vLLM nightly tests"},
+              {"display": "Metal microbenchmarks", "wkflw_name": "metal - Run microbenchmarks"},
+              {"display": "APC nightly debug run", "wkflw_name": "apc nightly debug run"}
+            ]
       - name: Upload status changes artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
         with:

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -245,6 +245,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -245,6 +245,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -231,20 +231,20 @@ jobs:
 
       # Slack notification moved to handle-failures job
 
-  handle-failures:
-    needs: analyze-data
-    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Handle failed workflows
-        run: |
-          echo "The following workflows have failed:"
-          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-          # Add any additional failure handling steps here
-      - name: Post regressions to Slack
-        uses: ./.github/actions/slack-report-analyze-workflow-data
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+  # handle-failures:
+  #   needs: analyze-data
+  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Handle failed workflows
+  #       run: |
+  #         echo "The following workflows have failed:"
+  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+  #         # Add any additional failure handling steps here
+  #     - name: Post regressions to Slack
+  #       uses: ./.github/actions/slack-report-analyze-workflow-data
+  #       with:
+  #         slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -13,7 +13,35 @@ on:
         default: '15'
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      workflow_configs: ${{ steps.config.outputs.workflow_configs }}
+    steps:
+      - name: Set workflow configs
+        id: config
+        run: |
+          echo 'workflow_configs<<EOF' >> $GITHUB_OUTPUT
+          cat >> $GITHUB_OUTPUT <<'CONFIG'
+          [
+            {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
+            {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
+            {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
+            {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
+            {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
+            {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
+            {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
+            {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},
+            {"display": "ttnn - Run sweeps", "wkflw_name": "ttnn - Run sweeps"},
+            {"display": "vLLM nightly tests", "wkflw_name": "vLLM nightly tests"},
+            {"display": "Metal microbenchmarks", "wkflw_name": "metal - Run microbenchmarks"},
+            {"display": "APC nightly debug run", "wkflw_name": "apc nightly debug run"}
+          ]
+          CONFIG
+          echo 'EOF' >> $GITHUB_OUTPUT
+
   fetch-data:
+    needs: setup
     runs-on: ubuntu-latest
     outputs:
       cache-path: ${{ steps.fetch.outputs.cache-path }}
@@ -38,6 +66,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           days: ${{ github.event.inputs.days || 15 }}
+          workflow_configs: ${{ needs.setup.outputs.workflow_configs }}
       - name: Upload workflow data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
         with:
@@ -90,7 +119,7 @@ jobs:
         run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
 
   analyze-data:
-    needs: fetch-data
+    needs: [setup, fetch-data]
     runs-on: ubuntu-latest
     outputs:
       failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
@@ -192,21 +221,7 @@ jobs:
           other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
           last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
           alert-all: 'false'
-          workflow_configs: |
-            [
-              {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
-              {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
-              {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
-              {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
-              {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
-              {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
-              {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
-              {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},
-              {"display": "ttnn - Run sweeps", "wkflw_name": "ttnn - Run sweeps"},
-              {"display": "vLLM nightly tests", "wkflw_name": "vLLM nightly tests"},
-              {"display": "Metal microbenchmarks", "wkflw_name": "metal - Run microbenchmarks"},
-              {"display": "APC nightly debug run", "wkflw_name": "apc nightly debug run"}
-            ]
+          workflow_configs: ${{ needs.setup.outputs.workflow_configs }}
       - name: Upload status changes artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
         with:

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -229,22 +229,21 @@ jobs:
           path: ${{ steps.analyze.outputs.status_changes_path }}
           retention-days: 1
 
-      # Slack notification moved to handle-failures job
 
-  # handle-failures:
-  #   needs: analyze-data
-  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Handle failed workflows
-  #       run: |
-  #         echo "The following workflows have failed:"
-  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-  #         # Add any additional failure handling steps here
-  #     - name: Post regressions to Slack
-  #       uses: ./.github/actions/slack-report-analyze-workflow-data
-  #       with:
-  #         slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+  handle-failures:
+    needs: analyze-data
+    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Handle failed workflows
+        run: |
+          echo "The following workflows have failed:"
+          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+          # Add any additional failure handling steps here
+      - name: Post regressions to Slack
+        uses: ./.github/actions/slack-report-analyze-workflow-data
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31351)

### Problem description
Aggregate Workflow Analysis uses too many API calls and takes too long to fetch all the data. Data should be re-used across runs and the fetch step should be made much faster

### What's changed
Artifacts from previous successful runs of Aggregate Workflow Data are now being downloaded and used as a caching mechanism to vastly reduce the number of github API calls needed, reducing the total time of the workflow from ~12.5 minutes to ~2 minutes

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18921452455