### PR TITLE
Expose TelemetryRunning health metric that survives UMD initialization failures

### DIFF
--- a/tt_telemetry/CMakeLists.txt
+++ b/tt_telemetry/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(
         telemetry/ethernet/ethernet_helpers.cpp
         telemetry/ethernet/ethernet_metrics.cpp
         telemetry/arc/arc_metrics.cpp
+        telemetry/system/system_metrics.cpp
         telemetry/hal/hal.cpp
 )
 target_include_directories(

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -89,6 +89,37 @@ protected:
     bool value_ = false;
 };
 
+// System-level boolean metric with labels (for host health, not device metrics)
+class SystemBoolMetric : public BoolMetric {
+public:
+    SystemBoolMetric(
+        std::string_view name,
+        const std::unordered_map<std::string, std::string>& labels = {},
+        MetricUnit metric_units = MetricUnit::UNITLESS) :
+        BoolMetric(metric_units), name_(name), labels_(labels) {}
+
+    void set_value(bool value) {
+        value_ = value;
+        changed_since_transmission_ = true;
+        timestamp_ =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+                .count();
+    }
+
+    void set_labels(const std::unordered_map<std::string, std::string>& labels) {
+        labels_ = labels;
+        changed_since_transmission_ = true;
+    }
+
+    std::string_view name() const { return name_; }
+
+    const std::unordered_map<std::string, std::string>& labels() const { return labels_; }
+
+private:
+    std::string name_;
+    std::unordered_map<std::string, std::string> labels_;
+};
+
 class UIntMetric: public Metric {
 public:
     UIntMetric(MetricUnit metric_units = MetricUnit::UNITLESS) : Metric(metric_units) {}

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -46,13 +46,7 @@ public:
 
     Metric(MetricUnit metric_units = MetricUnit::UNITLESS) : units(metric_units) {}
 
-    Metric(std::vector<std::string> path, MetricUnit metric_units = MetricUnit::UNITLESS) :
-        units(metric_units), custom_path_(std::move(path)) {}
-
     virtual const std::vector<std::string> telemetry_path() const {
-        if (!custom_path_.empty()) {
-            return custom_path_;
-        }
         return { "dummy", "metric", "someone", "forgot", "to", "implement", "telemetry", "path", "function" };
     }
 
@@ -87,17 +81,11 @@ protected:
 
     bool changed_since_transmission_ = false;
     uint64_t timestamp_ = 0;  // Unix timestamp in milliseconds, 0 = never set
-
-private:
-    std::vector<std::string> custom_path_;
 };
 
 class BoolMetric: public Metric {
 public:
     BoolMetric(MetricUnit metric_units = MetricUnit::UNITLESS) : Metric(metric_units) {}
-
-    BoolMetric(std::vector<std::string> path, MetricUnit metric_units = MetricUnit::UNITLESS) :
-        Metric(std::move(path), metric_units) {}
 
     bool value() const {
         return value_;

--- a/tt_telemetry/include/telemetry/system/system_metrics.hpp
+++ b/tt_telemetry/include/telemetry/system/system_metrics.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * telemetry/system/system_metrics.hpp
+ *
+ * System-level telemetry metrics that track host-level health and status.
+ * These metrics are independent of device telemetry.
+ */
+
+#include <memory>
+#include <vector>
+
+#include <telemetry/metric.hpp>
+
+/*
+ * TelemetryRunningMetric
+ *
+ * Boolean metric indicating whether telemetry collection is successfully running.
+ * - true: Telemetry initialization succeeded and metrics are being collected
+ * - false: Telemetry initialization failed (e.g., UMD initialization error)
+ *
+ * Path: system/TelemetryRunning
+ */
+class TelemetryRunningMetric : public BoolMetric {
+public:
+    TelemetryRunningMetric();
+
+    const std::vector<std::string> telemetry_path() const override;
+
+    // No update() needed - this metric is set manually via set_value()
+};

--- a/tt_telemetry/include/telemetry/telemetry_collector.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_collector.hpp
@@ -29,4 +29,5 @@ void run_telemetry_collector(
     const std::vector<std::string>& aggregate_endpoints,
     const tt::llrt::RunTimeOptions& rtoptions,
     tt::scaleout_tools::fsd::proto::FactorySystemDescriptor fsd,
-    int watchdog_timeout_seconds);
+    int watchdog_timeout_seconds,
+    int failure_exposure_duration_seconds);

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -29,12 +29,17 @@ struct TelemetrySnapshot {
     std::unordered_map<std::string, uint64_t> uint_metrics;
     std::unordered_map<std::string, double> double_metrics;
 
+    // System-level metrics (host health, not device telemetry)
+    std::unordered_map<std::string, bool> system_bool_metrics;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> system_bool_metric_labels;
+
     // Metadata maps: path -> metadata
     std::unordered_map<std::string, uint64_t> bool_metric_timestamps;
     std::unordered_map<std::string, uint16_t> uint_metric_units;
     std::unordered_map<std::string, uint64_t> uint_metric_timestamps;
     std::unordered_map<std::string, uint16_t> double_metric_units;
     std::unordered_map<std::string, uint64_t> double_metric_timestamps;
+    std::unordered_map<std::string, uint64_t> system_bool_metric_timestamps;
 
     // Unit label maps
     std::unordered_map<uint16_t, std::string> metric_unit_display_label_by_code;
@@ -44,11 +49,14 @@ struct TelemetrySnapshot {
         bool_metrics.clear();
         uint_metrics.clear();
         double_metrics.clear();
+        system_bool_metrics.clear();
+        system_bool_metric_labels.clear();
         bool_metric_timestamps.clear();
         uint_metric_units.clear();
         uint_metric_timestamps.clear();
         double_metric_units.clear();
         double_metric_timestamps.clear();
+        system_bool_metric_timestamps.clear();
         metric_unit_display_label_by_code.clear();
         metric_unit_full_label_by_code.clear();
     }
@@ -109,6 +117,17 @@ private:
         }
         for (const auto& [path, timestamp] : other.double_metric_timestamps) {
             double_metric_timestamps[path] = timestamp;
+        }
+
+        // Update system metrics and their metadata
+        for (const auto& [path, value] : other.system_bool_metrics) {
+            system_bool_metrics[path] = value;
+        }
+        for (const auto& [path, labels] : other.system_bool_metric_labels) {
+            system_bool_metric_labels[path] = labels;
+        }
+        for (const auto& [path, timestamp] : other.system_bool_metric_timestamps) {
+            system_bool_metric_timestamps[path] = timestamp;
         }
     }
 
