### PR TITLE
Protect against leaked compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,13 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.t
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")
 endif()
 
+# Clear any compile options that may have been set by consuming projects that have leaked into us.
+set_directory_properties(
+    PROPERTIES
+        COMPILE_OPTIONS
+            ""
+)
+
 ############################################
 # Project setup
 ############################################


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When a consuming project uses TT-Metalium, they may invoke `add_compile_options` BEFORE iterating down into our project.  This leaks their choice of compiler flags into TT-Metalium and (more brittle) into our deps.

While an idea project structure is to process all deps before manipulating the build flags, the reality is that we must not fall on our face when that has not been done.

### What's changed
Clear out all inherited compile options before we process any of our dependencies (or our own code).