### PR TITLE
[skip ci] [Reduce APC] Remove yolov tests from models-unit-tests in APC

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -41,12 +41,6 @@ run_python_model_tests_wormhole_b0() {
     # Mobilenetv2git
     pytest -svv models/demos/mobilenetv2/tests/pcc/test_mobilenetv2.py
 
-    #Yolov10
-    pytest -svv models/demos/yolov10x/tests/pcc/test_ttnn_yolov10x.py::test_yolov10x
-
-    #Yolov7
-    pytest -svv models/demos/yolov7/tests/pcc/test_ttnn_yolov7.py
-
     # ViT-base
     pytest -svv models/demos/vit/tests/pcc/test_ttnn_optimized_sharded_vit_wh.py
 


### PR DESCRIPTION
### What's changed
Remove yolov10x and yolov7 tests from models-unit-tests in APC which are already running in (Single-card) Frequent model and ttnn tests

yolov10x (N150): https://github.com/tenstorrent/tt-metal/actions/runs/18877548404/job/53882061097

yolov7 (N150): https://github.com/tenstorrent/tt-metal/actions/runs/18877548404/job/53882061228

yolov10x (N300): https://github.com/tenstorrent/tt-metal/actions/runs/18877548404/job/53882062711

yolov7 (N300): https://github.com/tenstorrent/tt-metal/actions/runs/18877548404/job/53882062426