@@ -211,6 +230,17 @@ private:
         for (const auto& [path, timestamp] : other.double_metric_timestamps) {
             double_metric_timestamps[path] = timestamp;
         }
+
+        // Validate and merge system metrics
+        for (const auto& [path, value] : other.system_bool_metrics) {
+            system_bool_metrics[path] = value;
+        }
+        for (const auto& [path, labels] : other.system_bool_metric_labels) {
+            system_bool_metric_labels[path] = labels;
+        }
+        for (const auto& [path, timestamp] : other.system_bool_metric_timestamps) {
+            system_bool_metric_timestamps[path] = timestamp;
+        }
     }
 
 public:
@@ -221,11 +251,14 @@ public:
          {"bool_metrics", t.bool_metrics},
          {"uint_metrics", t.uint_metrics},
          {"double_metrics", t.double_metrics},
+         {"system_bool_metrics", t.system_bool_metrics},
+         {"system_bool_metric_labels", t.system_bool_metric_labels},
          {"bool_metric_timestamps", t.bool_metric_timestamps},
          {"uint_metric_units", t.uint_metric_units},
          {"uint_metric_timestamps", t.uint_metric_timestamps},
          {"double_metric_units", t.double_metric_units},
          {"double_metric_timestamps", t.double_metric_timestamps},
+         {"system_bool_metric_timestamps", t.system_bool_metric_timestamps},
          {"metric_unit_display_label_by_code", t.metric_unit_display_label_by_code},
          {"metric_unit_full_label_by_code", t.metric_unit_full_label_by_code},
      };
