### PR TITLE
Support uint32 for multiply

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -49,6 +49,16 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
                 (80000, 200000, 0, 70000),
             ],
         ),
+        (
+            ttnn.mul,
+            [
+                (0, 100, 0, 500),
+                (500, 1e3, 1e3, 1e4),
+                (1e4, 1e5, 1e5, 1e6),
+                (1e6, 1e7, 1, 1e2),
+                (0, 65535, 0, 65535),
+            ],
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -131,6 +141,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         (ttnn.sub, 50000, 100000, 0, 40000),  # Subtraction: ensure a > b for valid results
         (ttnn.eq, 0, 1610612735, 536870911, 2147483647),
         (ttnn.ne, 0, 1610612735, 536870911, 2147483647),
+        (ttnn.mul, 0, 100, 200, 300),
     ],
 )
 @pytest.mark.parametrize(
@@ -330,7 +341,7 @@ def test_binary_add_uint32_upper_edge_cases(device):
     # Since ttnn.to_torch does not support int64, we cannot compare with the torch output. We can manually check the outputs:
     # Torch output: tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295])
     # TT output: ttnn.Tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295],
-    #               shape=Shape([3]), dtype=DataType::UINT32, layout=Layout::TILE)
+    #               shape=Shape([7]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
 @pytest.mark.parametrize(
@@ -544,3 +555,6 @@ def test_binary_comp_ops_uint32_edge_cases(ttnn_op, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -27,52 +27,102 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
 
 
 @pytest.mark.parametrize(
-    "ttnn_op, value_ranges",
+    "ttnn_op, value_ranges_a, value_ranges_b",
     [
+        # --- Addition op ---
         (
             ttnn.add,
             [
-                (0, 100, 0, 300),
-                (1000, 10000, 500, 1000),
-                (30000, 40000, 10000, 15000),
-                (50000, 55000, 1000, 2000),
-                (0, 70000, 80000, 200000),
+                (0, 100),
+                (1e3, 1e4),
+                (1e6, 1e8),
+                (1e9, 2e9),
+            ],
+            [
+                (0, 500),
+                (1e4, 1e6),
+                (1e7, 1e9),
+                (1e7, 1e8),
             ],
         ),
+        # --- Subtraction op ---
         (
             ttnn.sub,
             [
-                (100, 500, 0, 100),
-                (1000, 10000, 500, 1000),
-                (30000, 40000, 10000, 15000),
-                (50000, 55000, 1000, 2000),
-                (80000, 200000, 0, 70000),
+                (100, 500),
+                (1e5, 1e7),
+                (1e7, 2e9),
+                (2e9, 2147483647),
+            ],
+            [
+                (0, 100),
+                (1e3, 1e5),
+                (1e7, 1e9),
+                (1e9, 2e9),
+            ],
+        ),
+        # --- Multiplication op ---
+        (
+            ttnn.mul,
+            [
+                (0, 100),
+                (500, 1e3),
+                (1e4, 1e5),
+                (1e6, 1e7),
+                (2e9, 2147483647),
+            ],
+            [
+                (0, 500),
+                (1e3, 1e4),
+                (1e2, 1e4),
+                (1, 1e2),
+                (1, 1),
+            ],
+        ),
+        # --- Comparison ops ---
+        (
+            ttnn.eq,
+            [
+                (0, 1000),
+                (1e3, 1e6),
+                (1e6, 1e8),
+                (1e9, 2147483647),
+            ],
+            [
+                (0, 1500),
+                (1e4, 1e7),
+                (1e7, 1e9),
+                (2e9, 2147483647),
+            ],
+        ),
+        (
+            ttnn.ne,
+            [
+                (0, 1000),
+                (1e3, 1e6),
+                (1e6, 1e8),
+                (1e9, 2147483647),
+            ],
+            [
+                (0, 1500),
+                (1e4, 1e7),
+                (1e7, 1e9),
+                (2e9, 2147483647),
             ],
         ),
     ],
 )
 @pytest.mark.parametrize(
-    "a_shape, b_shape",
-    [
-        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
-        (torch.Size([1]), torch.Size([1, 5, 12])),
-        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
-        (torch.Size([]), torch.Size([])),
-        (torch.Size([5]), torch.Size([1])),
-    ],
+    "input_shapes",
+    ((torch.Size([1, 2, 32, 128])),),
 )
-@pytest.mark.parametrize("range_idx", [0, 1, 2, 3, 4])
-def test_binary_uint32_bcast(ttnn_op, value_ranges, a_shape, b_shape, range_idx, device):
-    """Test uint32 addition and subtraction with broadcast"""
-    low_a, high_a, low_b, high_b = value_ranges[range_idx]
-
-    num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
-    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
-    torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
-
-    num_elements = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)
-    torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
-    torch_input_tensor_b = torch_input_tensor_b[:num_elements].reshape(b_shape).nan_to_num(0.0)
+def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input_shapes, device):
+    torch_input_tensor_a = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
+    )
+    torch_input_tensor_b = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
+    )
 
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -85,6 +135,58 @@ def test_binary_uint32_bcast(ttnn_op, value_ranges, a_shape, b_shape, range_idx,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op, low_a, high_a, low_b, high_b",
+    [
+        (ttnn.add, 0, 1e4, 1e4, 1e8),
+        (ttnn.sub, 50000, 100000, 0, 40000),
+        (ttnn.eq, 0, 1e8, 1e5, 1e9),
+        (ttnn.ne, 0, 1e8, 1e5, 1e9),
+        (ttnn.mul, 0, 46340, 0, 46340),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        pytest.param([(1, 1, 1), (8, 16, 32)], id="broadcast_lhs_1"),  # scalar bcast
+        pytest.param([(1, 16, 1), (8, 1, 32)], id="broadcast_both_5"),  # mixed bcast
+    ],
+)
+def test_binary_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device):
+    a_shape, b_shape = input_shapes
+
+    num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
+    torch_input_tensor_a = torch.linspace(low_a, high_a, num_elements_a, dtype=torch.int32)
+    torch_input_tensor_a = torch_input_tensor_a[:num_elements_a].reshape(a_shape)
+
+    num_elements_b = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)
+    torch_input_tensor_b = torch.linspace(low_b, high_b, num_elements_b, dtype=torch.int32)
+    torch_input_tensor_b = torch_input_tensor_b[:num_elements_b].reshape(b_shape)
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
         dtype=ttnn.uint32,