@@ -235,11 +268,14 @@ static inline void from_json(const nlohmann::json &j, TelemetrySnapshot &t) {
     j.at("bool_metrics").get_to(t.bool_metrics);
     j.at("uint_metrics").get_to(t.uint_metrics);
     j.at("double_metrics").get_to(t.double_metrics);
+    j.at("system_bool_metrics").get_to(t.system_bool_metrics);
+    j.at("system_bool_metric_labels").get_to(t.system_bool_metric_labels);
     j.at("bool_metric_timestamps").get_to(t.bool_metric_timestamps);
     j.at("uint_metric_units").get_to(t.uint_metric_units);
     j.at("uint_metric_timestamps").get_to(t.uint_metric_timestamps);
     j.at("double_metric_units").get_to(t.double_metric_units);
     j.at("double_metric_timestamps").get_to(t.double_metric_timestamps);
+    j.at("system_bool_metric_timestamps").get_to(t.system_bool_metric_timestamps);
     j.at("metric_unit_display_label_by_code").get_to(t.metric_unit_display_label_by_code);
     j.at("metric_unit_full_label_by_code").get_to(t.metric_unit_full_label_by_code);
 }

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -29,17 +29,12 @@ struct TelemetrySnapshot {
     std::unordered_map<std::string, uint64_t> uint_metrics;
     std::unordered_map<std::string, double> double_metrics;
 
-    // System-level metrics (host health, not device telemetry)
-    std::unordered_map<std::string, bool> system_bool_metrics;
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> system_bool_metric_labels;
-
     // Metadata maps: path -> metadata
     std::unordered_map<std::string, uint64_t> bool_metric_timestamps;
     std::unordered_map<std::string, uint16_t> uint_metric_units;
     std::unordered_map<std::string, uint64_t> uint_metric_timestamps;
     std::unordered_map<std::string, uint16_t> double_metric_units;
     std::unordered_map<std::string, uint64_t> double_metric_timestamps;
-    std::unordered_map<std::string, uint64_t> system_bool_metric_timestamps;
 
     // Unit label maps
     std::unordered_map<uint16_t, std::string> metric_unit_display_label_by_code;
@@ -49,14 +44,11 @@ struct TelemetrySnapshot {
         bool_metrics.clear();
         uint_metrics.clear();
         double_metrics.clear();
-        system_bool_metrics.clear();
-        system_bool_metric_labels.clear();
         bool_metric_timestamps.clear();
         uint_metric_units.clear();
         uint_metric_timestamps.clear();
         double_metric_units.clear();
         double_metric_timestamps.clear();
-        system_bool_metric_timestamps.clear();
         metric_unit_display_label_by_code.clear();
         metric_unit_full_label_by_code.clear();
     }
@@ -117,17 +109,6 @@ private:
         }
         for (const auto& [path, timestamp] : other.double_metric_timestamps) {
             double_metric_timestamps[path] = timestamp;
-        }
-
-        // Update system metrics and their metadata
-        for (const auto& [path, value] : other.system_bool_metrics) {
-            system_bool_metrics[path] = value;
-        }
-        for (const auto& [path, labels] : other.system_bool_metric_labels) {
-            system_bool_metric_labels[path] = labels;
-        }
-        for (const auto& [path, timestamp] : other.system_bool_metric_timestamps) {
-            system_bool_metric_timestamps[path] = timestamp;
         }
     }
 
@@ -230,17 +211,6 @@ private:
         for (const auto& [path, timestamp] : other.double_metric_timestamps) {
             double_metric_timestamps[path] = timestamp;
         }
-
-        // Validate and merge system metrics
-        for (const auto& [path, value] : other.system_bool_metrics) {
-            system_bool_metrics[path] = value;
-        }
-        for (const auto& [path, labels] : other.system_bool_metric_labels) {
-            system_bool_metric_labels[path] = labels;
-        }
-        for (const auto& [path, timestamp] : other.system_bool_metric_timestamps) {
-            system_bool_metric_timestamps[path] = timestamp;
-        }
     }
 
 public:
@@ -251,14 +221,11 @@ public:
          {"bool_metrics", t.bool_metrics},
          {"uint_metrics", t.uint_metrics},
          {"double_metrics", t.double_metrics},
-         {"system_bool_metrics", t.system_bool_metrics},
-         {"system_bool_metric_labels", t.system_bool_metric_labels},
          {"bool_metric_timestamps", t.bool_metric_timestamps},
          {"uint_metric_units", t.uint_metric_units},
          {"uint_metric_timestamps", t.uint_metric_timestamps},
          {"double_metric_units", t.double_metric_units},
          {"double_metric_timestamps", t.double_metric_timestamps},
-         {"system_bool_metric_timestamps", t.system_bool_metric_timestamps},
          {"metric_unit_display_label_by_code", t.metric_unit_display_label_by_code},
          {"metric_unit_full_label_by_code", t.metric_unit_full_label_by_code},
      };