@@ -131,6 +233,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         (ttnn.sub, 50000, 100000, 0, 40000),  # Subtraction: ensure a > b for valid results
         (ttnn.eq, 0, 1610612735, 536870911, 2147483647),
         (ttnn.ne, 0, 1610612735, 536870911, 2147483647),
+        (ttnn.mul, 0, 23170, 23170, 46340),
     ],
 )
 @pytest.mark.parametrize(
@@ -146,7 +249,6 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b_shape, sharded_config, device):
-    """Test uint32 addition and subtraction with sharded memory configurations"""
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -253,26 +355,27 @@ def test_binary_sub_uint32_edge_cases(use_legacy, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # Expected output values for uint32 subtraction with these specific inputs
-    expected_output_values = torch.tensor(
-        [4294967294, 1147483647, 3147483649, 4294966796, 4294967295, 50, 4294967295, 4294967295], dtype=torch.uint32
-    )
-    expected_tensor = ttnn.from_torch(
-        expected_output_values,
+    golden_function = ttnn.get_golden_function(ttnn.sub)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+    output_tensor = ttnn.sub(input_tensor_a, input_tensor_b, use_legacy=use_legacy)
+
+    # Since ttnn.to_torch does not support int64, we convert torch_output_tensor to uint32 and compare the results using ttnn.eq
+    torch_output_tensor = ttnn.from_torch(
+        torch_output_tensor,
         dtype=ttnn.uint32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    output_tensor = ttnn.sub(input_tensor_a, input_tensor_b, use_legacy=use_legacy)
-
-    # Compare using ttnn.eq and check if all results are ones (all elements match)
-    comparison_result = ttnn.eq(output_tensor, expected_tensor)
-    comparison_torch = ttnn.to_torch(comparison_result, dtype=torch.bool)
+    comparison_result = ttnn.eq(output_tensor, torch_output_tensor)
+    comparison_torch = ttnn.to_torch(comparison_result)
 
     # Verify all comparisons are True (all elements match)
     assert torch.all(comparison_torch), f"Mismatch found in uint32 subtraction results"
+    # Torch output: tensor([4294967294, 1147483647, 3147483649, 4294966796, 4294967295, 50, 4294967295, 4294967295])
+    # TT output: ttnn.Tensor([4294967294, 1147483647, 3147483649, 4294966796, 4294967295, 50, 4294967295, 4294967295],
+    #               shape=Shape([8]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
 # For inputs within int32 range [0, 2147483647]
@@ -327,10 +430,24 @@ def test_binary_add_uint32_upper_edge_cases(device):
     golden_function = ttnn.get_golden_function(ttnn.add)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
     output_tensor = ttnn.add(input_tensor_a, input_tensor_b)
-    # Since ttnn.to_torch does not support int64, we cannot compare with the torch output. We can manually check the outputs:
+
+    # Since ttnn.to_torch does not support int64, we convert torch_output_tensor to uint32 and compare the results using ttnn.eq
+    torch_output_tensor = ttnn.from_torch(
+        torch_output_tensor,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    comparison_result = ttnn.eq(output_tensor, torch_output_tensor)
+    comparison_torch = ttnn.to_torch(comparison_result)
+
+    # Verify all comparisons are True (all elements match)
+    assert torch.all(comparison_torch), f"Mismatch found in uint32 addition results"
     # Torch output: tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295])
     # TT output: ttnn.Tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295],
-    #               shape=Shape([3]), dtype=DataType::UINT32, layout=Layout::TILE)
+    #               shape=Shape([7]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
 @pytest.mark.parametrize(
@@ -401,121 +518,6 @@ def test_bitwise_uint32_full_range(device, ttnn_function, use_legacy):
         ttnn.ne,
     ],
 )
-@pytest.mark.parametrize(
-    "input_shapes",
-    ((torch.Size([1, 2, 32, 128])),),
-)
-def test_binary_comp_ops_uint32_full_range(ttnn_op, input_shapes, device):
-    value_ranges_a = [
-        (0, 1000),  # Small numbers
-        (1e3, 1e6),  # Small - Medium numbers
-        (1e6, 1e8),  # Medium numbers
-        (1e9, 2147483647),  # Large numbers
-    ]
-
-    value_ranges_b = [
-        (0, 1500),  # Small numbers
-        (1e4, 1e7),  # Small - Medium numbers
-        (1e7, 1e9),  # Medium numbers
-        (2e9, 2147483647),  # Large numbers
-    ]
-
-    torch_input_tensor_a = create_full_range_tensor(
-        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
-    )
-    torch_input_tensor_b = create_full_range_tensor(
-        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
-    )
-
-    golden_function = ttnn.get_golden_function(ttnn_op)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
-
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=ttnn.uint32,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=ttnn.uint32,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
-
-    assert torch.equal(output_tensor, torch_output_tensor)
-
-
-@pytest.mark.parametrize(
-    "ttnn_op",
-    [
-        ttnn.eq,
-        ttnn.ne,
-    ],
-)
-@pytest.mark.parametrize(
-    "input_shapes",
-    [
-        pytest.param([(1, 1, 1), (8, 16, 32)], id="broadcast_lhs_1"),  # scalar bcast
-        pytest.param([(8, 1, 32), (8, 16, 32)], id="broadcast_lhs_3"),  # row bcast
-        pytest.param([(8, 16, 32), (8, 16, 1)], id="broadcast_rhs_5"),  # col bcast
-        pytest.param([(1, 16, 1), (8, 1, 32)], id="broadcast_both_5"),  # mixed bcast
-    ],
-)
-@pytest.mark.parametrize(
-    "low_a, high_a, low_b, high_b",
-    [
-        (0, 1e8, 1e5, 1e9),
-    ],
-)
-def test_binary_comp_ops_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device):
-    a_shape, b_shape = input_shapes
-    num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
-    torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
-    torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape)
-
-    num_elements = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)
-    torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
-    torch_input_tensor_b = torch_input_tensor_b[:num_elements].reshape(b_shape)
-
-    golden_function = ttnn.get_golden_function(ttnn_op)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
-
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=ttnn.uint32,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=ttnn.uint32,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
-
-    assert torch.equal(output_tensor, torch_output_tensor)
-
-
-@pytest.mark.parametrize(
-    "ttnn_op",
-    [
-        ttnn.eq,
-        ttnn.ne,
-    ],
-)
 def test_binary_comp_ops_uint32_edge_cases(ttnn_op, device):
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 2147483647, 2147483647, 2147483647, 1073741823, 1073741823, 4294967295, 4294967294]
@@ -544,3 +546,77 @@ def test_binary_comp_ops_uint32_edge_cases(ttnn_op, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+# For inputs within int32 range [0, 2147483647]
+def test_binary_mul_uint32_lower_edge_cases(device):
+    torch_input_tensor_a = torch.tensor([0, 1, 0, 2147483647, 1, 1073741823, 715827882, 46340])
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    torch_input_tensor_b = torch.tensor([0, 0, 1, 1, 2147483646, 2, 3, 46340])
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.mul)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn.mul(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+# For inputs outside int32 range [2147483648, 4294967295]
+def test_binary_mul_uint32_upper_edge_cases(device):
+    torch_input_tensor_a = torch.tensor(
+        [4294967295, 1, 4294967295, 4294967294, 2147483647, 1431655765, 16777215, 65535]
+    )
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    torch_input_tensor_b = torch.tensor([1, 4294967295, 0, 1, 2, 3, 256, 65535])
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.mul)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+    output_tensor = ttnn.mul(input_tensor_a, input_tensor_b)
+
+    # Since ttnn.to_torch does not support int64, we convert torch_output_tensor to uint32 and compare the results using ttnn.eq
+    torch_output_tensor = ttnn.from_torch(
+        torch_output_tensor,
+        dtype=ttnn.uint32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    comparison_result = ttnn.eq(output_tensor, torch_output_tensor)
+    comparison_torch = ttnn.to_torch(comparison_result)
+
+    # Verify all comparisons are True (all elements match)
+    assert torch.all(comparison_torch), f"Mismatch found in uint32 multiplication results"
+    # Torch output: tensor([4294967295, 4294967295, 0, 4294967294, 4294967294, 4294967295, 4294967040, 4294836225])
+    # TT output: ttnn.Tensor([4294967295, 4294967295, 0, 4294967294, 4294967294, 4294967295, 4294967040, 4294836225],
+    #               shape=Shape([8]), dtype=DataType::UINT32, layout=Layout::TILE)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -49,16 +49,6 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
                 (80000, 200000, 0, 70000),
             ],
         ),