@@ -268,14 +235,11 @@ static inline void from_json(const nlohmann::json &j, TelemetrySnapshot &t) {
     j.at("bool_metrics").get_to(t.bool_metrics);
     j.at("uint_metrics").get_to(t.uint_metrics);
     j.at("double_metrics").get_to(t.double_metrics);
-    j.at("system_bool_metrics").get_to(t.system_bool_metrics);
-    j.at("system_bool_metric_labels").get_to(t.system_bool_metric_labels);
     j.at("bool_metric_timestamps").get_to(t.bool_metric_timestamps);
     j.at("uint_metric_units").get_to(t.uint_metric_units);
     j.at("uint_metric_timestamps").get_to(t.uint_metric_timestamps);
     j.at("double_metric_units").get_to(t.double_metric_units);
     j.at("double_metric_timestamps").get_to(t.double_metric_timestamps);
-    j.at("system_bool_metric_timestamps").get_to(t.system_bool_metric_timestamps);
     j.at("metric_unit_display_label_by_code").get_to(t.metric_unit_display_label_by_code);
     j.at("metric_unit_full_label_by_code").get_to(t.metric_unit_full_label_by_code);
 }

--- a/tt_telemetry/server/prom_formatter.cpp
+++ b/tt_telemetry/server/prom_formatter.cpp
@@ -4,11 +4,12 @@
 
 #include <server/prom_formatter.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <sstream>
-#include <iomanip>
+#include <algorithm>
 #include <chrono>
-#include <stdexcept>
+#include <iomanip>
 #include <optional>
+#include <sstream>
+#include <stdexcept>
 #include <unordered_set>
 #include <ctime>
 
@@ -22,27 +23,53 @@ struct ParsedMetric {
     std::unordered_map<std::string, std::string> labels;
 };
 