-        (
-            ttnn.mul,
-            [
-                (0, 100, 0, 500),
-                (500, 1e3, 1e3, 1e4),
-                (1e4, 1e5, 1e5, 1e6),
-                (1e6, 1e7, 1, 1e2),
-                (0, 65535, 0, 65535),
-            ],
-        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -141,7 +131,6 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         (ttnn.sub, 50000, 100000, 0, 40000),  # Subtraction: ensure a > b for valid results
         (ttnn.eq, 0, 1610612735, 536870911, 2147483647),
         (ttnn.ne, 0, 1610612735, 536870911, 2147483647),
-        (ttnn.mul, 0, 100, 200, 300),
     ],
 )
 @pytest.mark.parametrize(
@@ -341,7 +330,7 @@ def test_binary_add_uint32_upper_edge_cases(device):
     # Since ttnn.to_torch does not support int64, we cannot compare with the torch output. We can manually check the outputs:
     # Torch output: tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295])
     # TT output: ttnn.Tensor([4294967290, 4150000000, 4294967295, 4294967294, 4294967292, 4294967295, 4294967295],
-    #               shape=Shape([7]), dtype=DataType::UINT32, layout=Layout::TILE)
+    #               shape=Shape([3]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
 @pytest.mark.parametrize(
@@ -555,6 +544,3 @@ def test_binary_comp_ops_uint32_edge_cases(ttnn_op, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
-
-
-

--- a/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/mul_int32_sfpu.h
@@ -13,7 +13,7 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Performs an elementwise mul operation with the two int32 inputs: y = mul(x0,x1)
+ * Performs an elementwise multiplication operation with the two 32-bit integer inputs: y = mul(x0,x1)
  * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
@@ -31,6 +31,10 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void mul_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_mul_int32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void mul_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_mul_int32<APPROX>(idst0, idst1, odst)));
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2199,7 +2199,7 @@ void py_module(py::module& module) {
         R"doc(Multiplies :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i * \mathrm{{input\_tensor\_b}}_i)doc",
         R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
-        R"doc(BFLOAT16, BFLOAT8_B, UINT16 (range: 0 - 65535), INT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, UINT16 (range: 0 - 65535), INT32, UINT32)doc");
 
     detail::bind_binary_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -231,6 +231,9 @@ std::map<std::string, std::string> get_defines_fp32(
             } else if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
                 new_defines.insert({"MUL_INT32_INIT", fmt::format("mul_int32_tile_init();")});
                 op_name = "mul_int32_tile";
+            } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"MUL_INT32_INIT", fmt::format("mul_int32_tile_init();")});
+                op_name = "mul_uint32_tile";
             } else {
                 new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
                 op_name = "mul_binary_tile";

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -21,12 +21,12 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
     switch (val) {
         case BinaryOpType::ADD:
         case BinaryOpType::SUB:
+        case BinaryOpType::MUL:
         case BinaryOpType::EQ:
         case BinaryOpType::NE:
             return (
                 (a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) ||
                 (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
-        case BinaryOpType::MUL:
         case BinaryOpType::LOGICAL_AND:
         case BinaryOpType::LOGICAL_OR:
         case BinaryOpType::LOGICAL_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -16,12 +16,12 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
     switch (val) {
         case ADD:
         case SUB:
+        case MUL:
         case EQ:
         case NE:
             return (
                 (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT32 && b == UINT32) ||
                 (a == UINT16 && b == UINT16));
-        case MUL:
         case LOGICAL_AND:
         case LOGICAL_OR:
         case LOGICAL_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -368,6 +368,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
                 return {"mul_int_tile_init();", "mul_uint16_tile"};
             } else if (dtype == DataType::INT32) {
                 return {"mul_int32_tile_init();", "mul_int32_tile"};
+            } else if (dtype == DataType::UINT32) {
+                return {"mul_int32_tile_init();", "mul_uint32_tile"};
             } else {
                 return {"mul_binary_tile_init();", "mul_binary_tile"};
             }


### PR DESCRIPTION
### Ticket
#29639 

### Problem description
ttnn.mul does not support UINT32

### What's changed
Added support for UINT32 in binary and binary ng infra.

### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/18992431574
Latest run: https://github.com/tenstorrent/tt-metal/actions/runs/19033830134
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/19033851920
- [x] New/Existing tests provide coverage for changes