+// Helper to extract hostname from path and return remaining path
+// Path format: hostname/rest/of/path
+// Returns: {hostname, rest/of/path}
+std::pair<std::string, std::string_view> extract_hostname_from_path(std::string_view path) {
+    size_t first_slash = path.find('/');
+    if (first_slash == std::string_view::npos) {
+        throw std::runtime_error("Metric path does not contain hostname separator: " + std::string(path));
+    }
+
+    std::string hostname(path.substr(0, first_slash));
+    std::string_view remaining = path.substr(first_slash + 1);
+    return {hostname, remaining};
+}
+
+// Parse system metric path (simpler format: hostname/system/MetricName)
+// Returns: metric_name with hostname as a label (labels from metric itself merged later)
+ParsedMetric parse_system_metric_path(std::string_view path) {
+    ParsedMetric result;
+    auto [hostname, path_after_hostname] = extract_hostname_from_path(path);
+
+    // Add hostname as a label
+    result.labels["hostname"] = hostname;
+
+    // Expected format: system/MetricName
+    constexpr std::string_view system_prefix = "system/";
+    if (path_after_hostname.starts_with(system_prefix)) {
+        result.metric_name = std::string(path_after_hostname.substr(system_prefix.length()));
+    } else {
+        throw std::runtime_error("System metric path must start with 'system/': " + std::string(path_after_hostname));
+    }
+
+    return result;
+}
+
 // Parse metric path and extract labels
 // Path format: hostname/tray3/chip0/[channel5/]metric_name
 // Returns: metric_name and labels (hostname, tray, chip, channel if present)
 ParsedMetric parse_metric_path(std::string_view path) {
     ParsedMetric result;
-    std::string path_str(path);
+    auto [hostname, path_after_hostname] = extract_hostname_from_path(path);
 
-    // Extract hostname from the first component
-    size_t first_slash = path_str.find('/');
-    if (first_slash == std::string::npos) {
-        throw std::runtime_error("Metric path does not contain hostname component: " + path_str);
-    }
-
-    std::string hostname = path_str.substr(0, first_slash);
+    // Add hostname as a label
     result.labels["hostname"] = hostname;
 
-    // Remove hostname and the slash
-    path_str = path_str.substr(first_slash + 1);
-
-    // Split path into components
+    // Split remaining path into components
     std::vector<std::string> components;
+    std::string path_str(path_after_hostname);
     size_t start = 0;
     size_t end = path_str.find('/');
     while (end != std::string::npos) {
@@ -64,18 +91,16 @@ ParsedMetric parse_metric_path(std::string_view path) {
         const std::string& component = components[i];
 
         // Extract label name and value (e.g., "tray3" -> label="tray", value="3")
-        size_t digit_pos = 0;
-        while (digit_pos < component.length() && !std::isdigit(component[digit_pos])) {
-            digit_pos++;
-        }
+        auto digit_it =
+            std::find_if(component.begin(), component.end(), [](unsigned char c) { return std::isdigit(c); });
 
-        if (digit_pos == 0 || digit_pos == component.length()) {
+        if (digit_it == component.begin() || digit_it == component.end()) {
             // No label/value structure, skip or use as-is
             continue;
         }
 
-        std::string label_name = component.substr(0, digit_pos);
-        std::string label_value = component.substr(digit_pos);
+        std::string label_name = component.substr(0, std::distance(component.begin(), digit_it));
+        std::string label_value = component.substr(std::distance(component.begin(), digit_it));
         result.labels[label_name] = label_value;
     }
 
@@ -180,6 +205,48 @@ void process_metrics(
     }
 }
 
+// Template helper to process system-level metrics
+template <typename ValueType, typename ValueConverter>
+void process_system_metrics(
+    std::stringstream& output,
+    const std::unordered_map<std::string, ValueType>& metrics,
+    const std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& labels_map,
+    const std::unordered_map<std::string, uint64_t>& timestamps,
+    std::string_view help_text,
+    ValueConverter value_converter) {
+    std::unordered_set<std::string> written_metric_names;
+
+    for (const auto& [path, value] : metrics) {
+        try {
+            // Parse system metric path (hostname/system/MetricName)
+            // Hostname is extracted from path and added as a label
+            ParsedMetric parsed = parse_system_metric_path(path);
+            std::string value_str = value_converter(value);
+
+            // Get timestamp
+            uint64_t timestamp = 0;
+            auto ts_it = timestamps.find(path);
+            if (ts_it != timestamps.end()) {
+                timestamp = ts_it->second;
+            }
+
+            // Merge labels from labels map (these override path-extracted labels if conflicts)
+            auto labels_it = labels_map.find(path);
+            if (labels_it != labels_map.end()) {
+                for (const auto& [label_name, label_value] : labels_it->second) {
+                    parsed.labels[label_name] = label_value;
+                }
+            }
+
+            format_metric(
+                output, parsed.metric_name, parsed.labels, value_str, help_text, "", timestamp, written_metric_names);
+        } catch (const std::exception& e) {
+            // Log warning but continue processing other metrics
+            log_warning(tt::LogAlways, "Failed to format system metric '{}': {}", path, e.what());
+        }
+    }
+}
+
 }  // anonymous namespace
 
 std::string format_snapshot_as_prometheus(const TelemetrySnapshot& snapshot) {
@@ -193,6 +260,15 @@ std::string format_snapshot_as_prometheus(const TelemetrySnapshot& snapshot) {
 
     output << "# Tenstorrent Metal Telemetry Metrics\n";
     output << "# Generated at: " << std::put_time(&tm_buf, "%c") << "\n\n";
+
+    // Process system metrics first (host-level health)
+    process_system_metrics(
+        output,
+        snapshot.system_bool_metrics,
+        snapshot.system_bool_metric_labels,
+        snapshot.system_bool_metric_timestamps,
+        "System-level health metric",
+        [](bool v) { return std::to_string(v ? 1 : 0); });
 
     // Process bool metrics (no units)
     process_metrics(

--- a/tt_telemetry/telemetry/arc/arc_metrics.cpp
+++ b/tt_telemetry/telemetry/arc/arc_metrics.cpp
@@ -182,9 +182,7 @@ void ARCUintMetric::update(
     uint64_t old_value = value_;
     changed_since_transmission_ = new_value != old_value;
     value_ = new_value;
-    timestamp_ =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-            .count();
+    set_timestamp_now();
 }
 
 /**************************************************************************************************
@@ -220,7 +218,5 @@ void ARCDoubleMetric::update(
     double old_value = value_;
     changed_since_transmission_ = new_value != old_value;
     value_ = new_value;
-    timestamp_ =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-            .count();
+    set_timestamp_now();
 }

--- a/tt_telemetry/telemetry/ethernet/ethernet_metrics.cpp
+++ b/tt_telemetry/telemetry/ethernet/ethernet_metrics.cpp
@@ -147,8 +147,7 @@ void EthernetEndpointUpMetric::update(
     bool is_up_old = value_;
     changed_since_transmission_ = is_up_now != is_up_old;
     value_ = is_up_now;
-    timestamp_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    set_timestamp_now();
 }
 
 /**************************************************************************************************
@@ -182,8 +181,7 @@ void EthernetCRCErrorCountMetric::update(
     uint32_t crc_error_val = 0;
     cluster->read_from_device(&crc_error_val, chip_id_, ethernet_core_, crc_addr_, sizeof(uint32_t));
     value_ = uint64_t(crc_error_val);
-    timestamp_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    set_timestamp_now();
 }
 
 /**************************************************************************************************
@@ -215,8 +213,7 @@ void EthernetRetrainCountMetric::update(
     uint32_t data = 0;
     cluster->read_from_device(&data, chip_id_, ethernet_core_, retrain_count_addr_, sizeof(uint32_t));
     value_ = uint64_t(data);
-    timestamp_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    set_timestamp_now();
 }
 
 /**************************************************************************************************
@@ -252,8 +249,7 @@ void EthernetCorrectedCodewordCountMetric::update(
     cluster->read_from_device(&hi, chip_id_, ethernet_core_, corr_addr_ + 0, sizeof(uint32_t));
     cluster->read_from_device(&lo, chip_id_, ethernet_core_, corr_addr_ + 4, sizeof(uint32_t));
     value_ = (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
-    timestamp_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    set_timestamp_now();
 }
 
 /**************************************************************************************************
@@ -289,6 +285,5 @@ void EthernetUncorrectedCodewordCountMetric::update(
     cluster->read_from_device(&hi, chip_id_, ethernet_core_, uncorr_addr_ + 0, sizeof(uint32_t));
     cluster->read_from_device(&lo, chip_id_, ethernet_core_, uncorr_addr_ + 4, sizeof(uint32_t));
     value_ = (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
-    timestamp_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    set_timestamp_now();
 }

--- a/tt_telemetry/telemetry/system/system_metrics.cpp
+++ b/tt_telemetry/telemetry/system/system_metrics.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * System-level telemetry metrics that track host health and status.
+ */
+
+#include <telemetry/system/system_metrics.hpp>
+
+/**************************************************************************************************
+| TelemetryRunningMetric Class
+**************************************************************************************************/
+
+TelemetryRunningMetric::TelemetryRunningMetric() : BoolMetric() {
+    value_ = false;  // Initially not running
+}
+
+const std::vector<std::string> TelemetryRunningMetric::telemetry_path() const { return {"system", "TelemetryRunning"}; }


### PR DESCRIPTION
### Ticket
Fixes #30929

### Problem description
When devices are down or in a bad state requiring reset, `tt::umd::Cluster` initialization fails with exceptions, causing the telemetry thread to abort completely. This means no metrics are exposed, making it impossible to detect the failure state via monitoring systems like Prometheus.

Example failures from ClosetBox (Oct 21):
- metal-wh-11: "Timeout waiting for Ethernet core service remote IO request"
- metal-wh-10: "No existing board type for board id 0x401e1e5200030166"

These exceptions prevent any telemetry from being broadcast, leaving monitoring systems blind to the failure.

### What's changed
Implemented solution [1] from the issue: expose a host-level `TelemetryRunning` boolean metric that survives UMD initialization failures.

**Key changes:**
- Added `SystemBoolMetric` class for host-level health metrics (separate from hierarchical device metrics) in tt_telemetry/include/telemetry/metric.hpp:89-117
- Create `TelemetryRunning` metric before UMD initialization in tt_telemetry/telemetry/telemetry_collector.cpp:269, ensuring it exists regardless of initialization outcome
- Wrapped UMD initialization in try-catch block at tt_telemetry/telemetry/telemetry_collector.cpp:282-338:
  - Success: `TelemetryRunning = true`
  - Failure: `TelemetryRunning = false` (error details in logs)
- When initialization fails, expose the failure metric for a configurable duration (default 30s via `--failure-exposure-duration` flag) before exiting
- Send periodic heartbeats during failure exposure to prevent watchdog timeout
- Extended `prom_formatter.cpp` to handle system metrics with simplified path format (`hostname/system/MetricName`)
- Updated `TelemetrySnapshot` infrastructure with system metric fields and JSON serialization
- Added Docker Compose monitoring stack with Prometheus and Grafana for testing and demonstration

**Impact:**
Monitoring systems can now detect telemetry failures via the `TelemetryRunning` metric. When the metric is `false`, orchestrators (e.g., Kubernetes) can restart the telemetry pod, enabling self-healing infrastructure. Error details remain in application logs to avoid Prometheus label cardinality issues.

**Prometheus output:**
```
# HELP TelemetryRunning System-level health metric
# TYPE TelemetryRunning gauge
TelemetryRunning{} 1
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes